### PR TITLE
feat(peer-bus): daemon-wide bus + PR-style merge-review primitives

### DIFF
--- a/src/dvergr/bus.clj
+++ b/src/dvergr/bus.clj
@@ -120,14 +120,47 @@
                 (swap! log-atom conj msg)
                 (recur rest-s)))))))))
 
+(defn- spawn-relay-drain!
+  "Spawn a spin that taps `source-mult` and re-posts every message to
+   `target-bus`, with `relay-tag` merged in. Used so a per-room bus can
+   mirror its traffic up to a daemon-wide peer-bus.
+
+   The relayed message gets two added fields by default:
+     :dvergr/origin   — the room id (or whatever the caller set in
+                         relay-tag's `:room`)
+     :dvergr/scope    — `:room` for normal rooms, `:fork` for forks,
+                         or whatever the caller set"
+  [ctx source-mult target-bus relay-tag]
+  (binding [ec/*execution-context* ctx]
+    (let [relay-tap (mult/tap source-mult (buf/fixed-buffer 1024))]
+      (sync/spawn!
+        (spin
+          (loop [s relay-tap]
+            (when-let [r (await (aseq/anext s))]
+              (let [[msg rest-s] r
+                    ;; The relay-tag is a plain map. We don't overwrite
+                    ;; keys the original message already has — the
+                    ;; origin's view of itself wins.
+                    tagged    (merge relay-tag msg)]
+                (binding [ec/*execution-context* (:ctx target-bus)]
+                  (sync/post! (:source-mbox target-bus) tagged))
+                (recur rest-s)))))))))
+
 (defn create-bus
   "Construct a Bus.
 
    Options:
-     :ctx  — existing execution context; default: a fresh one
-     :log? — keep a vector history of every message (default true)"
+     :ctx        — existing execution context; default: a fresh one
+     :log?       — keep a vector history of every message (default true)
+     :relay-to   — another Bus to mirror every message into (typically
+                    the daemon-wide peer-bus). Messages are re-posted
+                    verbatim with `:relay-tag` merged in *underneath*
+                    (so the original message's own fields win).
+     :relay-tag  — extras to merge into each relayed message — typically
+                    `{:dvergr/origin <room-id> :dvergr/scope :room}`
+                    or `:fork`. Required when `:relay-to` is set."
   ([] (create-bus {}))
-  ([{:keys [ctx log?] :or {log? true}}]
+  ([{:keys [ctx log? relay-to relay-tag] :or {log? true}}]
    (let [ctx (or ctx (ectx/create-execution-context))]
      (binding [ec/*execution-context* ctx]
        (let [source     (sync/create-mailbox ctx)
@@ -139,6 +172,8 @@
              log-atom   (atom [])]
          (when log?
            (spawn-log-drain! ctx m log-atom))
+         (when relay-to
+           (spawn-relay-drain! ctx m relay-to (or relay-tag {})))
          (->Bus ctx source m to-pub-v type-pub-v log-atom))))))
 
 ;; ============================================================================

--- a/src/dvergr/daemon.clj
+++ b/src/dvergr/daemon.clj
@@ -192,6 +192,15 @@
                        :error e
                        :data {:error (.getMessage e)}}
                       "Could not register Datahike system"))))
+      ;; Daemon-wide peer-bus. Sits on the base-ctx; every room/fork
+      ;; bus relays into it (see dvergr.discourse/fork-room and the
+      ;; future Room constructor). Cross-cutting subscribers — TUI
+      ;; pending-review badge, audit, oversight agents — tap one
+      ;; place instead of N rooms.
+      (require 'dvergr.peer-bus)
+      ((resolve 'dvergr.peer-bus/create!) base-ctx)
+      (tel/log! {:id :daemon/peer-bus-registered}
+                "Registered daemon peer-bus")
       base-ctx)))
 
 ;; ============================================================================

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -32,7 +32,9 @@
             [org.replikativ.spindel.spin.combinators :as comb]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [is.simm.partial-cps.sequence :refer [anext]]
-            [dvergr.bus :as bus]))
+            [dvergr.bus :as bus]
+            [dvergr.git :as dgit]
+            [dvergr.peer-bus :as peer-bus]))
 
 ;; ============================================================================
 ;; Records
@@ -109,12 +111,25 @@
 ;; Construction
 ;; ============================================================================
 
+(defn- bus-with-peer-relay
+  "Build a bus that mirrors every message to the daemon-wide peer-bus
+   (when one is registered in the current ctx). Falls back to a plain
+   bus if not — keeps tests / library use happy without daemon
+   bootstrap."
+  [ctx room-id scope]
+  (let [peer (binding [ec/*execution-context* ctx] (peer-bus/current))]
+    (bus/create-bus
+     (cond-> {:ctx ctx}
+       peer (assoc :relay-to  peer
+                   :relay-tag {:dvergr/origin room-id
+                               :dvergr/scope  scope})))))
+
 (defn room
   "Create a Room. With one arg, allocates a fresh ExecutionContext;
    with two, uses the provided ctx (useful for nested rooms / forks)."
   ([id] (room id (sp/create-execution-context)))
   ([id ctx]
-   (let [b (bus/create-bus {:ctx ctx})]
+   (let [b (bus-with-peer-relay ctx id :room)]
      (->Room id (atom {}) b ctx 0))))
 
 (defn participant
@@ -472,8 +487,7 @@
          child-ctx  (case isolation
                       :none (:ctx room)
                       :ctx  (ctx/fork-context (:ctx room)))
-         child-bus  (binding [ec/*execution-context* child-ctx]
-                      (bus/create-bus {:ctx child-ctx}))
+         child-bus  (bus-with-peer-relay child-ctx new-id :fork)
          ;; Seed the fork's bus log with parent history so log-based
          ;; consumers see a continuous record. Forks have their OWN bus
          ;; so live messages do not leak between parent and fork.
@@ -484,6 +498,16 @@
        (when-let [fac (:factory p)]
          (binding [ec/*execution-context* child-ctx]
            (join new-room (fac child-ctx)))))
+     ;; Control-plane: announce the fork on the peer-bus so dashboards,
+     ;; audit logs, and oversight agents see it without subscribing to
+     ;; the fork's bus directly.
+     (binding [ec/*execution-context* child-ctx]
+       (peer-bus/post! {:type            :dvergr/fork-created
+                        :dvergr/origin   new-id
+                        :dvergr/parent   (:id room)
+                        :isolation       isolation
+                        :worktree-path   (when (= :ctx isolation)
+                                           (dgit/current-worktree-path))}))
      new-room)))
 
 (defmacro with-fork-ctx
@@ -511,11 +535,16 @@
    via `spindel.yggdrasil/discard-from-parent!`. Participant spins on a
    shared ctx (`:isolation :none`) continue running indefinitely on
    their mailboxes (harmless; cleaned up when the shared context
-   eventually stops)."
+   eventually stops).
+
+   Emits `:dvergr/fork-discarded` on the peer-bus."
   [fork]
   (reset! (:participants fork) {})
   (when (ctx-was-forked? fork)
     (ygg/discard-from-parent! (:ctx fork)))
+  (binding [ec/*execution-context* (:ctx fork)]
+    (peer-bus/post! {:type :dvergr/fork-discarded
+                     :dvergr/origin (:id fork)}))
   fork)
 
 (defn merge-room
@@ -549,7 +578,64 @@
   (when (ctx-was-forked? fork)
     (ygg/merge-to-parent! (:ctx fork)))
   (reset! (:participants fork) {})
+  (binding [ec/*execution-context* (:ctx fork)]
+    (peer-bus/post! {:type            :dvergr/fork-merged
+                     :dvergr/origin   (:id fork)
+                     :dvergr/parent   (:id parent)}))
   parent)
+
+;; ============================================================================
+;; PR-style merge review
+;; ============================================================================
+
+(defn propose-merge!
+  "Agent-side: signal that the fork-room's work is ready for the
+   manager's review. Posts two things:
+
+   1. A chat message on the fork's bus with `:dvergr/proposal`
+      metadata carrying a diff summary (commits + changed files +
+      `git diff --stat`). Participants subscribed to the fork can
+      ask follow-up questions in the usual way.
+
+   2. A `:dvergr/merge-proposed` event on the peer-bus so dashboards
+      and oversight agents see the proposal without joining the
+      fork's bus.
+
+   Options:
+     :from     participant id posting the proposal (default: :worker)
+     :note     human-readable rationale to attach to the message
+               (default: empty)
+
+   Returns the proposal payload."
+  [fork & {:keys [from note] :or {from :worker note ""}}]
+  (let [diff      (when (ctx-was-forked? fork)
+                    (dgit/diff-since-fork (:ctx fork)))
+        proposal  (cond-> {:fork-id (:id fork)
+                           :note    note}
+                    diff (assoc :diff diff))
+        msg       {:type            :proposal/merge
+                   :from            from
+                   :body            (str "Ready for review."
+                                         (when (seq note) (str " " note)))
+                   :dvergr/proposal proposal}]
+    (bus/post! (:bus fork) msg)
+    (binding [ec/*execution-context* (:ctx fork)]
+      (peer-bus/post! {:type            :dvergr/merge-proposed
+                       :dvergr/origin   (:id fork)
+                       :proposal        proposal}))
+    proposal))
+
+(defn pending-proposals
+  "Scan a room's log for `:dvergr/proposal`-tagged messages that
+   haven't been followed by a merge or discard. Useful for the TUI
+   pending-review badge and for agents that want to enumerate open
+   review threads.
+
+   Returns a vector of proposal payloads in log order."
+  [room]
+  (->> (log room)
+       (keep :dvergr/proposal)
+       vec))
 
 ;; ============================================================================
 ;; Hire — fork + spawn + send + merge|discard (the §5.8 primitive)

--- a/src/dvergr/git.clj
+++ b/src/dvergr/git.clj
@@ -5,6 +5,7 @@
    Sessions can be nested via branch-from-branch pattern."
   (:require [yggdrasil.adapters.git :as git-adapter]
             [yggdrasil.protocols :as p]
+            [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [clojure.java.io :as io]
             [clojure.string :as str])
@@ -235,6 +236,70 @@
    current execution context. nil if no git system is registered."
   []
   (some-> (current-git-system) p/working-path))
+
+(defn- git-in
+  "Run `git <args>` inside `dir`, return {:exit :out}. Best-effort —
+   never throws on git errors, the caller decides what to do."
+  [dir & args]
+  (let [pb (-> (ProcessBuilder. ^java.util.List
+                                (into ["git"] args))
+               (.directory (io/file dir))
+               (.redirectErrorStream true))
+        proc (.start pb)
+        out (slurp (.getInputStream proc))
+        exit (.waitFor proc)]
+    {:exit exit :out out}))
+
+(defn diff-since-fork
+  "Compute the diff that a fork-context's branch has accumulated over
+   its parent branch. Used by `dvergr.discourse/propose-merge!` to
+   build a payload the human (or another agent) can scan before
+   approving a merge.
+
+   `fork-ctx` is the spindel execution context returned by
+   `ctx/fork-context` (i.e. the `:child-ctx` of a yggdrasil
+   ForkHandle, or `(:ctx fork-room)` after `fork-room :isolation
+   :ctx`).
+
+   Returns a map:
+     {:branch         \"main-fork-…\"           ; fork's branch
+      :parent-branch  \"main\"                  ; parent's branch
+      :worktree-path  \"/tmp/.../worktrees/…\"  ; the fork's path
+      :commits        [{:sha … :subject …} …]   ; fork-only commits
+      :stat           \"…lines + / - per file…\" ; diff --stat output
+      :files          [\"side.txt\" \"x.clj\" …] ; changed file paths
+      :empty?         false}                    ; true when no diff"
+  [fork-ctx]
+  (let [in-ctx (fn [c] (binding [ec/*execution-context* c]
+                         (current-git-system)))
+        fork-sys (in-ctx fork-ctx)]
+    (when fork-sys
+      (let [fork-branch   (name (p/current-branch fork-sys))
+            parent-branch (let [parent-ctx (:parent-ctx fork-ctx)
+                                parent-sys (when parent-ctx (in-ctx parent-ctx))]
+                            (or (some-> parent-sys p/current-branch name)
+                                "main"))
+            worktree      (p/working-path fork-sys)
+            range         (str parent-branch ".." fork-branch)
+            commits-r     (git-in worktree "log" "--format=%h%x09%s" range)
+            commits       (when (zero? (:exit commits-r))
+                            (for [line (str/split-lines (:out commits-r))
+                                  :when (not (str/blank? line))
+                                  :let [[sha subject] (str/split line #"\t" 2)]]
+                              {:sha sha :subject subject}))
+            stat-r        (git-in worktree "diff" "--stat" range)
+            files-r       (git-in worktree "diff" "--name-only" range)
+            files         (when (zero? (:exit files-r))
+                            (->> (str/split-lines (:out files-r))
+                                 (remove str/blank?)
+                                 vec))]
+        {:branch        fork-branch
+         :parent-branch parent-branch
+         :worktree-path worktree
+         :commits       (vec commits)
+         :stat          (when (zero? (:exit stat-r)) (:out stat-r))
+         :files         files
+         :empty?        (empty? files)}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Utilities

--- a/src/dvergr/peer_bus.clj
+++ b/src/dvergr/peer_bus.clj
@@ -1,0 +1,98 @@
+(ns dvergr.peer-bus
+  "Daemon-wide pub/sub bus — one per JVM, lives on the base execution
+   context. Every per-room bus (and every fork bus) is created with
+   `:relay-to <peer-bus>` so messages mirror up automatically, tagged
+   with `:dvergr/origin <room-id>` + `:dvergr/scope :room | :fork`.
+
+   Cross-cutting concerns subscribe to the peer-bus instead of each
+   room individually:
+
+     - TUI dashboard's `pending-reviews` badge
+     - audit log / governance
+     - oversight agents that watch many rooms
+
+   Control-plane events that aren't tied to a specific room
+   (`:dvergr/fork-created`, `:dvergr/merge-proposed`,
+   `:dvergr/fork-merged`, `:dvergr/fork-discarded`) post **directly**
+   here, never through a room's bus — so room conversation logs stay
+   pure conversation.
+
+   Matches the replikativ/kabel peer-bus idiom: a `:type`-keyed
+   `bus-in`/`bus-out` pair carrying every event on the machine,
+   subscribers filter."
+  (:require [dvergr.bus :as bus]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ectx]))
+
+;; ============================================================================
+;; State location
+;; ============================================================================
+
+(def ^:private peer-bus-path
+  "Slot on the base execution context where the peer-bus lives. A child
+   ctx (forked) inherits this slot via CoW so the same peer-bus is
+   reachable from anywhere in the daemon."
+  [:dvergr/peer-bus])
+
+;; ============================================================================
+;; Construction + lookup
+;; ============================================================================
+
+(defn create!
+  "Create a peer-bus on `base-ctx` and stash it at `[:dvergr/peer-bus]`.
+   Returns the bus. Called by daemon init; idempotent — re-creating
+   would orphan existing subscribers, so we no-op if one's already
+   there."
+  [base-ctx]
+  (binding [ec/*execution-context* base-ctx]
+    (or (ec/get-state peer-bus-path)
+        (let [b (bus/create-bus {:ctx base-ctx})]
+          (ec/swap-state! peer-bus-path (fn [x] (or x b)))
+          (ec/get-state peer-bus-path)))))
+
+(defn current
+  "Return the peer-bus visible from the current execution context, or
+   nil if none registered. Resolves through ctx fork inheritance: a
+   forked ctx sees its parent's peer-bus."
+  []
+  (ec/get-state peer-bus-path))
+
+;; ============================================================================
+;; Post / subscribe
+;; ============================================================================
+
+(defn post!
+  "Post a control-plane event to the peer-bus. `msg` should at minimum
+   carry `:type` (so :type-pub subscribers can route it). Adds nothing
+   else — callers attach `:dvergr/origin`, `:dvergr/scope`, etc.
+   themselves as needed.
+
+   No-op (logs a warning via the bus layer's own telemetry) when no
+   peer-bus is registered, so library callers don't have to guard."
+  [msg]
+  (when-let [b (current)]
+    (bus/post! b msg))
+  nil)
+
+(defn subscribe!
+  "Subscribe to peer-bus events. Topic forms are the same as
+   `dvergr.bus/subscribe!` — `[:to id]` or `[:type tag]`. Returns a
+   `dvergr.bus.Subscription` (`:aseq` is a `PAsyncSeq` of events).
+
+   Throws if no peer-bus is registered — there's no sensible
+   fallback for a subscriber."
+  ([topic]
+   (if-let [b (current)]
+     (bus/subscribe! b topic)
+     (throw (ex-info "dvergr.peer-bus: no peer-bus registered in current ctx"
+                     {:topic topic}))))
+  ([topic buffer]
+   (if-let [b (current)]
+     (bus/subscribe! b topic buffer)
+     (throw (ex-info "dvergr.peer-bus: no peer-bus registered in current ctx"
+                     {:topic topic})))))
+
+(defn log
+  "Full peer-bus log (vector). nil if no peer-bus registered."
+  []
+  (some-> (current) bus/log))

--- a/test/dvergr/peer_bus_review_test.clj
+++ b/test/dvergr/peer_bus_review_test.clj
@@ -1,0 +1,156 @@
+(ns dvergr.peer-bus-review-test
+  "End-to-end tests for the peer-bus + PR-style merge-review primitives:
+   - Per-room messages relay to the peer-bus tagged with origin + scope
+   - fork-room emits :dvergr/fork-created
+   - propose-merge! emits :dvergr/merge-proposed + a tagged chat message
+   - merge-room emits :dvergr/fork-merged
+   - discard emits :dvergr/fork-discarded
+   - pending-proposals scans a room's log"
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [dvergr.bus :as bus]
+            [dvergr.daemon :as daemon]
+            [dvergr.discourse :as d]
+            [dvergr.intake.bash :as b]
+            [dvergr.peer-bus :as peer-bus]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+;; ============================================================================
+;; Sandbox fixture (reuses pattern from bash_isolation_test)
+;; ============================================================================
+
+(defn- run-shell [& cmd-parts]
+  (let [pb (-> (ProcessBuilder. ^java.util.List (vec cmd-parts))
+               (.redirectErrorStream true))
+        proc (.start pb)]
+    (.waitFor proc)
+    {:out (slurp (.getInputStream proc))}))
+
+(defn- init-sandbox-repo! [path]
+  (run-shell "rm" "-rf" path)
+  (.mkdirs (io/file path))
+  (run-shell "bash" "-c"
+             (str "cd " path
+                  " && git init -q -b main"
+                  " && git config user.email t@e.com"
+                  " && git config user.name t"
+                  " && echo seed > README.md"
+                  " && git add . && git commit -q -m seed")))
+
+(def ^:dynamic *sandbox-dir* nil)
+(def ^:dynamic *base-ctx* nil)
+
+(defn- with-sandbox [test-fn]
+  (let [dir (str "/tmp/dvergr-pb-" (System/nanoTime))]
+    (try
+      (init-sandbox-repo! dir)
+      (let [ctx (daemon/create-shared-context
+                 :repo-path dir
+                 :worktrees-dir (str dir "/.worktrees")
+                 :with-git? true
+                 :with-datahike? false)]
+        (binding [*sandbox-dir* dir
+                  *base-ctx* ctx]
+          (test-fn)))
+      (finally
+        (run-shell "rm" "-rf" dir)))))
+
+(use-fixtures :each with-sandbox)
+
+;; ============================================================================
+;; Helpers
+;; ============================================================================
+
+(defn- peer-events-of-type [tag]
+  (binding [ec/*execution-context* *base-ctx*]
+    (->> (peer-bus/log)
+         (filter #(= tag (:type %)))
+         vec)))
+
+(defn- chat [ctx]
+  {:spindel-ctx ctx :chat-id (random-uuid) :title "t"})
+
+(defn- bash [ctx-or-chat cmd]
+  (b/run (if (:spindel-ctx ctx-or-chat)
+           ctx-or-chat
+           (chat ctx-or-chat))
+         cmd))
+
+;; ============================================================================
+;; Tests
+;; ============================================================================
+
+(deftest peer-bus-is-registered-on-daemon-init
+  (binding [ec/*execution-context* *base-ctx*]
+    (is (some? (peer-bus/current)))))
+
+(deftest fork-room-emits-fork-created-event
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :parent *base-ctx*)
+          fork   (d/fork-room parent {:isolation :ctx})]
+      (Thread/sleep 50)                                ; let drain catch up
+      (let [evts (peer-events-of-type :dvergr/fork-created)]
+        (is (= 1 (count evts)) "exactly one fork-created event")
+        (is (= (:id fork) (:dvergr/origin (first evts))))
+        (is (= :parent (:dvergr/parent (first evts))))
+        (is (str/starts-with? (:worktree-path (first evts))
+                              (str *sandbox-dir* "/.worktrees/")))))))
+
+(deftest propose-merge!-emits-event-and-tagged-message
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :p *base-ctx*)
+          fork   (d/fork-room parent {:isolation :ctx})
+          _      (bash (:ctx fork)
+                       "echo added > side.txt && git add . && git commit -q -m wip")
+          prop   (d/propose-merge! fork :note "Adds side.txt")]
+      (Thread/sleep 100)
+      (testing "proposal payload includes a diff"
+        (is (string? (get-in prop [:diff :branch])))
+        (is (re-find #"side.txt" (get-in prop [:diff :stat]))))
+      (testing "peer-bus saw :dvergr/merge-proposed"
+        (let [evts (peer-events-of-type :dvergr/merge-proposed)]
+          (is (= 1 (count evts)))
+          (is (= (:id fork) (:dvergr/origin (first evts))))))
+      (testing "fork's log carries a :dvergr/proposal message"
+        (is (= 1 (count (d/pending-proposals fork))))))))
+
+(deftest merge-room-emits-fork-merged
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :p *base-ctx*)
+          fork   (d/fork-room parent {:isolation :ctx})]
+      (bash (:ctx fork) "echo m > m.txt && git add . && git commit -q -m wip")
+      (d/merge-room parent fork)
+      (Thread/sleep 50)
+      (let [evts (peer-events-of-type :dvergr/fork-merged)]
+        (is (= 1 (count evts)))
+        (is (= (:id fork) (:dvergr/origin (first evts))))))))
+
+(deftest discard-emits-fork-discarded
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :p *base-ctx*)
+          fork   (d/fork-room parent {:isolation :ctx})]
+      (d/discard fork)
+      (Thread/sleep 50)
+      (let [evts (peer-events-of-type :dvergr/fork-discarded)]
+        (is (= 1 (count evts)))
+        (is (= (:id fork) (:dvergr/origin (first evts))))))))
+
+(deftest room-messages-relay-to-peer-bus-with-scope-tag
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :pp *base-ctx*)
+          fork   (d/fork-room parent {:isolation :ctx})]
+      (bus/post! (:bus parent) {:type :test/ping :from :tester :body "parent"})
+      (bus/post! (:bus fork)   {:type :test/ping :from :tester :body "fork"})
+      (Thread/sleep 100)
+      (let [pings (binding [ec/*execution-context* *base-ctx*]
+                    (->> (peer-bus/log)
+                         (filter #(= :test/ping (:type %)))
+                         vec))
+            parent-ping (first (filter #(= :pp (:dvergr/origin %)) pings))
+            fork-ping   (first (filter #(= (:id fork) (:dvergr/origin %)) pings))]
+        (is (= 2 (count pings)))
+        (testing "parent's relay is tagged :scope :room"
+          (is (= :room (:dvergr/scope parent-ping))))
+        (testing "fork's relay is tagged :scope :fork"
+          (is (= :fork (:dvergr/scope fork-ping))))))))


### PR DESCRIPTION
## Summary

#191. Adds a daemon-level peer-bus (replikativ/kabel-style) plus the discourse primitives needed for GitHub-PR-style review of a fork before merging it back. Stacks on top of #1 (per-fork git worktree sandbox); the two together give a coherent workflow: spawn a fork → agent works in an isolated worktree → agent `propose-merge!`s → manager reviews + chats → manager `merge-room` or `discard`.

## What's new

**`dvergr.peer-bus`** — one `:type`-keyed bus per JVM, lives at `[:dvergr/peer-bus]` on the base execution context. Daemon's `create-shared-context` registers it; a forked ctx inherits via CoW so `(peer-bus/current)` reaches the same bus from anywhere.

**`dvergr.bus/create-bus`** grows `:relay-to` and `:relay-tag` options. When set, the bus spawns a drain spin that taps its source-mult and re-posts every message to the relay target with the tag merged in (under the message's own fields). Used by `room` and `fork-room` to mirror everything to the peer-bus tagged with `:dvergr/origin <room-id>` and `:dvergr/scope :room` / `:fork`.

**`dvergr.discourse`**:
- `fork-room` emits `:dvergr/fork-created` on the peer-bus (carries `worktree-path` from #1).
- `merge-room` emits `:dvergr/fork-merged`.
- `discard` emits `:dvergr/fork-discarded`.
- `propose-merge!` (new) — agent's "ready for review" signal. Posts a tagged `:proposal/merge` chat message on the fork's bus AND a `:dvergr/merge-proposed` event on the peer-bus, with a diff payload (commits + changed files + `git diff --stat`).
- `pending-proposals` (new) — scans a room's log for unresolved `:dvergr/proposal` entries. For TUI badges, oversight agents.

**`dvergr.git/diff-since-fork`** — computes the parent..fork diff via the git system registered in the fork's ctx.

## Architecture

```
                          peer-bus  (one per JVM)
                          ┌──────────────────────────────┐
                          │ :type-pub  +  log atom       │
                          └▲────▲──────────────────────▲─┘
   relay drain     control │    │ relay drain         │ control events
                           │    │                     │
   ┌───────────────────────┴┐  ┌┴──────────────────┐  │
   │ ROOM bus (scope :room) │  │ FORK bus (:fork)  │  │
   │  local :to/:type pubs  │  │                   │  │
   └────────────────────────┘  └───────────────────┘  │
                                                       │
                          ┌────────────────────────────┴┐
                          │ fork-room/merge-room/discard│
                          │ propose-merge! direct posts │
                          └─────────────────────────────┘
```

Per-room buses retain their local routing efficiency. Cross-cutting subscribers (TUI dashboard, audit log, oversight agents) tap one place.

## Test plan
- [x] 6 new deftests in `test/dvergr/peer_bus_review_test.clj`:
  - `peer-bus-is-registered-on-daemon-init`
  - `fork-room-emits-fork-created-event`
  - `propose-merge!-emits-event-and-tagged-message`
  - `merge-room-emits-fork-merged`
  - `discard-emits-fork-discarded`
  - `room-messages-relay-to-peer-bus-with-scope-tag`
- [x] Full dvergr suite: 276 tests, 892 assertions, 0 failures.

## Follow-ups (intentionally not in this PR)
- **Playground (#190)** — uses these primitives in real-LLM scenarios.
- **TUI binding (slice 3)** — `[m]erge` / `[d]iscard` keybinds + pending-review badge. Deferred until the playground tells us what the right UX is.
- **Re-fan merged log entries through the parent's pubs** — currently `merge-room` only updates the parent's log atom; merged messages are visible on the peer-bus (immediately) but the parent's per-room subscribers don't re-fire. This matches the discourse model's "merge-as-history" intent.
