### PR TITLE
feat(tools): sane default tool grant + named profiles; seed contract tests

### DIFF
--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -18,7 +18,7 @@
           :spec   {:provider :anthropic
                    :model    \"claude-sonnet-4-6\"
                    :system-prompt \"You are a research assistant.\"}
-          :tools  #{:clojure_eval}
+          :tools  :knowledge-worker         ; a named profile — or an explicit set
           :budget {:dollars 0.50}}))
 
    When the dollar budget hits zero, the agent loop escalates via
@@ -106,8 +106,10 @@
 
    :id          — keyword participant id (required)
    :spec        — {:provider :model :system-prompt} (required)
-   :tools       — set/vector of tool names from `dvergr.tools` registry, OR
-                  a map of name → tool-def (for pre-wrapped tools)
+   :tools       — a `dvergr.tools` profile keyword (:dev-toolbelt,
+                  :knowledge-worker), a set/vector of tool names, OR a map of
+                  name → tool-def (pre-wrapped). Default: :dev-toolbelt
+                  (`minimal-coding-tools`). Pass `#{}` for a no-tools agent.
    :db-conn     — datahike connection for chat persistence (optional)
    :budget      — {:dollars n :checkpoint-grace-ms n}
                   (default {:dollars 1.0 :checkpoint-grace-ms 60000}).
@@ -135,7 +137,12 @@
     :or   {budget      {:dollars 1.0}
            compaction  {:auto? true :strategy :sync-before-turn}
            run-turn-fn default-run-turn
-           room-safe?  true}}]
+           room-safe?  true
+           ;; Sane default toolbelt instead of the bare `#{:clojure_eval}` poverty
+           ;; trap — file ops + jailed shell + clojure_eval (web/data/knowledge via
+           ;; the SCI sandbox). Override with a `dvergr.tools` profile keyword
+           ;; (:dev-toolbelt / :knowledge-worker) or an explicit tool set.
+           tools       tools/minimal-coding-tools}}]
   {:pre [(keyword? id) (map? spec)]}
   (let [ctx       (or ctx ec/*execution-context*)
         ;; Room-less FALLBACK working ctx (sidecar / d/hire / tests). When the

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -69,16 +69,30 @@
    program, no file mutation."
   #{:read-file :shell :clojure-eval})
 
+(def tool-profiles
+  "Named, reusable tool-sets — grant one by name (`:tools :dev-toolbelt`) instead
+   of re-listing individual tools per agent. A 'role' is just one of these (plain
+   data). All reach the web / datahike / knowledge / tasks surface through
+   `clojure_eval`'s SCI sandbox; the named tools are the structured file/shell ops."
+  {:dev-toolbelt     minimal-coding-tools     ; read/write/edit/clojure-edit + shell + clojure_eval
+   :knowledge-worker minimal-readonly-tools   ; read + shell + clojure_eval (inspect + program, no mutation)
+   :readonly         minimal-readonly-tools})
+
 (defn normalize-tools
   "Normalize a tools spec to the name→tool-def map `tool-definitions` expects.
-   Accepts a map (passed through), or a set/seq of tool NAMES (keywords or
-   strings) resolved against the registry. Keyword names are munged to the
-   registry's underscore form (e.g. :read-file → \"read_file\"). Anything else
-   passes through unchanged. Single source of truth for the `llm-agent` :tools
-   contract — callers (personas, daemon) should not reach into the registry
-   themselves."
+   Accepts:
+   - a **profile keyword** (`:dev-toolbelt`, `:knowledge-worker`, …) resolved via
+     `tool-profiles`,
+   - a map (passed through),
+   - a set/seq of tool NAMES (keywords or strings) resolved against the registry
+     (keyword names munged to the registry's underscore form, e.g. :read-file →
+     \"read_file\").
+   Single source of truth for the `llm-agent` :tools contract — callers (personas,
+   daemon) should not reach into the registry themselves."
   [tools]
   (cond
+    (and (keyword? tools) (contains? tool-profiles tools))
+    (recur (get tool-profiles tools))
     (map? tools) tools
     (or (set? tools) (sequential? tools))
     (let [name-strs (map #(if (keyword? %) (str/replace (name %) "-" "_") (str %)) tools)]

--- a/test/dvergr/contract_test.clj
+++ b/test/dvergr/contract_test.clj
@@ -1,0 +1,74 @@
+(ns dvergr.contract-test
+  "Contract tests — one assertion per claim the system (and the agent prompt)
+   makes about its own capabilities, so prompt and infra can't drift apart
+   silently. Each failure here means a promise the harness stopped keeping.
+   Grow this file whenever a prompt-vs-infra mismatch is fixed."
+  (:require [clojure.test :refer [deftest testing is]]
+            [dvergr.tools :as tools]
+            [dvergr.scheduler.cron :as cron]
+            [dvergr.sandbox.ns.io :as sio]
+            [sci.core :as sci]))
+
+;; ── Tool grant (the default must not be the `#{:clojure_eval}` poverty trap) ──
+
+(deftest tool-profiles-resolve
+  (testing "named profiles resolve to non-empty tool maps"
+    (doseq [p [:dev-toolbelt :knowledge-worker :readonly]]
+      (is (seq (tools/normalize-tools p)) (str p " resolves to some tools"))))
+  (testing ":dev-toolbelt is a real coding toolbelt, not bare clojure_eval"
+    (let [tset (set (keys (tools/normalize-tools :dev-toolbelt)))]
+      (is (contains? tset "clojure_eval"))
+      (is (contains? tset "read_file"))
+      (is (contains? tset "write_file"))
+      (is (contains? tset "shell"))
+      (is (> (count tset) 1) "more than the single clojure_eval")))
+  (testing ":knowledge-worker inspects + programs, no file mutation"
+    (let [tset (set (keys (tools/normalize-tools :knowledge-worker)))]
+      (is (contains? tset "read_file"))
+      (is (contains? tset "clojure_eval"))
+      (is (not (contains? tset "write_file")))))
+  (testing "explicit tool sets and no-tools still work (backward compat)"
+    (is (= #{"read_file" "shell"} (set (keys (tools/normalize-tools #{:read-file :shell})))))
+    (is (= {} (tools/normalize-tools #{})) "empty set ⇒ no tools")
+    (is (= :not-a-profile (tools/normalize-tools :not-a-profile)) "unknown keyword passes through")))
+
+;; ── Scheduler cron: :n / interval validation is strict (no silent wrong cadence) ──
+
+(deftest cron-rejects-bad-specs
+  (let [now (java.util.Date.)]
+    (testing ":n must be a positive integer"
+      (is (thrown? Exception (cron/spec->attrs {:every :hour :n 0} now)))
+      (is (thrown? Exception (cron/spec->attrs {:every :hour :n -2} now))))
+    (testing ":n can't combine with a calendar anchor"
+      (is (thrown? Exception (cron/spec->attrs {:every :week :n 2 :on :mon} now))))
+    (testing "raw interval must be positive"
+      (is (thrown? Exception (cron/spec->attrs {:interval-ms 0} now))))
+    (testing "valid specs still produce the right kind"
+      (is (= :interval (:schedule/kind (cron/spec->attrs {:every :hour :n 4} now))))
+      (is (= :recurring (:schedule/kind (cron/spec->attrs {:every :day :at "07:00" :on :mon} now)))))))
+
+;; ── Sandbox fs: paths agents see are workspace-relative, never the host path ──
+
+(deftest sandbox-fs-paths-are-workspace-relative
+  (let [base (.toFile (java.nio.file.Files/createTempDirectory
+                       "contract" (make-array java.nio.file.attribute.FileAttribute 0)))
+        _    (.mkdirs (java.io.File. base "src"))
+        _    (spit (java.io.File. base "src/a.txt") "hi")
+        ctx  (sci/init {})
+        _    (sio/add-fs-ns! ctx :base-path (.getAbsolutePath base))
+        run  #(sci/eval-string* ctx %)]
+    (testing "listings are workspace-relative, not the real .dvergr/systems/<uuid> path"
+      (is (= ["src/a.txt"] (run "(babashka.fs/list-dir \"src\")")))
+      (is (= "src" (run "(babashka.fs/parent \"src/a.txt\")"))))
+    (testing "fs/parent of the root never leaks the host path (returns nil)"
+      (is (nil? (run "(babashka.fs/parent \".\")"))))
+    (testing "a relative path round-trips back through slurp"
+      (is (= "hi" (run "(slurp (first (babashka.fs/list-dir \"src\")))"))))))
+
+;; ── Media: the capabilities the agent prompt references exist ──
+
+(deftest media-capabilities-exist
+  (testing "vision + document extraction fns the prompt/docs promise are present"
+    (is (some? (requiring-resolve 'dvergr.media.vision/describe)))
+    (is (some? (requiring-resolve 'dvergr.media.vision/extract)))
+    (is (some? (requiring-resolve 'dvergr.media.doc/extract-text)))))


### PR DESCRIPTION
Backlog items 2 and 1 (seed) from the trench list.

## Item 2 — default tool grant
`llm-agent` defaulted to bare `#{:clojure_eval}` — the poverty trap every host re-discovered (simmis hand-rolled `{:tools #{"clojure_eval" "knowledge_search" …}}`). dvergr already had `minimal-coding-tools` / `minimal-readonly-tools`; they just weren't the default or discoverable.

- `llm-agent` now defaults `:tools` to **`minimal-coding-tools`** (file ops + jailed shell + `clojure_eval`), not bare `clojure_eval`.
- **`dvergr.tools/tool-profiles`** — named, reusable sets granted by keyword: `:dev-toolbelt`, `:knowledge-worker`, `:readonly`. `normalize-tools` resolves a profile keyword, so `:tools :dev-toolbelt` works.
- Sets and `#{}` (no-tools) still work — backward compatible. The docstring example no longer teaches the trap.

## Item 1 (seed) — contract tests
`test/dvergr/contract_test.clj` — one assertion per capability the system (and the agent prompt) claims, so prompt and infra can't drift apart silently. Each failure = a promise the harness stopped keeping. Seeded with:
- the tool grant (profiles resolve; default isn't the poverty trap; sets/`#{}` still work),
- cron `:n`/interval validation (rejects `:n 0`/negative/`:n`+`:on`/`interval-ms 0`),
- sandbox fs workspace-relative paths (`fs/parent` of the root doesn't leak the host `.dvergr/systems/<uuid>` path),
- the media fns' existence (`vision/describe`, `vision/extract`, `doc/extract-text`).

Grow it whenever a prompt-vs-infra mismatch is fixed. 27 assertions green.