### PR TITLE
feat(sandbox): generic consumer namespace-injector hook for clojure_eval

### DIFF
--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -30,6 +30,32 @@
   (:import [java.io StringWriter]
            [java.lang.management ManagementFactory]))
 
+;; ---------------------------------------------------------------------------
+;; Consumer namespace-injector registry
+;;
+;; dvergr is a generic agent harness — it must not depend on any domain kernel.
+;; A consumer (e.g. an accounting kernel) registers an injector fn here at
+;; startup; the sandbox setup runs every registered injector so its surface is
+;; available in `clojure_eval`, WITHOUT dvergr knowing what it is. Each injector
+;; is `(fn [sci-ctx opts])`, opts = {:room-id :room-conn :kb-conn}.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private ns-injectors* (atom []))
+
+(defn register-ns-injector!
+  "Register an SCI namespace-injector `f` — `(fn [sci-ctx opts])`, opts =
+   {:room-id :room-conn :kb-conn} — run for every agent sandbox after the
+   built-in surface. Lets a consumer expose extra namespaces (a domain kernel)
+   in `clojure_eval` without dvergr depending on it. Idempotent per identical fn.
+   Returns `f`."
+  [f]
+  (swap! ns-injectors* (fn [v] (if (some #{f} v) v (conj v f))))
+  f)
+
+(defn unregister-ns-injector! [f] (swap! ns-injectors* (fn [v] (vec (remove #{f} v)))) nil)
+
+(defn registered-ns-injectors [] @ns-injectors*)
+
 ;; Lazy-load spindel SCI macro support to avoid compile-time dep
 (defn- spindel-sci-macro-ns []
   (require 'org.replikativ.spindel.sci.macro)
@@ -883,6 +909,13 @@
     (ns-dev/add-clojure-repl-ns! sci-ctx)
     (ns-dev/add-clojure-repl-deps-ns! sci-ctx)
     (ns-dev/add-hiccup-ns! sci-ctx)
+    ;; Consumer-registered injectors (register-ns-injector!) — domain kernels
+    ;; expose their surface here without dvergr depending on them. Run before
+    ;; reflection so overview sees them; a failing injector never breaks setup.
+    (doseq [f (registered-ns-injectors)]
+      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn})
+           (catch Throwable e
+             (binding [*out* *err*] (println "ns-injector failed:" (.getMessage e))))))
     ;; Self-reflection LAST, so (sandbox/overview) sees every ns injected above.
     (add-reflection-ns! sci-ctx)
     audit-log))

--- a/test/dvergr/sandbox/ns_injector_test.clj
+++ b/test/dvergr/sandbox/ns_injector_test.clj
@@ -1,0 +1,37 @@
+(ns dvergr.sandbox.ns-injector-test
+  "The generic consumer namespace-injector registry — how a domain kernel (e.g.
+   accounting) plugs a surface into `clojure_eval` WITHOUT dvergr depending on it."
+  (:require [clojure.test :refer [deftest is testing]]
+            [sci.core :as sci]
+            [dvergr.sandbox :as sb]))
+
+(deftest registry-is-idempotent-and-removable
+  (let [f (fn [_ _] nil)]
+    (try
+      (sb/register-ns-injector! f)
+      (sb/register-ns-injector! f)                 ; idempotent — same fn once
+      (is (= 1 (count (filter #{f} (sb/registered-ns-injectors)))))
+      (sb/unregister-ns-injector! f)
+      (is (not (some #{f} (sb/registered-ns-injectors))))
+      (finally (sb/unregister-ns-injector! f)))))
+
+(deftest registered-injector-exposes-a-callable-namespace
+  ;; A consumer registers an injector that mounts a namespace; the sandbox runs
+  ;; every registered injector during setup, so the surface is callable in SCI —
+  ;; and the room context (opts) reaches the injector. This is the exact seam a
+  ;; domain kernel uses; dvergr never names the kernel.
+  (let [injector (fn [sci-ctx opts]
+                   (sci/add-namespace! sci-ctx 'demo
+                                       {'ping    (constantly :pong)
+                                        'room-id (:room-id opts)}))]
+    (try
+      (sb/register-ns-injector! injector)
+      (let [ctx (sci/init {})]
+        ;; simulate the sandbox setup's injector pass
+        (doseq [f (sb/registered-ns-injectors)]
+          (f ctx {:room-id :r1 :room-conn ::rc :kb-conn ::kb}))
+        (testing "injected surface is callable in clojure_eval"
+          (is (= :pong (sci/eval-string* ctx "(require '[demo]) (demo/ping)"))))
+        (testing "room context reaches the injector via opts"
+          (is (= :r1 (sci/eval-string* ctx "demo/room-id")))))
+      (finally (sb/unregister-ns-injector! injector)))))


### PR DESCRIPTION
Adds a small **generic** extension point so a consumer can expose additional SCI namespaces to agents' `clojure_eval` — **without dvergr depending on what they are**.

- `register-ns-injector!` / `unregister-ns-injector!` / `registered-ns-injectors`
- the per-session sandbox setup runs every registered injector (before self-reflection); each is `(fn [sci-ctx opts])`, `opts = {:room-id :room-conn :kb-conn}`
- a failing injector never breaks setup

**Why generic, not kontor-specific:** the harness must stay domain-agnostic. A domain kernel (e.g. the kontor accounting kernel) registers its own injector at startup and validates it in *its* tests; dvergr tests only the mechanism with a **dummy** injector (no domain dependency, no domain code in the harness's test graph). This supersedes the earlier kontor-specific injector.

**Test:** `dvergr.sandbox.ns-injector-test` — registry idempotency/removal + a registered dummy injector exposes a callable SCI namespace and receives the room `opts`. 4 assertions green.

Companion: the kontor accounting integration in simmis registers its injector through this hook (replikativ/simmis-internal#13).