### PR TITLE
fix(discourse): deliver each message once + notebook landing & demo polish

### DIFF
--- a/examples/scenario_auditor.clj
+++ b/examples/scenario_auditor.clj
@@ -31,16 +31,20 @@
        nil))}))
 
 (defn make-noisy-agent
-  "Posts an escalation on every message it receives."
+  "Escalates on the task addressed to it — posts an :escalation/budget. The
+   `(= id (:to msg))` guard ignores the OTHER worker's escalation (escalations
+   carry no `:to`), so the two workers never cascade; the auditor observes each
+   worker's escalation via its tag subscription."
   [id room]
   (d/participant
    {:id id
     :on-message
     (fn [_p msg]
       (spin
-       (d/post! room {:type :escalation/budget
-                      :from id
-                      :payload {:reason :running-low}})
+       (when (= id (:to msg))
+         (d/post! room {:type :escalation/budget
+                        :from id
+                        :payload {:reason :running-low}}))
        nil))}))
 
 (defn -main

--- a/notebooks/notebooks/index.clj
+++ b/notebooks/notebooks/index.clj
@@ -1,0 +1,30 @@
+(ns notebooks.index
+  "Landing page for the dvergr example notebooks — rendered as the book's index
+   (see notebooks.render, :first-as-index).")
+
+;; # dvergr — examples
+
+;; **dvergr** is a Clojure framework for *continuous-time collaborative
+;; multi-agent rooms*: agents are reactive processes; humans, LLMs, and scripts
+;; are participants of the **same shape**; and everything composes through
+;; **tagged messages** on a small pub/sub kernel — over a forkable substrate (a
+;; spindel reactive runtime + Datahike + yggdrasil CRDTs).
+
+;; These notebooks build that model up from the kernel. Each one **runs live** —
+;; the outputs you see are produced by evaluating the code — and needs no API key
+;; or network, except where an LLM is explicitly used.
+
+;; ## The notebooks
+
+;; 1. **Getting started** — a from-zero tour: rooms, participants, tagged
+;;    messages, capability subscriptions, and the fork-and-merge proposal.
+;; 2. **Programming model** — the compositional kernel in depth: tag routing,
+;;    capability subscriptions beyond your inbox, escalation as a posted tag, and
+;;    per-consumer buffer policy.
+;; 3. **Humans and agents** — humans as first-class participants, background
+;;    tasks with notifications, and substrate-isolated fork → propose →
+;;    merge/discard.
+;; 4. **Agents and tools** — wiring LLM agents with tools into a room.
+
+;; Use the sidebar to navigate. The source lives under `notebooks/` in the
+;; [repository](https://github.com/replikativ/dvergr).

--- a/notebooks/notebooks/programming_model.clj
+++ b/notebooks/notebooks/programming_model.clj
@@ -41,8 +41,10 @@
      (d/join audit-room (aud/make-noisy-agent :worker-b audit-room)))
    nil))
 
-;; Each worker escalates on every message; the auditor also gets one direct
-;; message to its inbox.
+;; Each worker escalates once — on the task addressed to it — and the auditor
+;; also gets one direct message to its inbox. So the auditor observes three
+;; events: two budget escalations it was NOT addressed on (via the tag
+;; subscription) + one inbox message.
 
 (kind/hidden
  (with-room audit-room

--- a/notebooks/notebooks/render.clj
+++ b/notebooks/notebooks/render.clj
@@ -17,8 +17,12 @@
 ;; Order = reading order in the rendered book's sidebar. Paths are relative to
 ;; :base-source-path. The notebook namespaces live under `notebooks/notebooks/`,
 ;; so the `:clay` alias's `"notebooks"` extra-path is the classpath root.
+;; index.clj is FIRST + rendered as the book's index.html landing page (via
+;; :first-as-index below) — otherwise Clay generates an empty index and the real
+;; notebooks start at sidebar entry #2.
 (def notebooks
-  ["getting_started.clj"
+  ["index.clj"
+   "getting_started.clj"
    "programming_model.clj"
    "humans_and_agents.clj"
    "agents_and_tools.clj"])
@@ -55,6 +59,7 @@
       :source-path      notebooks
       :base-target-path "docs"
       :book             {:title "dvergr — examples"}
+      :first-as-index   true
       :show             false
       :browse           false})
     (catch Throwable e

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -293,31 +293,52 @@
    subscription has its own pump that forwards events into this single
    mailbox; the spin awaits the mailbox uniformly.
 
+   DELIVER-ONCE: a participant's subscriptions form a UNION filter. A message
+   that matches SEVERAL of them — e.g. a broadcast (`[:to nil]`) that also
+   carries a `:type` the participant subscribed to, so it matches both
+   `[:to nil]` and `[:type …]` — is pumped into the mailbox once per matching
+   subscription. This loop dedups by message `:id` (stamped by `bus/post!`) over
+   a bounded recent window, so `on-message` runs EXACTLY ONCE per message. The
+   duplicates arrive in the same publish wave, so a modest window suffices; on
+   eviction the worst case is a rare double, never a dropped distinct message
+   (ids are random-uuids and don't collide).
+
    Exceptions inside on-message are caught and logged so a single bad
    turn doesn't kill the participant — without this, an LLM error or
    tool-call exception in one message handler permanently stopped the
    agent from receiving further messages in the room."
   [p room mbx]
   (sp/spin
-   (loop []
-     (let [env         (sp/await mbx)
-           in-reply-to (when (instance? Message env) (:id env))
-           reply-spec
-           (sp/await
-            (sp/spin
-             (try
-               (sp/await ((:on-message p) p env))
-               (catch Throwable t
-                 (binding [*out* *err*]
-                   (println "participant" (:id p)
-                            "on-message error:" (.getMessage t)))
-                 nil))))]
-       (try (emit-reply! room p reply-spec in-reply-to)
-            (catch Throwable t
-              (binding [*out* *err*]
-                (println "participant" (:id p)
-                         "emit-reply error:" (.getMessage t))))))
-     (recur))))
+   (loop [seen  #{}
+          order clojure.lang.PersistentQueue/EMPTY]
+     (let [env (sp/await mbx)
+           id  (:id env)]
+       (if (and id (contains? seen id))
+         ;; already handled via another matching subscription — skip the duplicate
+         (recur seen order)
+         (let [in-reply-to (when (instance? Message env) (:id env))
+               reply-spec
+               (sp/await
+                (sp/spin
+                 (try
+                   (sp/await ((:on-message p) p env))
+                   (catch Throwable t
+                     (binding [*out* *err*]
+                       (println "participant" (:id p)
+                                "on-message error:" (.getMessage t)))
+                     nil))))]
+           (try (emit-reply! room p reply-spec in-reply-to)
+                (catch Throwable t
+                  (binding [*out* *err*]
+                    (println "participant" (:id p)
+                             "emit-reply error:" (.getMessage t)))))
+           (if id
+             (let [order' (conj order id)
+                   seen'  (conj seen id)]
+               (if (> (count order') 512)
+                 (recur (disj seen' (peek order')) (pop order'))
+                 (recur seen' order')))
+             (recur seen order))))))))
 
 (defn conversation-id
   "The id of the CONVERSATION this room persists into. For a normal room that's

--- a/src/dvergr/runtime/bus.clj
+++ b/src/dvergr/runtime/bus.clj
@@ -186,10 +186,19 @@
 
    A well-formed message has at least `:to` (direct routing) or
    `:type` (capability routing) — typically both. The bus does not
-   validate shape; conventions are an application concern."
+   validate shape; conventions are an application concern.
+
+   Every message is stamped with an `:id` (random-uuid) if it lacks one — done
+   HERE, before the mult fans it out, so a message reaching a participant via
+   several matching subscriptions carries the SAME id on each copy. That is what
+   lets `dvergr.discourse/participant-spin` dedup and deliver each message once
+   (a broadcast that also carries a subscribed `:type` matches both `[:to nil]`
+   and `[:type …]`)."
   [bus msg]
   (binding [ec/*execution-context* (:ctx bus)]
-    (sync/post! (:source-mbox bus) msg))
+    (sync/post! (:source-mbox bus)
+                (cond-> msg
+                  (and (map? msg) (nil? (:id msg))) (assoc :id (random-uuid)))))
   nil)
 
 (defn post-many!

--- a/test/dvergr/discourse_test.clj
+++ b/test/dvergr/discourse_test.clj
@@ -94,6 +94,28 @@
       (is (= :driver (:from (first log))))
       (is (= :bot (:from (second log)))))))
 
+(deftest capability-and-broadcast-overlap-delivers-once
+  (testing "a message matching SEVERAL of a participant's subscriptions is
+            delivered ONCE — a broadcast (`:to nil`) carrying a subscribed
+            `:type` matches both the default `[:to nil]` inbox and the
+            `[:type …]` capability sub, but on-message must run once (dedup by id
+            in participant-spin), not once per matching subscription."
+    (let [r    (d/room :dedup)
+          seen (atom [])]
+      (binding [ec/*execution-context* (:ctx r)]
+        (let [aud (d/join r (d/participant
+                             {:id         :auditor
+                              :on-message (fn [_p m]
+                                            (sp/spin (swap! seen conj (:type m)) nil))}))]
+          ;; the extra capability subscription, in ADDITION to the default inbox
+          (d/subscribe! r aud [:type :escalation/budget])))
+      ;; a broadcast tagged event: matches [:to nil] AND [:type :escalation/budget]
+      (d/post! r {:type :escalation/budget :from :worker})
+      (Thread/sleep 200)
+      (is (= 1 (count @seen))
+          "the overlapping-subscription message is delivered exactly once")
+      (is (= [:escalation/budget] @seen)))))
+
 (deftest forked-participant-operates-on-its-joined-room
   (testing "a participant cloned into a fork sees the FORK as its room
             (discourse/join sets :room on the participant), not the parent it


### PR DESCRIPTION
Two commits — a substrate correctness fix surfaced by the notebooks, and the notebook polish that depends on it.

## fix(discourse): deliver each message to a participant exactly once
A participant's inbox merges several independent subscriptions — `[:to id]`, the `[:to nil]` broadcast, and any `[:type …]` capability subs — each pumping into one mailbox. A message matching **several** of them was delivered **once per matching subscription**, so `on-message` ran multiple times. Concretely: a broadcast that also carries a subscribed `:type` (e.g. a budget escalation: no `:to`, so it's a broadcast, *and* `:type :escalation/budget`) matches both `[:to nil]` and `[:type :escalation/budget]` → a tag-subscribed auditor / policy-bot **double-processed every broadcast-tagged event** (would double-reply, double-act).

Fix:
- `bus/post!` stamps a stable `:id` on every message **before** the mult fans it out, so each copy carries the same id.
- `participant-spin` dedups by id over a bounded recent window → `on-message` runs **exactly once** per message. Docstrings now state the deliver-once contract (subscriptions are a *union filter*).
- Regression test `capability-and-broadcast-overlap-delivers-once`. Discourse suite green (**26 tests / 66 assertions / 0 failures**).

## docs(notebooks): book landing page + tighten the programming-model auditor demo
- **Landing page**: `index.clj` + `:first-as-index true` in `render.clj` → the book now has a real `index.html` (project intro + notebook map) instead of Clay's empty auto-index (which had buried getting_started at sidebar #2).
- **Auditor demo (§1)**: `scenario_auditor`'s noisy-agent now escalates only on the task addressed to it (the `(= id (:to msg))` guard) instead of on every message, so the two workers no longer cascade. Combined with the deliver-once fix, the auditor sees each escalation once → a clean **3 events (2 escalations + 1 inbox)**, matching the prose.

Verified: the book renders (all 5 chapters incl. the landing), programming_model shows the clean counts, no baked-in errors. The Pages workflow republishes on merge.