### PR TITLE
feat(bus): durable-cursor fan-out — log-first delivery, supervised pump, durability before visibility

### DIFF
--- a/src/dvergr/clients/client.clj
+++ b/src/dvergr/clients/client.clj
@@ -244,9 +244,14 @@
   [log-atom pred]
   (let [p (promise), wid (random-uuid)
         try! (fn [snap e] (when-not (realized? p) (when-let [v (pred snap e)] (deliver p v))))]
+    ;; The bus log atom holds {:entries [...] :cursor n} (durable-cursor
+    ;; bus) — watch the :entries vector.
     (add-watch log-atom wid
-               (fn [_ _ old new] (try! new (when (> (count new) (count old)) (peek new)))))
-    (doseq [e @log-atom :while (not (realized? p))] (try! @log-atom e))
+               (fn [_ _ old new]
+                 (let [o (:entries old) n (:entries new)]
+                   (try! n (when (> (count n) (count o)) (peek n))))))
+    (doseq [e (:entries @log-atom) :while (not (realized? p))]
+      (try! (:entries @log-atom) e))
     (future (try @p (finally (remove-watch log-atom wid))))
     p))
 
@@ -271,7 +276,7 @@
           (when-not (realized? p)
             (let [idle (- (System/currentTimeMillis) @last-at)]
               (if (>= idle idle-ms)
-                (deliver p @log-atom)
+                (deliver p (:entries @log-atom))
                 (do (Thread/sleep (max 100 (- idle-ms idle))) (recur))))))
         (finally (remove-watch log-atom wid))))
     p))

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -70,9 +70,10 @@
   ;; bus           : dvergr.runtime.bus.Bus — the routing substrate
   ;; ctx           : spindel ExecutionContext (== bus's ctx)
   ;; forked-at-len : index into bus's log at fork time (nil/0 for root rooms)
-  ;; store         : nil or PRoomStore for durability. When non-nil, an
-  ;;                 internal spin mirrors every message posted to the
-  ;;                 bus into the store.
+  ;; store         : nil or PRoomStore for durability. When non-nil, the
+  ;;                 bus persists every message-shaped event inside
+  ;;                 post! — durability BEFORE visibility (the bus's
+  ;;                 :durable-append! hook, wired in make-room).
   ;; meta          : atom of arbitrary metadata (:telegram-chat-id,
   ;;                 :type :internal | :telegram-mirror, etc.)
            [id slug title parent-id participants bus ctx forked-at-len store meta])
@@ -156,15 +157,14 @@
    (when one is registered in the current ctx). Falls back to a plain
    bus if not — keeps tests / library use happy without daemon
    bootstrap."
-  [ctx room-id scope]
+  [ctx room-id scope & [{:keys [durable-append!]}]]
   (let [peer (binding [ec/*execution-context* ctx] (peer-bus/current))]
     (bus/create-bus
      (cond-> {:ctx ctx}
+       durable-append! (assoc :durable-append! durable-append!)
        peer (assoc :relay-to  peer
                    :relay-tag {:dvergr/origin room-id
                                :dvergr/scope  scope})))))
-
-(declare spawn-persistence-listener!)
 
 (defn make-room
   "Create a Room from an opts map. The unified Room constructor.
@@ -188,16 +188,29 @@
   (let [ctx   (or ctx (sp/create-execution-context))
         slug  (or slug (name id))
         title (or title slug)
-        b     (bus-with-peer-relay ctx id :room)
+        ;; Durability-first (durable-cursor bus): the bus persists each
+        ;; message-shaped event into the store INSIDE post!, before the
+        ;; message becomes visible anywhere. A store failure fails the
+        ;; post loudly — the inverse of the old persistence LISTENER,
+        ;; which observed the ephemeral pipeline downstream and could
+        ;; silently lose durability (or, if the pipeline lost the
+        ;; message, lose it entirely). The conversation id is resolved
+        ;; from :meta here (a fork persists under its chain root — same
+        ;; rule as `conversation-id`, computed pre-construction).
+        conv-id (or (:conversation-id meta) id)
+        durable-append! (when store
+                          (fn [msg]
+                            (when (rstore/message-shape? msg)
+                              (rstore/-store-message! store conv-id msg))))
+        b     (bus-with-peer-relay ctx id :room
+                                   (when durable-append!
+                                     {:durable-append! durable-append!}))
         room  (->Room id slug title parent-id (atom {}) b ctx 0 store (atom (or meta {})))]
     ;; Persist metadata on creation so the store has it for re-hydration.
     (when store
       (rstore/-store-room! store id (cond-> {:id id :slug slug :title title}
                                       parent-id (assoc :parent-id parent-id)
-                                      (seq meta) (assoc :meta meta)))
-      ;; Spawn the durability listener — every message-shaped event on
-      ;; the bus gets mirrored into the store.
-      (spawn-persistence-listener! room))
+                                      (seq meta) (assoc :meta meta))))
     ;; Auto-register so every Room is discoverable via the registry.
     (binding [ec/*execution-context* ctx]
       (rreg/register! room))
@@ -355,30 +368,6 @@
    (no out-of-band `append-log!`). See doc/unified-fork-conversation.md."
   [room]
   (or (some-> room :meta deref :conversation-id) (:id room)))
-
-(defn- spawn-persistence-listener!
-  "When the Room has a `:store`, mirror every message-shaped event on
-   the bus into the store. Idempotent at the store layer (re-stores on
-   the same `:message/id` are no-ops), so re-firing across drain cycles
-   is harmless."
-  [room]
-  (binding [ec/*execution-context* (:ctx room)]
-    (let [sub (bus/subscribe! (:bus room) [:type :user/message])]
-      (sp/spawn!
-       (sp/spin
-        (loop [s (:aseq sub)]
-          (when-let [r (sp/await (anext s))]
-            (let [[msg rest-s] r]
-              (try
-                (when (rstore/message-shape? msg)
-                  (rstore/-store-message! (:store room) (conversation-id room) msg))
-                (catch Throwable t
-                    ;; Durability boundary — a failure here means a message did
-                    ;; NOT persist to the room store. Must be visible, never lost.
-                  (tel/log! {:level :error :id :room/persist-failed
-                             :data {:room (:id room) :from (:from msg)
-                                    :error (.getMessage t)}})))
-              (recur rest-s)))))))))
 
 (defn on-each-message
   "Spawn a listener that calls `(f msg)` for EVERY conversational message posted
@@ -696,11 +685,6 @@
          _          (when (= :ctx isolation)
                       (binding [ec/*execution-context* child-ctx]
                         (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
-         child-bus  (bus-with-peer-relay child-ctx new-id :fork)
-         ;; Seed the fork's bus log with parent history so log-based
-         ;; consumers see a continuous record. Forks have their OWN bus
-         ;; so live messages do not leak between parent and fork.
-         _          (bus/seed-log! child-bus parent-log)
          ;; `:isolation :ctx` forks BRANCH the parent's conversation. The fork
          ;; gets its OWN store wrapping the fork ctx's BRANCHED chat-db conn
          ;; (NOT the parent's fixed-conn store), and persists under the parent's
@@ -717,6 +701,20 @@
                       (some-> (binding [ec/*execution-context* child-ctx]
                                 (srooms/msgs-conn-for-slug (:slug room)))
                               store-dh/make))
+         ;; Durability-first for the fork too: fork-local messages persist
+         ;; onto the BRANCH (under the root conversation id) inside post!,
+         ;; before visibility — replacing the fork's persistence listener.
+         child-bus  (bus-with-peer-relay child-ctx new-id :fork
+                                         (when fork-store
+                                           {:durable-append!
+                                            (fn [msg]
+                                              (when (rstore/message-shape? msg)
+                                                (rstore/-store-message! fork-store conv-id msg)))}))
+         ;; Seed the fork's bus log with parent history so log-based
+         ;; consumers see a continuous record (the cursor starts past it —
+         ;; history is never re-delivered). Forks have their OWN bus so
+         ;; live messages do not leak between parent and fork.
+         _          (bus/seed-log! child-bus parent-log)
          new-room   (->Room new-id new-slug
                             (str (:title room) " · fork " short-uuid)
                             (:id room)
@@ -728,9 +726,8 @@
                             (atom (assoc @(:meta room)
                                          :forked-from (:id room)
                                          :conversation-id conv-id)))]
-     ;; Persist fork-local messages onto the branch under the root conversation.
-     (when (and (= :ctx isolation) fork-store)
-       (spawn-persistence-listener! new-room))
+     ;; (Fork-local persistence rides the bus's durable-append! hook now —
+     ;; wired at child-bus construction above.)
      ;; Register the fork in the PARENT ctx — where the daemon UI reads the
      ;; registry. A `:ctx` fork's own child-ctx is invisible to the parent
      ;; (CoW), so registering there would hide the fork from the tree (and it

--- a/src/dvergr/runtime/bus.clj
+++ b/src/dvergr/runtime/bus.clj
@@ -7,8 +7,21 @@
      [:to   <participant-id>]  — direct routing to a participant
      [:type <tag>]             — capability routing by message tag
 
-   Both dimensions are pubs over the same source mailbox via an upstream
-   mult, so each message reaches every matching subscription.
+   Both dimensions are pubs over one upstream mult, so each message
+   reaches every matching subscription.
+
+   LOG-FIRST FAN-OUT (durable-cursor model): `post!` (1) durably
+   persists the message when the bus carries a `:durable-append!` hook
+   (rooms with a store — durability BEFORE visibility), (2) appends it
+   to the bus log — the fan-out source of truth, so log order == post
+   order — and (3) rings a doorbell. A SUPERVISED pump delivers log
+   entries into the mult and advances a cursor AFTER each handoff.
+   Losing the pump loses promptness, never data: the supervisor
+   restarts it and it resumes from the cursor, re-delivering at most
+   the one in-flight entry (participants dedup by message :id, so the
+   observed contract is effectively-once). This replaces the previous
+   ephemeral-first pipeline, whose losses were total and whose pump
+   was only recoverable by the out-of-band watchdog healing.
 
    The opinionated layer is `default-buffers` — a map from tag namespace
    (the `namespace` of `:type`) to a 0-arg buffer-builder. The defaults
@@ -46,6 +59,7 @@
             [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.pubsub.pub :as pub]
             [org.replikativ.spindel.pubsub.buffer :as buf]
+            [org.replikativ.spindel.spin.supervisor :as supervisor]
             [taoensso.telemere :as tel]))
 
 ;; ============================================================================
@@ -96,30 +110,82 @@
 (defrecord Bus
            [;; spindel execution context
             ctx
-   ;; mailbox: every post! lands here; PAsyncSeq source for the mult
+   ;; mailbox feeding the mult — written ONLY by the fan-out pump
             source-mbox
-   ;; mult fanning out to the routing pubs + log
+   ;; mult fanning out to the routing pubs + relay
             source-mult
    ;; pub keyed by :to (direct-to-participant routing)
             to-pub
    ;; pub keyed by :type (capability routing)
             type-pub
-   ;; atom vector — history, updated by a tap on source-mult
-            log])
+   ;; atom of {:entries [msg…] :cursor n} — the LOG-FIRST fan-out model:
+   ;; post! appends here (upstream of delivery, so log order == post
+   ;; order and a message is on record before any consumer sees it);
+   ;; the pump delivers entries[cursor..] into the mult and advances.
+   ;; One atom for both so seed/append-as-history compose race-free
+   ;; with live posts (see append-log!).
+            log
+   ;; mailbox used as a data-free doorbell: post! rings it, the pump
+   ;; parks on it when the log is drained
+            hint-mbx
+   ;; optional (fn [msg]) called by post! BEFORE the message becomes
+   ;; visible — the durability-first hook (rooms pass a store append).
+   ;; A throw here fails the post loudly; nothing is half-delivered.
+            durable-append!
+   ;; the supervised fan-out pump (spin) — kept for introspection
+            pump])
 
-(defn- spawn-log-drain!
-  "Spawn a spin that consumes every message from the source-mult and
-   appends it to the log atom."
-  [ctx source-mult log-atom]
+(def ^:private history-key
+  "Metadata key marking log entries absorbed as HISTORY (fork seeding /
+   merge-as-history) — on record, never delivered to live handlers.
+   Metadata, not an entry field, so log readers see unpolluted messages."
+  ::history)
+
+(defn- spawn-fanout-pump!
+  "Spawn the supervised fan-out pump: delivers log entries[cursor..]
+   into `source-mbox` (feeding the existing mult topology) and advances
+   the cursor AFTER each handoff; parks on `hint-mbx` when drained.
+
+   Crash-only by construction: the cursor lives in the log-state atom,
+   so a pump that dies mid-stream is restarted by its supervisor and
+   resumes where it left off. The restart re-delivers at most the one
+   entry whose handoff was in flight (at-least-once); participants
+   dedup by message :id (see discourse/participant-spin), making the
+   observed contract effectively-once. Entries marked as history
+   (fork seeding / merge absorption) advance the cursor without
+   delivery.
+
+   The cursor advance uses a max-guard so it composes with seed-log!'s
+   cursor reset (which only ever moves it forward past history)."
+  [ctx log-state hint-mbx source-mbox]
   (binding [ec/*execution-context* ctx]
-    (let [log-tap (mult/tap source-mult (buf/fixed-buffer 1024))]
-      (sync/spawn!
-       (spin
-        (loop [s log-tap]
-          (when-let [r (await (aseq/anext s))]
-            (let [[msg rest-s] r]
-              (swap! log-atom conj msg)
-              (recur rest-s)))))))))
+    (let [pump-fn
+          (fn []
+            (spin
+             (loop []
+               (let [{:keys [entries cursor]} @log-state]
+                 (if (< cursor (count entries))
+                   (let [e (nth entries cursor)]
+                     (when-not (history-key (meta e))
+                       (sync/post! source-mbox e))
+                     (swap! log-state update :cursor
+                            (fn [c] (max c (inc cursor))))
+                     (recur))
+                   (do (await hint-mbx) ; doorbell; content ignored
+                       (recur)))))))
+          sup (supervisor/supervisor
+               [{:id :fanout-pump :start pump-fn}]
+               {:strategy :one-for-one
+                :max-restarts 5
+                :window-ms 60000
+                :on-fatal (fn [e]
+                            (tel/log! {:level :error :id ::pump-fatal
+                                       :msg "bus fan-out pump exceeded its restart budget"
+                                       :data {:error (str e)}}))})]
+      (sync/spawn! sup)
+      sup)))
+
+(declare post!)
 
 (defn- spawn-relay-drain!
   "Spawn a spin that taps `source-mult` and re-posts every message to
@@ -143,39 +209,57 @@
                     ;; keys the original message already has — the
                     ;; origin's view of itself wins.
                   tagged    (merge relay-tag msg)]
-              (binding [ec/*execution-context* (:ctx target-bus)]
-                (sync/post! (:source-mbox target-bus) tagged))
+              ;; Through the PUBLIC post! — under the log-first model the
+              ;; target's log is written at post time (there is no
+              ;; delivery-side log tap anymore), so poking its
+              ;; source-mbox directly would deliver without recording.
+              (post! target-bus tagged)
               (recur rest-s)))))))))
 
 (defn create-bus
   "Construct a Bus.
 
+   LOG-FIRST fan-out (the durable-cursor model): `post!` appends to the
+   bus log (and, for rooms with a store, durably persists FIRST via
+   `:durable-append!`), then rings a doorbell; a supervised pump
+   delivers log entries into the mult topology and advances a cursor.
+   Losing the pump loses promptness, never data — the supervisor
+   restarts it and it resumes from the cursor.
+
    Options:
-     :ctx        — existing execution context; default: a fresh one
-     :log?       — keep a vector history of every message (default true)
-     :relay-to   — another Bus to mirror every message into (typically
-                    the daemon-wide peer-bus). Messages are re-posted
-                    verbatim with `:relay-tag` merged in *underneath*
-                    (so the original message's own fields win).
-     :relay-tag  — extras to merge into each relayed message — typically
-                    `{:dvergr/origin <room-id> :dvergr/scope :room}`
-                    or `:fork`. Required when `:relay-to` is set."
+     :ctx             — existing execution context; default: a fresh one
+     :durable-append! — optional (fn [msg]); called by post! BEFORE the
+                        message becomes visible anywhere. Rooms pass a
+                        store append here (idempotent by :id at the
+                        store layer). A throw fails the post loudly.
+     :relay-to        — another Bus to mirror every message into
+                        (typically the daemon-wide peer-bus). Messages
+                        are re-posted verbatim with `:relay-tag` merged
+                        in *underneath* (the original's fields win).
+     :relay-tag       — extras to merge into each relayed message —
+                        typically `{:dvergr/origin <room-id>
+                        :dvergr/scope :room}` or `:fork`. Required when
+                        `:relay-to` is set.
+     :log?            — accepted for compatibility; the log is now the
+                        fan-out source of truth and always kept."
   ([] (create-bus {}))
-  ([{:keys [ctx log? relay-to relay-tag] :or {log? true}}]
-   (let [ctx (or ctx (ectx/create-execution-context))]
+  ([{:keys [ctx durable-append! relay-to relay-tag log?] :as _opts}]
+   (let [_ log? ;; vestigial — see docstring
+         ctx (or ctx (ectx/create-execution-context))]
      (binding [ec/*execution-context* ctx]
        (let [source     (sync/create-mailbox ctx)
+             hint-mbx   (sync/create-mailbox ctx)
              m          (mult/mult source)
              to-tap     (mult/tap m (buf/fixed-buffer 256))
              type-tap   (mult/tap m (buf/fixed-buffer 256))
              to-pub-v   (pub/pub to-tap :to)
              type-pub-v (pub/pub type-tap :type)
-             log-atom   (atom [])]
-         (when log?
-           (spawn-log-drain! ctx m log-atom))
+             log-state  (atom {:entries [] :cursor 0})]
          (when relay-to
            (spawn-relay-drain! ctx m relay-to (or relay-tag {})))
-         (->Bus ctx source m to-pub-v type-pub-v log-atom))))))
+         (let [pump (spawn-fanout-pump! ctx log-state hint-mbx source)]
+           (->Bus ctx source m to-pub-v type-pub-v
+                  log-state hint-mbx durable-append! pump)))))))
 
 ;; ============================================================================
 ;; Posting
@@ -195,17 +279,28 @@
    (a broadcast that also carries a subscribed `:type` matches both `[:to nil]`
    and `[:type …]`)."
   [bus msg]
-  (binding [ec/*execution-context* (:ctx bus)]
-    (sync/post! (:source-mbox bus)
-                (cond-> msg
-                  (and (map? msg) (nil? (:id msg))) (assoc :id (random-uuid)))))
+  (let [msg' (cond-> msg
+               (and (map? msg) (nil? (:id msg))) (assoc :id (random-uuid)))]
+    ;; 1. Durability FIRST. For a room with a store this persists the
+    ;;    message before it is visible anywhere — a store failure fails
+    ;;    the post loudly and nothing is half-delivered (this inverts
+    ;;    the old persistence-listener model, where a store failure
+    ;;    silently lost durability while the live message flowed).
+    (when-let [append! (:durable-append! bus)]
+      (append! msg'))
+    ;; 2. The log is the fan-out source of truth. Appending here (not
+    ;;    in a delivery tap) means log order == post order, and a
+    ;;    message is on record before any consumer runs.
+    (swap! (:log bus) update :entries conj msg')
+    ;; 3. Doorbell for the pump.
+    (binding [ec/*execution-context* (:ctx bus)]
+      (sync/post! (:hint-mbx bus) ::hint)))
   nil)
 
 (defn post-many!
-  "Post a sequence of messages in order under one ctx binding."
+  "Post a sequence of messages in order."
   [bus msgs]
-  (binding [ec/*execution-context* (:ctx bus)]
-    (doseq [m msgs] (sync/post! (:source-mbox bus) m)))
+  (doseq [m msgs] (post! bus m))
   nil)
 
 ;; ============================================================================
@@ -220,7 +315,8 @@
 ;; auto-printed at the REPL (e.g. the result of `subscribe!`). Print compact,
 ;; acyclic summaries instead.
 (defmethod print-method Bus [^Bus b ^java.io.Writer w]
-  (.write w (str "#Bus{:log " (count @(:log b)) "}")))
+  (let [{:keys [entries cursor]} @(:log b)]
+    (.write w (str "#Bus{:log " (count entries) " :cursor " cursor "}"))))
 
 (defmethod print-method Subscription [^Subscription s ^java.io.Writer w]
   (.write w (str "#Subscription{:topic " (pr-str (:topic s)) "}")))
@@ -266,28 +362,49 @@
 (defn log
   "Return the bus's full message log (vector)."
   [bus]
-  @(:log bus))
+  (:entries @(:log bus)))
+
+(defn log-cursor
+  "The fan-out cursor: entries below this index have been handed to the
+   delivery topology (or absorbed as history). Introspection/tests."
+  [bus]
+  (:cursor @(:log bus)))
 
 (defn clear-log!
-  "Reset the bus's log to empty."
+  "Reset the bus's log to empty (cursor included)."
   [bus]
-  (reset! (:log bus) [])
+  (reset! (:log bus) {:entries [] :cursor 0})
   nil)
 
 (defn seed-log!
   "Seed the bus's log with a prior history vector (e.g. a fork seeding the
    parent's log so log-based consumers see a continuous record). Replaces the
-   current log. This is the public op for the fork seam — callers should not
-   touch the `:log` atom directly."
+   current log; the cursor starts past the history so none of it is delivered
+   to live handlers. This is the public op for the fork seam — callers should
+   not touch the `:log` atom directly."
   [bus history]
-  (reset! (:log bus) (vec history))
+  (let [h (vec history)]
+    (reset! (:log bus) {:entries h :cursor (count h)}))
   nil)
 
 (defn append-log!
   "Append entries to the bus's log without re-posting them (merge-as-history:
    the parent absorbs a fork's exchange into its record without re-firing live
    handlers). The carry for a branchless (`:isolation :none`/ephemeral) fork on
-   merge — a `:ctx` fork merges its datahike branch natively instead."
+   merge — a `:ctx` fork merges its datahike branch natively instead.
+
+   Entries are marked as history via METADATA (invisible to log readers);
+   the pump advances past them without delivering. A single swap!, so this
+   composes race-free with concurrent live post!s — no cursor arithmetic
+   can skip a live entry."
   [bus entries]
-  (swap! (:log bus) into entries)
+  (swap! (:log bus) update :entries into
+         (map (fn [e] (if (instance? clojure.lang.IObj e)
+                        (vary-meta e assoc history-key true)
+                        e))
+              entries))
+  ;; Ring the doorbell so a parked pump advances its cursor past the
+  ;; absorbed history promptly (no delivery happens for marked entries).
+  (binding [ec/*execution-context* (:ctx bus)]
+    (sync/post! (:hint-mbx bus) ::hint))
   nil)

--- a/test/dvergr/runtime/durable_cursor_bus_test.clj
+++ b/test/dvergr/runtime/durable_cursor_bus_test.clj
@@ -1,0 +1,97 @@
+(ns dvergr.runtime.durable-cursor-bus-test
+  "Regression tests for the durable-cursor bus (log-first fan-out):
+   durability-before-visibility, cursor-resume-on-restart (at-least-once,
+   deduped by :id at participants), history absorption never delivered,
+   and post-order preservation."
+  (:require [clojure.test :refer [deftest is testing]]
+            [is.simm.partial-cps.sequence :as aseq]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [dvergr.runtime.bus :as bus]
+            [dvergr.runtime.bus-test :refer [drain-into! wait-until]]))
+
+(deftest durability-before-visibility
+  (testing "the durable-append! hook runs synchronously inside post!,
+          BEFORE the message is on the log or delivered anywhere; a
+          throwing hook fails the post and nothing is half-delivered"
+    (let [appended (atom [])
+          b (bus/create-bus {:durable-append! (fn [m] (swap! appended conj (:id m)))})
+          got (atom [])
+          sub (bus/subscribe! b [:to :x])]
+      (drain-into! b sub got :content)
+      (bus/post! b {:to :x :content "one"})
+      ;; Synchronous: by the time post! returns, durability happened —
+      ;; regardless of whether any delivery has run yet.
+      (is (= 1 (count @appended)))
+      (is (wait-until #(= ["one"] @got) 3000))
+      ;; Failure inversion: a store failure fails the post loudly and the
+      ;; message never becomes visible.
+      (let [b2 (bus/create-bus {:durable-append!
+                                (fn [_] (throw (ex-info "store down" {})))})
+            got2 (atom [])
+            sub2 (bus/subscribe! b2 [:to :x])]
+        (drain-into! b2 sub2 got2 :content)
+        (is (thrown-with-msg? Exception #"store down"
+                              (bus/post! b2 {:to :x :content "lost?"})))
+        (is (empty? (bus/log b2)) "nothing on the log")
+        (Thread/sleep 150)
+        (is (empty? @got2) "nothing delivered")))))
+
+(deftest cursor-resume-redelivers-in-flight-at-least-once
+  (testing "rewinding the cursor by one (simulating a pump crash after
+          handoff but before advance) re-delivers exactly that entry —
+          the at-least-once window; participants dedup by :id"
+    (let [b (bus/create-bus)
+          got (atom [])
+          sub (bus/subscribe! b [:to :x])]
+      (drain-into! b sub got :content)
+      (bus/post! b {:to :x :content "a"})
+      (bus/post! b {:to :x :content "b"})
+      (is (wait-until #(= ["a" "b"] @got) 3000))
+      (is (= 2 (bus/log-cursor b)))
+      ;; Simulate the crash window: cursor points before the last
+      ;; delivered entry; the (supervised, restarted) pump loop re-reads
+      ;; from the cursor. We reuse the live pump by ringing the doorbell.
+      (swap! (:log b) update :cursor dec)
+      (binding [ec/*execution-context* (:ctx b)]
+        (sync/post! (:hint-mbx b) :hint))
+      (is (wait-until #(= ["a" "b" "b"] @got) 3000)
+          "the in-flight entry is re-delivered (at-least-once), never lost")
+      (is (= 2 (bus/log-cursor b)) "cursor re-advanced"))))
+
+(deftest history-absorption-never-delivered
+  (testing "seed-log! and append-log! put entries on the record without
+          firing live handlers; live posts still deliver"
+    (let [b (bus/create-bus)
+          got (atom [])
+          sub (bus/subscribe! b [:to :x])]
+      (drain-into! b sub got :content)
+      (bus/seed-log! b [{:to :x :content "seeded-1"}
+                        {:to :x :content "seeded-2"}])
+      (bus/append-log! b [{:to :x :content "merged-1"}])
+      (bus/post! b {:to :x :content "live"})
+      (is (wait-until #(= ["live"] @got) 3000)
+          "only the live post reached the subscriber")
+      (Thread/sleep 150)
+      (is (= ["live"] @got) "…and nothing else trickled in")
+      (is (= ["seeded-1" "seeded-2" "merged-1" "live"]
+             (mapv :content (bus/log b)))
+          "the log shows the full record, history included")
+      (is (= 4 (bus/log-cursor b)) "cursor advanced past history"))))
+
+(deftest post-order-preserved
+  (testing "log order == post order == delivery order (the log is the
+          serialization point, upstream of delivery)"
+    (let [b (bus/create-bus)
+          got (atom [])
+          sub (bus/subscribe! b [:to :x])
+          n 50]
+      (drain-into! b sub got :content)
+      (dotimes [i n]
+        (bus/post! b {:to :x :content i}))
+      (is (wait-until #(= n (count @got)) 5000))
+      (is (= (vec (range n)) @got) "delivered in post order")
+      (is (= (vec (range n)) (mapv :content (bus/log b))) "logged in post order"))))


### PR DESCRIPTION
The room bus becomes crash-only software, riding spindel 0.1.35's loud-failure substrate. This is the structural successor to the watchdog-healing era.

## Before / after

**Before (ephemeral-first):** `post!` → mailbox → mult → taps, with the log and the datahike store as *downstream observers*. Any pipeline loss was a total loss; a store failure silently dropped durability while the live message flowed; a dead pump's position lived nowhere — recoverable only by the simmis watchdog re-invoking PENDING spins out-of-band.

**After (log-first):**
1. `post!` runs the bus's `:durable-append!` hook — rooms wire the store append here, so a message is **persisted before it is visible anywhere**, and a store failure fails the post loudly;
2. appends to the bus log (`{:entries [] :cursor n}` — one atom, so log order == post order, and history absorption composes race-free with live posts);
3. rings a data-free doorbell. A **supervised pump** (`spin/supervisor` `:one-for-one`, budget 5/60s, `::pump-fatal` telemetry) delivers `entries[cursor..]` into the *unchanged* mult/pub topology and advances the cursor after each handoff.

Pump death loses promptness, never data: the restart resumes from the cursor, re-delivering at most the one in-flight entry — participants already dedup by `:id`, so the observed contract is effectively-once.

## Details

- `seed-log!` starts the cursor past seeded history; `append-log!` marks merged entries as history via **metadata** (invisible to log readers) in a single swap — absorbed history is on record, never delivered. Fork seeding / merge-as-history semantics preserved.
- Both persistence listeners (`spawn-persistence-listener!`, room + fork variants) are deleted; `make-room`/`fork-room` wire `:durable-append!` with the same `message-shape?` filter and conversation-id rules.
- The peer-bus relay now goes through the target's public `post!` (it used to poke `source-mbox` directly — under the log-first model that delivered without recording; relayed messages now get the target's log ordering and durability hook for free).
- `clients/client.clj` log watchers adapted to the `{:entries …}` shape.
- Consumer-visible semantics preserved: subscription topology, buffer policies, pre-first-tap retention, `d/log`.

Deferred to the planned `spindel.depot` extraction (design doc `.internal/DURABLE_CURSOR_BUS.md` §7): store-persisted cursor (boot catch-up fan-out), pure ack-after-fanout, tick/telemetry log-bypass.

## Verification

- New `durable_cursor_bus_test.clj`: durability-before-visibility + loud store failure; cursor rewind re-delivers exactly the in-flight entry and re-advances; seeded/merged history never delivered while live posts flow; post order == log order == delivery order over 50 messages.
- Full dvergr suite: **362 tests / 1419 assertions / 0 failures**.
- simmis Maven baseline with this branch as `:local` dvergr: **20 / 135 / 0**.

Follow-up (separate, after release): simmis `pump_watchdog.clj` demotes from healer to alarm-only.