### PR TITLE
fix(harness): safety net — tool-input persist storm, loop bound, visible retries

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -423,7 +423,29 @@
                                                  (:error result)
                                                  (pr-str result))
                                     :turn-number turn-number}))
-          :continue)
+          ;; Loop bound: if the agent is repeating the SAME tool call with the
+          ;; same args and making no progress, stop the auto-continue cycle
+          ;; instead of spinning until budget runs out. History stays coherent
+          ;; (tool_uses + their results are both present); a nudge tells the
+          ;; model why it stopped, and the next human turn resumes it. This
+          ;; finally wires detect-doom-loop, which was dead code.
+          (if-let [looped (detect-doom-loop (chat-ctx/get-messages chat-ctx))]
+            (do
+              (tel/log! {:level :warn :id :agent/doom-loop
+                         :data {:tool (:tool-use/name looped) :turn turn-number}}
+                        "Repeated identical tool call with no progress — ending turn cycle")
+              (chat-ctx/add-message! chat-ctx
+                                     {:role :system
+                                      :important? true
+                                      :content (str "You have called `" (:tool-use/name looped)
+                                                    "` with identical arguments "
+                                                    doom-loop-threshold "+ times without making "
+                                                    "progress. Stop repeating it — either take a "
+                                                    "materially different approach, or reply to the "
+                                                    "room describing what you found and what is "
+                                                    "blocking you.")})
+              :complete)
+            :continue))
 
         ;; No tool calls. Usually that means the agent is done — but a model can
         ;; also fumble its code into the PROSE channel (stop_reason=stop, no

--- a/src/dvergr/chat/tool_schema.clj
+++ b/src/dvergr/chat/tool_schema.clj
@@ -23,6 +23,7 @@
        :tool-input.clj-kondo.config/linters (ref to component)
        ..."
   (:require [clojure.string :as str]
+            [clojure.edn :as edn]
             [datahike.api :as d]))
 
 ;; ============================================================================
@@ -236,8 +237,38 @@
 ;; Forward declaration for mutual recursion
 (declare convert-input)
 
+(defn- parse-embedded-coll
+  "An LLM sometimes emits an array/object arg as a STRING holding its JSON/EDN
+   form (e.g. tags as \"[\\\"a\\\" \\\"b\\\"]\"). Parse it back to a collection;
+   nil if the string is not a collection literal. Never iterates a string into
+   characters."
+  [s]
+  (let [t (str/trim s)]
+    (when (or (str/starts-with? t "[") (str/starts-with? t "{"))
+      (try (let [v (edn/read-string t)]
+             (when (coll? v) v))
+           (catch Exception _ nil)))))
+
+(defn- coerce-to-seq
+  "Normalize an array-valued arg into a sequence WITHOUT exploding a string
+   into characters — the char-explosion bug (`(vec \"[…]\")` → chars) that
+   detonated at transact time. Accepts a real sequence, a JSON/EDN-string
+   array, or a lone scalar (a one-element array)."
+  [value]
+  (cond
+    (sequential? value) value
+    (nil? value)        []
+    (string? value)     (or (parse-embedded-coll value) [value])
+    (coll? value)       (vec value)
+    :else               [value]))
+
 (defn- convert-value
-  "Convert a value for Datahike storage based on schema type."
+  "Convert a value for Datahike storage based on schema type. TOTAL over
+   malformed model output: returns a value that satisfies the attribute's
+   declared Datahike type, or throws `::uncoercible` so the caller
+   (serialize-tool-use) degrades to persisting the tool-use without structured
+   input — never a value that passes construction but fails the message
+   transact (the char-exploded-array storm)."
   [tool-name path param-name value param-schema]
   (let [json-type (get param-schema :type "string")]
     (case json-type
@@ -245,32 +276,48 @@
       "string"
       (str value)
 
-      "integer"
-      (if (string? value)
-        (Long/parseLong value)
-        (long value))  ;; LLMs may return numeric args as strings
+      "integer"  ;; LLMs may return numeric args as strings
+      (cond
+        (integer? value) (long value)
+        (number? value)  (long value)
+        (string? value)  (try (Long/parseLong (str/trim value))
+                              (catch Exception _
+                                (throw (ex-info "uncoercible integer"
+                                                {::uncoercible true :param param-name :value value}))))
+        :else (throw (ex-info "uncoercible integer"
+                              {::uncoercible true :param param-name :value value})))
 
       "number"
-      (if (string? value)
-        (Double/parseDouble value)
-        (double value))
+      (cond
+        (number? value)  (double value)
+        (string? value)  (try (Double/parseDouble (str/trim value))
+                              (catch Exception _
+                                (throw (ex-info "uncoercible number"
+                                                {::uncoercible true :param param-name :value value}))))
+        :else (throw (ex-info "uncoercible number"
+                              {::uncoercible true :param param-name :value value})))
 
-      "boolean"
-      (boolean value)
+      "boolean"  ;; (boolean \"false\") is truthy — coerce the string honestly
+      (cond
+        (boolean? value) value
+        (string? value)  (contains? #{"true" "1" "yes" "y" "t"} (str/lower-case (str/trim value)))
+        :else            (boolean value))
 
       ;; Arrays
       "array"
       (let [items (get param-schema :items {})
-            items-type (get items :type "string")]
+            items-type (get items :type "string")
+            xs (coerce-to-seq value)]
         (if (= items-type "object")
           ;; Array of objects - convert each
           (mapv #(convert-input tool-name
                                 (conj (vec path) param-name)
                                 %
                                 items)
-                value)
-          ;; Array of primitives - use as-is
-          (vec value)))
+                xs)
+          ;; Array of primitives - coerce EACH element to the declared item
+          ;; type (never `(vec value)`, which char-explodes a string arg)
+          (mapv #(convert-value tool-name path param-name % items) xs)))
 
       ;; Nested objects
       "object"

--- a/src/dvergr/model/chat.clj
+++ b/src/dvergr/model/chat.clj
@@ -9,7 +9,8 @@
             [hato.client :as hc]
             [jsonista.core :as json]
             [clojure.java.io :as io]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [taoensso.telemere :as log])
   (:import [java.io BufferedReader]
            [java.net SocketTimeoutException]
            [java.io IOException]))
@@ -201,9 +202,12 @@
             (:success result)
             (let [delay-ms (calculate-backoff attempt nil)]
               (when (> attempt 0)
-                (binding [*out* *err*]
-                  (println (str "Retry " (inc attempt) "/" (:max-retries retry-config)
-                                " after " delay-ms "ms: " (.getMessage (:error result))))))
+                (log/log! {:level :warn :id :model/chat-retry
+                           :data {:attempt (inc attempt)
+                                  :max-retries (:max-retries retry-config)
+                                  :delay-ms delay-ms
+                                  :error (.getMessage (:error result))}}
+                          "Retrying model chat after retryable error"))
               (Thread/sleep (long delay-ms))
               (recur (inc attempt) (:error result)))))))))
 


### PR DESCRIPTION
First of the harness-hardening passes (analysis + plan in simmis `doc/harness-hardening.md`, from the `dvergr-harness-audit` fan-out). Scoped deliberately to three files that are clean vs `main` so it does not collide with the in-flight kontor accounting WIP; the CJK token-estimate and model-visible `timeout_ms`/`background?` params (which touch `compaction.clj`/`tools.clj`) are held for a follow-up.

Prompted by the Playground derailment: a GLM turn stormed the room for ~4 min and spun until it drifted (to Mandarin, at only 43% context — a harness bug, not memory pressure).

### 1. Tool-input coercion is now TOTAL over malformed model output — `chat/tool_schema.clj`
GLM sent `knowledge_add`'s `tags` as a **stringified** array (`"[\"a\" \"b\"]"`); `convert-value`'s array branch did `(vec value)`, exploding the string into **characters**, which passed entity construction but failed the message `d/transact` against a `many string?` attribute — **past** `serialize-tool-use`'s try/catch — retried ~8×/cycle for ~4 min.
- arrays normalize via `coerce-to-seq` (parse an embedded JSON/EDN-array string, or wrap a lone scalar) and coerce **each element** to the item type — never `(vec string)`;
- integer/number parse defensively and throw `::uncoercible` on a non-numeric string; boolean coerces `"false"`/`"true"` honestly;
- any residual uncoercible value throws **at construction**, so the **existing** `serialize-tool-use` guard degrades to persisting the tool-use without structured input. A bad arg can no longer detonate at transact — **no poison message is written, so redelivery has nothing to amplify.**

### 2. The turn loop is actually bounded — `chat/agent.clj`
`detect-doom-loop` was **dead code** (zero call sites); the loop's only real bound was dollar budget. Now wired into `run-agent-turn!`: when the agent repeats the same tool call with identical args and no progress, the auto-continue cycle ends **coherently** (tool_uses + results both present) with a nudge, and the next human turn resumes it.

### 3. Model-chat retries are visible — `model/chat.clj`
The retry-backoff log was a `println` to `*err*`, outside Telemere — invisible to the log and the pump-watchdog (why the storm was hard to see). Now a Telemere `:model/chat-retry` warn.

### Verification
Exercised in a live REPL against the exact malformed `knowledge_add` payload → transactable entity (`tags` as strings, `relevance` coerced to long); non-numeric integer arg → throws `::uncoercible` and degrades gracefully; well-formed input unchanged; all three namespaces compile and `clj-kondo` clean.

### Invariants preserved
Quirk-sanitize still runs before persist; one tool-result per tool_use_id (doom-loop ends *after* results are added); SSE cancel untouched; `ensure-full-schema!` untouched. No new schema attributes introduced (the degrade path reuses the existing dissoc-input branch, not the raw-EDN fallback — that is the H1 follow-up).