### PR TITLE
Align to released ygg-signal stack + fix deprecated-model 404 + agent-repeat loop

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -26,11 +26,12 @@
         ;; SCI — Small Clojure Interpreter for sandboxing.
         org.babashka/sci           {:mvn/version "0.13.52"}
 
-        ;; partial-cps — CPS transform for SCI spin macro
-        is.simm/partial-cps        {:mvn/version "0.1.54"}
+        ;; partial-cps (CPS transform for the SCI spin macro) comes TRANSITIVELY
+        ;; via spindel — not declared here, so spindel is the single source of its
+        ;; version. The `:local` alias's `../spindel` override carries it too.
 
         ;; Spindel — Reactive runtime with CoW forking
-        org.replikativ/spindel     {:mvn/version "0.1.23"}
+        org.replikativ/spindel     {:mvn/version "0.1.24"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
@@ -42,11 +43,11 @@
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        org.replikativ/datahike    {:mvn/version "0.8.1689"}
+        org.replikativ/datahike    {:mvn/version "0.8.1708"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.2.27 carries composite Mergeable diff + conflicts (PR #3).
-        org.replikativ/yggdrasil   {:mvn/version "0.2.29"}
+        org.replikativ/yggdrasil   {:mvn/version "0.3.34"}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
         org.replikativ/scriptum    {:mvn/version "0.1.27"}
@@ -58,9 +59,9 @@
         ;; Kabel — WebSocket peer-to-peer transport. 0.3.98 pins javac --release 11
         ;; (0.3.97 shipped Java-25 bytecode → UnsupportedClassVersionError on JDK <25).
         org.replikativ/kabel       {:mvn/version "0.3.98"}
-        org.replikativ/hasch       {:mvn/version "0.4.98"}
+        org.replikativ/hasch       {:mvn/version "0.4.99"}
         org.replikativ/incognito   {:mvn/version "0.3.69"}
-        org.replikativ/konserve    {:mvn/version "0.9.347"}
+        org.replikativ/konserve    {:mvn/version "0.9.350"}
         org.replikativ/kabel-auth  {:mvn/version "0.1.19"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
         ;; version. The `:local` alias's `../spindel` override carries it too.
 
         ;; Spindel — Reactive runtime with CoW forking
-        org.replikativ/spindel     {:mvn/version "0.1.24"}
+        org.replikativ/spindel     {:mvn/version "0.1.26"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
@@ -47,7 +47,7 @@
 
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.2.27 carries composite Mergeable diff + conflicts (PR #3).
-        org.replikativ/yggdrasil   {:mvn/version "0.3.34"}
+        org.replikativ/yggdrasil   {:mvn/version "0.3.35"}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
         org.replikativ/scriptum    {:mvn/version "0.1.27"}
@@ -106,7 +106,7 @@
                        metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                        io.forward/clojure-mail {:mvn/version "1.0.8"} ; mail intake
                        org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)
-                       org.replikativ/spindel-tui {:mvn/version "0.1.10"}}}
+                       org.replikativ/spindel-tui {:mvn/version "0.1.12"}}}
 
   ;; src-clients/ on the test path so dvergr.web.server-test still
   ;; loads the namespaces it tests.
@@ -115,7 +115,7 @@
                        metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                        io.forward/clojure-mail {:mvn/version "1.0.8"} ; mail intake
                        org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)
-                       org.replikativ/spindel-tui {:mvn/version "0.1.10"}}
+                       org.replikativ/spindel-tui {:mvn/version "0.1.12"}}
          :main-opts   ["-m" "kaocha.runner"]}
 
   :repl {:main-opts ["-m" "nrepl.cmdline"
@@ -153,7 +153,7 @@
   ;; possible via --no-tui; otherwise the TUI launches automatically
   ;; because spindel-tui is on the classpath via this alias.
   :cli {:extra-paths ["src-clients"]
-        :extra-deps  {org.replikativ/spindel-tui {:mvn/version "0.1.10"}
+        :extra-deps  {org.replikativ/spindel-tui {:mvn/version "0.1.12"}
                       metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                       io.forward/clojure-mail    {:mvn/version "1.0.8"}    ; mail intake
                       org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)

--- a/deps.edn
+++ b/deps.edn
@@ -47,7 +47,7 @@
 
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.2.27 carries composite Mergeable diff + conflicts (PR #3).
-        org.replikativ/yggdrasil   {:mvn/version "0.3.35"}
+        org.replikativ/yggdrasil   {:mvn/version "0.3.36"}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
         org.replikativ/scriptum    {:mvn/version "0.1.27"}

--- a/resources/models.edn
+++ b/resources/models.edn
@@ -65,17 +65,8 @@
             :default-top-p       0.95
             :default-top-k       40}}
 
-  "accounts/fireworks/models/minimax-m2p5"
-  {:name "MiniMax M2.5"
-   :provider :fireworks
-   :api-type :openai-chat
-   :capabilities #{:tools :streaming}
-   :context 196608
-   :max-output 8192
-   :pricing {:input 0.30 :cache-read 0.03 :output 1.20}
-   :quirks {:default-temperature 1.0   ; MiniMax M2 recommended sampling
-            :default-top-p       0.95
-            :default-top-k       40}}
+  ;; MiniMax M2.5 removed 2026-07-02 — Fireworks now 404s it (deprecated).
+  ;; Use minimax-m2p7 (above). Re-probe the registry when models rotate.
 
   ;; ─── Qwen ──────────────────────────────────────────────────────────────────
 
@@ -134,7 +125,6 @@
   "kimi-k2p5"   "accounts/fireworks/models/kimi-k2p5"
   "glm"         "accounts/fireworks/models/glm-5p1"
   "minimax"     "accounts/fireworks/models/minimax-m2p7"
-  "minimax-m2p5" "accounts/fireworks/models/minimax-m2p5"
   "qwen"        "accounts/fireworks/models/qwen3p6-plus"
   "deepseek"    "accounts/fireworks/models/deepseek-v4-pro"
   "gpt-oss"     "accounts/fireworks/models/gpt-oss-20b"

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -159,3 +159,19 @@
                                        (seq reason) (assoc :reasoning reason)))))))
       (reset! posted (count tool-msgs)))
     nil))
+
+(defn post-turn-error!
+  "Surface a FAILED agent turn as a visible, NON-triggering activity row (→ room
+   `:_activity`, `:role :tool`, like `post-turn-activity!`) — so the turn loop can
+   report the failure instead of falling through to re-post a STALE prior reply
+   (which the room's other agents would answer, looping — the \"repeating\" bug).
+   `err` is the throwable from the errored turn result. No-op when `room` is nil.
+   Returns nil."
+  [room agent-id err]
+  (when room
+    (binding [rtc/*execution-context* (:ctx room)]
+      (let [detail (or (some-> err ex-message) (some-> err str) "LLM error")]
+        (d/post! room (d/message agent-id activity-id
+                                 (str "⚠️ turn failed — " detail) nil
+                                 {:role :tool})))))
+  nil)

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -187,7 +187,7 @@
       (compaction/maybe-compact! chat-ctx
                                  :model (or compaction-model
                                             (model-registry/get-default :compaction-model)
-                                            "accounts/fireworks/models/minimax-m2p5")
+                                            "accounts/fireworks/models/minimax-m2p7")
                                  :provider (or provider :fireworks)))
 
     (let [;; Get active messages (filtered by compaction point)

--- a/src/dvergr/chat/compaction.clj
+++ b/src/dvergr/chat/compaction.clj
@@ -462,7 +462,7 @@ Summary:")
 
    Uses a cheap/fast model to minimize cost."
   [messages {:keys [model provider]
-             :or {model "accounts/fireworks/models/minimax-m2p5"
+             :or {model "accounts/fireworks/models/minimax-m2p7"
                   provider :fireworks}}]
   (let [formatted (format-messages-for-summary messages)
         prompt (format summarization-prompt formatted)
@@ -518,7 +518,7 @@ Summary:")
    - :wiki-links - Extracted wiki-links
    - :summary - Generated summary"
   [chat-ctx & {:keys [model provider summarizer on-wiki-links context-window]
-               :or {model "accounts/fireworks/models/minimax-m2p5"
+               :or {model "accounts/fireworks/models/minimax-m2p7"
                     provider :fireworks
                     context-window 128000}}]
   (let [messages (chat-ctx/get-messages chat-ctx)
@@ -743,7 +743,7 @@ Summary:")
 
   ;; Manual compaction
   (compact! chat-ctx
-            :model "accounts/fireworks/models/minimax-m2p5"
+            :model "accounts/fireworks/models/minimax-m2p7"
             :on-wiki-links (fn [links]
                              (println "Extracted:" links)))
 

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -287,7 +287,8 @@
                                                          (conj prompt/planning-mode-guideline)))
                                     :auto-compact?    (and (:auto? compaction true)
                                                            (not race-compaction?))
-                                    :compaction-model (:model compaction)}]
+                                    :compaction-model (:model compaction)}
+                         errored           (atom nil)]
                  ;; The just-arrived user message. ROOM path: append-inbound!
                  ;; (deduped against the bus fold by msg id, decorated with author
                  ;; + time). Room-less: add directly to the fallback ctx.
@@ -349,7 +350,8 @@
                              (cond
                                @cancelled? nil
 
-                               (gen/error-result? result) nil
+                               (gen/error-result? result)
+                               (do (reset! errored (:dvergr.discourse.generation/error result)) nil)
 
                            ;; LLM finished cleanly (no more tool calls).
                                (not= result :continue) nil
@@ -374,7 +376,11 @@
                                :else (recur (inc turn) wrap-up-allowed?))))))
 
                      (when room (turn/unregister-room-turn! (:id room) id))
-                     (when-let [last-asst (last-assistant-message chat-ctx)]
+                     ;; A FAILED turn produced no new reply — surface it as a NON-triggering
+                     ;; :_activity row and DON'T fall through to re-post the STALE last reply
+                     ;; (which the room's other agents answer, looping — the "repeating" bug).
+                     (when @errored (turn/post-turn-error! room id @errored))
+                     (when-let [last-asst (when-not @errored (last-assistant-message chat-ctx))]
                        (when-let [reply (assistant-text last-asst)]
                      ;; Carry this turn's interleaved-thinking trace into the room
                      ;; record (metadata → store → seeding) so reasoning models

--- a/src/dvergr/model/providers.clj
+++ b/src/dvergr/model/providers.clj
@@ -137,7 +137,7 @@
   "Best default model per provider for auto-config. Fireworks ids must exist in
    resources/models.edn; the others are passed through to the provider."
   {:anthropic   "claude-sonnet-4-6"
-   :fireworks   "accounts/fireworks/models/minimax-m2p5"
+   :fireworks   "accounts/fireworks/models/minimax-m2p7"
    :openai      "gpt-4o"
    :claude-code "claude-code-sonnet"})
 

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -15,7 +15,7 @@
    Usage:
      (def d (start! {:telegram {:token (System/getenv \"TELEGRAM_BOT_TOKEN\")}
                      :agents {:var {:provider :fireworks
-                                    :model \"accounts/fireworks/models/minimax-m2p5\"
+                                    :model \"accounts/fireworks/models/minimax-m2p7\"
                                     :system-prompt \"You are a helpful assistant.\"}}}))
 
      (list-agents d)
@@ -341,7 +341,7 @@
        {:id      (:id safe-config)
         :spec    {:provider      (or (:provider safe-config) (:provider ds) :fireworks)
                   :model         (or (:model safe-config) (:model ds)
-                                     "accounts/fireworks/models/minimax-m2p5")
+                                     "accounts/fireworks/models/minimax-m2p7")
                   :system-prompt system-prompt
                   :isolation     (or (:isolation safe-config) :sci)}
         :tools   tools-map
@@ -1077,7 +1077,7 @@
   ;; Start daemon with Telegram bot
   (def d (start! {:telegram {:token (System/getenv "TELEGRAM_BOT_TOKEN")}
                   :agents {:var {:provider :fireworks
-                                 :model "accounts/fireworks/models/minimax-m2p5"
+                                 :model "accounts/fireworks/models/minimax-m2p7"
                                  :system-prompt "You are a helpful assistant. Answer questions clearly and concisely."
                                  :tags #{:secretary}
                                  :description "Default agent for new conversations"}}}))

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -86,9 +86,9 @@
 ;; ---------------------------------------------------------------------------
 ;; Unified diff + tier classification — the substrate the agent merge-reviewer
 ;; and the TUI/web review flow both read. The per-system merge-base diff/conflicts
-;; now live in the spindel bridge (`spindel.yggdrasil/workspace-diff` /
-;; `workspace-conflicts`), which resolves each sub-system on snapshot-ids over
-;; the one composite workspace. These are thin fork-shaped wrappers.
+;; now live in the spindel bridge (`spindel.yggdrasil/context-diff` /
+;; `context-conflicts`), which resolves each sub-system on snapshot-ids over
+;; the forked context's registered systems. These are thin fork-shaped wrappers.
 ;; ---------------------------------------------------------------------------
 
 (defn fork-diff
@@ -97,14 +97,14 @@
    nil for `:none` forks (no branched substrate)."
   [fork]
   (when (ctx-fork? fork)
-    (ygg/workspace-diff (:ctx fork))))
+    (ygg/context-diff (:ctx fork))))
 
 (defn fork-conflicts
   "Per-system conflicts of a `:ctx` fork vs its parent, each tagged `:system`.
    Often empty (datahike conflict detection is conservative today)."
   [fork]
   (when (ctx-fork? fork)
-    (ygg/workspace-conflicts (:ctx fork))))
+    (ygg/context-conflicts (:ctx fork))))
 
 (defn- delta-trivial?
   "Did the FORK contribute nothing meaningful in this system? Duck-typed over

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -1547,7 +1547,7 @@ Note: changes take effect on the next agent restart or reload."
                                                ;; a model that EXISTS in resources/models.edn (the qwen id
                                                ;; was removed from Fireworks; get-model! threw → spawn_agent
                                                ;; was broken on first use)
-                                             :model         "accounts/fireworks/models/minimax-m2p5"
+                                             :model         "accounts/fireworks/models/minimax-m2p7"
                                              :system-prompt prompt-text}
                                     :budget {:dollars (or budget 0.50)}
                                     :ctx    ctx}))

--- a/src/dvergr/tools/llm_call.clj
+++ b/src/dvergr/tools/llm_call.clj
@@ -18,14 +18,14 @@
 (def ^:private default-model
   "Default cheap model for llm_call. Override with LLM_CALL_MODEL env var."
   (or (System/getenv "LLM_CALL_MODEL")
-      "accounts/fireworks/models/minimax-m2p5"))
+      "accounts/fireworks/models/minimax-m2p7"))
 
 (defn cheap-llm-call
   "Make a cheap one-shot LLM call synchronously.
    Returns {:text :usage :model} on success, {:error} on failure.
 
    opts:
-   - :model      — model ID override (default: minimax-m2p5)
+   - :model      — model ID override (default: minimax-m2p7)
    - :max-tokens — max output tokens (default: 500)
    - :system     — optional system prompt string"
   [prompt content opts]

--- a/test/dvergr/intake/bash_isolation_test.clj
+++ b/test/dvergr/intake/bash_isolation_test.clj
@@ -104,7 +104,10 @@
       (is (= "main" parent-branch)))
     (testing "fork's bash is on a different, fork-named branch"
       (is (not= parent-branch child-branch))
-      (is (str/starts-with? child-branch "main-fork-")))
+      ;; yggdrasil 0.3 names an overlay-fork branch `overlay-<uuid>` (the unified
+      ;; overlay naming). dvergr doesn't depend on the git branch name — forks are
+      ;; event-driven and the room slug is dvergr's own — so just assert a fresh fork.
+      (is (str/starts-with? child-branch "overlay-")))
     (testing "fork's bash cwd is the sandbox root (its own worktree, mounted at
               \"/\" via make-host's :mount-at; muschel ≥ 0.2.16 cwd is
               sandbox-relative, not a real host path — fork isolation at the FS


### PR DESCRIPTION
Moves dvergr onto the fully-released replikativ stack and fixes two live bugs found while running the TUI.

## Deps → released stack
- **spindel 0.1.26** — branch-based convergent forks + fully-async fork/merge + the SCI `runtime/thunk?` fix (the last one is why the daemon now boots the sandbox).
- **yggdrasil 0.3.35** — convergent-overlay `:sync?` fix.
- **spindel-tui 0.1.12** — tmux box-drawing (ACS→UTF-8) + SIGINT terminal cleanup. Carries the fixes for **replikativ/dvergr#4** and **replikativ/dvergr#5**.

Compiles clean against the released maven stack (no `:local`).

## fix(models): default `minimax-m2p7` (m2p5 deprecated)
Live-probed the registry — `minimax-m2p5` is the *only* model Fireworks now 404s ('Model not found, inaccessible, and/or not deployed'), yet it was the stale hardcoded default across providers/daemon/tools/llm_call/agent/compaction, so **every agent turn failed**. Swapped the default to the live successor `minimax-m2p7` (already the registry `:defaults`) and dropped the dead m2p5 entry + alias.

## fix(discourse): surface a failed turn instead of re-posting the stale reply
On an errored/no-reply turn, the room agent loop fell through to `(last-assistant-message)` and **re-posted the agent's previous reply** — which the other room agents answered, looping (the 'agents keep repeating' report). Now tracks an `errored` flag; on failure it posts a **non-triggering** `:_activity` row via `turn/post-turn-error!` (`⚠️ turn failed — <detail>`) and skips the stale re-post. Clean turns reply as before.

## Also on this branch
- ygg bridge `context-diff`/`-conflicts` rename adoption + fork-branch naming test (the 0.3.x overlay-\<uuid\> naming).

Refs replikativ/dvergr#4, replikativ/dvergr#5 (fixed via the spindel-tui 0.1.12 bump — will close with comments after merge + release).