### PR TITLE
chore(deps): spindel 0.1.29 -> 0.1.35 (lost-wakeup redesign + thread-safe pubsub buffers)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,8 +32,23 @@
         ;; via spindel — not declared here, so spindel is the single source of its
         ;; version. The `:local` alias's `../spindel` override carries it too.
 
-        ;; Spindel — Reactive runtime with CoW forking
-        org.replikativ/spindel     {:mvn/version "0.1.29"}
+        ;; Spindel — Reactive runtime with CoW forking.
+        ;; 0.1.35 (#27 lost-wakeup redesign + follow-ups): continuation
+        ;; failures reject the owning spin (spawn!/supervisor observe
+        ;; them), one-shot waiter handoffs run as :cont-resume events
+        ;; with a transactional pop+enqueue, engine-wide fault hook
+        ;; (engine.fault/set-fault-reporter!). Forks inherit NO events —
+        ;; an event is delivered in exactly one world; in-flight mailbox
+        ;; claims are undone in the fork (spindel#30, fixes the
+        ;; duplicate room-log writes 0.1.31 caused in hire!). Node-record
+        ;; invariant enforced at field-write sites (spindel#31/#32).
+        ;; Pubsub buffers are atom-backed (spindel#34/#35): the JVM
+        ;; LinkedList buffers were a cross-thread data race that could
+        ;; silently lose one delivery in exactly OUR bus topology
+        ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
+        ;; Substrate for the durable-cursor bus pump + supervisor
+        ;; restart.
+        org.replikativ/spindel     {:mvn/version "0.1.35"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context


### PR DESCRIPTION
Adopts the spindel engine's failure-routing + resume-as-event + transactional handoff redesign and its follow-ups (replikativ/spindel#29 #30 #32 #33 #35; closes spindel#27 and the correctness scope of spindel#31/#34):

- A consumer/pump continuation that throws now **rejects its spin loudly** — `spawn!`'s `:on-error` and `spin/supervisor` restart policies observe it. The permanently-silent PENDING wedge class (room-bus source pump, participant inboxes) is gone.
- One-shot waiter handoffs (mailbox / deferred / pubsub promise / semaphore) run as `:cont-resume` drain events with a transactional pop+enqueue; a waiter cancelled in flight has its message re-posted losslessly.
- Engine-wide fault hook: `engine.fault/set-fault-reporter!` covers continuation and executor-task faults in addition to the pubsub events — worth routing into Telemere at daemon boot.
- **Forks deliver events in one world only**; in-flight mailbox claims are undone in the fork. (An intermediate release briefly inherited in-flight events into forks, which duplicated `hire!`'s durable `:running` log write — caught by this repo's `hire-tracks-lifecycle`; never pinned anywhere.)
- Node-record invariant enforced at field-write sites — completions can no longer be silently stranded by a plain-map node.
- **Pubsub buffers are atom-backed** (spindel#35): the JVM `LinkedList` buffers were a cross-thread data race that could silently lose one delivery in exactly *our* bus topology (mailbox → mult → tap → pub → topic-mult → tap) under load — 0/60 stress cycles with the fix vs ≈2/60 before.

Verified against the release (no `:local` overlay): **358 tests / 1403 assertions / 0 failures**, including `hire-tracks-lifecycle`.

This is the substrate for the planned durable-cursor bus pump + supervisor restart (retiring the simmis pump watchdog's out-of-band healing) — design to follow separately.