### PR TITLE
feat(drive): host-pluggable conn resolver + reconfig-aware blob store + link-blob!

### DIFF
--- a/src/dvergr/drive/blobs.clj
+++ b/src/dvergr/drive/blobs.clj
@@ -45,8 +45,19 @@
       (kstore/connect-store config opts)
       (kstore/create-store config opts))))
 
-(defonce ^:private store
-  (delay (connect-or-create! (resolve-config))))
+;; Config-keyed store cache (NOT a one-shot delay): a host calling
+;; set-store-config! after something already touched the store (boot
+;; ordering, another subsystem) must still get the reconfigured store —
+;; the cache invalidates when the resolved config changes.
+(defonce ^:private store-state (atom nil))
+
+(defn- the-store []
+  (let [cfg (resolve-config)
+        st  @store-state]
+    (if (= (:config st) cfg)
+      (:store st)
+      (:store (reset! store-state {:config cfg
+                                   :store (connect-or-create! cfg)})))))
 
 (defn sha256-hex [^bytes bs]
   (let [d (.digest (MessageDigest/getInstance "SHA-256") bs)]
@@ -57,7 +68,7 @@
    :blob/size n}. Idempotent (same content → same id, single copy)."
   [^bytes bytes mime]
   (let [id (sha256-hex bytes)]
-    (k/bassoc @store id bytes {:sync? true})
+    (k/bassoc (the-store) id bytes {:sync? true})
     (log/log! {:level :debug :id ::blob-stored
                :data {:blob id :size (count bytes) :mime mime}})
     {:blob/id id :blob/mime mime :blob/size (count bytes)}))
@@ -66,7 +77,7 @@
   "Fetch blob bytes by id, nil when absent."
   [id]
   (try
-    (k/bget @store id
+    (k/bget (the-store) id
             (fn [{:keys [input-stream]}]
               (.readAllBytes ^java.io.InputStream input-stream))
             {:sync? true})

--- a/src/dvergr/drive/core.clj
+++ b/src/dvergr/drive/core.clj
@@ -50,12 +50,23 @@
   [room-id]
   (srooms/room-db-conn room-id drive-db-name))
 
+(defonce ^{:doc "Host-pluggable room-id → drive tree conn resolver. Hosts with
+  their own drive topology (e.g. simmis: named drives in a registry, attached
+  to rooms via grants) install a resolver via `set-conn-resolver!` /
+  `integration/install! :drive-conn-fn`; nil (default) uses the room-owned
+  drive DB below. The resolver returns a datahike conn (schema: fs-node-schema)
+  or nil to fall through."}
+  conn-resolver (atom nil))
+
+(defn set-conn-resolver! [f] (reset! conn-resolver f))
+
 (defn ensure-room-drive!
-  "The room's drive tree conn, provisioning it on first need as a room-owned
-   datahike system (forks/merges with the room; grant persisted). Requires the
-   room's ctx bound (the caller runs in it)."
+  "The room's drive tree conn: the host resolver when installed, else the
+   room-owned datahike system (forks/merges with the room; grant persisted),
+   provisioned on first need. Requires the room's ctx bound."
   [room-id & {:keys [owner-id]}]
-  (or (room-drive-conn room-id)
+  (or (when-let [f @conn-resolver] (f room-id))
+      (room-drive-conn room-id)
       (srooms/create-room-db! room-id drive-db-name
                               :schema fs-node-schema :owner-id owner-id)))
 
@@ -129,6 +140,25 @@
     (d/transact conn [node])
     (log/log! {:level :info :id ::file-put
                :data {:name name :size (count bytes) :blob (:blob/id blob)}})
+    node))
+
+(defn link-blob!
+  "Upsert a file node pointing at an EXISTING CAS blob — the browser upload
+   path: bytes go to the blob store first, then the node transact references
+   the hash (no double transfer)."
+  [conn parent-id name blob-id mime size source]
+  (let [existing (child-by-name @conn parent-id name)
+        id (or (:fs.node/id existing) (random-uuid))
+        node (cond-> {:fs.node/id id
+                      :fs.node/name name
+                      :fs.node/kind :file
+                      :fs.node/blob (str blob-id)
+                      :fs.node/mime (or mime "application/octet-stream")
+                      :fs.node/size (long size)
+                      :fs.node/mtime (java.util.Date.)
+                      :fs.node/source (or source :upload)}
+               parent-id (assoc :fs.node/parent [:fs.node/id parent-id]))]
+    (d/transact conn [node])
     node))
 
 (defn stat

--- a/src/dvergr/drive/integration.clj
+++ b/src/dvergr/drive/integration.clj
@@ -50,6 +50,8 @@
   [config]
   (when-let [bs (:blob-store config)]
     (blobs/set-store-config! bs))
+  (when-let [f (:drive-conn-fn config)]
+    (drive/set-conn-resolver! f))
   (install-mounts!)
   (tel/log! {:id ::drive-installed
              :data {:blob-store (get-in config [:blob-store :backend] :file)}}


### PR DESCRIPTION
Drive follow-ups landed while porting simmis over to dvergr's drive — the hooks simmis needs to converge onto dvergr's version instead of keeping its own copies.

- **Host-pluggable conn resolver** (`drive.core/set-conn-resolver!`, `integration/install! :drive-conn-fn`): a host with its own drive topology — simmis has named drives in a registry attached to rooms via grants — installs a `room-id → drive-conn` resolver; `ensure-room-drive!` tries it first, falling back to dvergr's room-owned drive DB. Lets simmis reuse the whole tree/FS/blob layer with its own storage backing.
- **Reconfig-aware blob store**: replace the one-shot `delay` with a config-keyed cache, so a host calling `set-store-config!` *after* something already touched the store (boot ordering, another subsystem) still gets the reconfigured store — the cache invalidates when the resolved config changes.
- **`link-blob!`**: upsert a file node pointing at an existing CAS blob — the browser-upload path (bytes to the blob store first, then reference the hash; no double transfer).

Verified: compiles; the reconfig-store fix confirmed (set-store-config! after first touch takes effect); drive contract tests green (3/18). No API changes to existing callers.