### PR TITLE
feat(drive): content-addressed room drives + /drive mount, and start-room-subsystems!

### DIFF
--- a/src/dvergr/drive/blobs.clj
+++ b/src/dvergr/drive/blobs.clj
@@ -1,20 +1,37 @@
 (ns dvergr.drive.blobs
-  "Content-addressed blob storage: a konserve file store keyed by the SHA-256
-   of the content. Bytes-by-hash — the drive tree (dvergr.drive.core) references
-   blobs by hash; metadata (name, mime, size) lives with the tree node. Global,
-   not per-room: CAS dedup is content-based, so identical bytes uploaded to
-   different rooms are stored once.
+  "Content-addressed blob storage: a konserve store keyed by the SHA-256 of the
+   content. Bytes-by-hash — the drive tree (dvergr.drive.core) references blobs
+   by hash; metadata (name, mime, size) lives with the tree node. Global, not
+   per-room: CAS dedup is content-based, so identical bytes uploaded to different
+   rooms are stored once.
 
-   First consumers: Telegram voice notes / documents, web uploads. Under
-   `.dvergr/blobs/`."
-  (:require [konserve.filestore :refer [connect-fs-store]]
+   Backend is konserve-config-driven via the generic `connect-store` lifecycle,
+   so the store is selected by its `:backend` and any konserve backend works by
+   config alone. Default: a filestore under `.dvergr/blobs`. Override with
+   `set-store-config!` (the daemon sets it from `config.local.edn :blob-store`)
+   — e.g. `{:backend :s3 :bucket \"…\" :region \"…\"}` or a `:tiered` store.
+
+   First consumers: Telegram voice notes / documents, web uploads."
+  (:require [konserve.store :as kstore]
             [konserve.core :as k]
             [dvergr.substrate.paths :as paths]
             [taoensso.telemere :as log])
   (:import [java.security MessageDigest]))
 
+(defonce ^:private store-config (atom nil))
+
+(defn set-store-config!
+  "Set the blob store's konserve config (a `{:backend …}` map) — overrides the
+   filestore default. Must be called before first blob access."
+  [config]
+  (reset! store-config config))
+
+(defn- resolve-config []
+  (or @store-config
+      {:backend :file :path (paths/dir "blobs") :opts {:sync? true}}))
+
 (defonce ^:private store
-  (delay (connect-fs-store (paths/dir "blobs") :opts {:sync? true})))
+  (delay (kstore/connect-store (resolve-config) {:sync? true})))
 
 (defn sha256-hex [^bytes bs]
   (let [d (.digest (MessageDigest/getInstance "SHA-256") bs)]

--- a/src/dvergr/drive/blobs.clj
+++ b/src/dvergr/drive/blobs.clj
@@ -28,10 +28,25 @@
 
 (defn- resolve-config []
   (or @store-config
-      {:backend :file :path (paths/dir "blobs") :opts {:sync? true}}))
+      (let [path (paths/dir "blobs")]
+        ;; konserve requires a UUID :id (stable store identity across restarts /
+        ;; backends). Derive it deterministically from the path.
+        {:backend :file
+         :path    path
+         :id      (java.util.UUID/nameUUIDFromBytes (.getBytes (str "dvergr-blobs:" path) "UTF-8"))
+         :opts    {:sync? true}})))
+
+(defn- connect-or-create!
+  "Connect to the store, creating it first if it doesn't exist yet (the generic
+   konserve `connect-store` only connects — `:file` throws when absent)."
+  [config]
+  (let [opts {:sync? true}]
+    (if (kstore/store-exists? config opts)
+      (kstore/connect-store config opts)
+      (kstore/create-store config opts))))
 
 (defonce ^:private store
-  (delay (kstore/connect-store (resolve-config) {:sync? true})))
+  (delay (connect-or-create! (resolve-config))))
 
 (defn sha256-hex [^bytes bs]
   (let [d (.digest (MessageDigest/getInstance "SHA-256") bs)]

--- a/src/dvergr/drive/blobs.clj
+++ b/src/dvergr/drive/blobs.clj
@@ -1,0 +1,41 @@
+(ns dvergr.drive.blobs
+  "Content-addressed blob storage: a konserve file store keyed by the SHA-256
+   of the content. Bytes-by-hash — the drive tree (dvergr.drive.core) references
+   blobs by hash; metadata (name, mime, size) lives with the tree node. Global,
+   not per-room: CAS dedup is content-based, so identical bytes uploaded to
+   different rooms are stored once.
+
+   First consumers: Telegram voice notes / documents, web uploads. Under
+   `.dvergr/blobs/`."
+  (:require [konserve.filestore :refer [connect-fs-store]]
+            [konserve.core :as k]
+            [dvergr.substrate.paths :as paths]
+            [taoensso.telemere :as log])
+  (:import [java.security MessageDigest]))
+
+(defonce ^:private store
+  (delay (connect-fs-store (paths/dir "blobs") :opts {:sync? true})))
+
+(defn sha256-hex [^bytes bs]
+  (let [d (.digest (MessageDigest/getInstance "SHA-256") bs)]
+    (apply str (map #(format "%02x" %) d))))
+
+(defn store!
+  "Store bytes content-addressed. Returns {:blob/id sha :blob/mime m
+   :blob/size n}. Idempotent (same content → same id, single copy)."
+  [^bytes bytes mime]
+  (let [id (sha256-hex bytes)]
+    (k/bassoc @store id bytes {:sync? true})
+    (log/log! {:level :debug :id ::blob-stored
+               :data {:blob id :size (count bytes) :mime mime}})
+    {:blob/id id :blob/mime mime :blob/size (count bytes)}))
+
+(defn get-bytes
+  "Fetch blob bytes by id, nil when absent."
+  [id]
+  (try
+    (k/bget @store id
+            (fn [{:keys [input-stream]}]
+              (.readAllBytes ^java.io.InputStream input-stream))
+            {:sync? true})
+    (catch Exception _ nil)))

--- a/src/dvergr/drive/core.clj
+++ b/src/dvergr/drive/core.clj
@@ -1,0 +1,198 @@
+(ns dvergr.drive.core
+  "Drives — per-room file systems. A drive is the room's datahike fs.node TREE
+   plus content in the CAS blob store (dvergr.drive.blobs); the tree references
+   blobs by hash. The tree DB is a room-owned datahike system
+   (`dvergr.system.rooms/create-room-db!`), so it forks / merges / discards WITH
+   the room and its grant survives restart — no bespoke registry.
+
+   API-first: consumers (the shell /drive mount via dvergr.drive.fs, the media
+   fns, channel uploads) go through ls / put-file! / read-file / mkdir! / mv! /
+   rm! — the fs.node schema is an implementation detail.
+
+   Drives hold raw documents; the KB holds derived knowledge."
+  (:require [datahike.api :as d]
+            [dvergr.drive.blobs :as blobs]
+            [dvergr.system.rooms :as srooms]
+            [clojure.string :as str]
+            [taoensso.telemere :as log]))
+
+(def fs-node-schema
+  [{:db/ident :fs.node/id     :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+   {:db/ident :fs.node/name   :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :fs.node/parent :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc "Parent dir node; absent ⇒ child of the root"}
+   {:db/ident :fs.node/kind   :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one :db/doc ":file | :dir"}
+   {:db/ident :fs.node/blob   :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "Content hash into the CAS blob store — files only"}
+   {:db/ident :fs.node/mime   :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :fs.node/size   :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :fs.node/mtime  :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :fs.node/source :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc ":upload :telegram :photo :voice :agent :mail …"}])
+
+;; =============================================================================
+;; Room drive connection (reuses dvergr's room-owned, fork-aware DB machinery)
+;; =============================================================================
+
+(def ^:private drive-db-name "drive")
+
+(defn room-drive-conn
+  "The room's drive tree conn, or nil if not yet provisioned."
+  [room-id]
+  (srooms/room-db-conn room-id drive-db-name))
+
+(defn ensure-room-drive!
+  "The room's drive tree conn, provisioning it on first need as a room-owned
+   datahike system (forks/merges with the room; grant persisted). Requires the
+   room's ctx bound (the caller runs in it)."
+  [room-id & {:keys [owner-id]}]
+  (or (room-drive-conn room-id)
+      (srooms/create-room-db! room-id drive-db-name
+                              :schema fs-node-schema :owner-id owner-id)))
+
+;; =============================================================================
+;; The tree API — the contract every consumer programs against
+;; =============================================================================
+
+(defn- node-eid [db node-id]
+  (d/q '[:find ?e . :in $ ?id :where [?e :fs.node/id ?id]] db node-id))
+
+(defn- child-by-name
+  "Child of `parent-id` (nil ⇒ root level) named `name`, or nil."
+  [db parent-id name]
+  (if parent-id
+    (d/q '[:find (pull ?c [*]) . :in $ ?pid ?n
+           :where [?p :fs.node/id ?pid] [?c :fs.node/parent ?p] [?c :fs.node/name ?n]]
+         db parent-id name)
+    (d/q '[:find (pull ?c [*]) . :in $ ?n
+           :where [?c :fs.node/name ?n] [(missing? $ ?c :fs.node/parent)]]
+         db name)))
+
+(defn ls
+  "Children of `parent-id` (nil ⇒ root), sorted dirs-first by name."
+  [conn & [parent-id]]
+  (let [db @conn
+        rows (if parent-id
+               (d/q '[:find [(pull ?c [*]) ...] :in $ ?pid
+                      :where [?p :fs.node/id ?pid] [?c :fs.node/parent ?p]]
+                    db parent-id)
+               (d/q '[:find [(pull ?c [*]) ...]
+                      :where [?c :fs.node/id _] [(missing? $ ?c :fs.node/parent)]]
+                    db))]
+    (->> rows
+         (mapv #(dissoc % :db/id))
+         (sort-by (juxt #(if (= :dir (:fs.node/kind %)) 0 1)
+                        #(str/lower-case (or (:fs.node/name %) ""))))
+         vec)))
+
+(defn mkdir!
+  "Ensure a directory `name` under `parent-id` (nil ⇒ root). Idempotent; returns
+   the dir node's id."
+  [conn parent-id name]
+  (if-let [existing (child-by-name @conn parent-id name)]
+    (:fs.node/id existing)
+    (let [id (random-uuid)]
+      (d/transact conn [(cond-> {:fs.node/id id :fs.node/name name
+                                 :fs.node/kind :dir :fs.node/mtime (java.util.Date.)}
+                          parent-id (assoc :fs.node/parent [:fs.node/id parent-id]))])
+      id)))
+
+(defn ensure-path!
+  "Ensure the directory path `segments` (e.g. [\"telegram\"]) exists; returns the
+   deepest dir's node id (nil for empty path = root)."
+  [conn segments]
+  (reduce (fn [parent-id seg] (mkdir! conn parent-id seg)) nil segments))
+
+(defn put-file!
+  "Store `bytes` in the CAS and upsert a file node `name` under `parent-id`
+   (nil ⇒ root). Same name ⇒ new version (node points at the new hash; datahike
+   history keeps the old). Returns the node map."
+  [conn parent-id name bytes & {:keys [mime source]
+                                :or {mime "application/octet-stream" source :upload}}]
+  (let [blob     (blobs/store! bytes mime)
+        existing (child-by-name @conn parent-id name)
+        id       (or (:fs.node/id existing) (random-uuid))
+        node     (cond-> {:fs.node/id id :fs.node/name name :fs.node/kind :file
+                          :fs.node/blob (:blob/id blob) :fs.node/mime mime
+                          :fs.node/size (long (count bytes))
+                          :fs.node/mtime (java.util.Date.) :fs.node/source source}
+                   parent-id (assoc :fs.node/parent [:fs.node/id parent-id]))]
+    (d/transact conn [node])
+    (log/log! {:level :info :id ::file-put
+               :data {:name name :size (count bytes) :blob (:blob/id blob)}})
+    node))
+
+(defn stat
+  "Node map by id, or nil."
+  [conn node-id]
+  (when-let [e (d/q '[:find (pull ?e [*]) . :in $ ?id
+                      :where [?e :fs.node/id ?id]] @conn node-id)]
+    (dissoc e :db/id)))
+
+(defn read-file
+  "File bytes by node id (nil when absent or a dir)."
+  [conn node-id]
+  (when-let [hash (:fs.node/blob (stat conn node-id))]
+    (blobs/get-bytes hash)))
+
+(defn resolve-path
+  "Node map for a /-joined `path` (e.g. \"telegram/report.pdf\"), or nil."
+  [conn path]
+  (let [segs (remove str/blank? (str/split (or path "") #"/"))]
+    (loop [parent-id nil, [s & more] segs, node nil]
+      (if-not s
+        node
+        (when-let [n (child-by-name @conn parent-id s)]
+          (recur (:fs.node/id n) more (dissoc n :db/id)))))))
+
+(defn mv!
+  "Rename and/or reparent a node (no args but node-id ⇒ bump mtime only)."
+  [conn node-id & {:keys [name parent-id]}]
+  (when (stat conn node-id)
+    (d/transact conn [(cond-> {:fs.node/id node-id :fs.node/mtime (java.util.Date.)}
+                        name      (assoc :fs.node/name name)
+                        parent-id (assoc :fs.node/parent [:fs.node/id parent-id]))])
+    (stat conn node-id)))
+
+(defn rm!
+  "Retract a node (dirs must be empty). Blobs stay in the CAS (other versions may
+   reference them; GC is a later concern)."
+  [conn node-id]
+  (let [db @conn]
+    (when-let [eid (node-eid db node-id)]
+      (when (seq (d/q '[:find ?c :in $ ?p :where [?c :fs.node/parent ?p]] db eid))
+        (throw (ex-info "Directory not empty" {:node-id node-id})))
+      (d/transact conn [[:db/retractEntity eid]])
+      :removed)))
+
+(defn tree
+  "Whole tree as nested maps (children under :fs.node/children) — for a files
+   panel. Founder-scale; paginate later."
+  [conn & [parent-id]]
+  (mapv (fn [n]
+          (if (= :dir (:fs.node/kind n))
+            (assoc n :fs.node/children (tree conn (:fs.node/id n)))
+            n))
+        (ls conn parent-id)))
+
+;; =============================================================================
+;; Convenience — store bytes into a room's drive at a /-path
+;; =============================================================================
+
+(defn store-in-room!
+  "Ensure the room's drive, put `bytes` at directory `dir-segs` under `name`,
+   returning the node. The one call channels use to land an upload. Requires the
+   room's ctx bound."
+  [room-id dir-segs name bytes & {:keys [mime source] :or {source :upload}}]
+  (let [conn (ensure-room-drive! room-id)
+        dir  (ensure-path! conn (vec dir-segs))]
+    (put-file! conn dir name bytes :mime mime :source source)))

--- a/src/dvergr/drive/fs.clj
+++ b/src/dvergr/drive/fs.clj
@@ -1,0 +1,164 @@
+(ns dvergr.drive.fs
+  "muschel.fs/FS over a drive (dvergr.drive.core): the datahike fs.node tree +
+   CAS blobs exposed as a plain filesystem.
+
+   Mounted into the agent's shell host (muschel.fs.mount) at /drive, this makes
+   the room's drive transparently reachable with the bash idioms agents already
+   use — ls, cat, grep, echo >, mkdir, mv — through the EXISTING shell tool with
+   permits and tracing intact. No bespoke fs_* LLM tools.
+
+   Self-rooted: this FS's `/` is the drive root; the mount layer rebases sandbox
+   paths. Writes commit through the drive API (put-file! → CAS + node upsert),
+   so datahike history keeps every version; blobs stay in the CAS."
+  (:require [dvergr.drive.core :as core]
+            [muschel.fs :as mfs]
+            [clojure.string :as str]))
+
+(def ^:private ^:const read-cap-bytes (* 8 1024 1024))
+
+(defn- canonicalize
+  "Resolve `path` against `cwd`, collapse `.`/`..`. Nil on escape past /."
+  [cwd path]
+  (when (string? path)
+    (let [combined   (if (str/starts-with? path "/") path (str cwd "/" path))
+          normalized (mfs/normalize-segments (mfs/split-path combined))]
+      (when normalized
+        (let [p (mfs/join-path "" normalized)]
+          (if (= "" p) "/" p))))))
+
+(defn- drive-path
+  "Canonical sandbox path → drive-relative path string (\"\" = root)."
+  [p]
+  (str/replace p #"^/" ""))
+
+(defn- node-at [conn p]
+  (if (= "/" p) ::root (core/resolve-path conn (drive-path p))))
+
+(defn- parent-and-name [p]
+  (let [segs (vec (remove str/blank? (str/split p #"/")))]
+    [(pop segs) (peek segs)]))
+
+(defn- dir-id-at
+  "fs.node id of the DIR at path `p` (nil for root, ::none when the path is
+   missing or a file)."
+  [conn p]
+  (if (= "/" p)
+    nil
+    (let [n (core/resolve-path conn (drive-path p))]
+      (if (and n (= :dir (:fs.node/kind n)))
+        (:fs.node/id n)
+        ::none))))
+
+(defn- node->entry [n]
+  {:name (:fs.node/name n)
+   :type (:fs.node/kind n)
+   :size (or (:fs.node/size n) 0)
+   :mtime-ms (some-> ^java.util.Date (:fs.node/mtime n) .getTime)})
+
+(defrecord DriveFS [conn cwd-atom]
+  mfs/FS
+  (-resolve [_ path] (canonicalize @cwd-atom path))
+  (-cwd [_] @cwd-atom)
+  (-cd! [_ path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (let [d (dir-id-at conn p)]
+        (when (not= ::none d) (reset! cwd-atom p) p))))
+
+  (-exists? [_ path]
+    (when-let [p (canonicalize @cwd-atom path)] (some? (node-at conn p))))
+
+  (-stat [_ path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (if (= "/" p)
+        {:type :dir :size 0 :mtime-ms 0 :perms nil}
+        (when-let [n (node-at conn p)]
+          (when (map? n) (assoc (node->entry n) :perms nil))))))
+
+  (-list-dir [_ path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (let [d (dir-id-at conn p)]
+        (when (not= ::none d) (mapv node->entry (core/ls conn d))))))
+
+  (-read-file [this path]
+    (when-let [^bytes bs (mfs/-read-bytes this path)] (String. bs "UTF-8")))
+
+  (-read-bytes [_ path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (let [n (node-at conn p)]
+        (when (and (map? n) (= :file (:fs.node/kind n)))
+          (when-let [^bytes bs (core/read-file conn (:fs.node/id n))]
+            (if (> (alength bs) read-cap-bytes)
+              (java.util.Arrays/copyOf bs read-cap-bytes)
+              bs))))))
+
+  (-open-source [this path]
+    (when-let [^bytes bs (mfs/-read-bytes this path)]
+      (java.io.ByteArrayInputStream. bs)))
+
+  (-open-sink [this path append?]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (when (not= "/" p)
+        (let [[dir-segs name] (parent-and-name p)
+              parent-p (str "/" (str/join "/" dir-segs))
+              parent-d (dir-id-at conn (if (= "/" parent-p) "/" parent-p))]
+          (when (not= ::none parent-d)
+            (let [existing (when append?
+                             (let [n (node-at conn p)]
+                               (when (and (map? n) (= :file (:fs.node/kind n)))
+                                 (some-> ^bytes (core/read-file conn (:fs.node/id n))
+                                         (String. "UTF-8")))))
+                  acc (atom (or existing ""))
+                  commit! (fn [^String s]
+                            (core/put-file! conn parent-d name (.getBytes s "UTF-8")
+                                            :mime "text/plain" :source :agent))]
+              (commit! @acc)
+              (add-watch acc ::drive-flush (fn [_ _ _ new] (commit! new)))
+              {:acc acc ::path p ::drive-sink? true}))))))
+
+  (-mkdir [_ path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (when (not= "/" p)
+        (when (nil? (node-at conn p))
+          (let [[dir-segs name] (parent-and-name p)
+                parent-p (str "/" (str/join "/" dir-segs))
+                parent-d (dir-id-at conn (if (= "/" parent-p) "/" parent-p))]
+            (when (not= ::none parent-d) (core/mkdir! conn parent-d name) true))))))
+
+  (-delete [_ path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (when-let [n (node-at conn p)]
+        (when (map? n)
+          (try (core/rm! conn (:fs.node/id n)) true (catch Exception _ nil))))))
+
+  (-rename [_ from to]
+    (let [pf (canonicalize @cwd-atom from)
+          pt (canonicalize @cwd-atom to)]
+      (when (and pf pt (not= "/" pf) (not= "/" pt))
+        (let [n (node-at conn pf)]
+          (when (and (map? n) (nil? (node-at conn pt)))
+            (let [[dir-segs name] (parent-and-name pt)
+                  parent-p (str "/" (str/join "/" dir-segs))
+                  parent-d (dir-id-at conn (if (= "/" parent-p) "/" parent-p))]
+              (when (not= ::none parent-d)
+                (core/mv! conn (:fs.node/id n) :name name :parent-id parent-d)
+                true)))))))
+
+  (-touch [this path]
+    (when-let [p (canonicalize @cwd-atom path)]
+      (when (not= "/" p)
+        (if-let [n (node-at conn p)]
+          (when (map? n) (core/mv! conn (:fs.node/id n)) true)
+          (when-let [sink (mfs/-open-sink this p false)]
+            (remove-watch (:acc sink) ::drive-flush)
+            true)))))
+
+  (-chmod [_ _ _] nil)
+  (-symlink [_ _ _] nil)
+  (-chown [_ _ _ _] nil)
+  (-sandbox-relativize [_ path] path)
+  (-physical-path [_ _] nil))
+
+(defn make
+  "DriveFS over a connected drive tree conn (dvergr.drive.core/ensure-room-drive!)."
+  [drive-conn]
+  (->DriveFS drive-conn (atom "/")))

--- a/src/dvergr/drive/integration.clj
+++ b/src/dvergr/drive/integration.clj
@@ -7,7 +7,27 @@
             [dvergr.drive.fs :as dfs]
             [dvergr.drive.blobs :as blobs]
             [dvergr.intake.bash :as bash]
+            [dvergr.system.db :as sdb]
+            [org.replikativ.spindel.engine.core :as ec]
             [taoensso.telemere :as tel]))
+
+(defn store-upload!
+  "Store an uploaded file into `room`'s drive under `subdir`, returning
+   {:note \"/drive/<subdir>/<name>\" :attachment {:node-id … :mime …}} (the shape
+   channel handlers expect), or nil. Channel-agnostic — Telegram, the web upload
+   route, mail, etc. all call this; only resolving the target Room is
+   channel-specific. `room` is a discourse Room. Binds the room's ctx."
+  [room subdir {:keys [bytes file-name mime photo? source]}]
+  (when (and room (seq bytes))
+    (when-let [rid (some-> (sdb/room-by-slug (:slug room)) :room/id)]
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [name (or file-name
+                       (str (if photo? "photo-" "file-") (subs (blobs/sha256-hex bytes) 0 8)))
+              node (drive/store-in-room! rid [subdir] name bytes
+                                         :mime mime
+                                         :source (or source (if photo? :photo :upload)))]
+          {:note (str "/drive/" subdir "/" (:fs.node/name node))
+           :attachment {:node-id (str (:fs.node/id node)) :mime mime}})))))
 
 (defn install-mounts!
   "Install the bash mounts-fn so every room's shell sees its drive at /drive

--- a/src/dvergr/drive/integration.clj
+++ b/src/dvergr/drive/integration.clj
@@ -1,0 +1,36 @@
+(ns dvergr.drive.integration
+  "Wire the room drive (dvergr.drive.*) into a running host: mount each room's
+   drive at /drive in the agent shell, and configure the blob store from the
+   host's config. A host calls `install!` once at startup (the full daemon does;
+   simmis / custom hosts call the same fn)."
+  (:require [dvergr.drive.core :as drive]
+            [dvergr.drive.fs :as dfs]
+            [dvergr.drive.blobs :as blobs]
+            [dvergr.intake.bash :as bash]
+            [taoensso.telemere :as tel]))
+
+(defn install-mounts!
+  "Install the bash mounts-fn so every room's shell sees its drive at /drive
+   (plain ls/cat/grep + the media fns). The drive is provisioned lazily on the
+   room's first shell use (idempotent). Errors degrade to no mount, never break
+   the shell."
+  []
+  (bash/set-mounts-fn!
+   (fn [chat-ctx]
+     (when-let [rid (:room-id chat-ctx)]
+       (try {"/drive" (dfs/make (drive/ensure-room-drive! rid))}
+            (catch Throwable t
+              (tel/log! {:level :warn :id ::drive-mount-failed
+                         :data {:room-id rid :error (.getMessage t)}})
+              nil))))))
+
+(defn install!
+  "Configure the blob store from `config` (`:blob-store` = a konserve store
+   config; filestore default when absent) and install the /drive mount. Idempotent."
+  [config]
+  (when-let [bs (:blob-store config)]
+    (blobs/set-store-config! bs))
+  (install-mounts!)
+  (tel/log! {:id ::drive-installed
+             :data {:blob-store (get-in config [:blob-store :backend] :file)}}
+            "Room drive installed (/drive mount + blob store)"))

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -43,6 +43,9 @@
             [dvergr.system.rooms :as srooms]
             [dvergr.system.db :as sdb]
             [dvergr.system.mail :as mail]
+            [dvergr.drive.core :as drive]
+            [dvergr.drive.blobs :as blobs]
+            [dvergr.rooms.subsystems :as subsystems]
             [dvergr.runtime.clock :as clock]
             [dvergr.substrate.git :as git]
             ;; dvergr.web.server lives in src-clients/ and is loaded
@@ -577,13 +580,30 @@
                                             (tg-send/tool-activity-html (turn-tool-lines daemon chat-id))))
    ;; Native "typing…" cue while the agent works.
    :typing-fn     (fn [chat-id] (tg/send-chat-action! token chat-id "typing"))
-   ;; Voice notes: transcribe via dvergr.audio.stt (same backend as the web mic
-   ;; and REPL voice!). requiring-resolve keeps audio an optional feature — the
-   ;; telegram handler skips voice when this cap is absent. Returns the
-   ;; transcript string (handle-inbound! adds the 🎤 marker).
+   ;; Voice notes: keep the audio content-addressed (for later playback /
+   ;; re-processing) and transcribe via dvergr.audio.stt (same backend as the
+   ;; web mic + REPL voice!). Returns {:text :attachment} so the transcript flows
+   ;; as a 🎤 message with the audio blob referenced; nil when no speech.
    :transcribe-fn (fn [{:keys [bytes mime]}]
-                    ((requiring-resolve 'dvergr.audio.stt/transcribe)
-                     {:bytes bytes :mime mime}))
+                    (let [blob (blobs/store! bytes (or mime "audio/ogg"))]
+                      (when-let [t ((requiring-resolve 'dvergr.audio.stt/transcribe)
+                                    {:bytes bytes :mime mime})]
+                        {:text t :attachment {:blob-id (:blob/id blob)
+                                              :mime (or mime "audio/ogg")}})))
+   ;; Documents / photos: land them in the room's drive under /drive/telegram/ so
+   ;; agents read them with plain ls/cat + the media fns. Returns {:note :attachment}.
+   :store-file-fn (fn [{:keys [bytes file-name mime chat-id photo?]}]
+                    (when-let [room (ensure-dm-room! daemon chat-id default-agent-id)]
+                      (when-let [rid (some-> (sdb/room-by-slug (:slug room)) :room/id)]
+                        (binding [rtc/*execution-context* (:ctx room)]
+                          (let [name (or file-name
+                                         (str (if photo? "photo-" "file-")
+                                              (subs (blobs/sha256-hex bytes) 0 8)))
+                                node (drive/store-in-room!
+                                      rid ["telegram"] name bytes
+                                      :mime mime :source (if photo? :photo :telegram))]
+                            {:note (str "/drive/telegram/" (:fs.node/name node))
+                             :attachment {:node-id (str (:fs.node/id node)) :mime mime}})))))
    ;; Label each outbound message with its sender — through one bot every
    ;; actor's reply looks the same. Actor display name (:actor/name) if set,
    ;; else the id.
@@ -963,14 +983,16 @@
         ;; on the room-register hook + rebuilt by hydrate. No global schema
         ;; install or restore pass — the clock heartbeat below drives them all.
 
-        ;; Start the daemon's single reactive clock heartbeat — the one timer
-        ;; that drives all time-based reactivity (per-room schedulers, RF5).
+        ;; Bring up per-room subsystems in one call (the same entrypoint a custom
+        ;; host uses): the /drive mount + blob store, and the single reactive
+        ;; clock heartbeat that drives all time-based reactivity (per-room
+        ;; schedulers, RF5). Room subsystems self-attach on register via hooks
+        ;; armed by loading dvergr.rooms.subsystems.
         (try
-          (binding [rtc/*execution-context* exec-ctx]
-            (clock/start!))
+          (subsystems/start-room-subsystems! exec-ctx config)
           (catch Exception e
-            (tel/log! {:level :warn :id :daemon/clock-start-failed
-                       :data {:error (.getMessage e)}} "Clock heartbeat failed to start")))
+            (tel/log! {:level :warn :id :daemon/subsystems-start-failed
+                       :data {:error (.getMessage e)}} "Room subsystems failed to start")))
 
         ;; Optional mail: attach the configured mailbox to its room + start the
         ;; daemon-side READ-ONLY IMAP pull (local-only; fork/merge never touches the

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -43,8 +43,8 @@
             [dvergr.system.rooms :as srooms]
             [dvergr.system.db :as sdb]
             [dvergr.system.mail :as mail]
-            [dvergr.drive.core :as drive]
             [dvergr.drive.blobs :as blobs]
+            [dvergr.drive.integration :as drive-integration]
             [dvergr.rooms.subsystems :as subsystems]
             [dvergr.runtime.clock :as clock]
             [dvergr.substrate.git :as git]
@@ -591,19 +591,14 @@
                         {:text t :attachment {:blob-id (:blob/id blob)
                                               :mime (or mime "audio/ogg")}})))
    ;; Documents / photos: land them in the room's drive under /drive/telegram/ so
-   ;; agents read them with plain ls/cat + the media fns. Returns {:note :attachment}.
-   :store-file-fn (fn [{:keys [bytes file-name mime chat-id photo?]}]
+   ;; agents read them with plain ls/cat + the media fns. Only resolving the
+   ;; chat's Room is Telegram-specific; storage is the shared drive-integration
+   ;; helper (web uploads, other channels use the same).
+   :store-file-fn (fn [{:keys [chat-id photo?] :as upload}]
                     (when-let [room (ensure-dm-room! daemon chat-id default-agent-id)]
-                      (when-let [rid (some-> (sdb/room-by-slug (:slug room)) :room/id)]
-                        (binding [rtc/*execution-context* (:ctx room)]
-                          (let [name (or file-name
-                                         (str (if photo? "photo-" "file-")
-                                              (subs (blobs/sha256-hex bytes) 0 8)))
-                                node (drive/store-in-room!
-                                      rid ["telegram"] name bytes
-                                      :mime mime :source (if photo? :photo :telegram))]
-                            {:note (str "/drive/telegram/" (:fs.node/name node))
-                             :attachment {:node-id (str (:fs.node/id node)) :mime mime}})))))
+                      (drive-integration/store-upload!
+                       room "telegram"
+                       (assoc upload :source (if photo? :photo :telegram)))))
    ;; Label each outbound message with its sender — through one bot every
    ;; actor's reply looks the same. Actor display name (:actor/name) if set,
    ;; else the id.

--- a/src/dvergr/rooms/subsystems.clj
+++ b/src/dvergr/rooms/subsystems.clj
@@ -1,0 +1,31 @@
+(ns dvergr.rooms.subsystems
+  "One entrypoint a host calls to bring up every per-room subsystem — so a custom
+   host (simmis, an embed) can't silently miss one and leave a subsystem dormant.
+
+   Room-level subsystems attach to each room automatically via register-hooks
+   (the scheduler spin, the message-fold). Those hooks install simply by LOADING
+   the nses that self-register — which this ns does in its `:require`, so
+   requiring `dvergr.rooms.subsystems` is enough to arm them. `start-room-subsystems!`
+   then starts the daemon clock (drives scheduler firing) and installs the /drive
+   mount + blob store.
+
+   The full daemon calls this; a custom host calls the same fn instead of
+   re-deriving the wiring by hand."
+  (:require [dvergr.rooms.scheduler]    ; installs the ::scheduler register-hook
+            [dvergr.rooms.messages]     ; installs the ::eager-signal / ::drop-room hooks
+            [dvergr.runtime.clock :as clock]
+            [dvergr.drive.integration :as drive-integration]
+            [org.replikativ.spindel.engine.core :as ec]
+            [taoensso.telemere :as tel]))
+
+(defn start-room-subsystems!
+  "Bring up per-room subsystems once (idempotent). Room subsystems (scheduler,
+   message-fold) auto-attach on room register via the hooks armed by loading this
+   ns; here we install the /drive mount + blob store and start the reactive clock
+   that drives all time-based reactivity. `config` is the host config
+   (`:blob-store` optional). `exec-ctx` is the root execution context."
+  [exec-ctx config]
+  (drive-integration/install! config)
+  (binding [ec/*execution-context* exec-ctx]
+    (clock/start!))
+  (tel/log! {:id ::room-subsystems-started} "Room subsystems started (drive + clock)"))

--- a/test/dvergr/drive/drive_test.clj
+++ b/test/dvergr/drive/drive_test.clj
@@ -1,0 +1,71 @@
+(ns dvergr.drive.drive-test
+  "Contract tests for the room drive: the CAS blob store, the fs-node tree CRUD,
+   and the muschel FS adapter. Uses an in-memory datahike tree conn to exercise
+   the tree/FS without the room-ctx machinery (that seam is create-room-db!,
+   tested via system.rooms)."
+  (:require [clojure.test :refer [deftest testing is]]
+            [dvergr.drive.blobs :as blobs]
+            [dvergr.drive.core :as drive]
+            [dvergr.drive.fs :as dfs]
+            [muschel.fs :as mfs]
+            [datahike.api :as d]))
+
+(defn- mem-drive-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn drive/fs-node-schema)
+      conn)))
+
+(deftest blob-store-roundtrip
+  (testing "content-addressed store! + get-bytes"
+    (let [bs (.getBytes "hello blob" "UTF-8")
+          {:blob/keys [id size]} (blobs/store! bs "text/plain")]
+      (is (= 64 (count id)) "sha-256 hex")
+      (is (= (count bs) size))
+      (is (= "hello blob" (String. (blobs/get-bytes id) "UTF-8")))
+      (testing "idempotent — same bytes → same id"
+        (is (= id (:blob/id (blobs/store! bs "text/plain")))))
+      (is (nil? (blobs/get-bytes "deadbeef")) "missing → nil"))))
+
+(deftest tree-crud
+  (let [conn (mem-drive-conn)]
+    (testing "mkdir / ensure-path / put-file / resolve / read"
+      (let [dir  (drive/ensure-path! conn ["telegram" "docs"])
+            node (drive/put-file! conn dir "report.txt"
+                                  (.getBytes "line one" "UTF-8")
+                                  :mime "text/plain" :source :telegram)]
+        (is (= :file (:fs.node/kind node)))
+        (is (= "line one" (String. (drive/read-file conn (:fs.node/id node)) "UTF-8")))
+        (is (= (:fs.node/id node)
+               (:fs.node/id (drive/resolve-path conn "telegram/docs/report.txt"))))))
+    (testing "same name ⇒ new version (node points at new content)"
+      (let [dir (drive/ensure-path! conn ["telegram" "docs"])]
+        (drive/put-file! conn dir "report.txt" (.getBytes "line two" "UTF-8") :mime "text/plain")
+        (is (= "line two"
+               (String. (drive/read-file conn (:fs.node/id (drive/resolve-path conn "telegram/docs/report.txt")))
+                        "UTF-8")))))
+    (testing "ls sorts dirs first"
+      (let [root (drive/ls conn)]
+        (is (= ["telegram"] (mapv :fs.node/name root)))))
+    (testing "rm on a non-empty dir throws; empty succeeds"
+      (let [f (drive/resolve-path conn "telegram/docs/report.txt")]
+        (is (thrown? Exception (drive/rm! conn (:fs.node/id (drive/resolve-path conn "telegram")))))
+        (is (= :removed (drive/rm! conn (:fs.node/id f))))
+        (is (nil? (drive/resolve-path conn "telegram/docs/report.txt")))))))
+
+(deftest drive-fs-adapter
+  (let [conn (mem-drive-conn)
+        dir  (drive/ensure-path! conn ["inbox"])
+        _    (drive/put-file! conn dir "note.md" (.getBytes "# hi" "UTF-8") :mime "text/markdown")
+        fs   (dfs/make conn)]
+    (testing "muschel FS reads the tree through ls/read"
+      (is (= ["note.md"] (mapv :name (mfs/-list-dir fs "/inbox"))))
+      (is (= "# hi" (mfs/-read-file fs "/inbox/note.md")))
+      (is (some? (mfs/-stat fs "/inbox")))
+      (is (nil? (mfs/-read-bytes fs "/inbox/absent"))))
+    (testing "write through the FS commits to the tree + CAS"
+      (let [sink (mfs/-open-sink fs "/inbox/written.txt" false)]
+        (reset! (:acc sink) "from the shell")
+        (is (= "from the shell" (mfs/-read-file fs "/inbox/written.txt")))))))


### PR DESCRIPTION
Ports simmis's file-storage stack into dvergr so file storage is consistent for the standalone daemon (Telegram documents/photos, web uploads) and simmis can converge onto dvergr's version. Plus item 3 from the backlog (subsystem self-start).

## The drive
- **`dvergr.drive.blobs`** — content-addressed store keyed by SHA-256, via konserve's generic `connect-store` lifecycle (backend selected by config: filestore default under `.dvergr/blobs`, swappable to s3/tiered/… by config alone). CAS dedup is global across rooms.
- **`dvergr.drive.core`** — fs-node datahike tree + CRUD (`ls`/`put-file!`/`read-file`/`mkdir!`/`resolve-path`/`mv!`/`rm!`/`tree`). The tree DB is a room-owned system via `dvergr.system.rooms/create-room-db!`, so it **forks/merges with the room** and its grant persists — reusing dvergr's machinery instead of a bespoke registry.
- **`dvergr.drive.fs`** — `muschel.fs/FS` adapter; mounted at `/drive` so agents read files with plain `ls`/`cat`/`grep` through the existing shell tool.

## Wiring
- **`dvergr.drive.integration`** — `install!` configures the blob store from host config (`:blob-store`) and installs the bash mounts-fn (`/drive` per room, lazy, errors → no mount). `store-upload!` is the **channel-agnostic** helper (room + subdir + upload → `{:note :attachment}`); only resolving the target Room is channel-specific.
- **daemon telegram-caps** — `:store-file-fn` lands documents/photos in `/drive/telegram/`; `:transcribe-fn` content-addresses the audio blob and returns `{:text :attachment}`.

## Item 3 — subsystem self-start
- **`dvergr.rooms.subsystems/start-room-subsystems!`** — one entrypoint that arms the per-room register-hooks (by loading the self-registering nses), installs the drive, and starts the clock. The daemon calls it (replacing the scattered drive-install + clock-start); a custom host (simmis) calls the same fn instead of re-deriving the wiring — killing the "dormant subsystem" class.

## Config
Store configs are konserve config maps (same shape datahike uses). Resolution: `blobs/set-store-config!` override → `config.local.edn :blob-store` → filestore default.

Verified end-to-end (blob roundtrip, tree CRUD, DriveFS list/read/write); drive contract tests green (3 tests / 18 assertions); daemon cold-compiles.