### PR TITLE
fix(chat+discourse): null tool-call arguments on replay; leave leaks bus subscriptions (zombie double-reply agents)

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -96,8 +96,11 @@
                                                    {:id (:tool-use/id tu)
                                                     :type "function"
                                                     :function {:name (:tool-use/name tu)
+                                                               ;; nil input (no-arg tool call) must
+                                                               ;; replay as "{}" — "null" arguments
+                                                               ;; are a 400 on OpenAI-compat APIs.
                                                                :arguments (json/write-value-as-string
-                                                                           (strip-ns-keys (:tool-use/input tu)))}})
+                                                                           (or (strip-ns-keys (:tool-use/input tu)) {}))}})
                                                  tool-uses)}
                         (seq reasoning) (assoc :reasoning_content reasoning))
                       (cond-> {:role (name role)

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -501,13 +501,23 @@
   nil)
 
 (defn leave
-  "Remove participant from room's routing table and unsubscribe its inbox.
-   The participant's spin continues running (no per-spin cancel in spindel
-   today); messages addressed to it after leaving are not delivered."
+  "Remove participant from room's routing table and unsubscribe ALL of
+   its bus feeds: the direct inbox, the broadcast sub, and every dynamic
+   `:subs` entry (e.g. the llm-agent's [:type :user/message]). Leaving
+   only the inbox — the previous behavior — left the broadcast/type
+   subscriptions alive feeding the still-running participant spin: a
+   leave/re-join cycle then had TWO live agents answering every message
+   (observed live: duplicate replies 5s apart; one zombie accumulated
+   PER cycle). The deaf spin itself stays parked (no per-spin cancel
+   wired here yet) but receives nothing."
   [room participant-id]
   (when-let [p (get @(:participants room) participant-id)]
     (when-let [sub (:inbox-sub p)]
-      (bus/unsubscribe! sub)))
+      (bus/unsubscribe! sub))
+    (when-let [subs (:subs p)]
+      (doseq [[topic sub] @subs]
+        (bus/unsubscribe! sub)
+        (swap! subs dissoc topic))))
   (swap! (:participants room) dissoc participant-id)
   nil)
 


### PR DESCRIPTION
Two related participant-lifecycle fixes, both hit live in simmis today:

1. **Replay nil tool-call input as `{}`** — a model calling a no-argument tool emits `arguments: null`; the tool executes, but the next turn replays the assistant message with `"null"` arguments and fireworks 400s (`must decode to a JSON object, got NoneType`), killing the turn after the tool ran.

2. **`leave` unsubscribes ALL participant feeds** — `join` creates the direct inbox sub, the broadcast `[:to nil]` sub, and dynamic `:subs` (e.g. llm-agent's `[:type :user/message]`), but `leave` tore down only the inbox. The broadcast/type subs kept feeding the still-running participant spin: each leave/re-join cycle added a zombie agent answering every message. Observed: duplicate replies 5 s apart; a room with 1 registered participant had 4 broadcast subscribers and 2 `:user/message` subscribers. The deaf spin still parks (per-spin cancel not wired here — the Track 0 'listener rooting' remainder) but receives nothing.

Verification below in the simmis dev JVM (subscriber counts return to 1:1 after leave/re-join).