### PR TITLE
refactor(chat): one note-injection seam (add-system-note!) for out-of-band feedback

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -327,11 +327,9 @@
           ;; Inject threshold warnings as system messages
           _ (doseq [result [input-result output-result]
                     :when (:threshold-crossed? result)]
-              (chat-ctx/add-message! chat-ctx
-                                     {:role :system
-                                      :content (str "⚠️ BUDGET ALERT: "
-                                                    (:threshold-message result))
-                                      :important? true}))
+              (chat-ctx/add-system-note! chat-ctx
+                                         (str "⚠️ BUDGET ALERT: " (:threshold-message result))
+                                         :important? true))
 
           ;; Add assistant message if there's content
           _ (when (or (seq content) (seq tool-calls))
@@ -364,7 +362,7 @@
           ;; messages the agent reads next turn — same channel as budget alerts.
           _ (doseq [note reply-notes
                     :when (and (string? note) (seq note))]
-              (chat-ctx/add-message! chat-ctx {:role :system :content note}))]
+              (chat-ctx/add-system-note! chat-ctx note))]
 
       ;; Handle tool calls
       (if (seq tool-calls)
@@ -449,16 +447,15 @@
               (tel/log! {:level :warn :id :agent/doom-loop
                          :data {:tool (:tool-use/name looped) :turn turn-number}}
                         "Repeated identical tool call with no progress — ending turn cycle")
-              (chat-ctx/add-message! chat-ctx
-                                     {:role :system
-                                      :important? true
-                                      :content (str "You have called `" (:tool-use/name looped)
-                                                    "` with identical arguments "
-                                                    doom-loop-threshold "+ times without making "
-                                                    "progress. Stop repeating it — either take a "
-                                                    "materially different approach, or reply to the "
-                                                    "room describing what you found and what is "
-                                                    "blocking you.")})
+              (chat-ctx/add-system-note! chat-ctx
+                                         (str "You have called `" (:tool-use/name looped)
+                                              "` with identical arguments "
+                                              doom-loop-threshold "+ times without making "
+                                              "progress. Stop repeating it — either take a "
+                                              "materially different approach, or reply to the "
+                                              "room describing what you found and what is "
+                                              "blocking you.")
+                                         :important? true)
               :complete)
             :continue))
 
@@ -477,10 +474,7 @@
                        :data {:turn turn-number
                               :preview (subs (str content) 0 (min 80 (count (str content))))}}
                       "Model emitted code as content instead of a tool call — nudging")
-            (chat-ctx/add-message! chat-ctx
-                                   {:role :system
-                                    :content fragment-nudge
-                                    :important? true})
+            (chat-ctx/add-system-note! chat-ctx fragment-nudge :important? true)
             :continue)
           :complete)))
 

--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -194,6 +194,17 @@
 
     msg-entity))
 
+(defn add-system-note!
+  "Inject a system note the agent reads on its NEXT turn — the single seam for
+   out-of-band, model-directed feedback: budget alerts, embedder reply notes,
+   and correction nudges (code-in-prose, repeated-tool-call), with a
+   language-drift guard to come. It is an `:system` message; naming it gives
+   these one home and one place to evolve (dedup, or a queue drained at turn
+   start). `:important?` marks it protected from compaction pruning."
+  [chat-ctx content & {:keys [important?]}]
+  (add-message! chat-ctx (cond-> {:role :system :content content}
+                           important? (assoc :important? true))))
+
 (defn replace-messages!
   "Replace all messages in the chat context.
    Used by pruning to swap in pruned message versions without adding new messages.

--- a/test/dvergr/chat/context_test.clj
+++ b/test/dvergr/chat/context_test.clj
@@ -137,3 +137,17 @@
       (is (= :paused (ctx/get-status chat)))
       (ctx/set-status! chat :completed)
       (is (= :completed (ctx/get-status chat))))))
+
+(deftest add-system-note-test
+  (testing "add-system-note! is the single seam for out-of-band notes: an
+            :system message, optionally protected from pruning"
+    (let [chat (ctx/create-chat-context {:budget-dollars 1.0 :with-sci? false})]
+      (ctx/add-system-note! chat "plain")
+      (ctx/add-system-note! chat "urgent" :important? true)
+      (let [[m1 m2] (ctx/get-messages chat)]
+        (is (= :system (:message/role m1)))
+        (is (= "plain" (:message/content m1)))
+        (is (not (:message/important? m1)))
+        (is (= :system (:message/role m2)))
+        (is (= "urgent" (:message/content m2)))
+        (is (true? (:message/important? m2)))))))


### PR DESCRIPTION
H3 from the harness plan (`.internal/harness-hardening.md`). Lands on main (#28–#30 merged).

Four sites re-implemented the same *"inject an `:system` message the agent reads next turn"* pattern — budget alerts, embedder reply notes, the code-in-prose nudge, and the repeated-tool-call guard — each hand-building the message map. There was no single home for that channel, so the open **language-drift guard** (the Playground follow-up) had nowhere to hang.

Introduce **`chat-ctx/add-system-note!`** — the one seam for out-of-band, model-directed feedback (`:important?` marks it protected from compaction pruning) — and route all four `agent.clj` sites through it.

**Behaviour unchanged:** same content, same `:important?` flags, same idempotency for the fragment nudge (`nudged-for-fragment?` still matches on the text). `process.clj`'s `:inject-message` effect is intentionally left alone — it injects arbitrary roles (e.g. `:refocus`), a broader mechanism than a system-note, so folding it in would lose generality.

**Verification:** new `add-system-note-test` (6 assertions — plain vs `:important?` produce the right `:system` message); the full context suite passes clean via kaocha (**8 tests, 40 assertions, 0 failures**).