### PR TITLE
feat(agent): :on-reply hook to rewrite replies + inject learn-back notes

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -200,6 +200,13 @@
    - :tools - Tool registry
    - :tool-ctx - Tool execution context
    - :on-text - Callback for text chunks
+   - :on-reply - (fn [reply-content] → {:content str :notes [str…]}) optional
+                 embedder hook run on the assistant's text reply BEFORE it is
+                 added to the chat-ctx. :content replaces the reply (e.g. rewrite
+                 references) so the agent's own next-turn copy carries it; each
+                 :note is injected as a {:role :system} message the agent reads
+                 next turn (same channel as budget alerts). Fail-safe: a throw or
+                 nil return leaves the reply untouched.
    - :auto-compact? - Enable automatic compaction (default true)
    - :compaction-model - Model for summarization
    - :turn-number - Current turn number (for message grouping)
@@ -209,7 +216,7 @@
    - :complete if agent is done (no tool calls)
    - :error if something failed"
   [chat-ctx {:keys [provider model tools tool-ctx on-text auto-compact? compaction-model turn-number cancel?
-                    system-suffix]
+                    system-suffix on-reply]
              :or {auto-compact? true}}]
   (try
     ;; Check for automatic compaction before turn
@@ -271,6 +278,25 @@
                               :tokens usage}}
                       "LLM response received")
 
+          ;; Product reference hook: let the embedder rewrite outbound
+          ;; references in the reply (e.g. bare [[Title]] → [[dh://…]]) so the
+          ;; agent's OWN next-turn copy — and the reply it posts — carry
+          ;; resolved links, and surface system notes for anything the embedder
+          ;; couldn't resolve. The notes are injected below exactly like a
+          ;; budget alert, so the agent sees the feedback next turn without a
+          ;; visible message or an extra turn. Fail-safe: a hook error (or a nil
+          ;; return) leaves the reply untouched — a product hook must never
+          ;; break a turn.
+          reply-hook  (when (and on-reply (string? content) (seq content))
+                        (try (on-reply content)
+                             (catch Throwable t
+                               (tel/log! {:level :warn :id :agent/on-reply-failed
+                                          :data {:error (.getMessage t)}}
+                                         "on-reply hook threw; using raw reply")
+                               nil)))
+          content     (or (:content reply-hook) content)
+          reply-notes (:notes reply-hook)
+
           ;; Account for token usage and capture threshold warnings
           input-result (when (:input-tokens usage)
                          (chat-ctx/account-tokens! chat-ctx
@@ -317,7 +343,13 @@
                                                               :tool-use/input input}))
                                                          tool-calls))
                                       :tokens (:output-tokens usage)
-                                      :turn-number turn-number}))]
+                                      :turn-number turn-number}))
+
+          ;; Surface embedder reply notes (e.g. unresolvable links) as system
+          ;; messages the agent reads next turn — same channel as budget alerts.
+          _ (doseq [note reply-notes
+                    :when (and (string? note) (seq note))]
+              (chat-ctx/add-message! chat-ctx {:role :system :content note}))]
 
       ;; Handle tool calls
       (if (seq tool-calls)

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -127,10 +127,14 @@
                   Override for testing or to inject per-turn behaviour
                   (e.g. usage logging). Default calls
                   `dvergr.chat.agent/run-agent-turn!`.
+   :on-reply    — (fn [reply-content] → {:content str :notes [str…]}) optional
+                  embedder hook threaded to `run-agent-turn!` — rewrites the
+                  agent's outbound reply (e.g. resolve references) and returns
+                  system notes injected into the chat-ctx for the next turn.
    :ctx         — discourse room's execution context
                   (default: `*execution-context*`)"
   [{:keys [id spec tools db-conn budget compaction
-           chat-ctx participant-context tool-ctx run-turn-fn ctx room-safe?]
+           chat-ctx participant-context tool-ctx run-turn-fn ctx room-safe? on-reply]
     :or   {budget      {:dollars 1.0}
            compaction  {:auto? true :strategy :sync-before-turn}
            run-turn-fn default-run-turn
@@ -290,7 +294,11 @@
                                                          (conj prompt/planning-mode-guideline)))
                                     :auto-compact?    (and (:auto? compaction true)
                                                            (not race-compaction?))
-                                    :compaction-model (:model compaction)}
+                                    :compaction-model (:model compaction)
+                                ;; Product reference hook (see run-agent-turn!):
+                                ;; rewrites outbound refs in the reply + returns
+                                ;; system notes for unresolvable ones.
+                                    :on-reply         on-reply}
                          errored           (atom nil)]
                  ;; The just-arrived user message. ROOM path: append-inbound!
                  ;; (deduped against the bus fold by msg id, decorated with author


### PR DESCRIPTION
## What

`run-agent-turn!` gains an optional **`:on-reply`** hook — `(fn [reply-content] → {:content str :notes [str…]})` — applied to the assistant's text reply *before* it is added to the `chat-ctx`:

- **`:content`** replaces the reply, so the agent's own next-turn copy **and** the reply it posts both carry the rewrite. The motivating use is an embedder resolving bare `[[Title]]` wiki-links to explicit cross-database references.
- **`:notes`** are each injected as a `{:role :system}` message via the **same channel budget alerts already use** (`agent.clj`), so the agent reads the feedback next turn — no visible chat message, no extra turn triggered.

Threaded through `llm-agent` (`:on-reply` → `turn-opts`).

## Why

Embedders (e.g. simmis) need to (a) normalize an agent's outbound references against product state and (b) teach the agent when a reference can't be resolved — without bolting bespoke tools on, and without spamming the room. The existing budget-alert path already proves the pattern: a system note in the `chat-ctx` reaches the model's next turn cleanly. This generalizes that into a product hook.

## Safety

- **Fail-safe:** a hook throw or a `nil` return leaves the reply untouched (logged at `:warn`). A product hook must never break a turn.
- **No behaviour change when absent:** every existing caller omits `:on-reply`, so the path is inert unless opted in.

## Consumer

simmis wires `:on-reply` to resolve chat `[[Title]]` links to `[[dh://…]]` and nudge the agent (system note) toward `kb/link` / `kb/ensure-page!` for anything unresolvable.