### PR TITLE
fix(persist): total tool-input — preserve un-typeable args as raw EDN, round-trip on replay

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -423,7 +423,29 @@
                                                  (:error result)
                                                  (pr-str result))
                                     :turn-number turn-number}))
-          :continue)
+          ;; Loop bound: if the agent is repeating the SAME tool call with the
+          ;; same args and making no progress, stop the auto-continue cycle
+          ;; instead of spinning until budget runs out. History stays coherent
+          ;; (tool_uses + their results are both present); a nudge tells the
+          ;; model why it stopped, and the next human turn resumes it. This
+          ;; finally wires detect-doom-loop, which was dead code.
+          (if-let [looped (detect-doom-loop (chat-ctx/get-messages chat-ctx))]
+            (do
+              (tel/log! {:level :warn :id :agent/doom-loop
+                         :data {:tool (:tool-use/name looped) :turn turn-number}}
+                        "Repeated identical tool call with no progress — ending turn cycle")
+              (chat-ctx/add-message! chat-ctx
+                                     {:role :system
+                                      :important? true
+                                      :content (str "You have called `" (:tool-use/name looped)
+                                                    "` with identical arguments "
+                                                    doom-loop-threshold "+ times without making "
+                                                    "progress. Stop repeating it — either take a "
+                                                    "materially different approach, or reply to the "
+                                                    "room describing what you found and what is "
+                                                    "blocking you.")})
+              :complete)
+            :continue))
 
         ;; No tool calls. Usually that means the agent is done — but a model can
         ;; also fumble its code into the PROSE channel (stop_reason=stop, no

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -20,6 +20,7 @@
             [dvergr.tools :as tools]
             [dvergr.sandbox.workspace :as workspace]
             [jsonista.core :as json]
+            [clojure.edn :as edn]
             [datahike.api :as dh]
             [taoensso.telemere :as tel]))
 
@@ -32,6 +33,20 @@
   [m]
   (when (map? m)
     (into {} (map (fn [[k v]] [(if (keyword? k) (keyword (name k)) k) v]) m))))
+
+(defn- tool-use-input->args
+  "Reconstruct a tool_use's argument map for API replay from its persisted
+   :tool-use/input entity. A raw-EDN fallback entity (`:tool-input.raw/content`,
+   written when a tool arg couldn't be typed) round-trips via its stored EDN;
+   any other entity has its datahike namespace prefixes stripped. Always returns
+   a map — never nil (`null` arguments are a hard 400 on OpenAI-compat APIs)."
+  [input]
+  (or (when (map? input)
+        (if-let [raw (get input :tool-input.raw/content)]
+          (try (let [v (edn/read-string raw)] (when (map? v) v))
+               (catch Exception _ nil))
+          (strip-ns-keys input)))
+      {}))
 
 (declare messages->api-format)
 
@@ -74,7 +89,7 @@
                                                               ;; history: clean a leaked-envelope name and
                                                               ;; never send nil input.
                                                               :name (quirks/clean-tool-name (:tool-use/name tu))
-                                                              :input (or (strip-ns-keys (:tool-use/input tu)) {})})
+                                                              :input (tool-use-input->args (:tool-use/input tu))})
                                                            tool-uses)))}
                                    ;; Regular message
                                      {:role (name role)
@@ -104,7 +119,7 @@
                                                     ;; "null" arguments are also a 400 on OpenAI-compat APIs.
                                                     :function {:name (quirks/clean-tool-name (:tool-use/name tu))
                                                                :arguments (json/write-value-as-string
-                                                                           (or (strip-ns-keys (:tool-use/input tu)) {}))}})
+                                                                           (tool-use-input->args (:tool-use/input tu)))}})
                                                  tool-uses)}
                         (seq reasoning) (assoc :reasoning_content reasoning))
                       (cond-> {:role (name role)

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -910,10 +910,12 @@
 
    DEGRADES (never throws): if the tool is unregistered (a model can hallucinate
    a tool name, e.g. the sandbox ns \"intake.hn\" vs the real tool \"clojure_eval\"), the input isn't a
-   map, or schema conversion fails, the tool-use is recorded by NAME with no
-   structured input (`:tool-use/input` is an optional ref). Persisting an agent's
-   turn must not crash on a bad tool call — tool EXECUTION returns the
-   \"unknown tool\" / validation error the model then recovers from."
+   map, or schema conversion fails, the input is preserved as a raw-EDN fallback
+   entity (`:tool-input.raw/*`) rather than dropped — so the durable record keeps
+   the arguments (queryable later, and round-trippable on replay) and the write
+   is always transactable. Persisting an agent's turn must not crash on a bad
+   tool call — tool EXECUTION returns the \"unknown tool\" / validation error the
+   model then recovers from."
   [tool-use]
   (let [tool-name (:tool-use/name tool-use)
         input     (:tool-use/input tool-use)
@@ -924,17 +926,27 @@
                          (catch Throwable e
                            (tel/log! {:level :warn :id :schema/tool-input-unconvertible
                                       :data {:tool-name tool-name :error (.getMessage e)}}
-                                     "tool input could not be structured — storing tool-use without input")
+                                     "tool input could not be structured — falling back to raw EDN")
                            nil)))]
-    (if entity
+    (cond
+      entity
       (assoc tool-use :tool-use/input entity)
+
+      ;; No structured entity, but there IS an input: preserve it verbatim as raw
+      ;; EDN instead of dropping it. Always transactable (a string), and
+      ;; reconstructable on replay (see agent/tool-use-input->args).
+      (some? input)
       (do
         (when-not tool-def
           (tel/log! {:level :warn :id :schema/unregistered-tool-use
                      :data {:tool-name tool-name :available (keys registry)}}
                     (str "tool-use for unregistered tool '" tool-name
-                         "' persisted without structured input (likely a model hallucination)")))
-        (dissoc tool-use :tool-use/input)))))
+                         "' stored with raw-EDN input (likely a model hallucination)")))
+        (assoc tool-use :tool-use/input (tool-schema/raw-input->entity tool-name input)))
+
+      ;; No input at all — a legitimately arg-less call.
+      :else
+      (dissoc tool-use :tool-use/input))))
 
 (defn create-message-entity
   "Create a message entity map for transacting.

--- a/src/dvergr/chat/tool_schema.clj
+++ b/src/dvergr/chat/tool_schema.clj
@@ -214,8 +214,12 @@
             (throw e))
           (count schema))))))
 
+;; Defined below; referenced by install-all-tool-schemas! (resolved at call time).
+(declare raw-input-schema)
+
 (defn install-all-tool-schemas!
-  "Install schemas for all tools in a registry.
+  "Install schemas for all tools in a registry, plus the raw-EDN fallback
+   attributes.
 
    Args:
      conn     - Datahike connection
@@ -224,6 +228,14 @@
    Returns:
      Map of tool-name -> count of attributes installed."
   [conn registry]
+  ;; Always install the raw-EDN fallback attributes. serialize-tool-use degrades
+  ;; a tool input it cannot type into :tool-input.raw/*, so persistence stays
+  ;; total — these MUST exist before any such write can land.
+  (try
+    (d/transact conn raw-input-schema)
+    (catch Exception e
+      (when-not (re-find #"already exists|already defined" (.getMessage e))
+        (throw e))))
   (->> registry
        (map (fn [[tool-name tool-def]]
               [tool-name (install-tool-schema! conn tool-def)]))

--- a/src/dvergr/chat/tool_schema.clj
+++ b/src/dvergr/chat/tool_schema.clj
@@ -23,6 +23,7 @@
        :tool-input.clj-kondo.config/linters (ref to component)
        ..."
   (:require [clojure.string :as str]
+            [clojure.edn :as edn]
             [datahike.api :as d]))
 
 ;; ============================================================================
@@ -236,8 +237,38 @@
 ;; Forward declaration for mutual recursion
 (declare convert-input)
 
+(defn- parse-embedded-coll
+  "An LLM sometimes emits an array/object arg as a STRING holding its JSON/EDN
+   form (e.g. tags as \"[\\\"a\\\" \\\"b\\\"]\"). Parse it back to a collection;
+   nil if the string is not a collection literal. Never iterates a string into
+   characters."
+  [s]
+  (let [t (str/trim s)]
+    (when (or (str/starts-with? t "[") (str/starts-with? t "{"))
+      (try (let [v (edn/read-string t)]
+             (when (coll? v) v))
+           (catch Exception _ nil)))))
+
+(defn- coerce-to-seq
+  "Normalize an array-valued arg into a sequence WITHOUT exploding a string
+   into characters — the char-explosion bug (`(vec \"[…]\")` → chars) that
+   detonated at transact time. Accepts a real sequence, a JSON/EDN-string
+   array, or a lone scalar (a one-element array)."
+  [value]
+  (cond
+    (sequential? value) value
+    (nil? value)        []
+    (string? value)     (or (parse-embedded-coll value) [value])
+    (coll? value)       (vec value)
+    :else               [value]))
+
 (defn- convert-value
-  "Convert a value for Datahike storage based on schema type."
+  "Convert a value for Datahike storage based on schema type. TOTAL over
+   malformed model output: returns a value that satisfies the attribute's
+   declared Datahike type, or throws `::uncoercible` so the caller
+   (serialize-tool-use) degrades to persisting the tool-use without structured
+   input — never a value that passes construction but fails the message
+   transact (the char-exploded-array storm)."
   [tool-name path param-name value param-schema]
   (let [json-type (get param-schema :type "string")]
     (case json-type
@@ -245,32 +276,48 @@
       "string"
       (str value)
 
-      "integer"
-      (if (string? value)
-        (Long/parseLong value)
-        (long value))  ;; LLMs may return numeric args as strings
+      "integer"  ;; LLMs may return numeric args as strings
+      (cond
+        (integer? value) (long value)
+        (number? value)  (long value)
+        (string? value)  (try (Long/parseLong (str/trim value))
+                              (catch Exception _
+                                (throw (ex-info "uncoercible integer"
+                                                {::uncoercible true :param param-name :value value}))))
+        :else (throw (ex-info "uncoercible integer"
+                              {::uncoercible true :param param-name :value value})))
 
       "number"
-      (if (string? value)
-        (Double/parseDouble value)
-        (double value))
+      (cond
+        (number? value)  (double value)
+        (string? value)  (try (Double/parseDouble (str/trim value))
+                              (catch Exception _
+                                (throw (ex-info "uncoercible number"
+                                                {::uncoercible true :param param-name :value value}))))
+        :else (throw (ex-info "uncoercible number"
+                              {::uncoercible true :param param-name :value value})))
 
-      "boolean"
-      (boolean value)
+      "boolean"  ;; (boolean \"false\") is truthy — coerce the string honestly
+      (cond
+        (boolean? value) value
+        (string? value)  (contains? #{"true" "1" "yes" "y" "t"} (str/lower-case (str/trim value)))
+        :else            (boolean value))
 
       ;; Arrays
       "array"
       (let [items (get param-schema :items {})
-            items-type (get items :type "string")]
+            items-type (get items :type "string")
+            xs (coerce-to-seq value)]
         (if (= items-type "object")
           ;; Array of objects - convert each
           (mapv #(convert-input tool-name
                                 (conj (vec path) param-name)
                                 %
                                 items)
-                value)
-          ;; Array of primitives - use as-is
-          (vec value)))
+                xs)
+          ;; Array of primitives - coerce EACH element to the declared item
+          ;; type (never `(vec value)`, which char-explodes a string arg)
+          (mapv #(convert-value tool-name path param-name % items) xs)))
 
       ;; Nested objects
       "object"

--- a/src/dvergr/model/chat.clj
+++ b/src/dvergr/model/chat.clj
@@ -9,7 +9,8 @@
             [hato.client :as hc]
             [jsonista.core :as json]
             [clojure.java.io :as io]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [taoensso.telemere :as log])
   (:import [java.io BufferedReader]
            [java.net SocketTimeoutException]
            [java.io IOException]))
@@ -201,9 +202,12 @@
             (:success result)
             (let [delay-ms (calculate-backoff attempt nil)]
               (when (> attempt 0)
-                (binding [*out* *err*]
-                  (println (str "Retry " (inc attempt) "/" (:max-retries retry-config)
-                                " after " delay-ms "ms: " (.getMessage (:error result))))))
+                (log/log! {:level :warn :id :model/chat-retry
+                           :data {:attempt (inc attempt)
+                                  :max-retries (:max-retries retry-config)
+                                  :delay-ms delay-ms
+                                  :error (.getMessage (:error result))}}
+                          "Retrying model chat after retryable error"))
               (Thread/sleep (long delay-ms))
               (recur (inc attempt) (:error result)))))))))
 

--- a/src/dvergr/model/quirks.clj
+++ b/src/dvergr/model/quirks.clj
@@ -109,6 +109,16 @@
       (try ((requiring-resolve 'jsonista.core/read-value) t) (catch Exception _ v))
       v)))
 
+(defn- envelope->args
+  "The one canonical reader of GLM's `<arg_key>K</arg_key><arg_value>V</arg_value>`
+   envelope: parse every complete pair out of a string into a `{keyword value}`
+   map (values JSON-scalar-coerced via `glm-arg->value`); `{}` when the envelope
+   isn't present. The sanitize/parse paths all share this instead of each
+   re-walking `glm-arg-pair-re`."
+  [s]
+  (into {} (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
+                (re-seq glm-arg-pair-re (str s)))))
+
 (defn clean-tool-name
   "Strip a leaked GLM envelope (or any stray non-identifier tail) off a tool
    name: `clojure_eval<arg_key>code…` → `clojure_eval`. A real tool name is an
@@ -131,8 +141,7 @@
    structured input survived, recover the args from it."
   [{:keys [name input] :as call}]
   (let [envelope-pairs (when (and (string? name) (str/includes? name "<arg_key>"))
-                         (into {} (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                                       (re-seq glm-arg-pair-re name))))
+                         (envelope->args name))
         input' (cond
                  (map? input)     input
                  (seq envelope-pairs) envelope-pairs
@@ -156,16 +165,15 @@
                              (re-seq #"\"([^\"]+)\"")
                              (map second)
                              seq))
-          pairs (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                     (re-seq glm-arg-pair-re s))]
-      (when (and (seq names) (seq pairs))
+          args (envelope->args s)]
+      (when (and (seq names) (seq args))
         ;; Single-call is the common leak; when multiple names appear we give
         ;; every parsed pair to the first (safe: our tools take one arg-map).
         ;; clean-tool-name strips the envelope from the Fireworks echo form
         ;; `Tool calls: ["clojure_eval<arg_key>…"]`, whose quoted name captures
         ;; the whole leaked payload.
         [{:name (clean-tool-name (first names))
-          :input (into {} pairs)}]))))
+          :input args}]))))
 
 (defn sanitize-glm-structured-call
   "GLM also leaks its envelope INTO the structured tool_call NAME field:
@@ -179,14 +187,16 @@
   (if (and name (str/includes? (str name) "<arg_key>"))
     (let [n (str name)
           real-name (str/trim (subs n 0 (str/index-of n "<arg_key>")))
-          pairs (map (fn [[_ k v]] [(keyword (str/trim k)) (glm-arg->value v)])
-                     (re-seq glm-arg-pair-re n))
-          partial-pair (when (empty? pairs)
+          args (envelope->args n)
+          ;; An unterminated trailing <arg_value> yields no complete pair; keep
+          ;; its partial (raw, uncoerced) text so the tool fails informatively
+          ;; instead of the turn dying.
+          partial-pair (when (empty? args)
                          (when-let [[_ k v] (re-find #"(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*)\z" n)]
-                           [[(keyword (str/trim k)) v]]))]
+                           {(keyword (str/trim k)) v}))]
       (assoc call
              :name real-name
-             :input (merge (into {} (concat pairs partial-pair)) input)))
+             :input (merge args partial-pair input)))
     call))
 
 (defn strip-glm-tool-tokens

--- a/test/dvergr/chat/tool_input_roundtrip_test.clj
+++ b/test/dvergr/chat/tool_input_roundtrip_test.clj
@@ -1,0 +1,63 @@
+(ns dvergr.chat.tool-input-roundtrip-test
+  "H1 — tool-input persistence is TOTAL: an input that cannot be typed against a
+   tool's schema (or a hallucinated/unregistered tool) is preserved as a raw-EDN
+   fallback entity instead of dropped, and round-trips back to the original
+   argument map on replay. Guards against both the char-explosion storm class
+   and silent argument loss."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [dvergr.chat.schema :as sch]
+            [dvergr.chat.tool-schema :as ts]
+            [dvergr.chat.agent :as agent]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (doto (d/connect cfg) (sch/ensure-full-schema!))))
+
+(deftest reconstruct-tool-args
+  (testing "raw-EDN fallback entity round-trips to the original argument map"
+    (let [orig {:tags ["a" "b"] :relevance 5}
+          raw  (ts/raw-input->entity "mystery_tool" orig)]
+      (is (= orig (#'agent/tool-use-input->args raw)))))
+  (testing "a structured entity has its datahike namespace prefixes stripped"
+    (is (= {:tags ["a"] :title "x"}
+           (#'agent/tool-use-input->args
+            {:tool-input.knowledge-add/tags ["a"]
+             :tool-input.knowledge-add/title "x"}))))
+  (testing "nil / non-map input never replays as null (a hard 400)"
+    (is (= {} (#'agent/tool-use-input->args nil)))
+    (is (= {} (#'agent/tool-use-input->args "not-a-map")))))
+
+(deftest raw-fallback-schema-is-installed
+  (testing "ensure-full-schema! installs the :tool-input.raw/* fallback attrs"
+    (let [conn (fresh-conn)]
+      (is (boolean (d/q '[:find ?e . :where [?e :db/ident :tool-input.raw/content]]
+                        (d/db conn))))
+      (is (boolean (d/q '[:find ?e . :where [?e :db/ident :tool-input.raw/tool-name]]
+                        (d/db conn)))))))
+
+(deftest persist-then-replay-round-trip
+  (testing "an un-typeable tool input persists as raw EDN, pulls back, and
+            reconstructs to the original args for replay (was silently dropped)"
+    (let [conn    (fresh-conn)
+          orig    {:tags ["founders" "tools"] :relevance 5}
+          raw-ent (ts/raw-input->entity "mystery_tool" orig)
+          chat-id (random-uuid)
+          msg-id  (random-uuid)]
+      (d/transact conn [{:chat/id chat-id}])
+      (d/transact conn [{:message/id msg-id
+                         :message/chat [:chat/id chat-id]
+                         :message/role :assistant
+                         :message/content "x"
+                         :message/created-at (java.util.Date.)
+                         :message/tool-uses [{:tool-use/id "tu1"
+                                              :tool-use/name "mystery_tool"
+                                              :tool-use/input raw-ent}]}])
+      (let [eid    (d/q '[:find ?m . :in $ ?mid :where [?m :message/id ?mid]]
+                        (d/db conn) msg-id)
+            pulled (d/pull (d/db conn) '[*] eid)
+            tu     (first (:message/tool-uses pulled))]
+        (is (= orig (#'agent/tool-use-input->args (:tool-use/input tu))))))))

--- a/test/dvergr/model/quirks_test.clj
+++ b/test/dvergr/model/quirks_test.clj
@@ -146,3 +146,17 @@
                        "<arg_key>code</arg_key><arg_value>(+ 1 2)</arg_value>")
           [call] (quirks/parse-glm-tool-calls content)]
       (is (= "clojure_eval" (:name call))))))
+
+(deftest all-envelope-consumers-share-one-reader
+  (testing "sanitize-tool-call, sanitize-glm-structured-call and parse-glm-tool-calls
+            recover the SAME multi-arg pairs from the SAME envelope (they route
+            through the single canonical envelope reader) — with JSON-scalar
+            coercion on values"
+    (let [env  "<arg_key>title</arg_key><arg_value>\"Founders\"</arg_value><arg_key>relevance</arg_key><arg_value>5</arg_value>"
+          want {:title "Founders" :relevance 5}]
+      (is (= want (:input (quirks/sanitize-tool-call
+                           {:name (str "knowledge_add" env) :input nil}))))
+      (is (= want (:input (quirks/sanitize-glm-structured-call
+                           {:name (str "knowledge_add" env) :input nil}))))
+      (is (= want (:input (first (quirks/parse-glm-tool-calls
+                                  (str "<tool_call>knowledge_add" env "</tool_call>")))))))))


### PR DESCRIPTION
H1 from the harness plan (`.internal/harness-hardening.md`). **Stacked on #29 → #28** — merge those first; the diff below is only the four H1 files.

Completes the storm-hardening from #28. Before, a tool input that couldn't be structured against its schema (or a hallucinated/unregistered tool) was **dropped** (`dissoc :tool-use/input`); on a rehydrated replay that tool_use then sent `{}` as its arguments — **silent argument loss**, and the audit trail lost the args entirely. Now persistence is **total and lossless**:

- **serialize-tool-use** degrades to `raw-input->entity` — store the input verbatim as `:tool-input.raw/content` EDN — instead of dropping it, for any present input. Always transactable (a string), so a malformed arg can never wedge the message write.
- **install-all-tool-schemas!** now always installs the `:tool-input.raw/*` fallback attrs (idempotent), guaranteeing the fallback is writable before any such write lands — the critique's stated prerequisite for making raw the default.
- **Replay reconstruction** (`agent/tool-use-input->args`) recognises the raw entity and reads its EDN back to the **original** argument map; a structured entity still has its datahike namespaces stripped; nil/non-map still replays as `{}` (never `null`, a hard 400). Wired into both provider replay paths.

### Verification
Against a real datahike: `ensure-full-schema!` installs the raw attrs; an un-typeable input **persists → pulls back → reconstructs to the exact original args** (`round-trip-ok? true`). New `tool_input_roundtrip_test` (3 tests / 7 assertions, incl. the full persist→pull→replay path); existing `tool_schema` (15) and `quirks` (38) suites pass unchanged.

### Why this is strictly better than #28's interim behavior
#28 stopped the *crash* by making `convert-value` throw `::uncoercible` so the existing guard dropped the input. This preserves the input instead — no audit loss, correct replay — closing the invariant *"any value that fails typed decomposition degrades to a stored raw representation, always transactable"* from the plan.