### PR TITLE
feat(intake.bash): per-fork git worktree sandbox via yggdrasil

### DIFF
--- a/src/dvergr/git.clj
+++ b/src/dvergr/git.clj
@@ -5,6 +5,7 @@
    Sessions can be nested via branch-from-branch pattern."
   (:require [yggdrasil.adapters.git :as git-adapter]
             [yggdrasil.protocols :as p]
+            [org.replikativ.spindel.yggdrasil :as ygg]
             [clojure.java.io :as io]
             [clojure.string :as str])
   (:import [java.io File]))
@@ -212,6 +213,28 @@
      (spit (str (worktree-path @ygit) \"/new-file.clj\") \"...\")"
   [git-sys]
   (p/working-path git-sys))
+
+(defn current-git-system
+  "Find the registered git system in the **current** execution context
+   (must be bound via `binding [ec/*execution-context* …]`).
+
+   When the context has been forked, the git system stored under the
+   same external-ref id will be the forked one — pointing at the
+   child's worktree — so its `working-path` returns the per-fork
+   workspace.
+
+   Returns the git system, or nil if no git system is registered."
+  []
+  (some->> (ygg/registered-systems)
+           vals
+           (filter #(= :git (p/system-type %)))
+           first))
+
+(defn current-worktree-path
+  "Working-tree filesystem path of the registered git system in the
+   current execution context. nil if no git system is registered."
+  []
+  (some-> (current-git-system) p/working-path))
 
 ;; ---------------------------------------------------------------------------
 ;; Utilities

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -40,6 +40,8 @@
    of the commands themselves still need a git-worktree workspace
    to be truly contained (PR #8 — yggdrasil git-worktree wiring)."
   (:require [clojure.string :as str]
+            [dvergr.process :as dproc]
+            [muschel.budget :as mbudget]
             [muschel.builtins.posix :as posix]
             [muschel.core :as m]
             [muschel.env :as menv]
@@ -229,11 +231,72 @@
 
    Returns muschel's check map; `(= :allow (:decision result))` is the
    typical green-light. Useful for `clojure_eval` agents that want to
-   inspect what a command would be allowed to do before committing."
-  [cmd]
-  (let [ast (m/parse cmd)]
-    (m/check {:ast ast :rulesets [m/default-rules]
-              :prompter m/allow-all-prompter})))
+   inspect what a command would be allowed to do before committing.
+
+   Opts:
+     :prompter  default `m/allow-all-prompter`; pass
+                `m/deny-all-prompter` to inspect what the safe-default
+                policy would reject."
+  ([cmd] (check cmd {}))
+  ([cmd {:keys [prompter] :or {prompter m/allow-all-prompter}}]
+   (let [ast (m/parse cmd)]
+     (m/check {:ast ast :rulesets [m/default-rules]
+               :prompter prompter}))))
+
+;; ---------------------------------------------------------------------------
+;; Interrupt + tracing helpers — bridge muschel's resource budgets and
+;; introspection hooks into dvergr's process/telemere surface.
+;; ---------------------------------------------------------------------------
+
+(def ^:const default-timeout-ms
+  "Per-call wall-clock ceiling. Most bash commands return in ms; a
+   build can take a minute. Anything past this almost certainly is
+   stuck in a loop or waiting on stdin. Override via `:timeout-ms`
+   for legitimately long commands."
+  60000)
+
+(defn- process-abort-interrupt-fn
+  "Build a muschel interrupt-fn that polls a dvergr.process for
+   abort status. Returns nil when no process is active."
+  [process]
+  (when process
+    (fn []
+      (when (dproc/aborted? process)
+        (throw (ex-info "muschel: process aborted"
+                        {:muschel/budget :process-aborted}))))))
+
+(defn- trace-bridge
+  "Build a muschel `:trace` map that mirrors every tool/fs/deny event
+   into telemere so the TUI + log surface can see what the agent
+   actually did."
+  []
+  {:on-tool (fn [e]
+              (tel/log! {:level :debug :id ::tool
+                         :data {:cmd (:name e) :argv (:argv e)
+                                :exit (:exit e)
+                                :stdout-bytes (:stdout-bytes e)
+                                :stderr-bytes (:stderr-bytes e)
+                                :duration-ms (:duration-ms e)}}))
+   :on-fs   (fn [e]
+              (tel/log! {:level :trace :id ::fs
+                         :data {:op (:op e) :path (:path e)
+                                :result (:result e)}}))
+   :on-deny (fn [e]
+              (tel/log! {:level :warn :id ::denied
+                         :data {:tool (:tool e) :argv (:argv e)
+                                :reason (:reason e)
+                                :rule-id (:rule-id e)}}))})
+
+(defn- trace-summary
+  "Compress muschel's full trace snapshot into a small map the agent
+   can read without flooding its context. Full trace stays accessible
+   via the returned `:trace-full` when callers opt in."
+  [trace]
+  (when trace
+    {:tool-count   (count (:tools trace))
+     :fs-reads     (count (:reads trace))
+     :fs-writes    (count (:writes trace))
+     :denied-count (count (:denied trace))}))
 
 (defn builtins
   "Return a sorted seq of builtin command names the agent's
@@ -252,59 +315,92 @@
   "Execute a bash source string against the chat-ctx's session.
 
    Options:
-     :chat-ctx     - explicit chat-ctx (otherwise resolved from
-                     *current-chat-ctx* binding, if you set one)
-     :host         - override the muschel host (default: BuiltinHost
-                     rooted at the workspace via get-or-create-host!)
-     :max-out      - cap stdout / stderr returned (default 8000 chars
-                     each — protects the agent context window)
+     :host         override the muschel host (default: BuiltinHost
+                   rooted at the workspace via get-or-create-host!)
+     :max-out      cap stdout / stderr returned (default 8000 chars
+                   each — protects the agent context window)
+     :prompter     muschel prompter for `:ask` permit decisions
+                   (default `m/allow-all-prompter`; pass
+                   `m/deny-all-prompter` for safer policy)
+     :timeout-ms   per-call wall-clock ceiling
+                   (default 60_000; agents shouldn't block longer)
+     :process      a `dvergr.process` to honour for cancellation;
+                   when aborted, the bash run interrupts at the next
+                   safe point. Defaults to
+                   `dvergr.process/*current-process*` when bound,
+                   so any agent turn wrapped as a process gets
+                   cancellation for free.
+     :trace-full?  include the full muschel trace snapshot (tools,
+                   fs ops, denied) in the return map. Default false
+                   — only a `:trace` summary is included.
 
    Returns:
-     {:stdout str :stderr str :exit int :cwd str :truncated? bool}
-     or {:error str :exit 126} on permit deny."
-  [chat-ctx cmd & {:keys [host max-out]
-                   :or {max-out 8000}}]
+     {:stdout str :stderr str :exit int :cwd str :truncated? bool
+      :trace {:tool-count :fs-reads :fs-writes :denied-count}}
+     or {:error str :exit 126 :permit ...} on permit deny."
+  [chat-ctx cmd & {:keys [host max-out prompter timeout-ms process trace-full?]
+                   :or {max-out      8000
+                        prompter     m/allow-all-prompter
+                        timeout-ms   default-timeout-ms
+                        process      dproc/*current-process*}}]
   (try
-    (let [sess  (get-or-create-session! chat-ctx)
-          ast   (m/parse cmd)
-          host  (or host (get-or-create-host! chat-ctx))
-          ;; The session was seeded with make-sandboxed-env at creation
-          ;; time (see get-or-create-session!) so its env is already
-          ;; sanitised. Just snapshot it for this run.
-          env0      (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-                      (msession/-env sess))
-          permit-result (m/check {:ast ast
-                                  :rulesets [m/default-rules]
-                                  :prompter m/allow-all-prompter})]
-      (if (= :deny (:decision permit-result))
-        (let [denied (->> (:per-call permit-result)
-                          (filter #(= :deny (:decision %)))
-                          first)]
-          (tel/log! {:level :warn :id :bash/denied
-                     :data {:cmd cmd :reason (:reason denied)}}
-                    "Bash command denied")
-          {:error (str "permit denied: " (or (:reason denied) "no reason"))
-           :exit 126})
-        (let [{:keys [stdout stderr exit env]}
-              (m/run-and-capture env0 ast
-                                 {:session sess :host host
-                                  ;; agents don't write stdin; never
-                                  ;; inherit System/in (would block
-                                  ;; under nREPL / when daemonised).
-                                  :in (java.io.ByteArrayInputStream.
-                                        (.getBytes ""))})
-              clip (fn [s]
-                     (if (and s (> (count s) max-out))
-                       (str (subs s 0 max-out) "\n[...truncated]")
-                       (or s "")))]
-          {:stdout     (clip stdout)
-           :stderr     (clip stderr)
-           :exit       exit
-           :cwd        (some-> env :cwd)
-           :truncated? (or (and stdout (> (count stdout) max-out))
-                           (and stderr (> (count stderr) max-out)))})))
+    (let [sess (get-or-create-session! chat-ctx)
+          host (or host (get-or-create-host! chat-ctx))
+          ;; The session was seeded with a sanitised env at creation
+          ;; time (make-sandboxed-env), so the snapshot is already
+          ;; secret-free. Pass it as the explicit starting env so
+          ;; one-shot library use stays well-defined.
+          env0 (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+                 (msession/-env sess))
+          interrupt-fn (mbudget/combine (process-abort-interrupt-fn process))
+          {:keys [stdout stderr exit env permit trace]}
+          (m/run-and-capture
+           env0 cmd
+           (cond-> {:session     sess
+                    :host        host
+                    ;; Agents don't write stdin; never inherit System/in
+                    ;; (would block under nREPL / when daemonised).
+                    :in          (java.io.ByteArrayInputStream. (.getBytes ""))
+                    :permit      {:rulesets [m/default-rules] :prompter prompter}
+                    :timeout-ms  timeout-ms
+                    :trace       (trace-bridge)}
+             interrupt-fn (assoc :interrupt-fn interrupt-fn)))
+          ;; muschel's run-and-capture doesn't propagate :denied-reason
+          ;; (it lives one level deeper, on the run result). Re-derive
+          ;; from :permit so we can build a useful error message.
+          denied-reason (when (and permit (= :deny (:decision permit)))
+                          (some->> permit :per-call
+                                   (filter #(= :deny (:decision %)))
+                                   first :reason))
+          clip (fn [s]
+                 (if (and s (> (count s) max-out))
+                   (str (subs s 0 max-out) "\n[...truncated]")
+                   (or s "")))]
+      (if denied-reason
+        (do (tel/log! {:level :warn :id ::denied
+                       :data {:cmd cmd :reason denied-reason}}
+                      "Bash command denied")
+            (cond-> {:error  (str "permit denied: " denied-reason)
+                     :exit   126
+                     :permit permit}
+              trace-full? (assoc :trace-full trace)))
+        (cond-> {:stdout     (clip stdout)
+                 :stderr     (clip stderr)
+                 :exit       exit
+                 :cwd        (some-> env :cwd)
+                 :truncated? (or (and stdout (> (count stdout) max-out))
+                                 (and stderr (> (count stderr) max-out)))
+                 :trace      (trace-summary trace)}
+          ;; Full permit result is huge (AST per call). Only include
+          ;; when explicitly requested.
+          trace-full? (assoc :trace-full trace :permit permit))))
     (catch Exception e
-      (tel/log! {:level :error :id :bash/error
-                 :data {:cmd cmd :error (.getMessage e)}}
-                "Bash run error")
-      {:error (.getMessage e) :exit 1})))
+      (let [budget? (mbudget/budget-exceeded? e)]
+        (tel/log! {:level (if budget? :warn :error)
+                   :id    (if budget? ::budget-exceeded ::error)
+                   :data  {:cmd cmd
+                           :reason (some-> e ex-data :muschel/budget)
+                           :error (.getMessage e)}}
+                  (if budget? "Bash budget exceeded" "Bash run error"))
+        {:error (.getMessage e)
+         :exit  (if budget? 124 1)}))))

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -40,6 +40,7 @@
    of the commands themselves still need a git-worktree workspace
    to be truly contained (PR #8 — yggdrasil git-worktree wiring)."
   (:require [clojure.string :as str]
+            [dvergr.git :as dgit]
             [dvergr.process :as dproc]
             [muschel.budget :as mbudget]
             [muschel.builtins.posix :as posix]
@@ -100,10 +101,22 @@
   #{"git"})
 
 (defn default-workspace
-  "JVM cwd. Agents launched alongside a project see the project root.
-   Override via opts to `make-host` if you want per-chat isolation."
+  "Resolve the agent's workspace path.
+
+   Priority:
+   1. The registered yggdrasil git system's current working-tree
+      path. When the surrounding execution context has been forked,
+      this is the **forked** worktree, so each fork's bash session
+      sees its own isolated FS root automatically — the whole
+      isolation story flows through this one lookup.
+   2. JVM cwd as a fallback for when no git system is registered
+      (e.g. unit tests, bare REPL).
+
+   Callers can still pass `:workspace` explicitly to `make-host` to
+   override this."
   []
-  (System/getProperty "user.dir"))
+  (or (dgit/current-worktree-path)
+      (System/getProperty "user.dir")))
 
 ;; ---------------------------------------------------------------------------
 ;; Sanitised environment for the agent's shell
@@ -172,14 +185,20 @@
 ;; Per-chat-ctx host (forks with the chat-ctx)
 ;; ============================================================================
 
-(def ^:private session-path [:dvergr/bash-session])
-(def ^:private host-path    [:dvergr/bash-host])
+;; Host + session are cached in the chat-ctx's spindel state. The cache
+;; key is the workspace path — when a chat-ctx fork lands the
+;; execution context on a fresh git worktree, the new path becomes a
+;; cache miss and a host/session rooted at that worktree gets
+;; built. The parent's host stays alive under its own path, so future
+;; runs back in the parent context still resolve to its workspace.
+(defn- session-path [workspace] [:dvergr/bash-session workspace])
+(defn- host-path    [workspace] [:dvergr/bash-host workspace])
 
 (defn make-host
   "Build a BuiltinHost wrapping a DiskFS rooted at `:workspace`.
 
    Options:
-     :workspace          (default: JVM cwd)
+     :workspace          (default: `default-workspace`)
      :fallback-allowlist (default: default-fallback-allowlist)
      :builtins           (default: muschel.builtins.posix/standard)"
   [{:keys [workspace fallback-allowlist builtins]
@@ -193,34 +212,40 @@
               :fallback-allowlist fallback-allowlist})))
 
 (defn get-or-create-session!
-  "Return the chat-ctx's muschel session, creating it on first use.
+  "Return the chat-ctx's muschel session for the **current** workspace
+   (which depends on whether the surrounding execution context has
+   been forked), creating it on first use.
 
-   The session is seeded with a *sanitised* env via make-sandboxed-env
-   so the agent never sees the daemon's API keys / tokens — even if
-   the agent runs `export` mid-session, the inherited base never had
-   secrets in it.
+   Sessions are seeded with a sanitised env via make-sandboxed-env so
+   the agent never sees the daemon's API keys / tokens. The session's
+   env-atom CoW-forks alongside the chat-ctx, so worker-side `cd` and
+   `export` don't leak back into the parent's session — but only
+   within a single workspace; a fork onto a fresh worktree gets a
+   fresh session at that path.
 
-   Stored under [:dvergr/bash-session] in the chat-ctx's spindel-ctx
-   state so it forks via CoW alongside everything else when the
-   chat-ctx is forked."
+   Stored under `[:dvergr/bash-session WORKSPACE-PATH]`."
   [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (or (ec/get-state session-path)
-        (let [s (ms/spindel-session-using (:spindel-ctx chat-ctx)
-                                          (make-sandboxed-env {}))]
-          (ec/swap-state! session-path (fn [existing] (or existing s)))
-          (ec/get-state session-path)))))
+    (let [ws (default-workspace)
+          path (session-path ws)]
+      (or (ec/get-state path)
+          (let [s (ms/spindel-session-using (:spindel-ctx chat-ctx)
+                                            (make-sandboxed-env {:cwd ws}))]
+            (ec/swap-state! path (fn [existing] (or existing s)))
+            (ec/get-state path))))))
 
 (defn get-or-create-host!
-  "Return the chat-ctx's BuiltinHost, creating it on first use.
-   Stored under [:dvergr/bash-host] alongside the session so both
-   travel together through fork-context."
+  "Return the chat-ctx's BuiltinHost for the current workspace,
+   creating it on first use. See `get-or-create-session!` for why
+   this is keyed by workspace path."
   [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (or (ec/get-state host-path)
-        (let [h (make-host {})]
-          (ec/swap-state! host-path (fn [existing] (or existing h)))
-          (ec/get-state host-path)))))
+    (let [ws (default-workspace)
+          path (host-path ws)]
+      (or (ec/get-state path)
+          (let [h (make-host {:workspace ws})]
+            (ec/swap-state! path (fn [existing] (or existing h)))
+            (ec/get-state path))))))
 
 ;; ============================================================================
 ;; Public API

--- a/test/dvergr/intake/bash_isolation_test.clj
+++ b/test/dvergr/intake/bash_isolation_test.clj
@@ -1,0 +1,163 @@
+(ns dvergr.intake.bash-isolation-test
+  "End-to-end isolation tests for the agent's bash surface.
+
+   Verifies that `dvergr.intake.bash` correctly threads the workspace
+   path through yggdrasil's fork-context machinery, so a fork-context
+   gives the bash session an isolated git worktree, and merge / discard
+   plumbing works as advertised."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [dvergr.daemon :as daemon]
+            [dvergr.git :as dgit]
+            [dvergr.intake.bash :as b]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [yggdrasil.protocols :as yp]))
+
+;; ============================================================================
+;; Sandbox repo helpers
+;; ============================================================================
+
+(defn- run-shell [& cmd-parts]
+  (let [pb (-> (ProcessBuilder. ^java.util.List (vec cmd-parts))
+               (.redirectErrorStream true))
+        proc (.start pb)
+        exit (.waitFor proc)]
+    {:exit exit
+     :out (slurp (.getInputStream proc))}))
+
+(defn- init-sandbox-repo!
+  "Create a one-commit git repo at `path`. Idempotent — wipes any
+   existing dir at `path` first."
+  [path]
+  (run-shell "rm" "-rf" path)
+  (.mkdirs (io/file path))
+  (let [script (str "cd " path
+                    " && git init -q -b main"
+                    " && git config user.email test@example.com"
+                    " && git config user.name test"
+                    " && echo seed > README.md"
+                    " && git add . && git commit -q -m seed")
+        r (run-shell "bash" "-c" script)]
+    (when (not= 0 (:exit r))
+      (throw (ex-info "sandbox-init failed" r)))))
+
+(defn- chat-on
+  "Build a thin chat-ctx whose :spindel-ctx is the given execution
+   context. Enough for `intake.bash` — the fancier fields
+   (messages/budget signals) aren't read by the bash surface."
+  [spindel-ctx]
+  {:spindel-ctx spindel-ctx :chat-id (random-uuid) :title "test"})
+
+(defn- bash [chat-ctx cmd]
+  (let [r (b/run chat-ctx cmd)]
+    {:exit (:exit r)
+     :stdout (str/trim (or (:stdout r) ""))
+     :stderr (str/trim (or (:stderr r) ""))
+     :cwd (:cwd r)}))
+
+;; A unique sandbox per test run so tests can run in parallel and
+;; nothing leaks between runs.
+(def ^:dynamic *sandbox-dir* nil)
+(def ^:dynamic *base-ctx* nil)
+
+(defn- with-sandbox [test-fn]
+  (let [dir (str "/tmp/dvergr-bash-iso-" (System/nanoTime))]
+    (try
+      (init-sandbox-repo! dir)
+      (let [ctx (daemon/create-shared-context
+                 :repo-path dir
+                 :worktrees-dir (str dir "/.worktrees")
+                 :with-git? true
+                 :with-datahike? false)]
+        (binding [*sandbox-dir* dir
+                  *base-ctx* ctx]
+          (test-fn)))
+      (finally
+        (run-shell "rm" "-rf" dir)))))
+
+(use-fixtures :each with-sandbox)
+
+;; ============================================================================
+;; Tests
+;; ============================================================================
+
+(deftest workspace-resolves-to-registered-git-worktree
+  ;; Without a fork, bash in a chat-ctx attached to base-ctx should run
+  ;; with workspace = the registered git repo path.
+  (let [chat (chat-on *base-ctx*)]
+    (is (= *sandbox-dir*
+           (binding [ec/*execution-context* *base-ctx*]
+             (dgit/current-worktree-path))))
+    (is (= "main" (:stdout (bash chat "git branch --show-current"))))
+    (is (= "README.md" (:stdout (bash chat "ls"))))))
+
+(deftest fork-gives-bash-a-fresh-worktree-on-a-fresh-branch
+  (let [parent (chat-on *base-ctx*)
+        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child  (chat-on (:child-ctx fork))
+        parent-branch (:stdout (bash parent "git branch --show-current"))
+        child-branch  (:stdout (bash child  "git branch --show-current"))
+        child-cwd     (:cwd (bash child "pwd"))]
+    (testing "parent stays on main"
+      (is (= "main" parent-branch)))
+    (testing "fork's bash is on a different, fork-named branch"
+      (is (not= parent-branch child-branch))
+      (is (str/starts-with? child-branch "main-fork-")))
+    (testing "fork's bash workspace is a worktree under the parent's repo"
+      (is (str/starts-with? child-cwd (str *sandbox-dir* "/.worktrees/"))))))
+
+(deftest writes-in-fork-do-not-leak-to-parent
+  (let [parent (chat-on *base-ctx*)
+        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child  (chat-on (:child-ctx fork))]
+    ;; Fork writes a file
+    (is (= 0 (:exit (bash child "echo hello > side.txt"))))
+    (is (= "hello" (:stdout (bash child "cat side.txt"))))
+    ;; Parent can't see it
+    (let [r (bash parent "cat side.txt")]
+      (is (not= 0 (:exit r)))
+      (is (re-find #"No such file" (:stderr r))))))
+
+(deftest writes-in-parent-do-not-leak-to-fork
+  (let [parent (chat-on *base-ctx*)
+        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child  (chat-on (:child-ctx fork))]
+    (is (= 0 (:exit (bash parent "echo p > parent.txt"))))
+    (let [r (bash child "cat parent.txt")]
+      (is (not= 0 (:exit r))))))
+
+(deftest merge-fork-propagates-commits-to-parent
+  (let [parent (chat-on *base-ctx*)
+        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child  (chat-on (:child-ctx fork))]
+    ;; Fork writes + commits
+    (is (= 0 (:exit (bash child "echo merged > m.txt && git add . && git commit -m wip"))))
+    ;; Before merge: parent doesn't see m.txt
+    (is (not (re-find #"m.txt" (:stdout (bash parent "ls")))))
+    ;; Merge from parent's context
+    (binding [ec/*execution-context* *base-ctx*]
+      (ygg/merge-fork! fork))
+    ;; After merge: parent sees m.txt
+    (is (= "merged" (:stdout (bash parent "cat m.txt"))))))
+
+(deftest discard-fork-drops-the-worktree
+  (let [fork  (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child (chat-on (:child-ctx fork))
+        wt    (binding [ec/*execution-context* (:child-ctx fork)]
+                (dgit/current-worktree-path))]
+    (is (= 0 (:exit (bash child "echo throwaway > t.txt && git add . && git commit -m wip"))))
+    (is (.exists (io/file wt)))
+    (binding [ec/*execution-context* *base-ctx*]
+      (ygg/discard-fork! fork))
+    (is (not (.exists (io/file wt)))
+        "discard-fork! must remove the worktree directory from disk")))
+
+(deftest container-refuses-paths-outside-worktree
+  ;; Even though the parent's underlying FS is a real DiskFS, paths
+  ;; outside the sandbox root are rejected.
+  (let [parent (chat-on *base-ctx*)]
+    (let [r (bash parent "cat /etc/passwd")]
+      (is (not= 0 (:exit r)))
+      (is (re-find #"No such file" (:stderr r))))))


### PR DESCRIPTION
## Summary

#189. Each `(ygg/fork!)` now gives the agent's bash surface an isolated git worktree, automatically. No new yggdrasil or spindel work needed — the auto-fork machinery already exists; `dvergr.intake.bash` just needed to consult the current execution context's registered git system instead of hard-coding JVM cwd.

## How it works

1. `spindel.yggdrasil` already auto-branches every registered yggdrasil system on `(ctx/fork-context …)` via `PForkable`. The registered `GitSystem` fires `(ygg/branch! …)` under the hood → `git worktree add -b <fork-branch>`; the child context's `[:external-refs]` map holds the new system pointing at the new worktree.
2. New helpers `dvergr.git/current-git-system` and `dvergr.git/current-worktree-path` look up the git system in the current execution context (parent or fork) and return its working-tree path.
3. `dvergr.intake.bash/default-workspace` now consults `current-worktree-path` first, falling back to JVM cwd. So bash inside a forked chat automatically resolves to the fork's worktree — no plumbing required at call sites.
4. The host + session cache became workspace-keyed: `[:dvergr/bash-host workspace-path]` / `[:dvergr/bash-session workspace-path]`. When a fork swaps the resolved path, lookup misses and a fresh host/session at the new path is built. The parent's host keeps living under its own path key, so re-entry to the parent context resolves to its workspace.

## Test plan

- [x] 7 new deftest cases in `test/dvergr/intake/bash_isolation_test.clj` exercising the full lifecycle:
  - `workspace-resolves-to-registered-git-worktree` (parent baseline)
  - `fork-gives-bash-a-fresh-worktree-on-a-fresh-branch`
  - `writes-in-fork-do-not-leak-to-parent`
  - `writes-in-parent-do-not-leak-to-fork`
  - `merge-fork-propagates-commits-to-parent`
  - `discard-fork-drops-the-worktree`
  - `container-refuses-paths-outside-worktree`
- [x] Full dvergr test suite: 270 tests, 875 assertions, 0 failures.
- [x] REPL-verified end-to-end with a real `bash`/`git` round-trip: fork → commit → merge → parent sees the file; fork → commit → discard → worktree gone, parent untouched.
