### PR TITLE
fix(persist): one message-durability policy (surface + retry-once + dead-letter)

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -327,11 +327,9 @@
           ;; Inject threshold warnings as system messages
           _ (doseq [result [input-result output-result]
                     :when (:threshold-crossed? result)]
-              (chat-ctx/add-message! chat-ctx
-                                     {:role :system
-                                      :content (str "⚠️ BUDGET ALERT: "
-                                                    (:threshold-message result))
-                                      :important? true}))
+              (chat-ctx/add-system-note! chat-ctx
+                                         (str "⚠️ BUDGET ALERT: " (:threshold-message result))
+                                         :important? true))
 
           ;; Add assistant message if there's content
           _ (when (or (seq content) (seq tool-calls))
@@ -364,7 +362,7 @@
           ;; messages the agent reads next turn — same channel as budget alerts.
           _ (doseq [note reply-notes
                     :when (and (string? note) (seq note))]
-              (chat-ctx/add-message! chat-ctx {:role :system :content note}))]
+              (chat-ctx/add-system-note! chat-ctx note))]
 
       ;; Handle tool calls
       (if (seq tool-calls)
@@ -449,16 +447,15 @@
               (tel/log! {:level :warn :id :agent/doom-loop
                          :data {:tool (:tool-use/name looped) :turn turn-number}}
                         "Repeated identical tool call with no progress — ending turn cycle")
-              (chat-ctx/add-message! chat-ctx
-                                     {:role :system
-                                      :important? true
-                                      :content (str "You have called `" (:tool-use/name looped)
-                                                    "` with identical arguments "
-                                                    doom-loop-threshold "+ times without making "
-                                                    "progress. Stop repeating it — either take a "
-                                                    "materially different approach, or reply to the "
-                                                    "room describing what you found and what is "
-                                                    "blocking you.")})
+              (chat-ctx/add-system-note! chat-ctx
+                                         (str "You have called `" (:tool-use/name looped)
+                                              "` with identical arguments "
+                                              doom-loop-threshold "+ times without making "
+                                              "progress. Stop repeating it — either take a "
+                                              "materially different approach, or reply to the "
+                                              "room describing what you found and what is "
+                                              "blocking you.")
+                                         :important? true)
               :complete)
             :continue))
 
@@ -477,10 +474,7 @@
                        :data {:turn turn-number
                               :preview (subs (str content) 0 (min 80 (count (str content))))}}
                       "Model emitted code as content instead of a tool call — nudging")
-            (chat-ctx/add-message! chat-ctx
-                                   {:role :system
-                                    :content fragment-nudge
-                                    :important? true})
+            (chat-ctx/add-system-note! chat-ctx fragment-nudge :important? true)
             :continue)
           :complete)))
 

--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -25,6 +25,7 @@
             [org.replikativ.spindel.core :as d]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.accounting :as acct]
+            [dvergr.chat.persist :as persist]
             [dvergr.sandbox :as sandbox]
             [taoensso.telemere :as tel]
             [datahike.api :as dh]))
@@ -183,7 +184,8 @@
     ;; budget is reconstructed from the ledger on restore.
     (when-let [conn (:db-conn chat-ctx)]
       (when-not (false? (:durable? chat-ctx))
-        (dh/transact conn [msg-entity])))
+        (persist/persist-tx! conn [msg-entity]
+                             {:op :add-message :msg-id (:message/id msg-entity)})))
 
     ;; Account tokens if provided
     (when-let [tokens (:tokens message)]

--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -194,6 +194,17 @@
 
     msg-entity))
 
+(defn add-system-note!
+  "Inject a system note the agent reads on its NEXT turn — the single seam for
+   out-of-band, model-directed feedback: budget alerts, embedder reply notes,
+   and correction nudges (code-in-prose, repeated-tool-call), with a
+   language-drift guard to come. It is an `:system` message; naming it gives
+   these one home and one place to evolve (dedup, or a queue drained at turn
+   start). `:important?` marks it protected from compaction pruning."
+  [chat-ctx content & {:keys [important?]}]
+  (add-message! chat-ctx (cond-> {:role :system :content content}
+                           important? (assoc :important? true))))
+
 (defn replace-messages!
   "Replace all messages in the chat context.
    Used by pruning to swap in pruned message versions without adding new messages.

--- a/src/dvergr/chat/persist.clj
+++ b/src/dvergr/chat/persist.clj
@@ -1,0 +1,55 @@
+(ns dvergr.chat.persist
+  "One durability policy for message persistence.
+
+   Before this, the two persist paths disagreed on failure: the chat-ctx path
+   (`context/add-message!`) transacted UNGUARDED — a bad transact threw into the
+   turn — while the room-store path (`store.datahike/-store-message!`) caught the
+   throwable and SILENTLY log-dropped it (message loss, no surfacing, no retry),
+   with which path ran selected by a `:durable?` boolean set elsewhere.
+
+   `persist-tx!` is the single seam both call: attempt → retry once (transient
+   lock/contention, e.g. a write-lock held for a moment) → on a second failure
+   surface LOUDLY at :error and dead-letter the payload. It never throws and
+   never silently drops."
+  (:require [datahike.api :as d]
+            [taoensso.telemere :as log]))
+
+(def ^:private dead-letter-cap
+  "Bound the in-memory dead-letter buffer so a persistent failure can't grow it
+   without limit."
+  256)
+
+;; Messages that failed to persist even after a retry — kept for post-mortem and
+;; manual recovery (inspect/replay via the REPL). Bounded ring; every add is also
+;; surfaced at :error.
+(defonce dead-letters (atom []))
+
+(defn persist-tx!
+  "Transact `tx-data` on `conn` under the ONE message-durability policy: attempt
+   once, retry once on failure, and on a second failure surface at :error and
+   dead-letter the payload rather than dropping it silently or throwing into the
+   caller. Never throws; returns true on success, false on give-up. `ctx` is a
+   small diagnostics map, e.g. {:op :store-message :room-id … :msg-id …}."
+  ([conn tx-data] (persist-tx! conn tx-data {}))
+  ([conn tx-data {:keys [op room-id msg-id] :as ctx}]
+   (letfn [(attempt [] (d/transact conn tx-data) true)]
+     (try
+       (attempt)
+       (catch Throwable t1
+         (log/log! {:level :warn :id :persist/retry
+                    :data {:op op :room-id room-id :msg-id msg-id :error (.getMessage t1)}}
+                   "message persist failed — retrying once")
+         (try
+           (attempt)
+           (catch Throwable t2
+             (swap! dead-letters
+                    (fn [dl] (vec (take-last dead-letter-cap
+                                            (conj dl {:ctx ctx
+                                                      :error (.getMessage t2)
+                                                      :tx-data tx-data})))))
+             (log/log! {:level :error :id :persist/dead-letter
+                        :data {:op op :room-id room-id :msg-id msg-id
+                               :error (.getMessage t2)
+                               :dead-letter-count (count @dead-letters)}}
+                       "message persist failed twice — DEAD-LETTERED (message not durable)")
+             false)))))))

--- a/src/dvergr/chat/persist.clj
+++ b/src/dvergr/chat/persist.clj
@@ -44,9 +44,9 @@
            (catch Throwable t2
              (swap! dead-letters
                     (fn [dl] (vec (take-last dead-letter-cap
-                                            (conj dl {:ctx ctx
-                                                      :error (.getMessage t2)
-                                                      :tx-data tx-data})))))
+                                             (conj dl {:ctx ctx
+                                                       :error (.getMessage t2)
+                                                       :tx-data tx-data})))))
              (log/log! {:level :error :id :persist/dead-letter
                         :data {:op op :room-id room-id :msg-id msg-id
                                :error (.getMessage t2)

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -9,6 +9,7 @@
    `dvergr.room.store`)."
   (:require [datahike.api :as dh]
             [dvergr.chat.schema :as schema]
+            [dvergr.chat.persist :as persist]
             [dvergr.room.store :as store]
             [taoensso.telemere :as tel]))
 
@@ -157,16 +158,17 @@
       (if-let [ent (room-by-slug conn slug)]
         (let [chat-id (:chat/id ent)
               entity  (message->entity chat-id msg)]
-          (try
-            (dh/transact conn [entity
-                               {:db/id [:chat/id chat-id]
-                                :chat/updated-at (java.util.Date.)}])
-            (catch Throwable t
-              (tel/log! {:level :warn :id :room-store/datahike-store-message-failed
-                         :data {:room-id room-id :msg-id (:id msg)
-                                :error (.getMessage t)}}))))
-        (tel/log! {:level :warn :id :room-store/datahike-missing-room
-                   :data {:room-id room-id :msg-id (:id msg)}}))))
+          ;; One durability policy (surface + retry-once + dead-letter) instead
+          ;; of the old catch-and-silently-drop — a lost message is now visible
+          ;; and recoverable, not swallowed at :warn.
+          (persist/persist-tx! conn
+                               [entity
+                                {:db/id [:chat/id chat-id]
+                                 :chat/updated-at (java.util.Date.)}]
+                               {:op :store-message :room-id room-id :msg-id (:id msg)}))
+        (tel/log! {:level :error :id :room-store/datahike-missing-room
+                   :data {:room-id room-id :msg-id (:id msg)}}
+                  "message for unknown room — not persisted (dropped)"))))
 
   (-list-messages [_ room-id {:keys [limit since]}]
     (let [slug (store/room-id->slug room-id)]

--- a/test/dvergr/chat/context_test.clj
+++ b/test/dvergr/chat/context_test.clj
@@ -137,3 +137,17 @@
       (is (= :paused (ctx/get-status chat)))
       (ctx/set-status! chat :completed)
       (is (= :completed (ctx/get-status chat))))))
+
+(deftest add-system-note-test
+  (testing "add-system-note! is the single seam for out-of-band notes: an
+            :system message, optionally protected from pruning"
+    (let [chat (ctx/create-chat-context {:budget-dollars 1.0 :with-sci? false})]
+      (ctx/add-system-note! chat "plain")
+      (ctx/add-system-note! chat "urgent" :important? true)
+      (let [[m1 m2] (ctx/get-messages chat)]
+        (is (= :system (:message/role m1)))
+        (is (= "plain" (:message/content m1)))
+        (is (not (:message/important? m1)))
+        (is (= :system (:message/role m2)))
+        (is (= "urgent" (:message/content m2)))
+        (is (true? (:message/important? m2)))))))

--- a/test/dvergr/chat/persist_test.clj
+++ b/test/dvergr/chat/persist_test.clj
@@ -1,0 +1,34 @@
+(ns dvergr.chat.persist-test
+  "H2 — one message-durability policy: success, retry-once, and dead-letter
+   (never a silent drop, never a throw into the caller)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [dvergr.chat.persist :as persist]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn [{:db/ident :thing/name
+                         :db/valueType :db.type/string
+                         :db/cardinality :db.cardinality/one}])
+      conn)))
+
+(deftest persist-success
+  (testing "a good transact returns true and lands"
+    (let [conn (fresh-conn)]
+      (is (true? (persist/persist-tx! conn [{:thing/name "ok"}] {:op :t})))
+      (is (= #{["ok"]} (d/q '[:find ?n :where [_ :thing/name ?n]] (d/db conn)))))))
+
+(deftest persist-dead-letters-never-throws
+  (testing "a permanently-bad transact never throws, returns false, and is
+            dead-lettered + surfaced rather than silently dropped"
+    (let [conn (fresh-conn)
+          before (count @persist/dead-letters)
+          ;; a long where a string is required — fails schema, retry won't help
+          result (persist/persist-tx! conn [{:thing/name 123}]
+                                      {:op :store-message :msg-id "m1"})]
+      (is (false? result))
+      (is (= (inc before) (count @persist/dead-letters)))
+      (is (= "m1" (get-in (last @persist/dead-letters) [:ctx :msg-id]))))))


### PR DESCRIPTION
H2 from the harness plan. **Stacked on #31** (note-injection) — merge that first; the diff below is only the persist seam.

The two message-persist paths disagreed on failure:
- **chat-ctx** `context/add-message!` transacted **unguarded** — a bad transact threw into the turn.
- **room-store** `store.datahike/-store-message!` caught the throwable and **silently log-dropped it at :warn** — message loss, no surfacing, no retry.

…with which path runs selected by a `:durable?` boolean set in a different namespace.

Introduce **`dvergr.chat.persist/persist-tx!`** — the one seam both call: attempt → **retry once** (transient lock/contention, e.g. a briefly-held write lock — the class behind the fulltext-lock storm) → on a second failure **surface at :error and dead-letter** the payload (a bounded in-memory ring, inspectable/replayable via the REPL). Never throws, never silently drops. The room-missing branch is elevated `:warn`→`:error` (a message for an unknown room is a lost message).

**Verification:** new `persist_test` (success lands and returns true; a permanently-bad transact returns false, dead-letters, and never throws); context suite unchanged — **10 tests / 45 assertions / 0 failures** via clean kaocha.

Follow-ups the reference study (opencode/codex) suggests here: a persistent dead-letter store (vs the in-memory ring) and folding the room-missing drop into the same dead-letter path.