### PR TITLE
fix(glm): stop a leaked tool-name/null-args call from bricking a room

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -70,8 +70,11 @@
                                                      (mapv (fn [tu]
                                                              {:type "tool_use"
                                                               :id (:tool-use/id tu)
-                                                              :name (:tool-use/name tu)
-                                                              :input (strip-ns-keys (:tool-use/input tu))})
+                                                              ;; Guard replay of any pre-existing poisoned
+                                                              ;; history: clean a leaked-envelope name and
+                                                              ;; never send nil input.
+                                                              :name (quirks/clean-tool-name (:tool-use/name tu))
+                                                              :input (or (strip-ns-keys (:tool-use/input tu)) {})})
                                                            tool-uses)))}
                                    ;; Regular message
                                      {:role (name role)
@@ -95,10 +98,11 @@
                                :tool_calls (mapv (fn [tu]
                                                    {:id (:tool-use/id tu)
                                                     :type "function"
-                                                    :function {:name (:tool-use/name tu)
-                                                               ;; nil input (no-arg tool call) must
-                                                               ;; replay as "{}" — "null" arguments
-                                                               ;; are a 400 on OpenAI-compat APIs.
+                                                    ;; clean-tool-name guards replay of already-poisoned
+                                                    ;; history (a leaked `name<arg_key>…` is a hard 400);
+                                                    ;; nil input (no-arg tool call) must replay as "{}" —
+                                                    ;; "null" arguments are also a 400 on OpenAI-compat APIs.
+                                                    :function {:name (quirks/clean-tool-name (:tool-use/name tu))
                                                                :arguments (json/write-value-as-string
                                                                            (or (strip-ns-keys (:tool-use/input tu)) {}))}})
                                                  tool-uses)}
@@ -298,11 +302,19 @@
                                       ;; Interleaved-thinking trace, fed back to
                                       ;; the model next turn (see openai provider).
                                       :reasoning reasoning
+                                      ;; Sanitize BEFORE persisting: a leaked
+                                      ;; GLM envelope in the name or a nil
+                                      ;; argument map, once durable, makes every
+                                      ;; later turn replay an invalid tool_call
+                                      ;; and 400 forever (bricks the room). This
+                                      ;; is the load-bearing guard.
                                       :tool-uses (when (seq tool-calls)
                                                    (mapv (fn [tc]
-                                                           {:tool-use/id (:id tc)
-                                                            :tool-use/name (:name tc)
-                                                            :tool-use/input (:input tc)})
+                                                           (let [{:keys [id name input]}
+                                                                 (quirks/sanitize-tool-call tc)]
+                                                             {:tool-use/id id
+                                                              :tool-use/name name
+                                                              :tool-use/input input}))
                                                          tool-calls))
                                       :tokens (:output-tokens usage)
                                       :turn-number turn-number}))]

--- a/src/dvergr/model/quirks.clj
+++ b/src/dvergr/model/quirks.clj
@@ -109,6 +109,36 @@
       (try ((requiring-resolve 'jsonista.core/read-value) t) (catch Exception _ v))
       v)))
 
+(defn clean-tool-name
+  "Strip a leaked GLM envelope (or any stray non-identifier tail) off a tool
+   name: `clojure_eval<arg_key>code…` → `clojure_eval`. A real tool name is an
+   identifier — cut at the first char that can't be part of one. Returns the
+   trimmed head, or the input unchanged when it is already clean/blank."
+  [name]
+  (if (string? name)
+    (let [head (re-find #"^[A-Za-z0-9_.:-]+" (str/trim name))]
+      (or head name))
+    name))
+
+(defn sanitize-tool-call
+  "Make a tool-call map API-safe before it is persisted OR replayed: strip any
+   leaked envelope off the name, and coerce a nil/blank argument map to `{}` —
+   `null` arguments and a non-identifier function name are each a hard 400 on
+   OpenAI-compatible endpoints, and once such a call lands in durable history
+   EVERY later turn 400s (a single bad emission bricks the conversation). Works
+   on the agent's `{:id :name :input}` shape; leaves a clean call untouched.
+   When the name carried an inline `<arg_key>…<arg_value>…` payload and no
+   structured input survived, recover the args from it."
+  [{:keys [name input] :as call}]
+  (let [envelope-pairs (when (and (string? name) (str/includes? name "<arg_key>"))
+                         (into {} (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
+                                       (re-seq glm-arg-pair-re name))))
+        input' (cond
+                 (map? input)     input
+                 (seq envelope-pairs) envelope-pairs
+                 :else            {})]
+    (assoc call :name (clean-tool-name name) :input input')))
+
 (defn parse-glm-tool-calls
   "Extract tool call(s) leaked into `content` as GLM's <arg_key>/<arg_value>
    envelope. Returns [{:name str :input {kw val}} …] or nil when the pattern
@@ -131,7 +161,10 @@
       (when (and (seq names) (seq pairs))
         ;; Single-call is the common leak; when multiple names appear we give
         ;; every parsed pair to the first (safe: our tools take one arg-map).
-        [{:name (str/trim (first names))
+        ;; clean-tool-name strips the envelope from the Fireworks echo form
+        ;; `Tool calls: ["clojure_eval<arg_key>…"]`, whose quoted name captures
+        ;; the whole leaked payload.
+        [{:name (clean-tool-name (first names))
           :input (into {} pairs)}]))))
 
 (defn sanitize-glm-structured-call

--- a/test/dvergr/model/quirks_test.clj
+++ b/test/dvergr/model/quirks_test.clj
@@ -96,3 +96,53 @@
   (testing "a well-formed call passes through untouched"
     (let [call {:name "shell" :input {:command "ls"}}]
       (is (= call (quirks/sanitize-glm-structured-call call))))))
+
+;; ---------------------------------------------------------------------------
+;; clean-tool-name / sanitize-tool-call — the durable-poison guard
+;;
+;; 2026-07-15 Playground incident: on turn 18 of a market-research chain GLM
+;; emitted a tool call whose NAME absorbed the arg envelope AND whose value was
+;; truncated mid-emission. The recovered call was persisted verbatim, and from
+;; then on EVERY turn replayed it and got `API error 400: … function
+;; 'clojure_eval<arg_key>…' … arguments … must decode to a JSON object, got
+;; NoneType`. A single bad emission bricked the room. These guard both ends.
+;; ---------------------------------------------------------------------------
+
+(def ^:private playground-poison-name
+  "Verbatim tool name from the Playground room DB, truncated exactly as stored
+   (no closing </arg_value> — the emission was cut mid-value)."
+  "clojure_eval<arg_key>code</arg_key><arg_value>;; Let's also search for Glean and a few other enterprise AI search companies\n(def search21 (fetch")
+
+(deftest clean-tool-name-strips-leaked-envelope
+  (is (= "clojure_eval" (quirks/clean-tool-name playground-poison-name)))
+  (is (= "clojure_eval" (quirks/clean-tool-name "clojure_eval")))
+  (is (= "functions.shell:0" (quirks/clean-tool-name "functions.shell:0")))
+  (is (nil? (quirks/clean-tool-name nil))))
+
+(deftest sanitize-tool-call-never-yields-invalid-name-or-nil-args
+  (testing "the exact truncated poison: name cleaned, args coerced to a map"
+    (let [fixed (quirks/sanitize-tool-call {:id "glm-recovered-0"
+                                            :name playground-poison-name
+                                            :input nil})]
+      (is (= "clojure_eval" (:name fixed)))
+      (is (map? (:input fixed)) "nil args must become {} — never null (a 400)")))
+
+  (testing "a complete envelope recovers its args from the name"
+    (let [fixed (quirks/sanitize-tool-call
+                 {:name "clojure_eval<arg_key>code</arg_key><arg_value>(+ 1 2)</arg_value>"
+                  :input nil})]
+      (is (= "clojure_eval" (:name fixed)))
+      (is (= "(+ 1 2)" (:code (:input fixed))))))
+
+  (testing "a well-formed call passes through untouched"
+    (let [call {:id "abc" :name "shell" :input {:command "ls"}}]
+      (is (= call (quirks/sanitize-tool-call call))))))
+
+(deftest parse-glm-tool-calls-cleans-echo-form-name
+  (testing "Fireworks echo `Tool calls: [\"name<arg_key>…\"]` — the quoted name
+            captures the whole leaked payload; recovery must still yield a clean name"
+    (let [content (str "Tool calls: [\"clojure_eval<arg_key>code</arg_key>"
+                       "<arg_value>(+ 1 2)</arg_value>\"] "
+                       "<arg_key>code</arg_key><arg_value>(+ 1 2)</arg_value>")
+          [call] (quirks/parse-glm-tool-calls content)]
+      (is (= "clojure_eval" (:name call))))))


### PR DESCRIPTION
## What

A GLM `<arg_key>` tool-format leak (Fireworks) on a mid-research turn produced a tool call whose function **name** absorbed the argument envelope — `clojure_eval<arg_key>code</arg_key><arg_value>…` — truncated so no structured input survived. dvergr persisted it verbatim into the room's durable history. From then on **every** subsequent turn replayed that message and hit:

```
API error 400: Invalid tool call in messages: tool_calls[].function.arguments
for function 'clojure_eval<arg_key>…' must decode to a JSON object, got NoneType
```

A single malformed emission **permanently bricked the room** — the agent could never respond again. Observed 2026-07-15 in the Playground market-research thread (Vár "wound itself up").

## Root cause

Nothing validated a tool call before it entered durable history, and the recovered/echo-form path let the polluted name through. The null-arguments half was already fixed on `main` (the OpenAI request builder defaults input to `{}`); the polluted **name** was not, and neither end was guarded at the persistence boundary.

## Fix

- `quirks/clean-tool-name` — cut a tool name at the first non-identifier char, stripping a leaked `<arg_key>…` envelope.
- `quirks/sanitize-tool-call` — make a `{:id :name :input}` call API-safe: clean the name, coerce nil/blank args to `{}` (recovering args from the name's envelope when the envelope is complete).
- Apply it at the **persist** boundary in `chat/agent` so history can never be poisoned (the load-bearing guard), and clean the name at **both** request builders (OpenAI + Anthropic) so an already-poisoned store can still replay.
- `parse-glm-tool-calls` cleans the Fireworks echo-form name (`Tool calls: ["name<arg_key>…"]`) too.

## Tests

`quirks-test` reproduces the **verbatim truncated poison** from the room DB and asserts a clean name + a map (never null) args, plus echo-form recovery. `8 tests, 35 assertions, 0 failures`.

## Note

An already-poisoned room (like dev.simm.is Playground) needs its stored bad message scrubbed once — this prevents *new* poison and makes replay of *old* poison non-fatal, but a call already in history without recoverable args still needs the operator scrub (done manually for Playground).