### PR TITLE
feat(search): per-room fulltext memory search via datahike native secondary scriptum index

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -136,7 +136,14 @@
   ;; Also includes muschel — `:deps` pins the published version, but
   ;; if you need to develop muschel-side fixes in parallel, activate
   ;; this alias to override.
-  :local {:extra-deps {org.babashka/sci           {:local/root "../sci"}
+  ;; datahike's pluggable secondary-index adapters (scriptum fulltext + proximum
+  ;; vector) live in a separate `src-secondary` root. The RELEASED jar ships them
+  ;; (config.edn build :src-dirs include src-secondary — verified in
+  ;; datahike-0.8.1708.jar), so the maven dep needs nothing extra. But a
+  ;; `:local/root "../datahike"` override uses datahike's DEFAULT :paths (which
+  ;; exclude src-secondary), so we add it here for the source-override dev path.
+  :local {:extra-paths ["../datahike/src-secondary"]
+          :extra-deps {org.babashka/sci           {:local/root "../sci"}
                        org.replikativ/datahike    {:local/root "../datahike"}
                        org.replikativ/scriptum    {:local/root "../scriptum"}
                        org.replikativ/yggdrasil   {:local/root "../yggdrasil"}

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -87,7 +87,27 @@
                       (apply dh/datoms @db-atom a rest)))
         schema-fn (fn ([] (dh/schema @db-atom))
                     ([db] (dh/schema db)))
-        db-fn (fn [] @db-atom)]
+        db-fn (fn [] @db-atom)
+        ;; Fulltext memory search via datahike's native scriptum secondary index
+        ;; (dvergr.search.secondary/search). It's just a fn returning BM25-RANKED
+        ;; [[entity-id score] …], so the agent calls it INSIDE a datalog clause —
+        ;; fulltext ranking composed with structured constraints in one q:
+        ;;   (dh/q '[:find ?c ?score
+        ;;           :in $ ?ft
+        ;;           :where [(?ft :room/fulltext "gc reap") [[?e ?score]]]
+        ;;                  [?e :message/content ?c]]
+        ;;         (dh/db) dh/search)
+        ;; Resolve lazily + gracefully: the scriptum secondary-index adapter
+        ;; lives in datahike's src-secondary root, which a released build may
+        ;; not ship. The sandbox must still build; dh/search errors clearly only
+        ;; if actually called without support.
+        secondary  (try (requiring-resolve 'dvergr.search.secondary/search)
+                        (catch Throwable _ nil))
+        search-fn  (fn [ident query & [opts]]
+                     (if secondary
+                       (secondary @db-atom ident query (or opts {}))
+                       (throw (ex-info "fulltext search unavailable — datahike secondary index (:scriptum) not on classpath"
+                                       {:ident ident}))))]
 
     (sci/add-namespace! sci-ctx 'dh
                         {'q q-fn
@@ -96,6 +116,7 @@
                          'entity entity-fn
                          'datoms datoms-fn
                          'schema schema-fn
+                         'search search-fn
                          'db db-fn})))
 
 (defn add-inference-ns!

--- a/src/dvergr/search/secondary.clj
+++ b/src/dvergr/search/secondary.clj
@@ -1,0 +1,91 @@
+(ns dvergr.search.secondary
+  "Fulltext memory search via datahike's NATIVE pluggable secondary index
+   (`datahike.index.secondary` + the `:scriptum` adapter) — NOT a hand-rolled
+   sidecar. Declared in the room's schema, maintained by datahike on every
+   transact, planner-integrated, and fork-aware (`IVersionedSecondaryIndex`
+   forks the Lucene segments WITH the room's datahike branch — so per-room
+   memory branches on fork and merges on merge-room for free).
+
+   The retrieval unit is the datahike ENTITY: `search` returns BM25-ranked
+   `[[entity-id score] …]` (via `sec/-slice-ordered`), a datalog RELATION binding
+   — so ranked fulltext composes with structured constraints (room/author/time/
+   type) in one `d/q`:
+     [(search :room/fulltext \"gc reap\") [[?e ?score]]]  [?e :message/content ?c]
+   This is \"fulltext working in datalog queries themselves\": the search fn is
+   called inside a `:where` clause and its hits join on the entity.
+
+   NOTE: the `:scriptum`/`:proximum` adapters live in datahike's `src-secondary`
+   root, which the RELEASED jar already ships (verified in datahike-0.8.1708);
+   only a `:local/root \"../datahike\"` source override needs the extra path (see
+   deps.edn :local)."
+  (:require [datahike.api :as d]
+            [datahike.index.secondary :as sec]
+            ;; registers the :scriptum index type in the secondary registry
+            [datahike.index.secondary.scriptum]))
+
+(defn declare-index!
+  "Declare a scriptum fulltext secondary index `ident` over `attrs` on `conn`,
+   with scriptum storage at `path`. Idempotent-ish (re-transacting the same
+   ident updates it). datahike builds it async; poll `ready?`."
+  [conn ident attrs path]
+  (d/transact conn [{:db/ident              ident
+                     :db.secondary/type     :scriptum
+                     :db.secondary/attrs    (vec attrs)
+                     :db.secondary/config   {:path path}}])
+  ident)
+
+;; Standard per-room index idents (one scriptum index per corpus, forks with the
+;; room's datahike store). The scriptum storage path is derived from the store
+;; path so it sits alongside the room's data.
+(def message-fulltext-ident :room/fulltext)
+(def kb-fulltext-ident      :room/kb-fulltext)
+
+(defn declare-message-fulltext!
+  "Declare the standard messages fulltext index on a room's msgs `conn`; scriptum
+   storage at `<store-path>-ft`. Best-effort — a failure here must NOT break room
+   provisioning, only leave fulltext search unavailable for the room."
+  [conn store-path]
+  (try (declare-index! conn message-fulltext-ident [:message/content] (str store-path "-ft"))
+       (catch Throwable _ nil)))
+
+(defn declare-kb-fulltext!
+  "Declare the standard KB fulltext index on a room's kb `conn`; indexes entity
+   title + summary + contexts (the block-like atoms). Best-effort."
+  [conn store-path]
+  (try (declare-index! conn kb-fulltext-ident
+                       [:entity/title :entity/summary :entity/contexts]
+                       (str store-path "-ft"))
+       (catch Throwable _ nil)))
+
+(defn ready?
+  "True once datahike has finished building the secondary index `ident`."
+  [db ident]
+  (= :ready (get-in db [:schema ident :db.secondary/status])))
+
+(defn- index-of [db ident] (get-in db [:secondary-indices ident]))
+
+(defn search
+  "Relevance-RANKED fulltext search of secondary index `ident` on `db`. Returns
+   `[[entity-id score] …]` — Long eid + BM25 score, descending by score. That
+   tuple shape is a datalog RELATION binding, so ranking composes straight into a
+   `d/q`:
+
+     [(search :room/fulltext \"gc reap\") [[?e ?score]]]  ; in a :where clause
+     [?e :message/content ?content]                       ; joined with structure
+
+   `:limit` caps results (default 20), `:field` the datom field (default :value),
+   `:filter` an optional EntityBitSet that pre-restricts the candidate set (e.g.
+   the entity set of a prior structured query). Backed by datahike's native
+   `sec/-slice-ordered` on the :scriptum adapter."
+  ([db ident query] (search db ident query {}))
+  ([db ident query {:keys [field filter limit] :or {field :value limit 20}}]
+   (if-let [ft (index-of db ident)]
+     (mapv (fn [{:keys [entity-id score]}] [(long entity-id) score])
+           (sec/-slice-ordered ft {:query query :field field} filter nil :desc limit))
+     [])))
+
+(defn search-eids
+  "Ranked entity ids only (Long, descending relevance) — `(map first (search …))`.
+   Use when you don't need scores; binds as `[?e ...]` in datalog."
+  ([db ident query] (search-eids db ident query {}))
+  ([db ident query opts] (mapv first (search db ident query opts))))

--- a/src/dvergr/system/rooms.clj
+++ b/src/dvergr/system/rooms.clj
@@ -21,6 +21,7 @@
             [dvergr.system.db :as sdb]
             [dvergr.kb.schema :as kbs]
             [dvergr.chat.schema :as cschema]
+            [dvergr.search.secondary :as search-secondary]
             [dvergr.scheduler.schema :as sched-schema]
             [dvergr.runtime.ctx :as rctx]
             [dvergr.substrate.git :as git]
@@ -104,7 +105,11 @@
                    :seed-tx [(merge (cschema/create-chat-entity
                                      {:id (msgs-chat-id slug) :title (or name slug)})
                                     {:room/slug slug :room/type :internal})]
-                   :register? false}))
+                   :register? false})
+  ;; Declare the messages fulltext (scriptum) secondary index once, after the
+  ;; chat schema is installed. It's schema data in the store, so it forks with
+  ;; the room; datahike maintains it on every message transact. Best-effort.
+  (search-secondary/declare-message-fulltext! (d/connect (msgs-cfg path)) path))
 
 (defn register-room-systems!
   "Register a room's messages store + KB (DatahikeSystems) + repo (GitSystem) as
@@ -191,6 +196,10 @@
             _         (sdh/provision! {:cfg (kb-cfg kb-path) :schema? false
                                        :extra-schema (kbs/knowledge-datahike-schema)
                                        :register? false})
+            ;; Declare the KB fulltext (scriptum) secondary index over entity
+            ;; title/summary/contexts — forks with the KB store, maintained on
+            ;; every knowledge_add. Best-effort.
+            _         (search-secondary/declare-kb-fulltext! (d/connect (kb-cfg kb-path)) kb-path)
             _         (seed-msgs-store! msgs-path slug name)
             repo-id   (sdb/register-system! {:type :repo :name (str slug "-repo")
                                              :scope repo-path :owner-id owner-id})

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -960,17 +960,29 @@
                (if db-conn
                  (try
                    (let [limit (or limit 10)
+                         ;; Fulltext over the KB's scriptum secondary index
+                         ;; (title + summary + contexts), ranked; falls back to
+                         ;; the old title-regex when the index is unavailable or
+                         ;; not yet built, so recall never regresses.
+                         regex-search
+                         (fn [db]
+                           (let [pattern (re-pattern (str "(?i)" query))]
+                             (->> (d/q '[:find [(pull ?e [*]) ...]
+                                         :where [?e :entity/id _]] db)
+                                  (filter #(re-find pattern (:entity/title %)))
+                                  (sort-by #(- (or (:entity/mention-count %) 0)))
+                                  (take limit))))
                          results (case (or operation "search")
                                    "search"
                                    (when query
-                                     (let [pattern (re-pattern (str "(?i)" query))
-                                           all-entities (d/q '[:find [(pull ?e [*]) ...]
-                                                               :where [?e :entity/id _]]
-                                                             @db-conn)]
-                                       (->> all-entities
-                                            (filter #(re-find pattern (:entity/title %)))
-                                            (sort-by #(- (or (:entity/mention-count %) 0)))
-                                            (take limit))))
+                                     (let [db   @db-conn
+                                           ft   (requiring-resolve 'dvergr.search.secondary/search-eids)
+                                           ;; ranked by BM25 relevance (title/summary/contexts)
+                                           eids (try (ft db :room/kb-fulltext query {:limit limit})
+                                                     (catch Throwable _ nil))]
+                                       (if (seq eids)
+                                         (take limit (d/pull-many db '[*] eids)) ; keep relevance order
+                                         (regex-search db))))
 
                                    "top"
                                    (->> (d/q '[:find [(pull ?e [*]) ...]


### PR DESCRIPTION
Rooms get **relevance-ranked fulltext search** over their messages and KB, built on datahike's **native pluggable secondary index** (the `:scriptum` adapter) — declared in the room schema, maintained by datahike on every transact, and **fork-aware**: the Lucene segments fork WITH the room's datahike branch (`IVersionedSecondaryIndex`), so per-room memory branches on fork and merges on `merge-room` for free. That's the structural advantage openclaw's per-agent-global memory can't match. (From the openclaw memory gap analysis.)

## Design (one commit; the exploration was squashed out)
Fulltext is reached by calling a search fn — datahike's query planner routes only *stratum aggregates* through `d/q`, not scriptum fulltext — so the minimal surface is one function the agent can call **inside a datalog clause**:
```clojure
(dh/q '[:find ?c ?score
        :in $ ?ft
        :where [(?ft :room/fulltext "gc reap") [[?e ?score]]]   ; ranked fulltext, in-clause
               [?e :message/content ?c]]                          ; joined with structure
      (dh/db) dh/search)
;; => (["…strongly relevant" 0.59] ["…one mention" 0.43])
```
No query DSL, no wrapper over `d/q` — just `dh/search` (a plain fn) exposed to the sandbox.

## What's here
- **`dvergr.search.secondary`** — `declare-index!` + `declare-message-fulltext!` / `declare-kb-fulltext!` (best-effort — never breaks provisioning); `search` returns **BM25-ranked `[[entity-id score] …]`** via datahike's `sec/-slice-ordered` (a datalog relation binding); `search-eids` for the ids-only `[?e ...]` form.
- **Per-room provisioning** (`dvergr.system.rooms`) auto-declares `:room/fulltext` (`:message/content`) and `:room/kb-fulltext` (title+summary+contexts). Values stay in the **primary** (recoverable); `:db.secondary/only` is reserved for a future large-external-doc/intake tier — **not** messages, which must be read back verbatim.
- **Sandbox lift**: `dh/search`, lazy/graceful if the adapter is absent.
- **`knowledge_search`** upgraded to ranked KB fulltext (was regex-on-`:entity/title`), with a regex fallback so recall never regresses.

## Validation (real provisioned store)
- Provisioning: `DECLARED? true`, `READY? true`; transacted message found via ranked search + `d/q` join (unrelated excluded).
- **Fork** (`branch! :db → :feature`): fork inherits root's docs, fork writes isolated from root — per-room memory branches/merges for free.
- **Ranked**: heavy-mention message outranks single-mention (`0.59` > `0.43`); ranked+scored in-clause query through the SCI sandbox returns sorted `[content score]`.
- Tool: a query appearing **only in a context string** (never a title) now returns the entity — the old regex-on-title missed it.

## Packaging
The `:scriptum`/`:proximum` adapters ship in datahike's released jar (config.edn build `:src-dirs` include `src-secondary` — verified `datahike-0.8.1708.jar` loads the adapter from maven, no `:local`). The `deps.edn :local` extra-path is only for a `../datahike` source override.

## Follow-ups (not in this PR)
proximum vector arm (`:db.secondary/type :proximum`) + hybrid (fulltext-filter → vector-KNN) when embeddings land; a `:db.secondary/only` intake corpus for large external bodies; a full `fork-room` end-to-end test.