### PR TITLE
fix(agent): GLM tool-channel failures, tunable eval timeout, visible budget checkpoint

### DIFF
--- a/src/dvergr/agent/process.clj
+++ b/src/dvergr/agent/process.clj
@@ -324,66 +324,57 @@
     ;; don't trim here — list-processes filters terminal states later.
     :completed))
 
-(defn budget-checkpoint!
-  "Pause an agent's turn loop when the dollar budget is exhausted and
-   wait for the manager to extend or abort.
+(defn budget-exhausted!
+  "Record that an agent's turn loop has hit its dollar ceiling, and RETURN —
+   immediately.
 
-   Registers a tracking-only Process so the manager sees the agent as
-   :awaiting-decision in the Processes pane, snapshots the budget
-   breakdown into :progress-signal, then blocks up to `grace-ms` (in
-   milliseconds) for a directive via `(directive! …)`.
+   This function used to BLOCK on a CountDownLatch for `grace-ms`, waiting for a
+   manager directive. It was called from the turn loop, which runs inside the
+   participant spin — so the block landed on spindel's DRAIN thread, under the
+   `[:engine/draining?]` CAS. Every room in the process shares one execution
+   context (simmis `model/rooms.clj` → `ctx/server-context`), so one agent
+   running out of budget froze the entire server's event loop for the full
+   grace period. And since nothing ever called `directive!`, the latch was never
+   counted down: every budget exhaustion took the whole grace period, every
+   time.
 
-   Returns one of:
-     :extended — manager bumped :total via {:op :extend-budget …}
-     :abort    — manager sent {:type :abort}
-     :wrap-up  — grace expired with no directive, OR a :continue
-                 arrived without an :extend-budget effect
+   Worse, the block made its own remedy unreachable. The room row telling a
+   human to raise the budget within 60s cannot be delivered to anyone until the
+   drain loop resumes — i.e. until after the 60s have elapsed. And the in-band
+   `:directive/raise-budget` message cannot be received mid-turn by
+   construction, because `participant-spin` awaits `on-message` to completion.
+   A parked agent has no in-room channel. That is the whole argument for not
+   parking on a human.
 
-   The caller decides what each outcome does — typically:
-     :extended → recur the turn loop
-     :abort    → exit immediately, no further reply
-     :wrap-up  → inject a 'finish up, no tools' system message and run
-                 one final turn, then exit"
-  [agent-id chat-ctx grace-ms]
-  ;; Signal derefs MUST bind the chat-ctx's spindel-ctx — without it,
-  ;; @(:budget-signal …) returns cached/stale state instead of the
-  ;; freshly-extended value, and the :extended path never trips.
+   So: no latch, no stopwatch, no guess. We mark the process
+   `:awaiting-decision` (the Processes pane and the room row show it), and the
+   caller ENDS THE TURN. Nothing is held, nothing is spent, and the durable room
+   log is what resumes the agent — a human raises the budget and the next
+   message re-enters the loop with the chat-ctx seeded from the store.
+
+   A wrap-up turn is no longer implicit. It cost an unbudgeted LLM call, charged
+   *after* the ceiling was hit, triggered by nobody deciding anything. If a
+   summary is wanted it should be an explicit choice — which is what the
+   decision protocol makes it (see .internal/decision-protocol-assessment.md)."
+  [agent-id chat-ctx]
   (let [spc           (:spindel-ctx chat-ctx)
-        budget-before (binding [ec/*execution-context* spc]
+        budget        (binding [ec/*execution-context* spc]
                         @(:budget-signal chat-ctx))
-        used-dollars  (/ (:used budget-before)
-                         (double acct/MICRODOLLARS-PER-DOLLAR))
-        total-dollars (/ (:total budget-before)
-                         (double acct/MICRODOLLARS-PER-DOLLAR))
-        by-type       (:by-type budget-before)
+        used-dollars  (/ (:used budget) (double acct/MICRODOLLARS-PER-DOLLAR))
+        total-dollars (/ (:total budget) (double acct/MICRODOLLARS-PER-DOLLAR))
         proc          (register! chat-ctx
                                  {:description
-                                  (format "%s — budget exhausted ($%.3f / $%.3f). Extend or abort?"
-                                          (name agent-id)
-                                          used-dollars
-                                          total-dollars)
-                                  :grace-ms grace-ms})
-        ^AtomicReference dref (:directive-ref proc)
-        ^CountDownLatch  latch (:directive-latch proc)]
+                                  (format "%s — budget exhausted ($%.3f / $%.3f). Raise the budget to continue."
+                                          (name agent-id) used-dollars total-dollars)})]
     (binding [ec/*execution-context* spc]
       (reset! (:progress-signal proc)
-              {:budget                  budget-before
+              {:budget                  budget
                :used-dollars            used-dollars
                :total-dollars           total-dollars
-               :by-type                 by-type
+               :by-type                 (:by-type budget)
                :awaiting-decision-since (java.util.Date.)})
       (reset! (:status-signal proc) :awaiting-decision))
-    (.await latch grace-ms TimeUnit/MILLISECONDS)
-    (let [d            (or (.get dref) {:type :continue :effects-applied []})
-          budget-after (binding [ec/*execution-context* spc]
-                         @(:budget-signal chat-ctx))]
-      (binding [ec/*execution-context* spc]
-        (reset! (:status-signal proc) :running))
-      (complete! proc)
-      (cond
-        (= :abort (:type d))                              :abort
-        (> (:total budget-after) (:total budget-before))  :extended
-        :else                                             :wrap-up))))
+    :awaiting-decision))
 
 (defn aborted?
   "True if a manager has aborted the process. Work-owners poll this

--- a/src/dvergr/agent/room_context.clj
+++ b/src/dvergr/agent/room_context.clj
@@ -30,6 +30,7 @@
             [dvergr.chat.context :as chat-ctx]
             [dvergr.chat.schema :as schema]
             [dvergr.room.registry :as rreg]
+            [dvergr.chat.accounting :as acct]
             [dvergr.runtime.bus :as bus]
             [dvergr.system.db :as sdb]
             [dvergr.system.rooms :as srooms]
@@ -143,6 +144,24 @@
                                    (display-name room (:from m)) (:ts m))))
               (recur rest-s))))))
       sub)))
+
+(defn raise-budget!
+  "Set the live budget :total on every cached agent ctx of `room-id` to
+   `dollars`. The embedder calls this when its room-budget setting
+   changes, so an agent paused at a budget checkpoint resolves
+   :extended and continues instead of wrapping up. Returns the number
+   of ctxs updated."
+  [room-id dollars]
+  (let [micro (long (* (double dollars)
+                       acct/MICRODOLLARS-PER-DOLLAR))]
+    (reduce (fn [n [[rid _] {:keys [chat-ctx]}]]
+              (if (and (= rid room-id) chat-ctx)
+                (do (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+                      (swap! (:budget-signal chat-ctx) assoc :total micro))
+                    (inc n))
+                n))
+            0
+            @room-agent-ctxs)))
 
 (defn ensure-ctx!
   "Get-or-create the long-lived working chat-ctx for `agent-id` in `room`.

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -165,18 +165,22 @@
     nil))
 
 (defn post-budget-warning!
-  "Surface a budget checkpoint as a visible, NON-triggering activity row:
-   the agent has exhausted its dollar budget and pauses for `grace-ms`
-   awaiting an extension (raise the budget in the embedder's UI — e.g.
-   the simmis room settings — or via processes/directive!) before it
-   wraps up. No-op when `room` is nil. Returns nil."
-  [room agent-id used-dollars total-dollars grace-ms]
+  "Surface budget exhaustion as a visible, NON-triggering activity row: the
+   agent has hit its dollar ceiling and has STOPPED. Nothing is running, nothing
+   further is being spent, and nothing expires — raise the room's budget and
+   speak, and the agent picks up where it left off.
+
+   The old copy promised a countdown (\"raise it within 60s or I wrap up\").
+   That was untrue in two directions: the deadline forced a decision on a
+   stopwatch a human never agreed to, and letting it lapse SPENT MORE MONEY on a
+   wrap-up turn — after the ceiling had already been hit. No-op when `room` is
+   nil. Returns nil."
+  [room agent-id used-dollars total-dollars]
   (when room
     (binding [rtc/*execution-context* (:ctx room)]
       (d/post! room (d/message agent-id activity-id
-                               (format "⚠️ budget exhausted — $%.2f of $%.2f used. Raise the room budget within %ds to let me continue; otherwise I will wrap up with what I have."
-                                       (double used-dollars) (double total-dollars)
-                                       (long (/ grace-ms 1000)))
+                               (format "⚠️ budget exhausted — $%.2f of $%.2f used. I have stopped and am spending nothing. Raise the room budget and message me to continue."
+                                       (double used-dollars) (double total-dollars))
                                nil
                                {:role :tool}))))
   nil)

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -164,6 +164,23 @@
       (reset! posted (count tool-msgs)))
     nil))
 
+(defn post-budget-warning!
+  "Surface a budget checkpoint as a visible, NON-triggering activity row:
+   the agent has exhausted its dollar budget and pauses for `grace-ms`
+   awaiting an extension (raise the budget in the embedder's UI — e.g.
+   the simmis room settings — or via processes/directive!) before it
+   wraps up. No-op when `room` is nil. Returns nil."
+  [room agent-id used-dollars total-dollars grace-ms]
+  (when room
+    (binding [rtc/*execution-context* (:ctx room)]
+      (d/post! room (d/message agent-id activity-id
+                               (format "⚠️ budget exhausted — $%.2f of $%.2f used. Raise the room budget within %ds to let me continue; otherwise I will wrap up with what I have."
+                                       (double used-dollars) (double total-dollars)
+                                       (long (/ grace-ms 1000)))
+                               nil
+                               {:role :tool}))))
+  nil)
+
 (defn post-turn-error!
   "Surface a FAILED agent turn as a visible, NON-triggering activity row (→ room
    `:_activity`, `:role :tool`, like `post-turn-activity!`) — so the turn loop can

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -153,6 +153,29 @@
                          (hash (select-keys % [:tool-use/name :tool-use/input])))
                      recent-tool-calls)))))
 
+(def fragment-nudge
+  "Corrective shown to a model that emitted code as its message instead of
+   calling a tool. Names the mistake and the fix, without scolding — and it is
+   idempotent: `nudged-for-fragment?` matches on this exact text so we say it at
+   most once per turn loop."
+  (str "Your last message was CODE, not a reply to the room. Nobody ran it and "
+       "nobody read it.\n\n"
+       "If you meant to execute it, call the `clojure_eval` tool with that code "
+       "as the `code` argument — code placed in the message body is never "
+       "executed.\n\n"
+       "If you meant to speak to the humans, write prose."))
+
+(defn- nudged-for-fragment?
+  "Have we already told this agent, in this turn loop, that it fumbled code into
+   the prose channel? A second identical nudge cannot help — if the model does
+   it twice, let the turn end rather than burning budget in a nudge loop."
+  [chat-ctx]
+  (->> (chat-ctx/get-messages chat-ctx)
+       (some (fn [m]
+               (and (#{:system "system"} (or (:role m) (:message/role m)))
+                    (= fragment-nudge (or (:content m) (:message/content m))))))
+       boolean))
+
 ;; ============================================================================
 ;; Agent Turn (Non-Reactive Core)
 ;; ============================================================================
@@ -358,8 +381,27 @@
                                     :turn-number turn-number}))
           :continue)
 
-        ;; No tool calls - done
-        :complete))
+        ;; No tool calls. Usually that means the agent is done — but a model can
+        ;; also fumble its code into the PROSE channel (stop_reason=stop, no
+        ;; tool_calls, content = a code fragment). Read literally, that ends the
+        ;; turn and posts the fragment to the room as if it were an answer: the
+        ;; agent appears to spill code and quit mid-task. It hasn't finished; it
+        ;; misaddressed a tool call. Name that once and let it try again — the
+        ;; turn loop is bounded by BUDGET, not by a turn cap, so one corrective
+        ;; turn costs a few cents and rescues the work.
+        (if (and (quirks/code-fragment? content)
+                 (not (nudged-for-fragment? chat-ctx)))
+          (do
+            (tel/log! {:level :warn :id :agent/code-in-prose-channel
+                       :data {:turn turn-number
+                              :preview (subs (str content) 0 (min 80 (count (str content))))}}
+                      "Model emitted code as content instead of a tool call — nudging")
+            (chat-ctx/add-message! chat-ctx
+                                   {:role :system
+                                    :content fragment-nudge
+                                    :important? true})
+            :continue)
+          :complete)))
 
     (catch java.util.concurrent.CancellationException _
       (tel/log! {:level :info :id :agent/turn-cancelled} "Agent turn cancelled")

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -21,14 +21,15 @@
           :tools  :knowledge-worker         ; a named profile — or an explicit set
           :budget {:dollars 0.50}}))
 
-   When the dollar budget hits zero, the agent loop escalates via
-   `dvergr.agent.process/register!` — the manager sees the agent as
-   :awaiting-decision in the Processes pane and can call
-   `(proc/directive! chat-ctx pid {:type :continue :effects [{:op :extend-budget :dollars 0.25}]})`
-   to keep it going, or `{:type :abort}` to stop it. If no directive
-   arrives within :checkpoint-grace-ms (default 60s), the loop runs a
-   single final turn with NO tools and a wrap-up system message, then
-   exits cleanly.
+   When the dollar budget hits zero the turn simply ENDS: the room gets a
+   non-triggering row saying so, the process is marked :awaiting-decision, and
+   nothing further is spent. Resumption is an ordinary inbound message — raise
+   the room's budget and speak, and the next turn re-enters with the chat-ctx
+   seeded from the room store.
+
+   It used to block for :checkpoint-grace-ms waiting on a manager directive.
+   That block ran on spindel's DRAIN thread and froze every room in the process;
+   see `dvergr.agent.process/budget-exhausted!` for the autopsy.
 
    Tests pass `:run-turn-fn` (a stub returning :continue/:complete and
    writing to chat-ctx directly) to avoid real LLM calls — see
@@ -96,9 +97,6 @@
 ;; Wrap-up prompt for budget-checkpoint :wrap-up resolution
 ;; ============================================================================
 
-(def ^:private wrap-up-prompt
-  "Time to wrap up. Budget exhausted and no extension granted. Write a brief reply summarizing what you've done and what's unfinished. Don't call any more tools.")
-
 ;; ============================================================================
 ;; Public API
 ;; ============================================================================
@@ -113,12 +111,9 @@
                   name → tool-def (pre-wrapped). Default: :dev-toolbelt
                   (`minimal-coding-tools`). Pass `#{}` for a no-tools agent.
    :db-conn     — datahike connection for chat persistence (optional)
-   :budget      — {:dollars n :checkpoint-grace-ms n}
-                  (default {:dollars 1.0 :checkpoint-grace-ms 60000}).
-                  When the dollar budget runs out, the loop pauses and
-                  escalates via dvergr.agent.process; if no extension arrives
-                  within grace-ms, the agent gets one no-tools wrap-up
-                  turn and exits.
+   :budget      — {:dollars n} (default {:dollars 1.0}). When it runs out the
+                  turn ends and the process is marked :awaiting-decision; a
+                  human raises the budget and the next message resumes it.
    :compaction  — {:auto? bool :model str} (default {:auto? true})
    :chat-ctx    — pre-built ChatContext (optional). When provided, llm-agent
                   uses it as-is (no fresh creation, no system-prompt seeding).
@@ -166,7 +161,6 @@
                 (cc/add-message! c {:role :system :content sp}))
               c))
         ;; Grace window for the manager to extend the budget after exhaustion.
-        grace-ms  (long (or (:checkpoint-grace-ms budget) 60000))
         compaction-strategy (:strategy compaction :sync-before-turn)
         ;; In race mode, disable run-turn-fn's internal sync compaction — we
         ;; drive it from the agent's spin-race below.
@@ -320,13 +314,7 @@
                  ;; Loop state:
                  ;;   turn             — running turn counter (informational
                  ;;                       only; no upper bound)
-                 ;;   wrap-up-allowed? — true after a budget-checkpoint
-                 ;;                       resolved to :wrap-up. Next turn
-                 ;;                       runs with NO tools and must
-                 ;;                       produce the final reply; loop
-                 ;;                       exits after it.
-                     (loop [turn             0
-                            wrap-up-allowed? false]
+                     (loop [turn 0]
                        (if @cancelled?
                          nil
                          (do
@@ -349,9 +337,7 @@
                                                   (assoc turn-opts
                                                          :turn-number turn
                                                          :spec @spec-atom
-                                                      ;; Final-turn lock-out: no tools,
-                                                      ;; LLM must give a textual wrap-up.
-                                                         :tools (if wrap-up-allowed? {} tools))))
+                                                         :tools tools)))
                                  result (sp/await (:done h))]
                          ;; Mirror this turn's tool calls into the room as 🔧
                          ;; play-by-play rows (same as daemon agents).
@@ -365,36 +351,34 @@
                            ;; LLM finished cleanly (no more tool calls).
                                (not= result :continue) nil
 
-                           ;; The wrap-up slot was used — the loop made
-                           ;; its single no-tools turn, exit now.
-                               wrap-up-allowed? nil
-
-                           ;; Budget exhausted on a :continue turn:
-                           ;; escalate to manager via the Processes pane.
+                           ;; Budget exhausted → the turn ENDS here.
+                           ;;
+                           ;; It used to BLOCK for grace-ms waiting on a manager
+                           ;; directive — on the spin's DRAIN thread, freezing
+                           ;; every room in the process (see
+                           ;; `proc/budget-exhausted!` for the full autopsy).
+                           ;; Nothing is held now: we say so in the room, mark
+                           ;; the process :awaiting-decision, and stop.
+                           ;;
+                           ;; Resumption is an ordinary inbound message. A human
+                           ;; raises the room budget and speaks; the next turn
+                           ;; re-enters with the chat-ctx seeded from the store.
+                           ;; The durable room log IS the continuation — which is
+                           ;; the only kind spindel can actually have (it has no
+                           ;; durable conts, and a park would be lost on restart).
                                (cc/budget-exceeded? chat-ctx)
                                (do
-                                 ;; make the pause VISIBLE where the humans are:
-                                 ;; a non-triggering room activity row telling
-                                 ;; them the budget ran out and how long they
-                                 ;; have to extend it (simmis room settings /
-                                 ;; processes/directive!).
                                  (when room
                                    (let [b (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
                                              @(:budget-signal chat-ctx))
                                          used  (/ (:used b) (double acct/MICRODOLLARS-PER-DOLLAR))
                                          total (/ (:total b) (double acct/MICRODOLLARS-PER-DOLLAR))]
-                                     (turn/post-budget-warning! room id used total grace-ms)))
-                                 (case (proc/budget-checkpoint! id chat-ctx grace-ms)
-                                   :extended (recur (inc turn) false)
-                                   :abort    nil
-                                   :wrap-up  (do
-                                               (cc/add-message! chat-ctx
-                                                                {:role    :system
-                                                                 :content wrap-up-prompt})
-                                               (recur (inc turn) true))))
+                                     (turn/post-budget-warning! room id used total)))
+                                 (proc/budget-exhausted! id chat-ctx)
+                                 nil)
 
                            ;; Normal :continue, budget OK → next turn.
-                               :else (recur (inc turn) wrap-up-allowed?))))))
+                               :else (recur (inc turn)))))))
 
                      (when room (turn/unregister-room-turn! (:id room) id))
                      ;; A FAILED turn produced no new reply — surface it as a NON-triggering

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -56,6 +56,8 @@
             [dvergr.agent.process :as proc]
             [dvergr.room.store :as rstore]
             [dvergr.system.rooms :as srooms]
+            [dvergr.model.quirks :as quirks]
+            [taoensso.telemere :as tel]
             [dvergr.tools :as tools]))
 
 ;; ============================================================================
@@ -401,13 +403,28 @@
                      (when @errored (turn/post-turn-error! room id @errored))
                      (when-let [last-asst (when-not @errored (last-assistant-message chat-ctx))]
                        (when-let [reply (assistant-text last-asst)]
+                     ;; Last line of defence: a model that fumbled code into the
+                     ;; prose channel TWICE (agent.clj nudged it once) must still
+                     ;; not have that fragment posted as its reply — the room
+                     ;; would show code as an answer and other agents would reply
+                     ;; TO it. Surface it as a non-triggering activity row instead.
+                         (if (quirks/code-fragment? reply)
+                           (do (tel/log! {:level :warn :id ::reply-was-code-fragment
+                                          :data {:agent id}}
+                                         "Suppressed a code fragment posing as a reply")
+                               (when room
+                                 (turn/post-turn-error!
+                                   room id
+                                   (str "emitted code instead of a reply — the tool call "
+                                        "never reached the tool channel, so nothing ran")))
+                               nil)
                      ;; Carry this turn's interleaved-thinking trace into the room
                      ;; record (metadata → store → seeding) so reasoning models
                      ;; (MiniMax M2 / Kimi / DeepSeek) keep their <think> context
                      ;; across a rehydrate/restart, not just within a live session.
-                         (let [reasoning (or (:message/reasoning last-asst) (:reasoning last-asst))]
-                           (cond-> {:to (:from msg) :content reply}
-                             (seq reasoning) (assoc :metadata {:reasoning reasoning}))))))))))
+                           (let [reasoning (or (:message/reasoning last-asst) (:reasoning last-asst))]
+                             (cond-> {:to (:from msg) :content reply}
+                               (seq reasoning) (assoc :metadata {:reasoning reasoning})))))))))))
 
             :factory
             (fn [new-ctx]

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -370,14 +370,26 @@
                            ;; Budget exhausted on a :continue turn:
                            ;; escalate to manager via the Processes pane.
                                (cc/budget-exceeded? chat-ctx)
-                               (case (proc/budget-checkpoint! id chat-ctx grace-ms)
+                               (do
+                                 ;; make the pause VISIBLE where the humans are:
+                                 ;; a non-triggering room activity row telling
+                                 ;; them the budget ran out and how long they
+                                 ;; have to extend it (simmis room settings /
+                                 ;; processes/directive!).
+                                 (when room
+                                   (let [b (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+                                             @(:budget-signal chat-ctx))
+                                         used  (/ (:used b) (double acct/MICRODOLLARS-PER-DOLLAR))
+                                         total (/ (:total b) (double acct/MICRODOLLARS-PER-DOLLAR))]
+                                     (turn/post-budget-warning! room id used total grace-ms)))
+                                 (case (proc/budget-checkpoint! id chat-ctx grace-ms)
                                  :extended (recur (inc turn) false)
                                  :abort    nil
                                  :wrap-up  (do
                                              (cc/add-message! chat-ctx
                                                               {:role    :system
                                                                :content wrap-up-prompt})
-                                             (recur (inc turn) true)))
+                                             (recur (inc turn) true))))
 
                            ;; Normal :continue, budget OK → next turn.
                                :else (recur (inc turn) wrap-up-allowed?))))))

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -385,13 +385,13 @@
                                          total (/ (:total b) (double acct/MICRODOLLARS-PER-DOLLAR))]
                                      (turn/post-budget-warning! room id used total grace-ms)))
                                  (case (proc/budget-checkpoint! id chat-ctx grace-ms)
-                                 :extended (recur (inc turn) false)
-                                 :abort    nil
-                                 :wrap-up  (do
-                                             (cc/add-message! chat-ctx
-                                                              {:role    :system
-                                                               :content wrap-up-prompt})
-                                             (recur (inc turn) true))))
+                                   :extended (recur (inc turn) false)
+                                   :abort    nil
+                                   :wrap-up  (do
+                                               (cc/add-message! chat-ctx
+                                                                {:role    :system
+                                                                 :content wrap-up-prompt})
+                                               (recur (inc turn) true))))
 
                            ;; Normal :continue, budget OK → next turn.
                                :else (recur (inc turn) wrap-up-allowed?))))))
@@ -414,9 +414,9 @@
                                          "Suppressed a code fragment posing as a reply")
                                (when room
                                  (turn/post-turn-error!
-                                   room id
-                                   (str "emitted code instead of a reply — the tool call "
-                                        "never reached the tool channel, so nothing ran")))
+                                  room id
+                                  (str "emitted code instead of a reply — the tool call "
+                                       "never reached the tool channel, so nothing ran")))
                                nil)
                      ;; Carry this turn's interleaved-thinking trace into the room
                      ;; record (metadata → store → seeding) so reasoning models

--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -189,7 +189,14 @@
                           (mapv (fn [tc]
                                   {:id (:id tc)
                                    :name (:name tc)
-                                   :input (:input tc)})))
+                                   :input (:input tc)}))
+                          ;; GLM-only: the <arg_key> envelope sometimes leaks
+                          ;; INTO the structured name field — repair it or the
+                          ;; invalid name poisons the replayed history.
+                          ((fn [calls]
+                             (if (:glm-tool-leak? state)
+                               (mapv quirks/sanitize-glm-structured-call calls)
+                               calls))))
           ;; GLM leak RECOVERY: when Fireworks dumped the tool call into content
           ;; instead of tool_calls, parse it back into an executable call so the
           ;; turn continues (rather than dying on a garbage message). Only when

--- a/src/dvergr/model/quirks.clj
+++ b/src/dvergr/model/quirks.clj
@@ -134,6 +134,28 @@
         [{:name (str/trim (first names))
           :input (into {} pairs)}]))))
 
+(defn sanitize-glm-structured-call
+  "GLM also leaks its envelope INTO the structured tool_call NAME field:
+   `clojure_eval<arg_key>code</arg_key><arg_value>…` (often truncated
+   mid-value when the emission was cut). Left alone, the call fails as
+   an unknown tool AND the invalid name poisons the history — the next
+   turn 400s. Split off the real name; parse complete arg pairs into
+   :input; an unterminated trailing <arg_value> contributes its partial
+   text so the tool fails informatively instead of the turn dying."
+  [{:keys [name input] :as call}]
+  (if (and name (str/includes? (str name) "<arg_key>"))
+    (let [n (str name)
+          real-name (str/trim (subs n 0 (str/index-of n "<arg_key>")))
+          pairs (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
+                    (re-seq glm-arg-pair-re n))
+          partial-pair (when (empty? pairs)
+                         (when-let [[_ k v] (re-find #"(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*)\z" n)]
+                           [[(keyword (str/trim k)) v]]))]
+      (assoc call
+             :name real-name
+             :input (merge (into {} (concat pairs partial-pair)) input)))
+    call))
+
 (defn strip-glm-tool-tokens
   "Remove GLM's leaked tool-call envelope from assistant text `content` — the
    `Tool calls: [...]` echo plus every `<tool_call>…`, `<arg_key>…</arg_key>`,

--- a/src/dvergr/model/quirks.clj
+++ b/src/dvergr/model/quirks.clj
@@ -171,3 +171,69 @@
         (str/replace #"(?s)</?(tool_call|arg_key|arg_value)>" "")
         str/trim
         (as-> c (when (seq c) c)))))
+
+;; ---------------------------------------------------------------------------
+;; Code fumbled into the PROSE channel
+;;
+;; The leak above has a sibling that no recovery can catch: the model emits its
+;; code as plain content with NO envelope and stop_reason=stop. Nothing marks it
+;; as a tool call, so the agent loop reads "no tool calls" as "the agent has
+;; finished speaking", posts the fragment to the room, and ends the turn — the
+;; agent appears to spill code and quit mid-task. (Observed 2026-07-13: GLM
+;; miscounted a brace, its recovered call failed to parse, and it then re-emitted
+;; the repaired code as a message beginning with a stray `)`.)
+;;
+;; Detection is deliberately CONSERVATIVE. A reply may legitimately contain code
+;; — explaining a snippet is normal — so we flag only content that cannot be a
+;; deliberate message to a human:
+;;   - it opens with a CLOSING delimiter, or
+;;   - it closes more delimiters than it opens (a truncated / continued block), or
+;;   - it still carries a tool-call envelope after scrubbing.
+;; Balanced code in a reply is left alone.
+;; ---------------------------------------------------------------------------
+
+(defn- delimiter-balance
+  "Openers minus closers, ignoring delimiters inside strings, character literals
+   and line comments — those are text, not structure."
+  [^String s]
+  (loop [i 0, depth 0, in-str? false, in-cmt? false, escaped? false]
+    (if (>= i (count s))
+      depth
+      (let [c (.charAt s i)]
+        (cond
+          escaped?  (recur (inc i) depth in-str? in-cmt? false)
+          in-str?   (case c
+                      \\ (recur (inc i) depth true in-cmt? true)
+                      \" (recur (inc i) depth false in-cmt? false)
+                      (recur (inc i) depth true in-cmt? false))
+          in-cmt?   (recur (inc i) depth in-str? (not= c \newline) false)
+          :else     (case c
+                      \" (recur (inc i) depth true false false)
+                      \; (recur (inc i) depth false true false)
+                      (\( \[ \{) (recur (inc i) (inc depth) false false false)
+                      (\) \] \}) (recur (inc i) (dec depth) false false false)
+                      (recur (inc i) depth false false false)))))))
+
+(def ^:private emoticon-re
+  ;; :) ;) :-) =( 8] … — a smiley's paren is punctuation, not structure. Without
+  ;; this, "Sounds good :)" balances to -1 and reads as truncated code.
+  #"[:;=8][-o^]?[)\](\[]")
+
+(defn code-fragment?
+  "True when assistant `content` is code fumbled into the prose channel rather
+   than a message meant for a human. See the note above — conservative by
+   design: balanced code inside a reply is NOT a fragment, and neither is prose
+   that merely contains delimiters."
+  [content]
+  (let [s (str/trim (str content))
+        ;; balance over prose-stripped text: emoticons are not delimiters
+        structural (str/replace s emoticon-re "")]
+    (boolean
+      (and (seq s)
+           (or (contains? #{\) \] \}} (first s))
+               ;; more closers than openers — a truncated or continued block.
+               ;; Requires an opener to exist at all, so stray punctuation in
+               ;; prose can't trip it.
+               (and (re-find #"[(\[{]" structural)
+                    (neg? (delimiter-balance structural)))
+               (re-find #"<arg_key>|<tool_call>" s))))))

--- a/src/dvergr/model/quirks.clj
+++ b/src/dvergr/model/quirks.clj
@@ -147,7 +147,7 @@
     (let [n (str name)
           real-name (str/trim (subs n 0 (str/index-of n "<arg_key>")))
           pairs (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                    (re-seq glm-arg-pair-re n))
+                     (re-seq glm-arg-pair-re n))
           partial-pair (when (empty? pairs)
                          (when-let [[_ k v] (re-find #"(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*)\z" n)]
                            [[(keyword (str/trim k)) v]]))]
@@ -229,11 +229,11 @@
         ;; balance over prose-stripped text: emoticons are not delimiters
         structural (str/replace s emoticon-re "")]
     (boolean
-      (and (seq s)
-           (or (contains? #{\) \] \}} (first s))
+     (and (seq s)
+          (or (contains? #{\) \] \}} (first s))
                ;; more closers than openers — a truncated or continued block.
                ;; Requires an opener to exist at all, so stray punctuation in
                ;; prose can't trip it.
-               (and (re-find #"[(\[{]" structural)
-                    (neg? (delimiter-balance structural)))
-               (re-find #"<arg_key>|<tool_call>" s))))))
+              (and (re-find #"[(\[{]" structural)
+                   (neg? (delimiter-balance structural)))
+              (re-find #"<arg_key>|<tool_call>" s))))))

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -348,9 +348,7 @@
                   :system-prompt system-prompt
                   :isolation     (or (:isolation safe-config) :sci)}
         :tools   tools-map
-        :budget  {:dollars             (or (:budget-dollars safe-config) 0.25)
-                  :checkpoint-grace-ms (or (:budget-checkpoint-grace-ms safe-config)
-                                           60000)}
+        :budget  {:dollars (or (:budget-dollars safe-config) 0.25)}
         :ctx     exec-ctx}))))
 
 (defn join-agent-to-room!
@@ -372,10 +370,9 @@
      :isolation                 - :sci (sandboxed Clojure eval)
      :tools                     - safe-tools (excludes shell, run_tests, telegram_*)
      :budget-dollars            - 0.25 per task
-     :budget-checkpoint-grace-ms - 60000 ms grace window when budget
-                                  is exhausted and the manager is
-                                  asked to extend (see
-                                  dvergr.agent.process/budget-checkpoint!)
+     (budget exhaustion no longer has a grace window: the turn ENDS, the
+      process is marked :awaiting-decision, and nothing further is spent —
+      see dvergr.agent.process/budget-exhausted!)
 
    To grant extra power, pass explicit overrides in agent-config:
      :isolation :native       — full JVM (trusted agents only, never Telegram)

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -19,6 +19,14 @@
 
 (def registry (atom {}))
 
+(defonce eval-timeout-ms
+  ;; Hard per-call timeout for clojure_eval. 60s suits interactive
+  ;; probing; embedders doing heavy in-sandbox work (e.g. simmis agents
+  ;; chewing an 11MB PDF's text) reset! it higher — timeouts feed back
+  ;; as tool errors the model then retries with variations, burning
+  ;; budget on work that just needed more runway.
+  (atom 60000))
+
 (defn coerce-tags
   "Coerce a `tags` tool-input into a set of non-blank string tags, robust to the
    ways an LLM/agent actually passes them. A BARE STRING is ONE tag (split on
@@ -482,7 +490,7 @@
                                                    (= :aborted @(:status-signal p)))
                                                  (catch Throwable _ false))))]
                                      (sandbox/eval-code sci-ctx code
-                                                        :timeout-ms 60000
+                                                        :timeout-ms @eval-timeout-ms
                                                         :cancel? proc-aborted?))))
                   ;; Block on process completion / abort.
                  (let [{:keys [ok aborted]} @result-p]
@@ -525,7 +533,7 @@
                 ;; same cancel-poll plumbing but no process registration.
                sci-ctx
                (let [result (sandbox/eval-code sci-ctx code
-                                               :timeout-ms 60000
+                                               :timeout-ms @eval-timeout-ms
                                                :cancel? cancel?)]
                  (if (:success result)
                    {:type :success

--- a/test/dvergr/discourse/llm_budget_test.clj
+++ b/test/dvergr/discourse/llm_budget_test.clj
@@ -1,0 +1,126 @@
+(ns dvergr.discourse.llm-budget-test
+  "What happens when an agent runs out of money.
+
+   There were NO budget tests, which is how the following shipped: the turn loop
+   blocked on a CountDownLatch for `grace-ms` (60s) waiting for a manager
+   directive — from inside the participant spin, i.e. on spindel's DRAIN thread,
+   under the [:engine/draining?] CAS. Every room in a process shares one
+   execution context, so ONE agent exhausting its budget froze the entire
+   server's event loop for a full minute. Nothing ever called `directive!`, so
+   the latch was never counted down: it was not an occasional stall, it was
+   every time.
+
+   And when the stopwatch expired, the loop 'soft-continued' into a wrap-up turn
+   — an extra LLM call, charged AFTER the ceiling was hit, chosen by nobody.
+
+   These tests pin the two properties that autopsy demands:
+     1. exhaustion ENDS the turn — promptly, holding nothing;
+     2. exhaustion spends NOTHING further — no wrap-up turn."
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [dvergr.discourse :as d]
+            [dvergr.discourse.llm :as llm]
+            [dvergr.chat.accounting :as acct]
+            [dvergr.chat.context :as cc]))
+
+(defn- spendthrift-turn-fn
+  "A turn-fn that burns `per-turn` dollars and always wants ANOTHER turn.
+
+   It debits the budget signal directly rather than going through
+   `account-usage!`, whose cost comes from the model pricing table — a mock
+   model prices at zero, and a test that cannot spend cannot test a ceiling.
+
+   Counts its invocations: an agent that respects its ceiling must stop calling
+   this the moment the money is gone. `seen-ctx` captures the chat-ctx so a test
+   can play the human who raises the budget."
+  [calls per-turn seen-ctx]
+  (fn [chat-ctx _opts]
+    (swap! calls inc)
+    (reset! seen-ctx chat-ctx)
+    (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+      (swap! (:budget-signal chat-ctx) update :used
+             + (long (* per-turn acct/MICRODOLLARS-PER-DOLLAR))))
+    (cc/add-message! chat-ctx {:role :assistant :content "still working…"})
+    :continue))
+
+(defn- ask-and-wait
+  "Ask the agent and wait for the participant's turn loop to settle.
+   Returns [reply elapsed-ms]. A reply of ::timeout means the loop is STUCK —
+   which, before the fix, is exactly what a budget-exhausted agent did."
+  [room agent-id wait-ms]
+  (let [p     (promise)
+        start (System/currentTimeMillis)]
+    (binding [ec/*execution-context* (:ctx room)]
+      (sp/spawn!
+       (sp/spin (deliver p (sp/await (d/ask room agent-id {:content "go"}))))))
+    (let [reply (deref p wait-ms ::timeout)]
+      [reply (- (System/currentTimeMillis) start)])))
+
+(deftest budget-exhaustion-ends-the-turn-promptly
+  (testing "an agent out of budget STOPS — it does not park, and it does not
+            hold the engine. Before the fix this blocked the drain thread for
+            grace-ms (60s), freezing every room in the process."
+    (let [r        (d/room :budget-t)
+          calls    (atom 0)
+          seen-ctx (atom nil)]
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent
+                   {:id :spender
+                    :spec {:provider :mock :model "mock" :system-prompt "spend"}
+                    ;; a ceiling it blows through on the first turn
+                    :budget {:dollars 0.01}
+                    :run-turn-fn (spendthrift-turn-fn calls 0.05 seen-ctx)})))
+      (let [[_ elapsed] (ask-and-wait r :spender 10000)]
+        (is (< elapsed 5000)
+            (str "the turn loop must not hold anything while awaiting a human. "
+                 "Took " elapsed "ms — a latch/stopwatch has crept back in."))))))
+
+(deftest budget-exhaustion-spends-nothing-further
+  (testing "no wrap-up turn: the ceiling is a ceiling. The old loop answered
+            budget exhaustion with ANOTHER LLM call — unbudgeted, over the
+            limit, and triggered by a timer rather than by a person."
+    (let [r        (d/room :budget-t2)
+          calls    (atom 0)
+          seen-ctx (atom nil)]
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent
+                   {:id :spender
+                    :spec {:provider :mock :model "mock" :system-prompt "spend"}
+                    :budget {:dollars 0.01}
+                    :run-turn-fn (spendthrift-turn-fn calls 0.05 seen-ctx)})))
+      (ask-and-wait r :spender 10000)
+      ;; ONE turn ran, blew the ceiling, and the loop ended. A second call would
+      ;; be the wrap-up turn — money spent past a limit nobody agreed to lift.
+      (is (= 1 @calls)
+          (str "expected exactly 1 turn (the one that exhausted the budget); "
+               "got " @calls ". A wrap-up turn is spending past the ceiling.")))))
+
+(deftest budget-is-resumable-by-raising-it
+  (testing "resumption is an ORDINARY message, not a parked continuation:
+            raise the budget, speak again, and the agent carries on. This is the
+            whole design — the durable room log is the continuation, which is the
+            only kind spindel can have (it has no durable conts)."
+    (let [r        (d/room :budget-t3)
+          calls    (atom 0)
+          seen-ctx (atom nil)]
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent
+                   {:id :spender
+                    :spec {:provider :mock :model "mock" :system-prompt "spend"}
+                    :budget {:dollars 0.01}
+                    :run-turn-fn (spendthrift-turn-fn calls 0.05 seen-ctx)})))
+      (ask-and-wait r :spender 10000)
+      (is (= 1 @calls) "first ask: one turn, then the ceiling stops it")
+
+      ;; the human raises the room's budget (simmis: room settings → raise-budget!)
+      (let [chat-ctx @seen-ctx]
+        (is (some? chat-ctx) "the agent ran, so we have its chat-ctx")
+        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+          (swap! (:budget-signal chat-ctx) update :total
+                 + (long (* 1.0 acct/MICRODOLLARS-PER-DOLLAR)))))
+
+      ;; …and speaks. No latch was waiting; the message itself is the resume.
+      (ask-and-wait r :spender 10000)
+      (is (>= @calls 2)
+          "after the budget was raised, an ordinary message must resume work"))))

--- a/test/dvergr/model/quirks_test.clj
+++ b/test/dvergr/model/quirks_test.clj
@@ -47,9 +47,9 @@
             This is the false positive that would matter most: suppressing it
             would silently swallow the agent's most useful answers."
     (is (not (quirks/code-fragment?
-               "Here is how I fetched it:\n\n(http/get \"https://wttr.in\")\n\nThat returned +21°C.")))
+              "Here is how I fetched it:\n\n(http/get \"https://wttr.in\")\n\nThat returned +21°C.")))
     (is (not (quirks/code-fragment?
-               "```clojure\n(defn add [a b] (+ a b))\n```\nCall it as (add 1 2)."))))
+              "```clojure\n(defn add [a b] (+ a b))\n```\nCall it as (add 1 2)."))))
 
   (testing "emoticons are punctuation, not structure — `:)` balances to -1"
     (is (not (quirks/code-fragment? "Sounds good :) let me know")))

--- a/test/dvergr/model/quirks_test.clj
+++ b/test/dvergr/model/quirks_test.clj
@@ -1,0 +1,98 @@
+(ns dvergr.model.quirks-test
+  "Provider quirks — the defenses against models mis-addressing their tool calls.
+
+   Every case here is a shape we have actually observed in production traffic,
+   not a hypothetical. The 2026-07-13 GLM incident is the reference story: a
+   model emitted its tool call as prose, our recovery ran the (mis-braced) code
+   it found, the model re-emitted the repaired code as a MESSAGE, and the agent
+   loop read that as 'I am done speaking' and quit mid-task."
+  (:require [clojure.test :refer [deftest testing is]]
+            [dvergr.model.quirks :as quirks]))
+
+;; ---------------------------------------------------------------------------
+;; code-fragment? — code fumbled into the prose channel
+;; ---------------------------------------------------------------------------
+
+(def ^:private real-spill
+  "Verbatim from the room DB, 2026-07-13 16:55:47. Note the leading `)`: the
+   tail of an expression whose head went into a mangled tool call."
+  ")\n(def resp (http/get \"https://wttr.in/Vancouver\" {:query-params {\"format\" \"v2\"}}))\n(:body resp)")
+
+(deftest code-fragment-catches-fumbled-code
+  (testing "the real spill that ended Vár's turn"
+    (is (quirks/code-fragment? real-spill)))
+
+  (testing "a block that closes more than it opens is truncated or continued"
+    (is (quirks/code-fragment? "(def x 1)))"))
+    (is (quirks/code-fragment? "))")))
+
+  (testing "content opening on a closing delimiter is never a message to a human"
+    (is (quirks/code-fragment? "} :as opts]"))
+    (is (quirks/code-fragment? "] (recur))")))
+
+  (testing "a tool-call envelope surviving in content is a leak, not a reply"
+    (is (quirks/code-fragment? "Tool calls: [\"clojure_eval\"] <arg_key>code</arg_key>"))
+    (is (quirks/code-fragment? "<tool_call>shell"))))
+
+(deftest code-fragment-leaves-real-replies-alone
+  (testing "prose"
+    (is (not (quirks/code-fragment? "The weather in Vancouver is +21°C and partly cloudy.")))
+    (is (not (quirks/code-fragment? ""))))
+
+  (testing "prose that merely contains delimiters"
+    (is (not (quirks/code-fragment? "It is warm (about 21°C) today — nice for a walk!")))
+    (is (not (quirks/code-fragment? "Use the map [:a :b] for that."))))
+
+  (testing "a reply that EXPLAINS code — balanced, so not a fragment.
+            This is the false positive that would matter most: suppressing it
+            would silently swallow the agent's most useful answers."
+    (is (not (quirks/code-fragment?
+               "Here is how I fetched it:\n\n(http/get \"https://wttr.in\")\n\nThat returned +21°C.")))
+    (is (not (quirks/code-fragment?
+               "```clojure\n(defn add [a b] (+ a b))\n```\nCall it as (add 1 2)."))))
+
+  (testing "emoticons are punctuation, not structure — `:)` balances to -1"
+    (is (not (quirks/code-fragment? "Sounds good :) let me know")))
+    (is (not (quirks/code-fragment? "haha :) (nice one)")))
+    (is (not (quirks/code-fragment? "done ;)"))))
+
+  (testing "delimiters inside strings and comments are text"
+    (is (not (quirks/code-fragment? "(println \"hi :) ]]] )\")")))
+    (is (not (quirks/code-fragment? "(def x 1) ; closes ) here")))))
+
+;; ---------------------------------------------------------------------------
+;; The GLM envelope: recovery must be FAITHFUL
+;; ---------------------------------------------------------------------------
+
+(deftest parse-glm-tool-calls-round-trips-code-exactly
+  (testing "the parser may only SLICE — never rewrite the model's code.
+            (During the 2026-07-13 incident this was the prime suspect for a
+            stray brace; it was exonerated, and this test keeps it that way.)"
+    (let [code (str "(require '[babashka.http-client :as http])\n"
+                    "(def resp (http/get \"https://wttr.in/Vancouver\" "
+                    "{:query-params {\"format\" \"v2\"}}))\n"
+                    "(:body resp)")
+          envelope (str "Tool calls: [\"clojure_eval\"] "
+                        "<arg_key>code</arg_key><arg_value>" code "</arg_value>")
+          [call] (quirks/parse-glm-tool-calls envelope)]
+      (is (= "clojure_eval" (:name call)))
+      (is (= code (:code (:input call)))
+          "recovered code must be byte-identical to what the model emitted"))))
+
+(deftest parse-glm-tool-calls-ignores-clean-content
+  (testing "no envelope, no recovery"
+    (is (nil? (quirks/parse-glm-tool-calls "Just a normal reply.")))
+    (is (nil? (quirks/parse-glm-tool-calls nil)))))
+
+(deftest sanitize-glm-structured-call-splits-name-from-leaked-envelope
+  (testing "GLM leaks the envelope INTO the tool NAME; left alone it is an
+            unknown tool and the invalid name poisons the next request"
+    (let [call {:name "clojure_eval<arg_key>code</arg_key><arg_value>(+ 1 2)</arg_value>"
+                :input nil}
+          fixed (quirks/sanitize-glm-structured-call call)]
+      (is (= "clojure_eval" (:name fixed)))
+      (is (= "(+ 1 2)" (:code (:input fixed))))))
+
+  (testing "a well-formed call passes through untouched"
+    (let [call {:name "shell" :input {:command "ls"}}]
+      (is (= call (quirks/sanitize-glm-structured-call call))))))


### PR DESCRIPTION
Four fixes found by dogfooding simmis agents on real work (a long PDF
analysis + tool-heavy chats). Every one of them was a case of an agent
appearing to "give up" for reasons that had nothing to do with the task.

Continues the work merged in #21 (which landed the null-args and
`leave` fixes); these four never made it in.

### 1. Code fumbled into the prose channel no longer ends the turn

A model can emit its tool call as plain content — `stop_reason=stop`, no
`tool_calls`, body = a code fragment. Read literally, the loop concludes
"no tool calls, so the agent has finished speaking", posts the fragment
to the room as if it were an answer, and ends the turn. The agent looks
like it spilled code and quit mid-task. It had not finished; it
misaddressed a tool call.

Observed 2026-07-13: GLM miscounted a brace, the recovered call failed
to parse, and it then re-emitted the repaired code as a MESSAGE opening
on a stray `)`. The user watched an agent abandon a task it had already
completed on its first tool call.

- `agent.clj` names the mistake once and returns `:continue`. The loop is
  bounded by BUDGET, not a turn cap, so a corrective turn costs cents and
  rescues the work. A second identical nudge cannot help, so it is said
  at most once.
- `llm.clj` refuses to POST a fragment as a reply even if the model
  fumbles twice — otherwise the room shows code as an answer and other
  agents reply *to* it.

`code-fragment?` is deliberately conservative: a reply that merely
CONTAINS balanced code is a legitimate answer and must never be
suppressed. It flags only content that cannot be addressed to a human —
opening on a closing delimiter, closing more than it opens, or still
carrying a tool-call envelope. Emoticons are stripped first: `:)`
balances to -1 and would otherwise read as truncated code.

### 2. GLM leaks its envelope into the structured tool-call NAME

`clojure_eval<arg_key>code</arg_key><arg_value>…` — an unknown tool, and
the invalid name poisons the history so the NEXT request 400s.

### 3. The clojure_eval timeout is embedder-tunable

60s suits interactive probing, but an agent chewing a large document hits
it as a tool ERROR, which the model then retries with a variation —
burning budget on work that only needed runway. simmis measured 60,329ms
failures on PDF-scale text ops.

### 4. The budget checkpoint is visible in the room, and extendable

Budget exhaustion was invisible: the agent simply stopped. Now it posts a
non-triggering activity row, and `raise-budget!` lets a supervisor extend
a LIVE agent's budget so the loop resumes instead of dying.

⚠️ **Reviewer note — the grace window is the weak part of this.** The
checkpoint currently waits `grace-ms` (60s) for a directive and then
soft-continues into a wrap-up turn. A stopwatch is the wrong primitive:
a supervisor is not necessarily watching, and the wrap-up turn *spends
more money after the budget is exhausted*. The right model is to PARK
until the supervisor (human or agent) decides — with wrap-up as an
explicit directive, not a timeout outcome. Happy to land that here or as
a follow-up.

### Tests

Adds `test/dvergr/model/quirks_test.clj` — the GLM defenses had none,
which is part of why this went unnoticed. 5 tests, 25 assertions. It also
pins `parse-glm-tool-calls` to a byte-exact round trip: the recovery may
only SLICE, never rewrite (it was the prime suspect for the stray brace,
and was exonerated).