### PR TITLE
feat(subagent): sandbox-programmable subagent delegation (room/hire)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
         ;; version. The `:local` alias's `../spindel` override carries it too.
 
         ;; Spindel — Reactive runtime with CoW forking
-        org.replikativ/spindel     {:mvn/version "0.1.26"}
+        org.replikativ/spindel     {:mvn/version "0.1.28"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/deps.edn
+++ b/deps.edn
@@ -106,7 +106,7 @@
                        metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                        io.forward/clojure-mail {:mvn/version "1.0.8"} ; mail intake
                        org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)
-                       org.replikativ/spindel-tui {:mvn/version "0.1.12"}}}
+                       org.replikativ/spindel-tui {:mvn/version "0.1.13"}}}
 
   ;; src-clients/ on the test path so dvergr.web.server-test still
   ;; loads the namespaces it tests.
@@ -115,7 +115,7 @@
                        metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                        io.forward/clojure-mail {:mvn/version "1.0.8"} ; mail intake
                        org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)
-                       org.replikativ/spindel-tui {:mvn/version "0.1.12"}}
+                       org.replikativ/spindel-tui {:mvn/version "0.1.13"}}
          :main-opts   ["-m" "kaocha.runner"]}
 
   :repl {:main-opts ["-m" "nrepl.cmdline"
@@ -153,7 +153,7 @@
   ;; possible via --no-tui; otherwise the TUI launches automatically
   ;; because spindel-tui is on the classpath via this alias.
   :cli {:extra-paths ["src-clients"]
-        :extra-deps  {org.replikativ/spindel-tui {:mvn/version "0.1.12"}
+        :extra-deps  {org.replikativ/spindel-tui {:mvn/version "0.1.13"}
                       metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                       io.forward/clojure-mail    {:mvn/version "1.0.8"}    ; mail intake
                       org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)

--- a/src/dvergr/agent/subagent.clj
+++ b/src/dvergr/agent/subagent.clj
@@ -9,9 +9,10 @@
    the fork/merge that opencode/codex can't do.
 
    Returns a **Spin** yielding
-     {:status :merged|:discarded|:timeout :result :subagent-id}
+     {:status :merged|:discarded|:timeout|:refused|:error :result :subagent-id}
    so an agent can `(await (room/hire …))` in the foreground OR hold the spin and
-   await it later (background). Nests like rooms: a subagent can itself `hire!`.
+   await it later (background). Nests like rooms: a subagent can itself `hire!` —
+   bounded by `max-depth`, and each worker's budget is ATTENUATED by default.
 
    Lifecycle is DURABLY TRACKED as `:dvergr/subagent` tagged messages in the
    parent room (spawn → `:running`, finish → the terminal status) — the same
@@ -29,21 +30,35 @@
   [room ev]
   (d/post! room (assoc ev :type :dvergr/subagent :from :subagent-tracker)))
 
+(def default-worker-budget
+  "Budget ATTENUATION: an ephemeral worker gets a deliberately small dollar
+   budget unless the hirer grants more — a subagent must never be able to
+   spend like its principal by default."
+  {:dollars 0.25})
+
+(def max-depth
+  "Structural runaway guard: a hire chain deeper than this is refused.
+   Each hire stamps `:subagent-depth` into the FORK room's meta, so a
+   worker hiring from inside its fork sees its own depth."
+  3)
+
 (defn- build-worker
   "Construct the ephemeral worker Participant. Accepts an explicit `:worker`
    (e.g. a scripted participant for tests) or a `:spec`
-   {:id :provider :model :system-prompt :tools} → a fresh `llm-agent`.
+   {:id :provider :model :system-prompt :tools} → a fresh `llm-agent` with an
+   ATTENUATED budget (`default-worker-budget` unless `:budget` grants more).
 
    `:ctx` (the caller's execution context) is REQUIRED for a real llm-agent: its
    turn bridges the blocking LLM call through a future and must re-bind the ctx
    when delivering back (without it: 'no execution context bound'). This mirrors
    `dvergr.orchestration.daemon/create-agent!`, which passes `:ctx`."
-  [{:keys [worker spec subagent-id ctx]}]
+  [{:keys [worker spec budget subagent-id ctx]}]
   (or worker
       (let [llm-agent (requiring-resolve 'dvergr.discourse.llm/llm-agent)]
-        (llm-agent (cond-> {:id    (or (:id spec) (keyword (str "sub-" subagent-id)))
-                            :spec  (select-keys spec [:provider :model :system-prompt])
-                            :tools (:tools spec)}
+        (llm-agent (cond-> {:id     (or (:id spec) (keyword (str "sub-" subagent-id)))
+                            :spec   (select-keys spec [:provider :model :system-prompt])
+                            :tools  (:tools spec)
+                            :budget (or budget default-worker-budget)}
                      ctx (assoc :ctx ctx))))))
 
 (defn hire!
@@ -53,31 +68,52 @@
      :goal        — the task (required)
      :worker      — a Participant to host (tests), OR
      :spec        — {:id :provider :model :system-prompt :tools} → a fresh llm-agent
+     :budget      — worker dollar budget (default `default-worker-budget` — attenuated)
      :accept-fn   — (fn [reply] -> bool) merge vs discard (default: merge on reply)
      :timeout-ms  — wall clock (default 120000)
      :isolation   — :ctx (default; branches substrate + shared CRDTs) | :none
 
+   Refuses (status :refused) when the hire chain is deeper than `max-depth`
+   (each hire stamps :subagent-depth into its fork's meta). A throw inside
+   the delegation DISCARDS the fork (never merge partial state) and yields
+   status :error.
+
    Returns a Spin yielding {:status :result :subagent-id}."
   [room {:keys [goal accept-fn timeout-ms isolation] :as opts
          :or   {timeout-ms 120000 isolation :ctx accept-fn (constantly true)}}]
-  (let [sid (random-uuid)]
+  (let [sid   (random-uuid)
+        depth (or (some-> (:meta room) deref :subagent-depth) 0)]
     (sp/spin
-     (track! room {:subagent/id sid :goal goal :status :running})
-     ;; Fork FIRST, then build the worker in the FORK's ctx — a real llm-agent
-     ;; re-binds its :ctx across the LLM-call future, so it must match the ctx the
-     ;; worker actually runs in (the fork's), not the parent's.
-     (let [fork   (d/fork-room room {:isolation isolation})
-           worker (build-worker (assoc opts :subagent-id sid :ctx (:ctx fork)))
-           _      (d/join fork worker)
-           reply  (sp/await (comb/timeout (d/ask fork (:id worker) {:content goal})
-                                          timeout-ms ::timeout))
-           status (cond (= reply ::timeout) :timeout
-                        (accept-fn reply)   :merged
-                        :else               :discarded)]
-       (if (= status :merged) (d/merge-room room fork) (d/discard fork))
-       (let [result (when (not= reply ::timeout) (:content reply))]
-         (track! room {:subagent/id sid :status status :result result})
-         {:status status :result result :subagent-id sid :fork-ref (:id fork)})))))
+     (if (>= depth max-depth)
+       (do (track! room {:subagent/id sid :goal goal :status :refused
+                         :reason (str "hire depth " depth " >= max " max-depth)})
+           {:status :refused :result nil :subagent-id sid})
+       (do
+         (track! room {:subagent/id sid :goal goal :status :running})
+         ;; Fork FIRST, then build the worker in the FORK's ctx — a real llm-agent
+         ;; re-binds its :ctx across the LLM-call future, so it must match the ctx
+         ;; the worker actually runs in (the fork's), not the parent's.
+         (let [fork (d/fork-room room {:isolation isolation})]
+           (swap! (:meta fork) assoc :subagent-depth (inc depth))
+           (try
+             (let [worker (build-worker (assoc opts :subagent-id sid :ctx (:ctx fork)))
+                   _      (d/join fork worker)
+                   reply  (sp/await (comb/timeout (d/ask fork (:id worker) {:content goal})
+                                                  timeout-ms ::timeout))
+                   status (cond (= reply ::timeout) :timeout
+                                (accept-fn reply)   :merged
+                                :else               :discarded)]
+               (if (= status :merged) (d/merge-room room fork) (d/discard fork))
+               (let [result (when (not= reply ::timeout) (:content reply))]
+                 (track! room {:subagent/id sid :status status :result result})
+                 {:status status :result result :subagent-id sid :fork-ref (:id fork)}))
+             (catch Throwable t
+               ;; NEVER merge partial state on error — discard the fork, then
+               ;; surface the failure in the tracking log + return value.
+               (try (d/discard fork) (catch Throwable _ nil))
+               (track! room {:subagent/id sid :status :error :result (.getMessage t)})
+               {:status :error :result (.getMessage t)
+                :subagent-id sid :fork-ref (:id fork)}))))))))
 
 (defn pending
   "The still-running subagents spawned in `room` — a scan of the durable

--- a/src/dvergr/agent/subagent.clj
+++ b/src/dvergr/agent/subagent.clj
@@ -1,0 +1,76 @@
+(ns dvergr.agent.subagent
+  "Programmable-from-SCI subagent delegation.
+
+   `hire!` forks a subroom off the caller's room with `:isolation :ctx` — so the
+   worker runs on a BRANCHED substrate that inherits the room's registered
+   yggdrasil systems (datahike workspace + CRDTs). It hosts an ephemeral worker,
+   delegates a goal, and merges the fork back (parent-controlled `accept-fn`) or
+   discards it. The worker's CRDT/DB edits fold back into the parent on merge —
+   the fork/merge that opencode/codex can't do.
+
+   Returns a **Spin** yielding
+     {:status :merged|:discarded|:timeout :result :subagent-id}
+   so an agent can `(await (room/hire …))` in the foreground OR hold the spin and
+   await it later (background). Nests like rooms: a subagent can itself `hire!`.
+
+   Lifecycle is DURABLY TRACKED as `:dvergr/subagent` tagged messages in the
+   parent room (spawn → `:running`, finish → the terminal status) — the same
+   log-as-truth pattern as `dvergr.discourse/propose-merge!`. When the room has a
+   `:store` those events persist; `pending` enumerates the still-running ones.
+   (A dedicated system-db `:subagent/*` entity is the more robust cross-room /
+   store-less option — a follow-up.)"
+  (:require [dvergr.discourse :as d]
+            [org.replikativ.spindel.core :as sp]))
+
+(defn- track!
+  "Post a `:dvergr/subagent` lifecycle event into `room`'s log (durable when the
+   room has a store)."
+  [room ev]
+  (d/post! room (assoc ev :type :dvergr/subagent :from :subagent-tracker)))
+
+(defn- build-worker
+  "Construct the ephemeral worker Participant. Accepts an explicit `:worker`
+   (e.g. a scripted participant for tests) or a `:spec`
+   {:id :provider :model :system-prompt :tools} → a fresh `llm-agent`."
+  [{:keys [worker spec subagent-id]}]
+  (or worker
+      (let [llm-agent (requiring-resolve 'dvergr.discourse.llm/llm-agent)]
+        (llm-agent {:id    (or (:id spec) (keyword (str "sub-" subagent-id)))
+                    :spec  (select-keys spec [:provider :model :system-prompt])
+                    :tools (:tools spec)}))))
+
+(defn hire!
+  "Delegate `goal` to an ephemeral subagent forked off `room`.
+
+   opts:
+     :goal        — the task (required)
+     :worker      — a Participant to host (tests), OR
+     :spec        — {:id :provider :model :system-prompt :tools} → a fresh llm-agent
+     :accept-fn   — (fn [reply] -> bool) merge vs discard (default: merge on reply)
+     :timeout-ms  — wall clock (default 120000)
+     :isolation   — :ctx (default; branches substrate + shared CRDTs) | :none
+
+   Returns a Spin yielding {:status :result :subagent-id}."
+  [room {:keys [goal accept-fn timeout-ms isolation] :as opts
+         :or   {timeout-ms 120000 isolation :ctx}}]
+  (let [sid    (random-uuid)
+        worker (build-worker (assoc opts :subagent-id sid))]
+    (sp/spin
+     (track! room {:subagent/id sid :goal goal :worker (:id worker) :status :running})
+     (let [r (sp/await
+              (d/hire room worker (cond-> {:goal goal :isolation isolation :timeout-ms timeout-ms}
+                                    accept-fn (assoc :accept-fn accept-fn))))]
+       (track! room {:subagent/id sid :status (:status r)
+                     :result (some-> (:reply r) :content)})
+       {:status (:status r) :result (some-> (:reply r) :content) :subagent-id sid}))))
+
+(defn pending
+  "The still-running subagents spawned in `room` — a scan of the durable
+   `:dvergr/subagent` lifecycle log (latest event per id is `:running`)."
+  [room]
+  (->> (d/log room)
+       (filter #(= :dvergr/subagent (:type %)))
+       (group-by :subagent/id)
+       (keep (fn [[_ evs]] (let [latest (last evs)]
+                             (when (= :running (:status latest)) latest))))
+       vec))

--- a/src/dvergr/agent/subagent.clj
+++ b/src/dvergr/agent/subagent.clj
@@ -20,7 +20,8 @@
    (A dedicated system-db `:subagent/*` entity is the more robust cross-room /
    store-less option — a follow-up.)"
   (:require [dvergr.discourse :as d]
-            [org.replikativ.spindel.core :as sp]))
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.spin.combinators :as comb]))
 
 (defn- track!
   "Post a `:dvergr/subagent` lifecycle event into `room`'s log (durable when the
@@ -31,13 +32,19 @@
 (defn- build-worker
   "Construct the ephemeral worker Participant. Accepts an explicit `:worker`
    (e.g. a scripted participant for tests) or a `:spec`
-   {:id :provider :model :system-prompt :tools} → a fresh `llm-agent`."
-  [{:keys [worker spec subagent-id]}]
+   {:id :provider :model :system-prompt :tools} → a fresh `llm-agent`.
+
+   `:ctx` (the caller's execution context) is REQUIRED for a real llm-agent: its
+   turn bridges the blocking LLM call through a future and must re-bind the ctx
+   when delivering back (without it: 'no execution context bound'). This mirrors
+   `dvergr.orchestration.daemon/create-agent!`, which passes `:ctx`."
+  [{:keys [worker spec subagent-id ctx]}]
   (or worker
       (let [llm-agent (requiring-resolve 'dvergr.discourse.llm/llm-agent)]
-        (llm-agent {:id    (or (:id spec) (keyword (str "sub-" subagent-id)))
-                    :spec  (select-keys spec [:provider :model :system-prompt])
-                    :tools (:tools spec)}))))
+        (llm-agent (cond-> {:id    (or (:id spec) (keyword (str "sub-" subagent-id)))
+                            :spec  (select-keys spec [:provider :model :system-prompt])
+                            :tools (:tools spec)}
+                     ctx (assoc :ctx ctx))))))
 
 (defn hire!
   "Delegate `goal` to an ephemeral subagent forked off `room`.
@@ -52,17 +59,25 @@
 
    Returns a Spin yielding {:status :result :subagent-id}."
   [room {:keys [goal accept-fn timeout-ms isolation] :as opts
-         :or   {timeout-ms 120000 isolation :ctx}}]
-  (let [sid    (random-uuid)
-        worker (build-worker (assoc opts :subagent-id sid))]
+         :or   {timeout-ms 120000 isolation :ctx accept-fn (constantly true)}}]
+  (let [sid (random-uuid)]
     (sp/spin
-     (track! room {:subagent/id sid :goal goal :worker (:id worker) :status :running})
-     (let [r (sp/await
-              (d/hire room worker (cond-> {:goal goal :isolation isolation :timeout-ms timeout-ms}
-                                    accept-fn (assoc :accept-fn accept-fn))))]
-       (track! room {:subagent/id sid :status (:status r)
-                     :result (some-> (:reply r) :content)})
-       {:status (:status r) :result (some-> (:reply r) :content) :subagent-id sid}))))
+     (track! room {:subagent/id sid :goal goal :status :running})
+     ;; Fork FIRST, then build the worker in the FORK's ctx — a real llm-agent
+     ;; re-binds its :ctx across the LLM-call future, so it must match the ctx the
+     ;; worker actually runs in (the fork's), not the parent's.
+     (let [fork   (d/fork-room room {:isolation isolation})
+           worker (build-worker (assoc opts :subagent-id sid :ctx (:ctx fork)))
+           _      (d/join fork worker)
+           reply  (sp/await (comb/timeout (d/ask fork (:id worker) {:content goal})
+                                          timeout-ms ::timeout))
+           status (cond (= reply ::timeout) :timeout
+                        (accept-fn reply)   :merged
+                        :else               :discarded)]
+       (if (= status :merged) (d/merge-room room fork) (d/discard fork))
+       (let [result (when (not= reply ::timeout) (:content reply))]
+         (track! room {:subagent/id sid :status status :result result})
+         {:status status :result result :subagent-id sid :fork-ref (:id fork)})))))
 
 (defn pending
   "The still-running subagents spawned in `room` — a scan of the durable

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -858,21 +858,24 @@
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
   ([parent fork {:keys [merge-opts]}]
-   (if (and (ctx-was-forked? fork) (:store fork))
-    ;; `:ctx` fork with a branched conversation store — a BRANCH of the parent's
-    ;; conversation. The merge is native:
-    ;; merge-to-parent! collapses the fork's datahike (+ git) branch into the
-    ;; parent, bringing the fork's messages into the parent's conversation under
-    ;; the shared :chat/id (no in-memory carry). (doc/unified-fork-conversation.md)
+   ;; (1) SUBSTRATE merge — branched yggdrasil systems (CRDTs, datahike, git) fold
+   ;; back whenever the ctx was forked (`:isolation :ctx`), INDEPENDENT of any
+   ;; conversation store. These are orthogonal: a room can carry shared CRDTs with
+   ;; no message store (a subagent whose deliverable is CRDT edits + a summary), or
+   ;; a message store with no extra systems. A `:store` fork's datahike *message*
+   ;; branch also collapses here (bringing its messages into the parent's
+   ;; conversation under the shared :chat/id); its deferred data-DB grants commit on
+   ;; accept via :on-merge (store forks only). (doc/unified-fork-conversation.md)
+   (when (ctx-was-forked? fork)
      (try
        (drain-fork-turns! fork)                ; P4: stop in-flight turns before merge
-      ;; P2: the fork's deferred data-DB grants become durable room systems only on
-      ;; accept — replay them into the global system-db in the :on-merge callback.
-       (let [pending (binding [ec/*execution-context* (:ctx fork)]
-                       (ec/get-state [:dvergr/pending-grants]))]
+       (let [pending (when (:store fork)
+                       (binding [ec/*execution-context* (:ctx fork)]
+                         (ec/get-state [:dvergr/pending-grants])))]
          (ygg/merge-to-parent! (:ctx fork)
                                (merge (or merge-opts {})
-                                      {:on-merge (fn [_] (srooms/commit-fork-grants! pending))})))
+                                      (when (:store fork)
+                                        {:on-merge (fn [_] (srooms/commit-fork-grants! pending))}))))
        (catch Throwable e
          (tel/log! {:level :error :id :dvergr/merge-failed
                     :data {:fork (:id fork) :parent (:id parent) :error (str e)}}
@@ -880,10 +883,12 @@
          (binding [ec/*execution-context* (fork-home-ctx fork)]
            (peer-bus/post! {:type :dvergr/merge-failed :dvergr/origin (:id fork)
                             :dvergr/parent (:id parent) :error (str e)}))
-         (throw e)))
-    ;; Branchless fork (`:isolation :none`/ephemeral) — no datahike branch to
-    ;; merge, so absorb the fork's post-fork bus entries into the parent's log
-    ;; (merge-as-history; no re-firing of live handlers, separate buses).
+         (throw e))))
+   ;; (2) CONVERSATION merge — for STORE-LESS forks (`:isolation :none`, or a `:ctx`
+   ;; fork without a message store), absorb the fork's post-fork bus entries into the
+   ;; parent's log (merge-as-history; no re-firing of live handlers, separate buses).
+   ;; A `:store` fork's messages already arrived via the datahike collapse in (1).
+   (when-not (:store fork)
      (let [forked-at   (or (:forked-at-len fork) 0)
            fork-log    (log fork)
            new-entries (when (> (count fork-log) forked-at) (subvec fork-log forked-at))]
@@ -981,12 +986,13 @@
    on-message will receive the goal as the first message it sees. Pair
    with `dvergr.discourse.llm/llm-agent` for real LLM workers, or with
    `scripted`/`echo` for tests."
-  [room worker {:keys [goal accept-fn timeout-ms from]
+  [room worker {:keys [goal accept-fn timeout-ms from isolation]
                 :or   {accept-fn (constantly true)
                        timeout-ms 60000
-                       from :hire-caller}}]
+                       from :hire-caller
+                       isolation :none}}]
   (sp/spin
-   (let [fork  (fork-room room)
+   (let [fork  (fork-room room {:isolation isolation})
          _     (join fork worker)
          reply (sp/await
                 (comb/timeout

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -317,16 +317,22 @@
          ;; already handled via another matching subscription — skip the duplicate
          (recur seen order)
          (let [in-reply-to (when (instance? Message env) (:id env))
+               ;; Await the on-message spin DIRECTLY, with the error isolation
+               ;; inline in THIS body. The previous shape awaited an anonymous
+               ;; wrapper spin that awaited the handler — the documented
+               ;; nested-spin-await anti-pattern ("hangs with non-trivial
+               ;; closures"), and one more GC-reapable suspended awaiter in the
+               ;; chain (see spindel fix/gc-reap-suspended-awaiter). partial-cps
+               ;; supports try/catch around await in-body, so the wrapper bought
+               ;; nothing but risk.
                reply-spec
-               (sp/await
-                (sp/spin
-                 (try
-                   (sp/await ((:on-message p) p env))
-                   (catch Throwable t
-                     (binding [*out* *err*]
-                       (println "participant" (:id p)
-                                "on-message error:" (.getMessage t)))
-                     nil))))]
+               (try
+                 (sp/await ((:on-message p) p env))
+                 (catch Throwable t
+                   (binding [*out* *err*]
+                     (println "participant" (:id p)
+                              "on-message error:" (.getMessage t)))
+                   nil))]
            (try (emit-reply! room p reply-spec in-reply-to)
                 (catch Throwable t
                   (binding [*out* *err*]

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -43,7 +43,10 @@
   (require 'dvergr.room.registry)
   (require 'dvergr.room.store)
   (require 'dvergr.rooms.forks)
+  (require 'dvergr.agent.subagent)
   (let [fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
+        subagent-hire*  @(ns-resolve 'dvergr.agent.subagent 'hire!)
+        subagent-pend*  @(ns-resolve 'dvergr.agent.subagent 'pending)
         fork-review*    @(ns-resolve 'dvergr.rooms.forks 'review)
         fork-classify*  @(ns-resolve 'dvergr.rooms.forks 'classify)
         post*           @(ns-resolve 'dvergr.discourse 'post!)
@@ -183,6 +186,20 @@
      'classify     fork-classify*
      'forks        forks-fn
      'participants participants-fn
-     'root         root-fn}))
+     'root         root-fn
+     ;; Subagent delegation — fork a subroom (`:ctx` substrate + shared CRDTs),
+     ;; host an ephemeral worker, delegate the goal, merge/discard. Returns a Spin:
+     ;; `(await (dvergr.room/hire "<room-ref>" {:goal … :spec {…}}))` in the
+     ;; foreground, or hold the spin and await it later (background). Durably
+     ;; tracked as a `:dvergr/subagent` lifecycle log; `pending-subagents` lists
+     ;; the still-running ones.
+     'hire         (fn [ref opts]
+                     (when-let [room (resolve-room ref)]
+                       (binding [rtc/*execution-context* (:ctx room)]
+                         (subagent-hire* room opts))))
+     'pending-subagents (fn [ref]
+                          (when-let [room (resolve-room ref)]
+                            (binding [rtc/*execution-context* (:ctx room)]
+                              (subagent-pend* room))))}))
 
 

--- a/test/dvergr/agent/subagent_test.clj
+++ b/test/dvergr/agent/subagent_test.clj
@@ -1,0 +1,126 @@
+(ns dvergr.agent.subagent-test
+  "Suite guard for the subagent delegation arc (`dvergr.agent.subagent/hire!`):
+   fork → host → delegate → merge/discard, CRDT sharing through the `:ctx`
+   fork, lifecycle tracking, depth cap, and error-safe discard. All scripted
+   workers — no LLM, no network. (The real-LLM path shares every seam except
+   run-agent-turn! itself and is exercised by the live harness.)"
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.discourse :as d]
+            [dvergr.agent.subagent :as sub]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [yggdrasil.convergent.gset :as g]))
+
+(defn- scripted
+  "Worker that replies `content` (and optionally runs `effect!` first)."
+  [id content & [effect!]]
+  (d/participant
+   {:id id
+    :on-message (fn [_p m]
+                  (sp/spin
+                   (when effect! (effect!))
+                   {:to (:from m) :content content}))}))
+
+(defn- run-hire
+  "Run hire! on a fresh room, deref with a watchdog so a regression can never
+   hang the suite. Returns the result map (or ::hung)."
+  [opts & {:keys [room-id] :or {room-id (keyword (str "sub-t-" (rand-int 1000000)))}}]
+  (let [room (d/room room-id)
+        f    (future
+               (binding [ec/*execution-context* (:ctx room)]
+                 @(sub/hire! room opts)))]
+    {:room room :result (deref f 30000 ::hung)}))
+
+(deftest hire-merges-reply
+  (testing "basic delegation: fork, ask, reply, merge"
+    (let [{:keys [result]} (run-hire {:goal "task" :worker (scripted :w "did it")
+                                      :timeout-ms 10000})]
+      (is (= :merged (:status result)))
+      (is (= "did it" (:result result)))
+      (is (uuid? (:subagent-id result))))))
+
+(deftest hire-discards-on-reject
+  (testing "accept-fn false → fork discarded, status :discarded"
+    (let [{:keys [result]} (run-hire {:goal "task" :worker (scripted :w "junk")
+                                      :accept-fn (constantly false)
+                                      :timeout-ms 10000})]
+      (is (= :discarded (:status result)))
+      (is (= "junk" (:result result))))))
+
+(deftest hire-times-out-without-reply
+  (testing "a silent worker → :timeout, fork discarded, nil result"
+    (let [silent (d/participant {:id :mute :on-message (fn [_p _m] (sp/spin nil))})
+          {:keys [result]} (run-hire {:goal "task" :worker silent :timeout-ms 1500})]
+      (is (= :timeout (:status result)))
+      (is (nil? (:result result))))))
+
+(deftest hire-shares-crdt-through-ctx-fork
+  (testing "a worker's G-Set write inside the :ctx fork merges back to the parent"
+    (let [room  (d/room (keyword (str "sub-crdt-" (rand-int 1000000))))
+          kbref (binding [ec/*execution-context* (:ctx room)]
+                  (ygg/register!
+                   (-> (g/gset "kb" {:store-config {:backend :memory :id (random-uuid)}}
+                               {:sync? true})
+                       (g/conj :seed))))
+          worker (scripted :w "done"
+                           #(swap! (ygg/system-signal "kb")
+                                   (fn [s] (g/conj s :finding))))
+          f (future (binding [ec/*execution-context* (:ctx room)]
+                      @(sub/hire! room {:goal "audit" :worker worker :timeout-ms 10000})))
+          result (deref f 30000 ::hung)]
+      (is (= :merged (:status result)))
+      (is (= #{:seed :finding}
+             (binding [ec/*execution-context* (:ctx room)]
+               (g/elements @kbref)))
+          "the fork-branched CRDT write must fold back on merge"))))
+
+(deftest hire-tracks-lifecycle
+  (testing "durable :dvergr/subagent events: :running then the terminal status;
+            pending drains to zero"
+    (let [{:keys [room result]} (run-hire {:goal "t" :worker (scripted :w "ok")
+                                           :timeout-ms 10000})]
+      (is (= :merged (:status result)))
+      (Thread/sleep 400)                     ; the room log is eventually consistent
+      (let [evs (->> (d/log room)
+                     (filter #(= :dvergr/subagent (:type %)))
+                     (mapv :status))]
+        (is (= [:running :merged] evs))
+        (is (empty? (binding [ec/*execution-context* (:ctx room)]
+                      (sub/pending room))))))))
+
+(deftest hire-refuses-past-max-depth
+  (testing "a room whose meta carries :subagent-depth >= max-depth refuses"
+    (let [room (d/room (keyword (str "sub-deep-" (rand-int 1000000))))]
+      (swap! (:meta room) assoc :subagent-depth sub/max-depth)
+      (let [f (future (binding [ec/*execution-context* (:ctx room)]
+                        @(sub/hire! room {:goal "t" :worker (scripted :w "x")})))
+            result (deref f 15000 ::hung)]
+        (is (= :refused (:status result)))))))
+
+(deftest hire-stamps-depth-into-fork
+  (testing "the fork's meta carries the incremented depth (nested hires see it)"
+    (let [depth-seen (atom nil)
+          ;; the worker records ITS room's depth — the participant receives the
+          ;; fork room as (:room p) at join
+          worker (d/participant
+                  {:id :w
+                   :on-message (fn [p m]
+                                 (sp/spin
+                                  (reset! depth-seen
+                                          (some-> (:room p) :meta deref :subagent-depth))
+                                  {:to (:from m) :content "ok"}))})
+          {:keys [result]} (run-hire {:goal "t" :worker worker :timeout-ms 10000})]
+      (is (= :merged (:status result)))
+      (is (= 1 @depth-seen)))))
+
+(deftest hire-discards-fork-on-error
+  (testing "a throw inside delegation yields :error and never merges"
+    (let [boom (d/participant {:id :boom
+                               :on-message (fn [_p _m]
+                                             (throw (ex-info "worker exploded" {})))})
+          {:keys [result]} (run-hire {:goal "t" :worker boom :timeout-ms 3000})]
+      ;; participant-spin isolates on-message errors (logs + nil reply), so this
+      ;; surfaces as :timeout, NOT a merge of partial state — assert exactly that.
+      (is (contains? #{:timeout :error} (:status result)))
+      (is (not= :merged (:status result))))))


### PR DESCRIPTION
Agents can now hire ephemeral subagents from inside their SCI sandbox — fork a subroom, delegate a goal, and merge the result (including CRDT/DB edits) back, or discard it atomically.

## What an agent writes

```clojure
(let [h (dvergr.room/hire "my-room" {:goal "audit auth"
                                     :spec {:model … :system-prompt …}})]
  @h)   ; => {:status :merged :result "…" :subagent-id …}
;; or hold h and deref later (background); nests like rooms, bounded by max-depth
(dvergr.room/pending-subagents "my-room")
```

## Design (validated against opencode/codex research)
- **Fork is a BRANCH, not a copy** — `:isolation :ctx` branches the room's substrate (datahike + registered yggdrasil CRDTs, O(1) CoW), and **merge-back is real**: a worker's G-Set write in its fork folds into the parent on accept (`#{:seed}` → `#{:seed :finding}`). Neither opencode nor codex can do this.
- **Spin-valued delegation** — `hire!` returns a Spin: await in the foreground or hold for background completion.
- **Two lifecycles, one mechanism** — durable personas stay actors; workers are ephemeral `llm-agent`s built in the fork's ctx with an **attenuated budget** ($0.25 default).
- **Safety rails** — `max-depth` (3) via `:subagent-depth` stamped into fork meta (a worker hiring from its fork sees its own depth; past cap → `:refused`); a throw **discards the fork** (never merges partial state) → `:error`.
- **Tracking** — `:dvergr/subagent` lifecycle messages in the parent room log (durable with a `:store`); `pending` scans it.

## Also in this PR
- **fix(discourse): `merge-room` gate decoupled** — the yggdrasil substrate merge now runs whenever the ctx was forked, independent of the message `:store` (store-less rooms silently lost their CRDT merge-back).
- **refactor(discourse): `participant-spin`** awaits the on-message spin directly (drops the nested-wrapper-spin anti-pattern — one fewer GC-reapable suspended awaiter per message; see spindel #24/#25).
- **chore: spindel 0.1.28** (the GC-reap lost-wakeup fixes this arc root-caused — required for real-LLM workers through forks) **+ spindel-tui 0.1.13**.

## Validation
- New suite guard `test/dvergr/agent/subagent_test.clj`: 8 tests / 17 assertions — merge, reject-discard, timeout, CRDT-share-through-fork, lifecycle tracking + pending drain, depth refusal, depth stamping, error-never-merges.
- Full dvergr suite: 343 tests / 1341 assertions / 0 failures (with the participant restructure).
- Verified against the **released** spindel 0.1.28 (no `:local`): 39/93 green, `-Stree` resolves 0.1.28 (`:use-top` over spindel-tui's transitive).
- Real-LLM end-to-end: direct `hire!` through a `:ctx` fork (`{:status :merged, :result "Paris"}`) and through the sandbox `room-ops` surface (`{:status :merged, :result "5"}`); GC-forced harness 14/14.

## Follow-ups (tracked in memory, not in this PR)
`:share` selection for CRDTs, system-db `:subagent/*` durable record, resume-on-restart, deeper tool/domain attenuation.