### PR TITLE
fix: claude-code subprocess isolation (#11), room membership restore (#12), TUI Ctrl+C (#4)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -108,7 +108,7 @@
                        metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                        io.forward/clojure-mail {:mvn/version "1.0.8"} ; mail intake
                        org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)
-                       org.replikativ/spindel-tui {:mvn/version "0.1.13"}}}
+                       org.replikativ/spindel-tui {:mvn/version "0.1.14"}}}
 
   ;; src-clients/ on the test path so dvergr.web.server-test still
   ;; loads the namespaces it tests.
@@ -117,7 +117,7 @@
                        metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                        io.forward/clojure-mail {:mvn/version "1.0.8"} ; mail intake
                        org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)
-                       org.replikativ/spindel-tui {:mvn/version "0.1.13"}}
+                       org.replikativ/spindel-tui {:mvn/version "0.1.14"}}
          :main-opts   ["-m" "kaocha.runner"]}
 
   :repl {:main-opts ["-m" "nrepl.cmdline"
@@ -162,7 +162,7 @@
   ;; possible via --no-tui; otherwise the TUI launches automatically
   ;; because spindel-tui is on the classpath via this alias.
   :cli {:extra-paths ["src-clients"]
-        :extra-deps  {org.replikativ/spindel-tui {:mvn/version "0.1.13"}
+        :extra-deps  {org.replikativ/spindel-tui {:mvn/version "0.1.14"}
                       metosin/reitit-ring {:mvn/version "0.7.2"} metosin/reitit-malli {:mvn/version "0.7.2"} metosin/reitit-middleware {:mvn/version "0.7.2"} metosin/reitit-swagger {:mvn/version "0.7.2"} io.github.nextjournal/markdown {:mvn/version "0.7.222"} ; web (reitit, sans swagger-ui — add reitit-swagger-ui for the /docs page)
                       io.forward/clojure-mail    {:mvn/version "1.0.8"}    ; mail intake
                       org.replikativ/briefkasten {:mvn/version "0.1.2"} ; briefkasten (mail)

--- a/src/dvergr/model/api/claude_code.clj
+++ b/src/dvergr/model/api/claude_code.clj
@@ -193,7 +193,16 @@
              "--model" model
              "--max-turns" "0"
              "--no-session-persistence"
-             "--tools" ""]
+             ;; Isolate the subprocess from the host's Claude Code environment,
+             ;; or its leaked native tools shadow dvergr's text <tool_use>
+             ;; protocol and tool calls fail non-deterministically (dvergr #11):
+             ;;  - MCP: --strict-mcp-config + an empty config drops the user's
+             ;;    global MCP servers ("{}" alone is rejected — needs mcpServers).
+             ;;  - Built-ins: --tools "" is a no-op in print mode, so DENY the
+             ;;    built-in tools explicitly to force the model onto <tool_use>.
+             "--strict-mcp-config"
+             "--mcp-config" "{\"mcpServers\":{}}"
+             "--disallowedTools" "Bash Read Edit Write Glob Grep Task WebFetch WebSearch"]
       system (into ["--system-prompt" system])
       effort (into ["--effort" effort]))))
 

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -863,6 +863,23 @@
                       "Autostarting file-defined agent")
             (create-agent! daemon cfg)))))
 
+    ;; Restore ROOM-side membership. An agent added to a UI-created room is
+    ;; stored in that room's durable `:room/agent-ids`, but the loops above only
+    ;; re-join AGENT-side membership (each agent's config `:rooms`). Nothing
+    ;; re-reads `:room/agent-ids`, so a UI-created room shows "0 agents" after a
+    ;; restart even though the membership persisted. Now that every agent is
+    ;; online, re-join each room's durable members — `join-agent-to-room!` is
+    ;; idempotent, so this composes with the config/:rooms joins. (dvergr #12)
+    (binding [rtc/*execution-context* exec-ctx]
+      (doseq [{:room/keys [slug agent-ids]} (sdb/all-rooms)
+              :when (seq agent-ids)
+              :let  [room (rreg/lookup (rstore/slug->room-id slug))]
+              :when room
+              aid   agent-ids
+              :let  [cfg (agent-join-config daemon aid)]
+              :when cfg]
+        (join-agent-to-room! daemon (resolve-safe-config cfg) room)))
+
     ;; Boardroom-mirror sink: DROPPED (D/E/F 3b-1). Agent replies now live in
     ;; the room where the conversation happened; an agent that should post to
     ;; boardroom is a participant there and replies into it directly. DM


### PR DESCRIPTION
Three reported bugs, all with verified analysis in their issues (thanks @Guliy).

### #11 — `:claude-code` provider leaks host tools/MCP into the agent
`claude -p` inherited the user's global MCP servers *and* the CLI's built-in tools (Bash/Read/Edit/…), which surfaced to the model as native tools — so it called those instead of dvergr's text `<tool_use>` protocol and tool calls failed non-deterministically (`clojure_eval` → "No such tool available"). `build-command` now isolates the subprocess: `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` (drop MCP) and `--disallowedTools "…"` replacing the ineffective `--tools ""` (a no-op in print mode). Fixes #11.

### #12 — UI-created room membership lost on restart
Startup re-joined only *agent-side* membership (each agent's config `:rooms`), never the durable *room-side* `:room/agent-ids` set when you add an agent to a UI-created room — so such rooms showed "0 agents" after every restart. Added a pass, after all agents are online, that re-joins each room's durable `agent-ids` via the idempotent `join-agent-to-room!`. Fixes #12.

### #4 — TUI wedges the terminal on Ctrl+C
Fixed upstream in [spindel-tui#5](https://github.com/replikativ/spindel-tui/pull/5) (explicit `sun.misc.Signal` handlers + charset reset, since Ctrl+C arrives as SIGINT and the earlier shutdown hook was unreliable). This bumps the pin to **spindel-tui 0.1.14** to pick it up. Fixes #4.

Independent of the voice/media PR #13; if that merges first this rebases cleanly (the `daemon.clj` changes touch different sections).