### PR TITLE
feat(tools): transparent+actionable output truncation (+ raise shell cap)

### DIFF
--- a/src/dvergr/chat/compaction.clj
+++ b/src/dvergr/chat/compaction.clj
@@ -109,7 +109,10 @@
                            "Showing first " (int (* 100 truncation-prefix-ratio))
                            "% and last " (int (* 100 (- 1.0 truncation-prefix-ratio)))
                            "% of " estimated " total tokens. "
-                           "If you need the full output, re-run the tool with more specific parameters.]\n\n")]
+                           "This clips only what is PRINTED — any value you computed is intact. "
+                           "Don't re-print it: in clojure_eval capture it with `def` and reduce it "
+                           "programmatically (filter/select/count/parse) so you return only the small "
+                           "result you need; for a file or URL, read/fetch a slice instead of the whole.]\n\n")]
            (str prefix marker suffix)))))))
 
 (defn truncate-tool-result

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -436,6 +436,15 @@
    - You can require namespaces
    - Changes don't affect other sessions
 
+   LARGE DATA — hold and reduce, don't dump. The printed result is truncated
+   for context (~15K tokens), but that clips only what is PRINTED — the VALUE
+   persists in the session. So for a fetched page/feed or a big file, capture
+   it (`(def body (slurp url))`) and reduce it programmatically — `(count body)`,
+   `(re-seq re body)`, parse and select the few fields you need — returning only
+   the small result. Never print a whole page/feed/file; this is how you work
+   with data far larger than the output cap. Prefer this over the `shell` tool
+   (whose stdout is truncated) when a response might be large.
+
    Execution budget: a 60-second hard timeout applies to each call. If
    you exceed it the tool returns a TimeoutException with a hint about
    likely causes (hung @spin, infinite loop, oversized inference). Keep
@@ -579,8 +588,10 @@
    - Default permits auto-allow read-only commands (ls, cat, grep, git
      status/log/diff, rg, etc.) and auto-deny destructive ones (sudo,
      rm -rf, dd, reboot). Other commands pass through (run).
-   - Output is capped at 8000 chars per stream; :truncated? signals
-     when the cap fired.
+   - Output is capped at 30000 chars per stream; :truncated? signals
+     when the cap fired (the global tool-result truncation at ~60K chars
+     is the real backstop — this per-stream cap just avoids one runaway
+     stream from dominating).
    - Session state (cwd, env vars, bg jobs) is per chat-ctx and
      forks alongside it — a worker in a substrate-fork gets an
      isolated session for free.
@@ -596,7 +607,7 @@
                {:type :error
                 :error "shell tool requires a chat-ctx in the tool-ctx."}
                (let [r ((requiring-resolve 'dvergr.intake.bash/run)
-                        chat-ctx command)]
+                        chat-ctx command :max-out 30000)]
                  (if (:error r)
                    {:type :error
                     :error (:error r)


### PR DESCRIPTION
Truncation was a silent trap — an agent debugging a large payload (a legal RSS feed embeds ~18KB of full-article HTML per item) saw a clipped fragment and gave up, not realizing it was truncated OR that the value was still intact in the REPL session. Raising the cap alone just makes that less likely; the real fix is transparency + the hold-and-reduce pattern.

- **Marker**: now says the clip is only on what's PRINTED (the value persists) and to reduce it programmatically (`def` + filter/parse/count) or read/fetch a slice — instead of the old 're-run with more specific parameters'.
- **clojure_eval description**: teaches hold-and-reduce for large data (the session persists values; only the printed result truncates), and to prefer it over `shell` (whose stdout truncates) for big responses.
- **shell cap**: 8000 → 30000 chars/stream (the ~60K global tool-result truncation is the real context backstop).