### PR TITLE
refactor(quirks): one canonical GLM envelope reader (collapse 3 duplicate parsers)

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -423,7 +423,29 @@
                                                  (:error result)
                                                  (pr-str result))
                                     :turn-number turn-number}))
-          :continue)
+          ;; Loop bound: if the agent is repeating the SAME tool call with the
+          ;; same args and making no progress, stop the auto-continue cycle
+          ;; instead of spinning until budget runs out. History stays coherent
+          ;; (tool_uses + their results are both present); a nudge tells the
+          ;; model why it stopped, and the next human turn resumes it. This
+          ;; finally wires detect-doom-loop, which was dead code.
+          (if-let [looped (detect-doom-loop (chat-ctx/get-messages chat-ctx))]
+            (do
+              (tel/log! {:level :warn :id :agent/doom-loop
+                         :data {:tool (:tool-use/name looped) :turn turn-number}}
+                        "Repeated identical tool call with no progress — ending turn cycle")
+              (chat-ctx/add-message! chat-ctx
+                                     {:role :system
+                                      :important? true
+                                      :content (str "You have called `" (:tool-use/name looped)
+                                                    "` with identical arguments "
+                                                    doom-loop-threshold "+ times without making "
+                                                    "progress. Stop repeating it — either take a "
+                                                    "materially different approach, or reply to the "
+                                                    "room describing what you found and what is "
+                                                    "blocking you.")})
+              :complete)
+            :continue))
 
         ;; No tool calls. Usually that means the agent is done — but a model can
         ;; also fumble its code into the PROSE channel (stop_reason=stop, no

--- a/src/dvergr/chat/tool_schema.clj
+++ b/src/dvergr/chat/tool_schema.clj
@@ -23,6 +23,7 @@
        :tool-input.clj-kondo.config/linters (ref to component)
        ..."
   (:require [clojure.string :as str]
+            [clojure.edn :as edn]
             [datahike.api :as d]))
 
 ;; ============================================================================
@@ -236,8 +237,38 @@
 ;; Forward declaration for mutual recursion
 (declare convert-input)
 
+(defn- parse-embedded-coll
+  "An LLM sometimes emits an array/object arg as a STRING holding its JSON/EDN
+   form (e.g. tags as \"[\\\"a\\\" \\\"b\\\"]\"). Parse it back to a collection;
+   nil if the string is not a collection literal. Never iterates a string into
+   characters."
+  [s]
+  (let [t (str/trim s)]
+    (when (or (str/starts-with? t "[") (str/starts-with? t "{"))
+      (try (let [v (edn/read-string t)]
+             (when (coll? v) v))
+           (catch Exception _ nil)))))
+
+(defn- coerce-to-seq
+  "Normalize an array-valued arg into a sequence WITHOUT exploding a string
+   into characters — the char-explosion bug (`(vec \"[…]\")` → chars) that
+   detonated at transact time. Accepts a real sequence, a JSON/EDN-string
+   array, or a lone scalar (a one-element array)."
+  [value]
+  (cond
+    (sequential? value) value
+    (nil? value)        []
+    (string? value)     (or (parse-embedded-coll value) [value])
+    (coll? value)       (vec value)
+    :else               [value]))
+
 (defn- convert-value
-  "Convert a value for Datahike storage based on schema type."
+  "Convert a value for Datahike storage based on schema type. TOTAL over
+   malformed model output: returns a value that satisfies the attribute's
+   declared Datahike type, or throws `::uncoercible` so the caller
+   (serialize-tool-use) degrades to persisting the tool-use without structured
+   input — never a value that passes construction but fails the message
+   transact (the char-exploded-array storm)."
   [tool-name path param-name value param-schema]
   (let [json-type (get param-schema :type "string")]
     (case json-type
@@ -245,32 +276,48 @@
       "string"
       (str value)
 
-      "integer"
-      (if (string? value)
-        (Long/parseLong value)
-        (long value))  ;; LLMs may return numeric args as strings
+      "integer"  ;; LLMs may return numeric args as strings
+      (cond
+        (integer? value) (long value)
+        (number? value)  (long value)
+        (string? value)  (try (Long/parseLong (str/trim value))
+                              (catch Exception _
+                                (throw (ex-info "uncoercible integer"
+                                                {::uncoercible true :param param-name :value value}))))
+        :else (throw (ex-info "uncoercible integer"
+                              {::uncoercible true :param param-name :value value})))
 
       "number"
-      (if (string? value)
-        (Double/parseDouble value)
-        (double value))
+      (cond
+        (number? value)  (double value)
+        (string? value)  (try (Double/parseDouble (str/trim value))
+                              (catch Exception _
+                                (throw (ex-info "uncoercible number"
+                                                {::uncoercible true :param param-name :value value}))))
+        :else (throw (ex-info "uncoercible number"
+                              {::uncoercible true :param param-name :value value})))
 
-      "boolean"
-      (boolean value)
+      "boolean"  ;; (boolean \"false\") is truthy — coerce the string honestly
+      (cond
+        (boolean? value) value
+        (string? value)  (contains? #{"true" "1" "yes" "y" "t"} (str/lower-case (str/trim value)))
+        :else            (boolean value))
 
       ;; Arrays
       "array"
       (let [items (get param-schema :items {})
-            items-type (get items :type "string")]
+            items-type (get items :type "string")
+            xs (coerce-to-seq value)]
         (if (= items-type "object")
           ;; Array of objects - convert each
           (mapv #(convert-input tool-name
                                 (conj (vec path) param-name)
                                 %
                                 items)
-                value)
-          ;; Array of primitives - use as-is
-          (vec value)))
+                xs)
+          ;; Array of primitives - coerce EACH element to the declared item
+          ;; type (never `(vec value)`, which char-explodes a string arg)
+          (mapv #(convert-value tool-name path param-name % items) xs)))
 
       ;; Nested objects
       "object"

--- a/src/dvergr/model/chat.clj
+++ b/src/dvergr/model/chat.clj
@@ -9,7 +9,8 @@
             [hato.client :as hc]
             [jsonista.core :as json]
             [clojure.java.io :as io]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [taoensso.telemere :as log])
   (:import [java.io BufferedReader]
            [java.net SocketTimeoutException]
            [java.io IOException]))
@@ -201,9 +202,12 @@
             (:success result)
             (let [delay-ms (calculate-backoff attempt nil)]
               (when (> attempt 0)
-                (binding [*out* *err*]
-                  (println (str "Retry " (inc attempt) "/" (:max-retries retry-config)
-                                " after " delay-ms "ms: " (.getMessage (:error result))))))
+                (log/log! {:level :warn :id :model/chat-retry
+                           :data {:attempt (inc attempt)
+                                  :max-retries (:max-retries retry-config)
+                                  :delay-ms delay-ms
+                                  :error (.getMessage (:error result))}}
+                          "Retrying model chat after retryable error"))
               (Thread/sleep (long delay-ms))
               (recur (inc attempt) (:error result)))))))))
 

--- a/src/dvergr/model/quirks.clj
+++ b/src/dvergr/model/quirks.clj
@@ -109,6 +109,16 @@
       (try ((requiring-resolve 'jsonista.core/read-value) t) (catch Exception _ v))
       v)))
 
+(defn- envelope->args
+  "The one canonical reader of GLM's `<arg_key>K</arg_key><arg_value>V</arg_value>`
+   envelope: parse every complete pair out of a string into a `{keyword value}`
+   map (values JSON-scalar-coerced via `glm-arg->value`); `{}` when the envelope
+   isn't present. The sanitize/parse paths all share this instead of each
+   re-walking `glm-arg-pair-re`."
+  [s]
+  (into {} (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
+                (re-seq glm-arg-pair-re (str s)))))
+
 (defn clean-tool-name
   "Strip a leaked GLM envelope (or any stray non-identifier tail) off a tool
    name: `clojure_eval<arg_key>code…` → `clojure_eval`. A real tool name is an
@@ -131,8 +141,7 @@
    structured input survived, recover the args from it."
   [{:keys [name input] :as call}]
   (let [envelope-pairs (when (and (string? name) (str/includes? name "<arg_key>"))
-                         (into {} (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                                       (re-seq glm-arg-pair-re name))))
+                         (envelope->args name))
         input' (cond
                  (map? input)     input
                  (seq envelope-pairs) envelope-pairs
@@ -156,16 +165,15 @@
                              (re-seq #"\"([^\"]+)\"")
                              (map second)
                              seq))
-          pairs (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                     (re-seq glm-arg-pair-re s))]
-      (when (and (seq names) (seq pairs))
+          args (envelope->args s)]
+      (when (and (seq names) (seq args))
         ;; Single-call is the common leak; when multiple names appear we give
         ;; every parsed pair to the first (safe: our tools take one arg-map).
         ;; clean-tool-name strips the envelope from the Fireworks echo form
         ;; `Tool calls: ["clojure_eval<arg_key>…"]`, whose quoted name captures
         ;; the whole leaked payload.
         [{:name (clean-tool-name (first names))
-          :input (into {} pairs)}]))))
+          :input args}]))))
 
 (defn sanitize-glm-structured-call
   "GLM also leaks its envelope INTO the structured tool_call NAME field:
@@ -179,14 +187,16 @@
   (if (and name (str/includes? (str name) "<arg_key>"))
     (let [n (str name)
           real-name (str/trim (subs n 0 (str/index-of n "<arg_key>")))
-          pairs (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                     (re-seq glm-arg-pair-re n))
-          partial-pair (when (empty? pairs)
+          args (envelope->args n)
+          ;; An unterminated trailing <arg_value> yields no complete pair; keep
+          ;; its partial (raw, uncoerced) text so the tool fails informatively
+          ;; instead of the turn dying.
+          partial-pair (when (empty? args)
                          (when-let [[_ k v] (re-find #"(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*)\z" n)]
-                           [[(keyword (str/trim k)) v]]))]
+                           {(keyword (str/trim k)) v}))]
       (assoc call
              :name real-name
-             :input (merge (into {} (concat pairs partial-pair)) input)))
+             :input (merge args partial-pair input)))
     call))
 
 (defn strip-glm-tool-tokens

--- a/test/dvergr/model/quirks_test.clj
+++ b/test/dvergr/model/quirks_test.clj
@@ -146,3 +146,17 @@
                        "<arg_key>code</arg_key><arg_value>(+ 1 2)</arg_value>")
           [call] (quirks/parse-glm-tool-calls content)]
       (is (= "clojure_eval" (:name call))))))
+
+(deftest all-envelope-consumers-share-one-reader
+  (testing "sanitize-tool-call, sanitize-glm-structured-call and parse-glm-tool-calls
+            recover the SAME multi-arg pairs from the SAME envelope (they route
+            through the single canonical envelope reader) — with JSON-scalar
+            coercion on values"
+    (let [env  "<arg_key>title</arg_key><arg_value>\"Founders\"</arg_value><arg_key>relevance</arg_key><arg_value>5</arg_value>"
+          want {:title "Founders" :relevance 5}]
+      (is (= want (:input (quirks/sanitize-tool-call
+                           {:name (str "knowledge_add" env) :input nil}))))
+      (is (= want (:input (quirks/sanitize-glm-structured-call
+                           {:name (str "knowledge_add" env) :input nil}))))
+      (is (= want (:input (first (quirks/parse-glm-tool-calls
+                                  (str "<tool_call>knowledge_add" env "</tool_call>")))))))))


### PR DESCRIPTION
Second harness-cleanup pass (plan in simmis `.internal/harness-hardening.md`). **Stacked on #28** — review/merge that first; this branch includes #28's three commits and the diff below is only `quirks.clj` + its test.

GLM's `<arg_key>K</arg_key><arg_value>V</arg_value>` envelope was walked by **three verbatim copies** of the same `(map … (re-seq glm-arg-pair-re …))` expression — in `sanitize-tool-call`, `parse-glm-tool-calls`, and `sanitize-glm-structured-call` — each building a `{kw val}` map with `glm-arg->value` coercion. Adding a model whose leak differs meant editing three sites that could silently drift apart on how they read the same envelope.

Introduce one private `envelope->args` reader; the three consumers now share it and differ only in **where** the envelope comes from (name field vs raw content) and what they return.

**Behavior-preserving.** The value coercion, the unterminated-trailing-`<arg_value>` partial-pair path in the structured-call fix, and the merge/override order are all unchanged. These are load-bearing anti-brick guards (a malformed durable tool_call 400s a room forever), so the refactor is pinned by tests: the existing **35 assertions pass unchanged**, plus one new test asserting all three consumers recover the **same** pairs from the **same** envelope.

This is the audit's *"collapse the five overlapping GLM fns to one parser"* win — the honest, shippable slice, **without** the speculative generic transform-pipeline framework (only two quirky families exist, and a new family's quirk is usually new parsing code, not a data row — per the critique).