### PR TITLE
Geschichte-backed agent workspaces + crypto-hashed room store

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -56,11 +56,16 @@
         ;; (jobs, cd, env) for free.
         org.replikativ/muschel     {:mvn/version "0.2.17"}
 
+        ;; Geschichte — authoritative virtual filesystem + Git compatibility.
+        ;; Released coordinate — 0.1.10 carries code-search (#6) + the native-release
+        ;; CI fix (#5); no local root needed.
+        org.replikativ/geschichte  {:mvn/version "0.1.10"}
+
         ;; rewrite-clj for structural editing
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        org.replikativ/datahike    {:mvn/version "0.8.1708"}
+        org.replikativ/datahike    {:mvn/version "0.8.1744"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.2.27 carries composite Mergeable diff + conflicts (PR #3).
@@ -76,9 +81,9 @@
         ;; Kabel — WebSocket peer-to-peer transport. 0.3.98 pins javac --release 11
         ;; (0.3.97 shipped Java-25 bytecode → UnsupportedClassVersionError on JDK <25).
         org.replikativ/kabel       {:mvn/version "0.3.98"}
-        org.replikativ/hasch       {:mvn/version "0.4.99"}
+        org.replikativ/hasch       {:mvn/version "0.4.101"}
         org.replikativ/incognito   {:mvn/version "0.3.69"}
-        org.replikativ/konserve    {:mvn/version "0.9.350"}
+        org.replikativ/konserve    {:mvn/version "0.9.363"}
         org.replikativ/kabel-auth  {:mvn/version "0.1.19"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -54,7 +54,11 @@
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
         ;; so a forked chat-ctx gets an isolated muschel session
         ;; (jobs, cd, env) for free.
-        org.replikativ/muschel     {:mvn/version "0.2.17"}
+        ;; 0.2.18 is the release that carries the Geschichte-workspace mount
+        ;; API this branch's agent workspaces are built on (isolated worktrees,
+        ;; checkout semantics delegated to Geschichte, Git served from a virtual
+        ;; GeschichteFS base) — so no local root is needed to build it.
+        org.replikativ/muschel     {:mvn/version "0.2.18"}
 
         ;; Geschichte — authoritative virtual filesystem + Git compatibility.
         ;; Released coordinate — 0.1.10 carries code-search (#6) + the native-release

--- a/src/dvergr/agent/prompt.clj
+++ b/src/dvergr/agent/prompt.clj
@@ -132,7 +132,7 @@
         ;; (nil at the daemon root / no room ctx → global skills only), so an
         ;; agent assembled within a room sees that room's own skills.
         room-dir (or room-dir
-                     (try ((requiring-resolve 'dvergr.substrate.git/current-worktree-path))
+                     (try ((requiring-resolve 'dvergr.sandbox.workspace/workspace-root))
                           (catch Throwable _ nil)))]
     (cond-> (skills/inject-skills
              (str discourse-preamble "\n\n---\n\n" base-prompt)

--- a/src/dvergr/clients/client.clj
+++ b/src/dvergr/clients/client.clj
@@ -77,7 +77,8 @@
    peer-bus + git — and register it as current-daemon so every `c/*` fn drives it.
    Idempotent. Returns :attached | :booted-lite.
 
-   Lite options: :worktrees-dir (default .dvergr/worktrees)."
+   `:worktrees-dir` is accepted as a legacy no-op; workspaces are virtual
+   Datahike branches."
   [& {:keys [worktrees-dir]
       :or {worktrees-dir ".dvergr/worktrees"}}]
   (if @daemon/current-daemon
@@ -222,7 +223,7 @@
   "The git diff this fork has accumulated over its parent — {:branch :parent-branch
    :commits :stat}."
   [fork]
-  ((requiring-resolve 'dvergr.substrate.git/diff-since-fork) (:ctx fork)))
+  ((requiring-resolve 'dvergr.substrate.geschichte/diff-since-fork) (:ctx fork)))
 
 (defn merge!
   "Merge the fork into its parent (derived from the fork's :parent-id) — land it."

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -33,7 +33,7 @@
             [org.replikativ.spindel.yggdrasil :as ygg]
             [is.simm.partial-cps.sequence :refer [anext]]
             [dvergr.runtime.bus :as bus]
-            [dvergr.substrate.git :as dgit]
+            [dvergr.substrate.geschichte :as geschichte]
             [dvergr.runtime.peer-bus :as peer-bus]
             [dvergr.room.store :as rstore]
             [dvergr.room.store.datahike :as store-dh]
@@ -757,8 +757,8 @@
                         :dvergr/origin   new-id
                         :dvergr/parent   (:id room)
                         :isolation       isolation
-                        :worktree-path   (when (= :ctx isolation)
-                                           (dgit/current-worktree-path))}))
+                        :workspace-id    (when (= :ctx isolation)
+                                           (:id (geschichte/current-workspace)))}))
      new-room)))
 
 (defmacro with-fork-ctx
@@ -957,7 +957,7 @@
    Returns the proposal payload."
   [fork & {:keys [from note] :or {from :worker note ""}}]
   (let [diff      (when (ctx-was-forked? fork)
-                    (dgit/diff-since-fork (:ctx fork)))
+                    (geschichte/diff-since-fork (:ctx fork)))
         proposal  (cond-> {:fork-id (:id fork)
                            :note    note}
                     diff (assoc :diff diff))

--- a/src/dvergr/discourse/definitions.clj
+++ b/src/dvergr/discourse/definitions.clj
@@ -16,7 +16,8 @@
    where <kind> ∈ {\"skills\", \"agents\"}. Files are the source of truth; a
    KB-derived index (Phase 3) is a queryable projection, never authoritative."
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [muschel.fs :as mfs]))
 
 ;; ============================================================================
 ;; Frontmatter parser
@@ -135,6 +136,34 @@
       (str/replace #"\.md$" "")
       (str/replace #"/SKILL$" "")))
 
+(defn- virtual-definition-files [{:keys [fs root]} kind]
+  (let [base (str (str/replace root #"/$" "") "/" kind)]
+    (letfn [(walk [path]
+              (mapcat (fn [{:keys [name type]}]
+                        (let [child (str (str/replace path #"/$" "") "/" name)]
+                          (case type
+                            :dir (walk child)
+                            :file (when (str/ends-with? name ".md") [child])
+                            nil)))
+                      (or (mfs/list-dir fs path) [])))]
+      (for [path (walk base)
+            :let [rel (subs path (inc (count base)))
+                  name (-> rel
+                           (str/replace #"\.md$" "")
+                           (str/replace #"/SKILL$" ""))]]
+        {:name name
+         :content (mfs/read-file fs path)
+         :file (last (str/split path #"/"))
+         :path (str "geschichte:" path)
+         :storage {:fs fs :path path}}))))
+
+(defn- virtual-mkdirs! [fs path]
+  (loop [path path pending []]
+    (if (or (= path "/") (mfs/exists? fs path))
+      (doseq [directory (reverse pending)] (mfs/mkdir fs directory))
+      (let [i (.lastIndexOf ^String path "/")]
+        (recur (if (<= i 0) "/" (subs path 0 i)) (conj pending path))))))
+
 (defn- builtin-files
   "Built-in definitions under the `<kind>` classpath resource, as
    `[{:name :content :file :path}]`. Jar-safe (handles `file:` dev dirs and
@@ -204,22 +233,34 @@
                                                :name (or (:name parsed) name)
                                                :file file :path path :scope :builtin))))
                       {} (builtin-files kind))
+         virtual-room? (and (map? room-dir) (satisfies? mfs/FS (:fs room-dir)))
          scopes (cond-> (roots kind)
-                  (and room-dir (.isDirectory (io/file room-dir kind)))
-                  (conj [:room (io/file room-dir kind)]))]
-     (reduce
-      (fn [acc [scope root]]
-        (reduce
-         (fn [a ^java.io.File f]
-           (let [name'  (relative-name root f)
-                 parsed (parse-frontmatter (slurp f))]
-             (assoc a name'
-                    (assoc parsed
-                           :name (or (:name parsed) name')
-                           :file (.getName f) :path (.getPath f) :scope scope))))
-         acc (list-md-files root)))
-      seed
-      scopes))))
+                  (and room-dir (not virtual-room?)
+                       (.isDirectory (io/file room-dir kind)))
+                  (conj [:room (io/file room-dir kind)]))
+         loaded (reduce
+                 (fn [acc [scope root]]
+                   (reduce
+                    (fn [a ^java.io.File f]
+                      (let [name'  (relative-name root f)
+                            parsed (parse-frontmatter (slurp f))]
+                        (assoc a name'
+                               (assoc parsed
+                                      :name (or (:name parsed) name')
+                                      :file (.getName f) :path (.getPath f) :scope scope))))
+                    acc (list-md-files root)))
+                 seed
+                 scopes)]
+     (if virtual-room?
+       (reduce (fn [acc {:keys [name content file path storage]}]
+                 (let [parsed (parse-frontmatter content)]
+                   (assoc acc name
+                          (assoc parsed :name (or (:name parsed) name)
+                                 :file file :path path :storage storage
+                                 :scope :room))))
+               loaded
+               (virtual-definition-files room-dir kind))
+       loaded))))
 
 (defn load-one
   "The single parsed definition named `name` within `kind`, honoring the scope
@@ -302,14 +343,22 @@
    gate keeps them out of prompts / autostart until promoted. `dir` is typically
    a room's sandbox-repo path. Returns the file path (string)."
   [kind dir name frontmatter body]
-  (let [d (io/file dir kind)
-        _ (.mkdirs d)
-        f (io/file d (str name ".md"))
-        fm (merge {:kind ({"agents" :agent "skills" :skill} kind (keyword kind))
+  (let [fm (merge {:kind ({"agents" :agent "skills" :skill} kind (keyword kind))
                    :name name :vetted false}
-                  frontmatter)]
-    (spit f (str (render-frontmatter fm) "\n" (or body "")))
-    (.getPath f)))
+                  frontmatter)
+        content (str (render-frontmatter fm) "\n" (or body ""))]
+    (if (and (map? dir) (satisfies? mfs/FS (:fs dir)))
+      (let [base (str (str/replace (:root dir) #"/$" "") "/" kind)
+            path (str base "/" name ".md")]
+        (virtual-mkdirs! (:fs dir)
+                         (subs path 0 (.lastIndexOf ^String path "/")))
+        (mfs/write-string! (:fs dir) path content false)
+        (str "geschichte:" path))
+      (let [d (io/file dir kind)
+            _ (.mkdirs d)
+            f (io/file d (str name ".md"))]
+        (spit f content)
+        (.getPath f)))))
 
 (defn promote!
   "Mark the definition file at `path` vetted — flip `vetted: false` → `true` and
@@ -317,15 +366,19 @@
    The reviewer action that lets an agent-authored or externally-lifted
    definition become eligible. `date` is an ISO yyyy-mm-dd string (pass it in;
    no clock is read here). Returns the new file text."
-  [path by date]
-  (let [text  (slurp path)
+  [path-or-definition by date]
+  (let [storage (when (map? path-or-definition) (:storage path-or-definition))
+        path (if storage (:path storage) path-or-definition)
+        text  (if storage (mfs/read-file (:fs storage) path) (slurp path))
         text' (-> text
                   (str/replace #"(?m)^vetted:\s*false\s*$" "vetted: true")
                   (cond->
                    (not (re-find #"(?m)^vetted_by:" text))
                     (str/replace #"(?m)^(vetted:\s*true\s*)$"
                                  (str "$1\nvetted_by: " by "\nvetted_at: " date))))]
-    (spit path text')
+    (if storage
+      (mfs/write-string! (:fs storage) path text' false)
+      (spit path text'))
     text'))
 
 (defn autostart-agents

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -41,6 +41,7 @@
    to be truly contained (PR #8 — yggdrasil git-worktree wiring)."
   (:require [clojure.string :as str]
             [dvergr.substrate.git :as dgit]
+            [dvergr.substrate.geschichte :as geschichte]
             [dvergr.agent.process :as dproc]
             [muschel.budget :as mbudget]
             [muschel.builtins.posix :as posix]
@@ -100,7 +101,7 @@
    pytest for a Python repo, cargo for a Rust crate). That choice
    belongs to the human running dvergr — not to a default that
    ships open."
-  #{"git"})
+  #{})
 
 ;; ---------------------------------------------------------------------------
 ;; git is the one allowlisted real-process fallback, and it runs UNJAILED (it
@@ -155,25 +156,18 @@
    "GIT_TERMINAL_PROMPT" "0"})
 
 (defn default-workspace
-  "Resolve the agent's workspace path.
+  "Resolve the agent's workspace.
 
    Priority:
-   1. The registered yggdrasil git system's current working-tree
-      path. When the surrounding execution context has been forked,
-      this is the **forked** worktree, so each fork's bash session
-      sees its own isolated FS root automatically — the whole
-      isolation story flows through this one lookup.
-   2. JVM cwd as a fallback for when no git system is registered
-      (e.g. unit tests, bare REPL).
+   1. The bound Geschichte workspace descriptor. A fork resolves to its own
+      Datahike branch while retaining the same logical Git branch name.
+   2. The isolated legacy workspace path for room-less tests/REPL use.
 
    Callers can still pass `:workspace` explicitly to `make-host` to
    override this."
   []
-  ;; current-worktree-path → current-execution-context THROWS when no ctx is bound
-  ;; (not nil), so guard it — else the documented fallback is unreachable.
-  (or (try (dgit/current-worktree-path) (catch Throwable _ nil))
-      ;; No git system in scope → the isolated `.dvergr/workspace` clone, NEVER the
-      ;; host JVM cwd (the dvergr source tree). The shell must not escape the sandbox.
+  (or (try (geschichte/current-workspace) (catch Throwable _ nil))
+      ;; Never use the daemon source checkout as a fallback.
       (dgit/safe-workspace-root)))
 
 ;; ---------------------------------------------------------------------------
@@ -251,11 +245,8 @@
 ;; ============================================================================
 
 ;; Host + session are cached in the chat-ctx's spindel state. The cache
-;; key is the workspace path — when a chat-ctx fork lands the
-;; execution context on a fresh git worktree, the new path becomes a
-;; cache miss and a host/session rooted at that worktree gets
-;; built. The parent's host stays alive under its own path, so future
-;; runs back in the parent context still resolve to its workspace.
+;; key is the Geschichte workspace id (or legacy fallback path). A fork's new
+;; Datahike branch gets its own host/session while the parent's remains cached.
 (defn- session-path [workspace] [:dvergr/bash-session workspace])
 (defn- host-path    [workspace] [:dvergr/bash-host workspace])
 
@@ -291,8 +282,9 @@
         (host/-spawn inner opts)))))
 
 (defn make-host
-  "Build a BuiltinHost wrapping a DiskFS rooted at `:workspace`. The real-process
-   fallback host is git-guarded (see `git-guarded-host`).
+  "Build a BuiltinHost rooted in a Geschichte workspace. A string `:workspace`
+  remains as a transitional test/runner projection, but the normal room path is
+  a virtual workspace descriptor and exposes no physical path.
 
    `:mount-at \"/\"` makes the workspace dir ITSELF the sandbox root (so sandbox
    `/` ↔ the worktree), rather than muschel's default `/home/agent` + `/tmp`
@@ -313,14 +305,22 @@
     :or {workspace          (default-workspace)
          fallback-allowlist default-fallback-allowlist
          builtins           posix/standard}}]
-  (let [fs (fs.disk/make workspace {:mount-at "/"})
-        fs (if (seq mounts)
-             (fs.mount/make fs mounts)
-             fs)]
-    (hb/make {:fs fs
-              :fallback-host (git-guarded-host (host.jvm/make))
+  (let [filesystem (if (map? workspace)
+                     (geschichte/filesystem workspace)
+                     (fs.disk/make workspace {:mount-at "/"}))
+        filesystem (if (seq mounts)
+                     (if (instance? muschel.fs.mount.MountFS filesystem)
+                       (do (doseq [[path child] mounts]
+                             (fs.mount/mount! filesystem path child
+                                              {:allow-nested? true}))
+                           filesystem)
+                       (fs.mount/make filesystem mounts))
+                     filesystem)]
+    (hb/make {:fs filesystem
+              :fallback-host (host.jvm/make)
               :builtins builtins
-              :fallback-allowlist fallback-allowlist})))
+              :fallback-allowlist fallback-allowlist
+              :geschichte (when (map? workspace) true)})))
 
 (defonce ^{:doc "Embedder hook: (fn [chat-ctx] {\"/drive\" <muschel FS>, …})
   or nil. Consulted once per host build (per workspace); errors are
@@ -350,14 +350,14 @@
    the agent never sees the daemon's API keys / tokens. The session's
    env-atom CoW-forks alongside the chat-ctx, so worker-side `cd` and
    `export` don't leak back into the parent's session — but only
-   within a single workspace; a fork onto a fresh worktree gets a
-   fresh session at that path.
+   within a single workspace; a fork gets a fresh session for its branch.
 
-   Stored under `[:dvergr/bash-session WORKSPACE-PATH]`."
+   Stored under `[:dvergr/bash-session WORKSPACE-ID]`."
   [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
     (let [ws (default-workspace)
-          path (session-path ws)]
+          key (if (map? ws) (:id ws) ws)
+          path (session-path key)]
       (or (ec/get-state path)
           ;; cwd is the SANDBOX root "/" (= the worktree via make-host's
           ;; :mount-at "/"); `ws` (the real path) stays only as the cache key.
@@ -373,7 +373,8 @@
   [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
     (let [ws (default-workspace)
-          path (host-path ws)]
+          key (if (map? ws) (:id ws) ws)
+          path (host-path key)]
       (or (ec/get-state path)
           (let [h (make-host {:workspace ws
                               :mounts (resolve-mounts chat-ctx)})]

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -47,7 +47,7 @@
             [dvergr.drive.integration :as drive-integration]
             [dvergr.rooms.subsystems :as subsystems]
             [dvergr.runtime.clock :as clock]
-            [dvergr.substrate.git :as git]
+            [dvergr.substrate.geschichte :as geschichte]
             ;; dvergr.web.server lives in src-clients/ and is loaded
             ;; opt-in via the :cli/:tui aliases. Use `web-server-fn`
             ;; below to resolve it lazily so the core daemon can boot
@@ -132,39 +132,34 @@
 ;; ============================================================================
 
 (defn create-shared-context
-  "Create a shared execution context with optional git + datahike systems
-   registered for fork-isolated agent work and persistent chat DB.
+  "Create a shared execution context with optional Geschichte + Datahike
+   systems registered for fork-isolated agent work and persistent chat data.
 
    Options:
-     :with-git?       — register git system for isolated agent worktrees
+     :with-git?       — register the Geschichte workspace system (legacy option
+                        name retained for callers)
                         (default true)
      :with-datahike?  — register Datahike system for the chat DB
                         (default true)
-     :repo-path       — git repo path (default cwd)
-     :worktrees-dir   — where to create worktrees (default: per-repo, derived by
-                        create-git-system so multiple repos in one composite
-                        don't collide on `<dir>/<branch>` when forked)
+     :repo-path       — Geschichte Datahike store path
+     :worktrees-dir   — ignored legacy option; virtual workspaces are Datahike
+                        branches and have no worktree directory
      :db-path         — datahike file-store path (default .dvergr/db)"
   [& {:keys [with-git? with-datahike? repo-path worktrees-dir db-path]
       :or {with-git?      true
            with-datahike? true
-           ;; The agent code workspace (.dvergr/workspace), NOT dvergr's own
-           ;; source tree — the sandbox forks this, not user.dir. Pass an
-           ;; explicit :repo-path to point a room at a user project instead.
-           ;; worktrees-dir left nil ⇒ create-git-system derives a PER-REPO dir.
-           repo-path      (paths/workspace-dir)}}]
+           ;; The authoritative agent workspace store, never dvergr's checkout.
+           repo-path      (paths/workspace-store)}}]
   (let [base-ctx (ctx/create-execution-context)]
     (binding [rtc/*execution-context* base-ctx]
       (when with-git?
         (try
-          ;; create-git-system auto-initialises the default .dvergr/workspace repo.
-          (ygg/register! (git/create-git-system
-                          :repo-path repo-path
-                          :worktrees-dir worktrees-dir))
+          ;; create-system initializes/imports the sandbox seed when necessary.
+          (ygg/register! (geschichte/create-system :scope repo-path))
           (catch Exception e
             (tel/log! {:level :warn :id :daemon/git-init-failed
                        :data {:error (.getMessage e)}}
-                      "Could not register git system"))))
+                      "Could not register Geschichte workspace system"))))
       ;; RF5 S4.3: the shared "dvergr-chat-db" datahike is GONE. The room registry
       ;; + identity live in the global system-db (dvergr.system.db); each room's
       ;; conversation + cost ledger live in its OWN per-room messages store. The
@@ -720,7 +715,7 @@
   ;; composite (forked + collided on the shared worktrees-dir). Room-less sandboxes
   ;; (sidecar/REPL) fall back to the `.dvergr/workspace` directory directly
   ;; (workspace-root), so we just keep that dir present.
-  (git/ensure-workspace-repo!)
+  (geschichte/ensure-repository! (paths/workspace-store))
   (let [exec-ctx       (create-shared-context :with-git? false
                                               :with-datahike? true
                                               :db-path (:db-path config))

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -11,7 +11,7 @@
      conversation-log append, and there is no git history to browse."
   (:require [dvergr.room.registry :as rreg]
             [dvergr.discourse :as d]
-            [dvergr.substrate.git :as git]
+            [dvergr.substrate.geschichte :as git]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]))

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -846,6 +846,12 @@
   [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id]
                           :or   {proc-allow #{}}}]
   (let [audit-log  (make-audit-log)
+        workspace  (binding [rtc/*execution-context* spindel-ctx]
+                     (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
+                          (catch Throwable _ nil)))
+        filesystem (when workspace
+                     ((requiring-resolve 'dvergr.substrate.geschichte/filesystem)
+                      workspace))
         ;; The agent's PROJECT is its room's OWN git repo (a per-room yggdrasil git
         ;; system), not the daemon's cwd. Default `fs`/`git`/`proc` (and so the
         ;; `require` workspace) to that worktree — resolved fork-aware under the
@@ -855,9 +861,7 @@
         ;; ctxs: sidecar/tests, or the bare root room) we fall back to the isolated
         ;; `.dvergr/workspace` clone — NEVER the host cwd / dvergr source tree.
         cwd        (or base-path
-                       (binding [rtc/*execution-context* spindel-ctx]
-                         (try ((requiring-resolve 'dvergr.substrate.git/current-worktree-path))
-                              (catch Throwable _ nil)))
+                       (when workspace "/")
                        ((requiring-resolve 'dvergr.substrate.git/safe-workspace-root)))]
     (binding [rtc/*execution-context* spindel-ctx]
       ;; The agent's DATA lives in ITS room (fork-aware) — `*room*` = the room's own
@@ -883,9 +887,11 @@
     (ns-data/add-spindel-extras-ns! sci-ctx spindel-ctx)
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)
-    (ns-io/add-fs-ns!   sci-ctx :base-path cwd :audit-log audit-log)
+    (ns-io/add-fs-ns!   sci-ctx :base-path cwd :filesystem filesystem
+                        :audit-log audit-log)
     ;; (proc folded into the muschel-backed babashka.process — add-bash-ns! in turn.clj)
-    (ns-io/add-git-ns!  sci-ctx :base-path cwd :audit-log audit-log)
+    (ns-io/add-git-ns!  sci-ctx :base-path cwd :workspace workspace
+                        :audit-log audit-log)
     (ns-kb/add-llm-ns!  sci-ctx)
     ;; Boundary secret injection (doc/boundary-secret-injection.md): build the
     ;; host-side secret registry from config `:secrets` (resolved against the host

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -681,8 +681,27 @@
   (->> (:namespaces @(:env sci-ctx))
        (filter (fn [[ns-sym _]] (interesting-ns? ns-sym)))
        (keep (fn [[ns-sym vars]]
-               (let [fns (->> (keys vars) (filter symbol?) (map str) sort vec)]
-                 (when (seq fns) {:ns (str ns-sym) :fns fns}))))
+               (let [fns  (->> (keys vars) (filter symbol?) (map str) sort vec)
+                     ;; Signatures too, not just names. `sci/copy-var` carries a
+                     ;; var's :doc and :arglists across (45 core vars already do),
+                     ;; but this fn used to take `(keys vars)` and throw the
+                     ;; VALUES away — so every one of those docstrings rendered
+                     ;; as nothing and an agent had no way to learn an arity
+                     ;; except by calling and reading the error. Keeping the
+                     ;; values is what makes documenting anything worthwhile.
+                     sigs (into (sorted-map)
+                                (keep (fn [[sym v]]
+                                        (when (symbol? sym)
+                                          (let [m (meta v)]
+                                            (when (or (:doc m) (:arglists m))
+                                              [(str sym)
+                                               (cond-> {}
+                                                 (:arglists m) (assoc :arglists (:arglists m))
+                                                 (:doc m) (assoc :doc (first (str/split-lines (str (:doc m))))))])))))
+                                vars)]
+                 (when (seq fns)
+                   (cond-> {:ns (str ns-sym) :fns fns}
+                     (seq sigs) (assoc :sigs sigs))))))
        (sort-by :ns)
        vec))
 
@@ -733,7 +752,16 @@
       (let [[purpose eg] (ns-guide n)]
         (str "`" n "`" (when purpose (str " — " purpose)) "\n"
              (when eg (str "e.g. " eg "\n"))
-             "fns: " (str/join " " (:fns entry)))))))
+             ;; Signatures when the vars carry them, names otherwise. An agent
+             ;; that can read an arity does not have to discover it by calling.
+             (if-let [sigs (seq (:sigs entry))]
+               (str/join "\n"
+                         (for [[sym {:keys [arglists doc]}] sigs]
+                           (str "  (" sym (when (seq arglists)
+                                            (str " " (str/join " | "
+                                                               (map #(str/join " " %) arglists))))
+                                ")" (when doc (str "  — " doc)))))
+               (str "fns: " (str/join " " (:fns entry)))))))))
 
 (def sandbox-prompt-pointer
   "System-prompt block teaching the agent how to use its `clojure_eval` sandbox

--- a/src/dvergr/sandbox/deps.clj
+++ b/src/dvergr/sandbox/deps.clj
@@ -240,53 +240,148 @@
 ;; Namespace denylist (sensitive host internals)
 ;; ============================================================================
 
-(def default-namespace-denylist
-  "Namespaces the sandbox MUST NOT mirror into the agent's SCI ctx,
-   even when they're on the host classpath. The curated SCI surface
-   (dvergr.sandbox/add-*-ns! family) is the agent's authorized view
-   of dvergr internals; reaching for the raw host equivalents would
-   leak the daemon's authority into the sandbox."
-  ["^dvergr\\.daemon($|\\..*)"
-   "^dvergr\\.config($|\\..*)"
-   "^dvergr\\.cli($|\\..*)"
-   "^dvergr\\.web($|\\..*)"
-   "^dvergr\\.actors($|\\..*)"
-   "^dvergr\\.skills($|\\..*)"
-   "^dvergr\\.rooms($|\\..*)"
-   "^dvergr\\.discourse($|\\..*)"
-   "^dvergr\\.sandbox($|\\..*)"
-   "^dvergr\\.tools($|\\..*)"
-   "^dvergr\\.registry($|\\..*)"
-   ;; clojure.repl and clojure.repl.deps are intentionally custom-wrapped
-   ;; in dvergr.sandbox; mirroring the host versions would bypass our gates.
+;; ---------------------------------------------------------------------------
+;; Host-namespace mirror policy
+;;
+;; The sandbox has three trust layers, and all three are ALLOWLISTS:
+;;
+;;   1. `dvergr.sandbox/base-classes` — the JVM-escape barrier.
+;;   2. The curated SCI surface (`dvergr.sandbox/add-*-ns!`) — the agent's
+;;      authorized view of dvergr internals, injected directly.
+;;   3. This policy — what `(require …)` may pull in from the HOST classpath.
+;;
+;; Layer 3 used to be a denylist, which is the wrong polarity for a trust
+;; boundary: every namespace nobody thought to name was reachable, and
+;; `ensure-mirrored!` copies EVERY public var of whatever it mirrors. That made
+;; the host application's credentials and connections reachable from agent code
+;; — and agents read untrusted input (mail, web, chat), so prompt injection was
+;; sufficient to reach them.
+;;
+;; The fall-through to host mirroring exists for ONE reason (see `make-load-fn`):
+;; libraries the agent pulled in with `add-libs`. That is the boundary we encode
+;; — a curated set of pure libraries, plus whatever an APPROVED `add-libs!` call
+;; brought in. `add-libs!` is already manager-gated, so provenance inherits an
+;; existing trust decision instead of inventing a new one.
+;; ---------------------------------------------------------------------------
+
+(def default-namespace-allowlist
+  "Namespace prefixes `(require …)` MAY mirror from the host classpath.
+
+   Deliberately narrow: pure data/format/util libraries with no ambient
+   authority. Anything that hands out a connection, a credential, a host file
+   handle or a process is NOT here — the agent reaches those (when it should at
+   all) through the curated SCI surface, which scopes them to its own room.
+
+   Notably absent, on purpose:
+     - `clojure.java.*`   — host filesystem and processes; the agent gets
+                            muschel's virtual FS instead.
+     - `datahike.*`       — `dvergr.sandbox.ns.datahike` injects the data-ops
+                            while keeping create/connect/delete room-guarded;
+                            mirroring the raw API would undo that.
+     - `konserve.*` / `kabel.*` — the store and wire layers underneath it."
+  ["^cheshire($|\\..*)"
+   "^hiccup($|\\..*)"
+   "^babashka($|\\..*)"
+   "^medley($|\\..*)"
+   "^camel-snake-kebab($|\\..*)"
+   "^clj-yaml($|\\..*)"
+   "^clojure\\.data($|\\..*)"
+   "^clojure\\.math$"
+   "^clojure\\.zip$"
+   "^clojure\\.pprint$"
+   "^clojure\\.test($|\\..*)"
+   "^clojure\\.string$"
+   "^clojure\\.set$"
+   "^clojure\\.walk$"
+   "^clojure\\.edn$"])
+
+(def hard-namespace-denylist
+  "Never mirrored — not by the allowlist, not by `add-libs` provenance, not by a
+   caller-supplied allowlist. These are the namespaces that can dismantle the
+   sandbox itself or the guarantees built on top of it.
+
+   `datahike.tx-preds` is the subtle one: the accounting governor is a per-STORE
+   transaction predicate enforced inside datahike's writer, which is what makes
+   it hold even for a raw `d/transact` on a conn the agent legitimately owns.
+   Mirroring this namespace exposes `unregister-tx-pred!` — one call and the
+   guarantee is gone. Denying it is what makes governance meaningful."
+  ["^sci($|\\..*)"
+   "^datahike\\.tx-preds($|\\..*)"
+   "^dvergr($|\\..*)"
+   "^is\\.simm($|\\..*)"
+   "^org\\.replikativ\\.spindel($|\\..*)"
+   "^org\\.replikativ\\.yggdrasil($|\\..*)"
+   "^kontor($|\\..*)"
+   "^konserve($|\\..*)"
+   "^kabel($|\\..*)"
    "^clojure\\.repl$"
    "^clojure\\.repl\\..*"
-   ;; tools.deps is the dep-resolution machinery; nothing good comes
-   ;; from giving an agent direct handle on it.
    "^clojure\\.tools\\.deps.*"
-   ;; sci's own internals — keep the sandbox from peeking at its host.
-   "^sci\\..*"
-   ;; spindel + yggdrasil — the substrate that backs forks. Manager
-   ;; controls those; agents should not.
-   "^org\\.replikativ\\.spindel($|\\..*)"
-   "^org\\.replikativ\\.yggdrasil($|\\..*)"])
+   "^clojure\\.java\\..*"])
 
-(def ^:private NS-DENYLIST-KEY [:dvergr/deps-policy :ns-denylist])
+(def ^:private NS-ALLOWLIST-KEY [:dvergr/deps-policy :ns-allowlist])
+(def ^:private NS-PROVENANCE-KEY [:dvergr/deps-policy :ns-added-prefixes])
 
-(defn set-namespace-denylist!
-  "Override the default namespace denylist with regex patterns."
+(defn set-namespace-allowlist!
+  "Override the default mirror allowlist with regex patterns. The hard denylist
+   still applies on top — a caller cannot widen the boundary past it."
   [patterns]
-  (ec/swap-state! NS-DENYLIST-KEY (constantly (vec patterns))))
+  (ec/swap-state! NS-ALLOWLIST-KEY (constantly (vec patterns))))
+
+(defn- matches-any? [patterns s]
+  (boolean
+   (some (fn [p] (try (re-find (re-pattern p) s)
+                      (catch Throwable _ nil)))
+         patterns)))
+
+(defn allow-added-lib-namespaces!
+  "Record that an APPROVED `add-libs!` brought `lib-coords` onto the classpath,
+   so the agent may then require what it just asked for. Each coord's own
+   namespace root becomes mirrorable (`org.clojure/data.csv` → `clojure.data.csv`
+   is NOT inferable, so we allow the artifact id and the group's last segment,
+   which covers the common conventions and nothing broader)."
+  [lib-coords]
+  (let [prefixes (into #{}
+                       (mapcat (fn [coord]
+                                 (let [s (str coord)
+                                       [grp art] (if (re-find #"/" s)
+                                                   (str/split s #"/" 2)
+                                                   [s s])]
+                                   [(str "^" (java.util.regex.Pattern/quote art) "($|\\..*)")
+                                    (str "^" (java.util.regex.Pattern/quote
+                                              (last (str/split grp #"\.")))
+                                         "($|\\..*)")])))
+                       lib-coords)]
+    (ec/swap-state! NS-PROVENANCE-KEY #(into (or % #{}) prefixes))
+    prefixes))
+
+(defn- policy-state
+  "Read a policy key, falling back to `default` when no execution context is
+   bound. `ec/get-state` resolves through the ambient context and THROWS without
+   one — a security predicate must not depend on that, so an unreadable policy
+   degrades to the built-in default (which denies) rather than to an exception
+   the caller might mistake for a load failure."
+  [k default]
+  (or (try (ec/get-state k) (catch Throwable _ nil))
+      default))
+
+(defn namespace-mirrorable?
+  "May `ns-sym` be mirrored from the host classpath into an SCI ctx?
+
+   Deny by default. Allowed only when it matches the allowlist or a prefix an
+   approved `add-libs!` recorded — and never when it matches the hard denylist."
+  [ns-sym]
+  (let [s (str ns-sym)]
+    (and (not (matches-any? hard-namespace-denylist s))
+         (or (matches-any? (policy-state NS-ALLOWLIST-KEY default-namespace-allowlist) s)
+             (matches-any? (policy-state NS-PROVENANCE-KEY #{}) s)))))
 
 (defn namespace-denied?
-  "Is `ns-sym` blocked from being mirrored into an SCI ctx?"
+  "Inverse of `namespace-mirrorable?`. Kept because the mirror path reads as a
+   denial; note the policy is now deny-by-default, so an unknown namespace is
+   denied rather than allowed."
   [ns-sym]
-  (let [patterns (or (ec/get-state NS-DENYLIST-KEY) default-namespace-denylist)
-        s        (str ns-sym)]
-    (boolean
-     (some (fn [p] (try (re-find (re-pattern p) s)
-                        (catch Throwable _ nil)))
-           patterns))))
+  (not (namespace-mirrorable? ns-sym)))
 
 ;; ============================================================================
 ;; Mirror host namespace into SCI
@@ -330,10 +425,12 @@
   (require 'sci.core)
   (let [add-namespace! @(resolve 'sci.core/add-namespace!)]
     (cond
-      (namespace-denied? ns-sym)
+      (not (namespace-mirrorable? ns-sym))
       (do (tel/log! {:id :sandbox.deps/ns-denied
                      :data {:ns ns-sym}}
-                    "Namespace mirror denied by denylist")
+                    (str "Namespace mirror denied — not on the sandbox allowlist. "
+                         "If an agent legitimately needs it, add it via an approved "
+                         "add-libs! (provenance) or widen set-namespace-allowlist!."))
           false)
 
       :else
@@ -442,6 +539,10 @@
 
       :else
       (let [pre-ns (set (all-ns))]
+        ;; Every coord passed the gate, so the agent is now entitled to require
+        ;; what it just asked for: record the provenance BEFORE loading, since
+        ;; `mirror-namespaces-into-sci!` below consults the mirror policy.
+        (allow-added-lib-namespaces! coords)
         ;; clojure.repl.deps/add-libs guards on `clojure.core/*repl*`
         ;; being bound to true. We're a server-side call, not a REPL,
         ;; but the gate has already enforced human approval — so bind

--- a/src/dvergr/sandbox/deps.clj
+++ b/src/dvergr/sandbox/deps.clj
@@ -31,7 +31,9 @@
    (a vector of regex patterns); install via `set-allowlist!`."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [dvergr.sandbox.workspace :as workspace]
+            [muschel.fs :as mfs]
             [dvergr.runtime.peer-bus :as peer-bus]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
@@ -465,9 +467,14 @@
    parsed EDN map, or nil if the file is missing / unreadable."
   [worktree]
   (try
-    (let [f (io/file worktree "deps.edn")]
-      (when (and (.exists f) (.canRead f))
-        (edn/read-string (slurp f))))
+    (if (workspace/virtual-root? worktree)
+      (some-> (mfs/read-file (:fs worktree)
+                             (str (str/replace (:root worktree) #"/$" "")
+                                  "/deps.edn"))
+              edn/read-string)
+      (let [f (io/file worktree "deps.edn")]
+        (when (and (.exists f) (.canRead f))
+          (edn/read-string (slurp f)))))
     (catch Throwable t
       (tel/log! {:level :warn :id :sandbox.deps/deps-edn-read-failed
                  :data {:worktree worktree :error (.getMessage t)}})
@@ -499,9 +506,7 @@
    ({:status :loaded :coords ... :namespaces ...}), or
    {:status :no-changes :reason ...} when there's nothing to do."
   [sci-ctx]
-  (require 'dvergr.substrate.git)
-  (let [worktree (or ((requiring-resolve 'dvergr.substrate.git/current-worktree-path))
-                     (System/getProperty "user.dir"))
+  (let [worktree (workspace/workspace-root)
         deps-map (read-deps-edn worktree)]
     (cond
       (nil? deps-map)
@@ -524,4 +529,3 @@
                               :candidate-count (count candidates)}}
                       "sync-deps reading worktree deps.edn")
             (add-libs! sci-ctx candidates)))))))
-

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -58,7 +58,7 @@
         ;; `all`/`read` see skills the room itself defines (highest precedence)
         ;; and `author!`/`promote!` write into the room's own repo.
         room-dir    (fn [] (try ((requiring-resolve
-                                  'dvergr.substrate.git/current-worktree-path))
+                                  'dvergr.sandbox.workspace/workspace-root))
                                 (catch Throwable _ nil)))]
     (sci/add-namespace! sci-ctx 'dvergr.skills
                         {'all       (fn [] (load-all* (room-dir)))
@@ -89,8 +89,8 @@
                                         (throw (ex-info "skills/lift! needs a room sandbox repo (no room ctx bound)" {}))))
                          ;; Promote a room skill to vetted (reviewer action).
                          'promote!  (fn [skill-name by date]
-                                      (if-let [path (:path (get (load-all* (room-dir)) (str skill-name)))]
-                                        (do (promote* path (str by) (str date)) true)
+                                      (if-let [definition (get (load-all* (room-dir)) (str skill-name))]
+                                        (do (promote* definition (str by) (str date)) true)
                                         (throw (ex-info (str "no such skill to promote: " skill-name) {}))))})))
 
 (defn add-actors-ns!
@@ -242,5 +242,4 @@
                          'create   (fn [cfg] (sched-create (room!) cfg))
                          'cancel   (fn [id] (sched-cancel (room!) id))
                          'list     (fn [] (sched-list (room!)))})))
-
 

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -6,7 +6,8 @@
   (:require [sci.core :as sci]
             [clojure.string :as str]
             [jsonista.core :as j]
-            [babashka.fs :as fs])
+            [babashka.fs :as fs]
+            [muschel.fs :as mfs])
   (:import [java.io File]))
 
 (declare fs-safe-resolve git-run* parse-porcelain-status parse-git-log)
@@ -199,7 +200,7 @@
         (throw (ex-info "HTTP request to internal/loopback address blocked (SSRF)"
                         {:url url :resolved (.getHostAddress addr)}))))))
 
-(defn add-fs-ns!
+(defn- add-physical-fs-ns!
   "Expose rich filesystem operations as 'fs namespace in SCI.
 
    Backed by babashka.fs. All user-supplied paths are canonicalised via
@@ -291,6 +292,153 @@
                                      (when-let [par (bb-parent f)] (bb-create-dirs par))
                                      (apply clojure.core/spit f content opts) (str f)))}}})))
 
+(defn- virtual-path [filesystem path]
+  (let [path (str path)]
+    (sensitive-path-policy path)
+    (or (mfs/resolve filesystem path)
+        (throw (ex-info "Invalid virtual filesystem path" {:path path})))))
+
+(defn- virtual-parent [path]
+  (let [i (.lastIndexOf ^String path "/")]
+    (cond (<= i 0) "/" :else (subs path 0 i))))
+
+(defn- virtual-mkdirs! [filesystem path]
+  (loop [path path pending []]
+    (if (mfs/exists? filesystem path)
+      (doseq [directory (reverse pending)]
+        (mfs/mkdir filesystem directory))
+      (recur (virtual-parent path) (conj pending path))))
+  path)
+
+(defn- virtual-walk [filesystem root]
+  (letfn [(walk [path]
+            (let [stat (mfs/stat filesystem path)]
+              (cons path
+                    (when (= :dir (:type stat))
+                      (mapcat #(walk (str (str/replace path #"/$" "")
+                                          "/" (:name %)))
+                              (mfs/list-dir filesystem path))))))]
+    (walk root)))
+
+(defn- virtual-write-bytes! [filesystem path bytes]
+  (when-let [sink (mfs/-open-sink filesystem path false)]
+    (if (instance? java.io.OutputStream sink)
+      (do (.write ^java.io.OutputStream sink ^bytes bytes)
+          (.close ^java.io.OutputStream sink)
+          true)
+      (throw (ex-info "Virtual filesystem sink does not accept binary content"
+                      {:path path})))))
+
+(defn- glob-regex [pattern]
+  (-> pattern
+      (str/replace "." "\\.")
+      (str/replace "**/" "\u0001")
+      (str/replace "**" "\u0002")
+      (str/replace "*" "\u0003")
+      (str/replace "?" "\u0004")
+      (str/replace "\u0001" "(?:.*/)?")
+      (str/replace "\u0002" ".*")
+      (str/replace "\u0003" "[^/]*")
+      (str/replace "\u0004" "[^/]")))
+
+(defn- add-virtual-fs-ns! [sci-ctx filesystem audit-log]
+  (let [resolve! #(virtual-path filesystem %)
+        relative #(str/replace % #"^/+" "")
+        stat-map (fn [path]
+                   (when-let [stat (mfs/stat filesystem path)]
+                     (assoc stat :path (relative path))))
+        delete-tree! (fn delete-tree! [path]
+                       (doseq [child (reverse (virtual-walk filesystem path))]
+                         (mfs/delete filesystem child))
+                       true)
+        copy-tree! (fn copy-tree! [source target]
+                     (let [stat (mfs/stat filesystem source)]
+                       (case (:type stat)
+                         :dir (do (virtual-mkdirs! filesystem target)
+                                  (doseq [entry (mfs/list-dir filesystem source)]
+                                    (copy-tree!
+                                     (str (str/replace source #"/$" "") "/" (:name entry))
+                                     (str (str/replace target #"/$" "") "/" (:name entry)))))
+                         :file (do (virtual-mkdirs! filesystem (virtual-parent target))
+                                   (virtual-write-bytes!
+                                    filesystem target
+                                    (mfs/read-bytes filesystem source)))
+                         nil)
+                       target))]
+    (letfn [(glob-paths [directory pattern]
+              (let [root (resolve! directory)
+                    matcher (re-pattern (str "^" (glob-regex (str pattern)) "$"))
+                    prefix (str (str/replace root #"/$" "") "/")]
+                (->> (virtual-walk filesystem root)
+                     (remove #{root})
+                     (map #(if (str/starts-with? % prefix)
+                             (subs % (count prefix)) %))
+                     (filter #(re-matches matcher %))
+                     vec)))]
+      (sci/add-namespace!
+       sci-ctx 'babashka.fs
+       {'list-dir (fn [directory & _]
+                    (let [path (resolve! directory)]
+                      (audit! audit-log :fs/ls {:path path})
+                      (mapv #(relative (str (str/replace path #"/$" "")
+                                            "/" (:name %)))
+                            (or (mfs/list-dir filesystem path) []))))
+        'glob (fn
+                ([pattern] (glob-paths "." pattern))
+                ([directory pattern & _] (glob-paths directory pattern)))
+        'exists? #(mfs/exists? filesystem (resolve! %))
+        'directory? #(= :dir (:type (mfs/stat filesystem (resolve! %))))
+        'regular-file? #(= :file (:type (mfs/stat filesystem (resolve! %))))
+        'sym-link? #(= :symlink (:type (mfs/stat filesystem (resolve! %))))
+        'size #(some-> (mfs/stat filesystem (resolve! %)) :size)
+        'last-modified-time #(str (or (:mtime-ms (mfs/stat filesystem (resolve! %))) 0))
+        'create-dir (fn [path] (let [path (resolve! path)] (mfs/mkdir filesystem path) (relative path)))
+        'create-dirs (fn [path] (relative (virtual-mkdirs! filesystem (resolve! path))))
+        'delete (fn [path] (mfs/delete filesystem (resolve! path)))
+        'delete-if-exists (fn [path] (let [path (resolve! path)]
+                                       (if (mfs/exists? filesystem path)
+                                         (mfs/delete filesystem path) false)))
+        'delete-tree (fn [path] (delete-tree! (resolve! path)))
+        'move (fn [source target & _]
+                (let [source (resolve! source) target (resolve! target)]
+                  (audit! audit-log :fs/move {:src source :dst target})
+                  (mfs/rename filesystem source target)
+                  (relative target)))
+        'copy (fn [source target & _]
+                (relative (copy-tree! (resolve! source) (resolve! target))))
+        'copy-tree (fn [source target & _]
+                     (relative (copy-tree! (resolve! source) (resolve! target))))
+        'parent (fn [path] (let [path (resolve! path)]
+                             (when-not (= path "/") (relative (virtual-parent path)))))
+        'file-name #(last (str/split (str %) #"/"))
+        'absolutize #(relative (resolve! %))
+        'canonicalize #(relative (resolve! %))
+        'stat #(stat-map (resolve! %))})
+      (sci/merge-opts
+       sci-ctx
+       {:namespaces
+        {'clojure.core
+         {'slurp (fn [path & _]
+                   (let [path (resolve! path)]
+                     (audit! audit-log :fs/read {:path path})
+                     (or (mfs/read-file filesystem path)
+                         (throw (ex-info "No such virtual file" {:path path})))))
+          'spit (fn [path content & options]
+                  (let [path (resolve! path)
+                        append? (boolean (:append (first options)))]
+                    (audit! audit-log :fs/write {:path path})
+                    (virtual-mkdirs! filesystem (virtual-parent path))
+                    (mfs/write-string! filesystem path (str content) append?)
+                    (relative path)))}}}))))
+
+(defn add-fs-ns!
+  "Expose a filesystem namespace backed by Muschel when `:filesystem` is
+  supplied; otherwise retain the transitional physical adapter."
+  [sci-ctx & {:keys [filesystem] :as options}]
+  (if filesystem
+    (add-virtual-fs-ns! sci-ctx filesystem (:audit-log options))
+    (apply add-physical-fs-ns! sci-ctx (mapcat identity options))))
+
 (defn add-git-ns!
   "Expose structured git operations as 'git namespace in SCI.
 
@@ -318,9 +466,17 @@
 
      (git/commit \"Add feature\")
      ;; => \"[main abc1234] Add feature\""
-  [sci-ctx & {:keys [base-path audit-log]
+  [sci-ctx & {:keys [base-path audit-log workspace]
               :or   {base-path ((requiring-resolve 'dvergr.substrate.git/safe-workspace-root))}}]
-  (let [run!      (fn [& args] (apply git-run* base-path args))
+  (let [run!      (if workspace
+                    (fn [& args]
+                      (let [result ((requiring-resolve
+                                     'dvergr.substrate.geschichte/execute-git)
+                                    workspace (vec args))]
+                        (if (zero? (:exit result))
+                          (:stdout result)
+                          (throw (ex-info (str/trim (:stderr result)) result)))))
+                    (fn [& args] (apply git-run* base-path args)))
 
         status-fn (fn []
                     (parse-porcelain-status
@@ -639,5 +795,3 @@
                   :message (str/trim (str msg))
                   :author  (str/trim (str author))
                   :date    (str/trim (str date))})))))
-
-

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -82,9 +82,25 @@
         gc!            (fn gc!
                          ([] (gc! {}))
                          ([opts] (safe #(binding [ec/*execution-context* ctx] (ygg/gc! opts)))))
+        ;; Which KBs this room may WRITE, and which one `*kb*` is. A room's own
+        ;; KB is the default, but a room whose knowledge lives in an ATTACHED KB
+        ;; would otherwise write into its own empty one with nothing saying so —
+        ;; the agent could not even name the alternatives. These make the choice
+        ;; visible and addressable.
+        kbs (fn [] (safe #(binding [ec/*execution-context* ctx]
+                            (let [ws (srooms/writable-kbs room-id)]
+                              (into [] (map-indexed
+                                        (fn [i {:keys [slug permission]}]
+                                          {:name slug :permission permission
+                                           :default? (zero? i)}))
+                                    ws)))))
+        kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
+                                (srooms/room-kb-conn room-id slug))))
         room-map (merge (ns-kb/room-ops-map ctx)        ; create!/fork!/merge!/post!/messages/…
                         {'*room*          room-conn      ; the room's own datahike (messages store)
-                         '*kb*            kb-conn         ; the room's knowledge base
+                         '*kb*            kb-conn         ; the DEFAULT writable KB (see kbs)
+                         'kbs             kbs             ; [{:name :permission :default?}] — writable KBs
+                         'kb              kb              ; fork-aware conn to a writable KB by name
                          'databases       databases       ; [{:name :type :permission}] — your DBs
                          'db              db              ; fork-aware conn to one by name
                          'kb-find         kb-find

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -32,24 +32,52 @@
    store; `kb-conn` = its knowledge base. Any of `room-conn`/`kb-conn`/`room-id`
    may be nil (room-less ctx) — the helpers degrade gracefully."
   [sci-ctx room-conn kb-conn room-id ctx]
-  (let [kb-find        (fn [title]
-                         (safe #(when kb-conn
-                                  (d/q '[:find (pull ?e [*]) . :in $ ?t
-                                         :where [?e :entity/title ?t]] @kb-conn title))))
+  (let [;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
+        ;; its own KB plus whatever is granted to it, and the two are written
+        ;; through different bindings of the same katzen schema — dvergr's
+        ;; `:entity/title` and a product's `:S.Page/title`. Reading one store
+        ;; through one binding is why an agent could write knowledge and then
+        ;; fail to find it: it was searching a different store.
+        ;;
+        ;; Results carry `:kb` so the agent knows WHERE a hit lives and can
+        ;; address that KB by name (see `kbs` / `kb`).
+        title-attrs    [:entity/title :S.Page/title]
+        readable       (fn []
+                         (if room-id
+                           (binding [ec/*execution-context* ctx]
+                             (srooms/room-kb-conns room-id))
+                           (when kb-conn [{:conn kb-conn :slug "kb"}])))
+        titled         (fn [db]
+                         ;; [{:title … :summary …}] across whichever binding the
+                         ;; store actually uses; a store carrying both yields both.
+                         (into []
+                               (mapcat (fn [a]
+                                         (map (fn [[t summ]] {:title t :summary summ})
+                                              (d/q '[:find ?t ?summ :in $ ?a
+                                                     :where [?e ?a ?t]
+                                                     [(get-else $ ?e :entity/summary "") ?summ]]
+                                                   db a))))
+                               title-attrs))
+        each-kb        (fn [f]
+                         (into [] (mapcat (fn [{:keys [conn slug]}]
+                                            (map #(assoc % :kb slug) (f @conn))))
+                               (readable)))
+        kb-find        (fn [title]
+                         (safe #(first (each-kb (fn [db]
+                                                  (filter (comp #{title} :title)
+                                                          (titled db)))))))
         kb-by-type     (fn [t]
-                         (safe #(when kb-conn
-                                  (d/q '[:find [(pull ?e [:entity/title :entity/summary :entity/type]) ...]
-                                         :in $ ?ty :where [?e :entity/type ?ty]]
-                                       @kb-conn (keyword t)))))
+                         (safe #(each-kb (fn [db]
+                                           (d/q '[:find [(pull ?e [:entity/title :entity/summary :entity/type]) ...]
+                                                  :in $ ?ty :where [?e :entity/type ?ty]]
+                                                db (keyword t))))))
         kb-search      (fn [term]
-                         (safe #(when kb-conn
-                                  (let [lc (str/lower-case (str term))]
-                                    (->> (d/q '[:find [(pull ?e [:entity/title :entity/summary]) ...]
-                                                :where [?e :entity/title _]] @kb-conn)
-                                         (filter (fn [e] (str/includes?
-                                                          (str/lower-case (str (:entity/title e) " " (:entity/summary e)))
-                                                          lc)))
-                                         (take 25) vec)))))
+                         (safe #(let [lc (str/lower-case (str term))]
+                                  (->> (each-kb titled)
+                                       (filter (fn [e] (str/includes?
+                                                        (str/lower-case (str (:title e) " " (:summary e)))
+                                                        lc)))
+                                       (take 25) vec))))
         msg-time       (fn [m] (or (some-> ^java.util.Date (:message/created-at m) .getTime) 0))
         recent-msgs    (fn [n]
                          (safe #(when room-conn

--- a/src/dvergr/sandbox/workspace.clj
+++ b/src/dvergr/sandbox/workspace.clj
@@ -10,7 +10,8 @@
    loading source here does not widen it."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [dvergr.substrate.paths :as paths]))
+            [dvergr.substrate.paths :as paths]
+            [muschel.fs :as mfs]))
 
 (def ^:dynamic *workspace-dir*
   "Explicit override for the directory the sandbox loads code from (mainly for
@@ -19,18 +20,24 @@
    `.dvergr/workspace`."
   nil)
 
-(defn- current-worktree
-  "Worktree path of the git system registered in the bound execution context, or
-   nil. Resolved lazily to avoid a hard dep on the yggdrasil/git stack."
+(defn- current-virtual-workspace
+  "Virtual Geschichte workspace registered in the bound execution context."
   []
-  (try ((requiring-resolve 'dvergr.substrate.git/current-worktree-path))
+  (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
        (catch Throwable _ nil)))
 
 (defn workspace-root
-  "The single primary workspace root: the explicit override, else the current
-   ctx's (per-fork) worktree, else the shared `.dvergr/workspace`."
-  ^java.io.File []
-  (io/file (or *workspace-dir* (current-worktree) (paths/workspace-dir))))
+  "The primary workspace root. Geschichte workspaces return a virtual root
+  descriptor; explicit test overrides and the transitional fallback remain
+  physical paths."
+  []
+  (or (some-> *workspace-dir* io/file)
+      (when-let [workspace (current-virtual-workspace)]
+        {:id (:id workspace)
+         :root "/"
+         :fs ((requiring-resolve 'dvergr.substrate.geschichte/filesystem)
+              workspace)})
+      (io/file (paths/workspace-dir))))
 
 (def ^:dynamic *workspace-roots*
   "Ordered override list of roots the load-fn searches — a room's own repo first,
@@ -51,6 +58,9 @@
     (or (= fp rp)
         (str/starts-with? fp (str rp java.io.File/separator)))))
 
+(defn virtual-root? [root]
+  (and (map? root) (satisfies? mfs/FS (:fs root))))
+
 (defn- ns->rel-paths
   "Candidate workspace-relative file paths for a namespace symbol
    (mirrors Clojure's namespace→file munging): `my-app.core` → my_app/core.clj."
@@ -63,12 +73,19 @@
    string), or nil if absent. Path-clamped — only files genuinely inside `root`
    are read."
   [root lib]
-  (let [root (io/file root)]
+  (if (virtual-root? root)
     (some (fn [rel]
-            (let [f (io/file root rel)]
-              (when (and (.isFile f) (under-root? root f))
-                {:file (.getCanonicalPath f) :source (slurp f)})))
-          (ns->rel-paths lib))))
+            (let [path (str (str/replace (:root root) #"/$" "") "/" rel)]
+              (when (= :file (:type (mfs/stat (:fs root) path)))
+                {:file (str "geschichte:" (:id root) ":" path)
+                 :source (mfs/read-file (:fs root) path)})))
+          (ns->rel-paths lib))
+    (let [root (io/file root)]
+      (some (fn [rel]
+              (let [f (io/file root rel)]
+                (when (and (.isFile f) (under-root? root f))
+                  {:file (.getCanonicalPath f) :source (slurp f)})))
+            (ns->rel-paths lib)))))
 
 (def ^:private source-subdirs
   "Per workspace root, the source-root candidates the load-fn searches, in
@@ -84,7 +101,12 @@
   "Resolve `lib` under `root`, trying each source-subdir (root, root/src)."
   [root lib]
   (some (fn [sub]
-          (resolve-source (if (str/blank? sub) (io/file root) (io/file root sub)) lib))
+          (resolve-source
+           (cond
+             (str/blank? sub) root
+             (virtual-root? root) (update root :root #(str % "/" sub))
+             :else (io/file root sub))
+           lib))
         source-subdirs))
 
 (defn workspace-guide
@@ -99,11 +121,15 @@
   ([root] (workspace-guide root 8192))
   ([root max-chars]
    (try
-     (let [root (io/file root)
-           f (io/file root "AGENTS.md")]
-       (when (and (.isFile f) (under-root? root f))
-         (let [s (slurp f)]
-           (if (> (count s) max-chars) (subs s 0 max-chars) s))))
+     (let [s (if (virtual-root? root)
+               (mfs/read-file (:fs root)
+                              (str (str/replace (:root root) #"/$" "")
+                                   "/AGENTS.md"))
+               (let [root (io/file root)
+                     f (io/file root "AGENTS.md")]
+                 (when (and (.isFile f) (under-root? root f))
+                   (slurp f))))]
+       (when s (if (> (count s) max-chars) (subs s 0 max-chars) s)))
      (catch Throwable _ nil))))
 
 (defn load-fn

--- a/src/dvergr/substrate/datahike.clj
+++ b/src/dvergr/substrate/datahike.clj
@@ -15,6 +15,26 @@
             [org.replikativ.spindel.yggdrasil :as ygg]
             [dvergr.chat.schema :as cschema]))
 
+(def diff-buf-size
+  "Content-only child diffs buffered into the ancestor, cutting stored-object
+   growth. Create-time-fixed and irreversible, so it applies to NEW stores only.
+   Lives here rather than next to a store config because EVERY dvergr store uses
+   the same value and `system.rooms` <-> `substrate.geschichte` cannot require
+   each other.
+
+   128, not the 256 the datahike-saas-starter uses: measured on a room-shaped
+   store over 2000 message transactions, 256 is past the knee — MORE disk than
+   128 (78 vs 57 MB) and slower (p50 13.4 vs 10.9 ms, p99 31.7 vs 17.1 ms). The
+   budget counts ENTRIES, not bytes, so datom-sized elements want a smaller
+   buffer than a blob-shaped workload.
+
+     diff-buf   disk     objects   p50      p99
+     0          320 MB   35355     25.1 ms  40.2 ms
+     32          57 MB   14210     10.8 ms  18.4 ms
+     128         57 MB   12697     10.9 ms  17.1 ms   <- knee
+     256         78 MB   12436     13.4 ms  31.7 ms"
+  128)
+
 (defn connect!
   "Connect to `cfg`, creating the database first when it doesn't exist.
    Plain create+connect — no schema, no registration. Returns the conn."

--- a/src/dvergr/substrate/geschichte.clj
+++ b/src/dvergr/substrate/geschichte.clj
@@ -148,9 +148,33 @@
                       argv)
      {:stdout "" :stderr "fatal: not a Geschichte repository\n" :exit 128})))
 
+(def review-excluded-prefixes
+  "Worktree prefixes kept OUT of fork/merge review.
+
+   These paths are versioned like everything else — this is not `.gitignore`,
+   which means \"never tracked\". They are excluded from the REVIEW because a
+   merge review is a judgement about code, and user media is neither reviewable
+   as a diff nor mergeable as text: a room member uploading a voice note should
+   not be able to put a binary conflict in front of whoever approves the fork.
+
+   Consumer-side convention for now. The honest home for this is geschichte
+   itself (repo-config-backed exclusion honoured by `repo/changes`, `status` and
+   `git diff`), so that the CLI and the review agree — until then `git status`
+   inside the sandbox will still show these paths."
+  ["media/"])
+
+(defn- reviewable?
+  "Is this change part of the code review, or user data riding along?"
+  [{:keys [path]}]
+  (let [p (str/replace (str path) #"^/+" "")]
+    (not-any? #(str/starts-with? p %) review-excluded-prefixes)))
+
 (defn diff-since-fork
   "Review payload for a forked virtual workspace. Includes committed and dirty
-  paths; unlike the old implementation it has no host worktree path."
+  paths; unlike the old implementation it has no host worktree path.
+
+  Excludes `review-excluded-prefixes` — media travels with the fork, it just
+  does not show up as something to review."
   [fork-ctx]
   (let [in-ctx (fn [ctx]
                  (binding [ec/*execution-context* ctx] (current-system)))
@@ -161,9 +185,10 @@
             parent-conn (some-> parent-system gy/connection)
             base (some-> parent-conn repo/head-commit :geschichte.commit/id)
             head (some-> conn repo/head-commit :geschichte.commit/id)
-            changes (if base
-                      (repo/changes conn base :worktree)
-                      (repo/changes conn :empty :worktree))
+            changes (filterv reviewable?
+                             (if base
+                               (repo/changes conn base :worktree)
+                               (repo/changes conn :empty :worktree)))
             files (mapv :path changes)
             commits (when (and base head (not= base head))
                       (->> (repo/log conn {:limit 100})

--- a/src/dvergr/substrate/geschichte.clj
+++ b/src/dvergr/substrate/geschichte.clj
@@ -6,6 +6,7 @@
   trusted bootstrap import from `../dvergr-sandbox`; production bootstrap uses
   Geschichte smart HTTP directly."
   (:require [clojure.java.io :as io]
+            [dvergr.substrate.datahike :as sdh]
             [clojure.string :as str]
             [datahike.api :as d]
             [dvergr.substrate.paths :as paths]
@@ -46,11 +47,34 @@
              :path path
              :id (java.util.UUID/nameUUIDFromBytes
                   (.getBytes (str "dvergr-geschichte:" scope-path) "UTF-8"))}
-     :index-config {:diff-buf-size 256}
-     :fuse-index-roots? true
+     ;; 128, not 256 — measured knee on a room-shaped store; see
+     ;; `dvergr.substrate.datahike/diff-buf-size` for the table.
+     :index-config {:diff-buf-size sdh/diff-buf-size}
      :schema-flexibility :write
-     :keep-history? true
-     :commit-graph? true}))
+     ;; `:crypto-hash?` matches every other room store, so ONE mechanism
+     ;; (`datahike.audit/verify-chain`) verifies books, wiki, chat AND code.
+     ;; Geschichte needs it: its own hashing covers CONTENT only —
+     ;; `:geschichte.content/id` is a hash of the bytes, verified on read — while
+     ;; `:geschichte.commit/id` is a random uuid and refs are ordinary datoms. So
+     ;; repointing a path at other content, or rewriting commit parentage, is
+     ;; invisible to geschichte and visible only to datahike's merkle.
+     ;;
+     ;; It costs `:fuse-index-roots?`, which datahike disables under crypto-hash
+     ;; (measured: 296 -> 840 objects over 60 commits). Accepted because the
+     ;; object count matters most for a full-store sync handshake, and the
+     ;; roadmap is windowed partial loading rather than full handshakes.
+     :crypto-hash? true
+     :commit-graph? true
+     ;; The ONE flag that differs from the datom stores, and the reason is that
+     ;; Geschichte already implements history at a higher layer: its commit graph
+     ;; IS the version history, so datahike's temporal index is redundant here.
+     ;; Keeping it would be actively harmful — under `:keep-history? true` a
+     ;; retracted store-ref survives in the temporal AEVT and keeps its blob
+     ;; whitelisted forever, so deleted files and media could NEVER be reclaimed
+     ;; (measured: 10 MB retracted -> 10 MB retained; with history off the same
+     ;; test freed 10.57 MB -> 0.017 MB). Repos hold media; unbounded growth is
+     ;; not a trade worth making for a redundant index.
+     :keep-history? false}))
 
 (defn- fallback-workspace! [conn source error]
   (tel/log! {:level :warn :id :workspace/seed-clone-failed

--- a/src/dvergr/substrate/geschichte.clj
+++ b/src/dvergr/substrate/geschichte.clj
@@ -1,0 +1,188 @@
+(ns dvergr.substrate.geschichte
+  "Geschichte-backed room workspaces.
+
+  A workspace is a Datahike branch and a Muschel virtual filesystem, not a
+  native checkout. The only native repository access in this namespace is the
+  trusted bootstrap import from `../dvergr-sandbox`; production bootstrap uses
+  Geschichte smart HTTP directly."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [datahike.api :as d]
+            [dvergr.substrate.paths :as paths]
+            [geschichte.git.command :as command]
+            [geschichte.git.http :as git-http]
+            [geschichte.git.local :as git-local]
+            [geschichte.repo :as repo]
+            [geschichte.yggdrasil :as gy]
+            [muschel.fs.geschichte :as mgeschichte]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [taoensso.telemere :as tel]
+            [yggdrasil.protocols :as p]))
+
+(def sandbox-repo-url
+  "Published source for the sandbox standard library."
+  "https://github.com/replikativ/dvergr-sandbox.git")
+
+(defn default-sandbox-repo []
+  (let [sibling (io/file ".." "dvergr-sandbox" ".git")]
+    (if (.exists sibling) "../dvergr-sandbox" sandbox-repo-url)))
+
+(defn sandbox-repo []
+  (or (System/getenv "DVERGR_SANDBOX_REPO")
+      (try (:sandbox-repo ((requiring-resolve 'dvergr.substrate.config/config)))
+           (catch Throwable _ nil))
+      (default-sandbox-repo)))
+
+(defn repository-config
+  "Portable Datahike configuration for one persistent Geschichte repository."
+  [scope]
+  (let [scope-path (.getCanonicalPath (io/file scope))
+        ;; Keep the store below the repository scope. Besides leaving room for
+        ;; future repository metadata, this lets callers hand us an existing
+        ;; empty scope directory (the old native-worktree API commonly did).
+        path (.getCanonicalPath (io/file scope "datahike"))]
+    {:store {:backend :file
+             :path path
+             :id (java.util.UUID/nameUUIDFromBytes
+                  (.getBytes (str "dvergr-geschichte:" scope-path) "UTF-8"))}
+     :index-config {:diff-buf-size 256}
+     :fuse-index-roots? true
+     :schema-flexibility :write
+     :keep-history? true
+     :commit-graph? true}))
+
+(defn- fallback-workspace! [conn source error]
+  (tel/log! {:level :warn :id :workspace/seed-clone-failed
+             :data {:source source :error (ex-message error)}}
+            "Geschichte sandbox seed import failed — creating an empty workspace")
+  (repo/write! conn "user.clj" (.getBytes "(ns user)\n" "UTF-8"))
+  (repo/stage-all! conn)
+  (repo/commit! conn {:message "workspace: empty (stdlib source unreachable)"
+                      :author "dvergr <agent@dvergr.local>"}))
+
+(defn- import-seed! [conn source]
+  (if-let [local-source (git-local/source-file (io/file ".") source)]
+    (git-local/import! conn local-source
+                       {:remote "upstream" :clone? true})
+    (git-http/clone! conn "upstream" source)))
+
+(defn ensure-repository!
+  "Create and seed a persistent Geschichte repository at `scope`. Existing
+  repositories are left untouched. Returns the Datahike config."
+  ([scope] (ensure-repository! scope {}))
+  ([scope {:keys [source] :or {source (sandbox-repo)}}]
+   (let [cfg (repository-config scope)]
+     (when-not (d/database-exists? cfg)
+       (when-let [parent (.getParentFile (io/file scope))]
+         (.mkdirs parent))
+       (d/create-database cfg)
+       (let [conn (d/connect cfg)]
+         (try
+           (repo/init! conn {:name "dvergr workspace"})
+           (try
+             (import-seed! conn source)
+             (catch Throwable error
+               (fallback-workspace! conn source error)))
+           (finally (d/release conn)))))
+     cfg)))
+
+(defn create-system
+  "Open a persistent repository as a Geschichte Yggdrasil system."
+  [& {:keys [scope system-name source]}]
+  (let [scope (or scope (paths/workspace-store))
+        cfg (ensure-repository! scope (cond-> {} source (assoc :source source)))]
+    (gy/create (d/connect cfg) {:system-name system-name})))
+
+(defn delete-repository! [scope]
+  (let [cfg (repository-config scope)]
+    (when (d/database-exists? cfg)
+      (d/delete-database cfg))))
+
+(defn current-system
+  "The room-owned Geschichte system in the bound Spindel context."
+  []
+  (let [systems (->> (ygg/registered-systems)
+                     vals
+                     (filter #(= :geschichte (p/system-type %))))]
+    (or (first (filter #(some-> (p/system-id %) str
+                                (str/starts-with? "room-repo-"))
+                       systems))
+        (first systems))))
+
+;; Small named accessors keep dvergr.system.rooms independent of Geschichte's
+;; record fields while it resolves a specific attached repository by system id.
+(def gy-connection gy/connection)
+(def gy-workspace-id gy/workspace-id)
+
+(defn current-workspace
+  "Virtual workspace descriptor for the bound context, or nil."
+  []
+  (when-let [system (current-system)]
+    (let [conn (gy/connection system)]
+      {:system system
+       :conn conn
+       :id (gy/workspace-id system)
+       :repository {:conn conn
+                    :config (:config @conn)
+                    :workspace-branch (get-in @conn [:config :branch])}})))
+
+(defn filesystem
+  "Create a Muschel MountFS rooted in a workspace descriptor. The returned
+  filesystem is fully virtual and supports nested Geschichte worktree mounts."
+  ([] (some-> (current-workspace) filesystem))
+  ([{:keys [repository] :as workspace}]
+   (when workspace
+     (mgeschichte/make-root repository))))
+
+(defn execute-git
+  "Execute Git-compatible argv against a virtual workspace."
+  ([argv] (execute-git (current-workspace) argv))
+  ([workspace argv]
+   (if-let [{:keys [conn]} workspace]
+     (command/execute {:conn conn :root "/" :config (atom {})
+                       :repo-relative #(let [path (str %)]
+                                         (if (contains? #{"." "/"} path)
+                                           ""
+                                           (str/replace path #"^/+" "")))}
+                      argv)
+     {:stdout "" :stderr "fatal: not a Geschichte repository\n" :exit 128})))
+
+(defn diff-since-fork
+  "Review payload for a forked virtual workspace. Includes committed and dirty
+  paths; unlike the old implementation it has no host worktree path."
+  [fork-ctx]
+  (let [in-ctx (fn [ctx]
+                 (binding [ec/*execution-context* ctx] (current-system)))
+        fork-system (in-ctx fork-ctx)
+        parent-system (some-> fork-ctx :parent-ctx in-ctx)]
+    (when fork-system
+      (let [conn (gy/connection fork-system)
+            parent-conn (some-> parent-system gy/connection)
+            base (some-> parent-conn repo/head-commit :geschichte.commit/id)
+            head (some-> conn repo/head-commit :geschichte.commit/id)
+            changes (if base
+                      (repo/changes conn base :worktree)
+                      (repo/changes conn :empty :worktree))
+            files (mapv :path changes)
+            commits (when (and base head (not= base head))
+                      (->> (repo/log conn {:limit 100})
+                           (take-while #(not= base (:geschichte.commit/id %)))
+                           (mapv (fn [commit]
+                                   {:sha (str (:geschichte.commit/id commit))
+                                    :subject (:geschichte.commit/message commit)}))))
+            ;; Review must include dirty worktree paths as well as commits. A
+            ;; CLI `diff --stat` against HEAD drops that distinction after a
+            ;; commit, so summarize the already-computed base→worktree changes.
+            stat (when (seq changes)
+                   (str (str/join "\n" (map #(str " " (:path %) " | changed") changes))
+                        "\n " (count changes) " file"
+                        (when (not= 1 (count changes)) "s") " changed\n"))]
+        {:branch (name (p/current-branch fork-system))
+         :parent-branch (some-> parent-system p/current-branch name)
+         :workspace-id (gy/workspace-id fork-system)
+         :worktree-path nil
+         :commits (or commits [])
+         :stat stat
+         :files files
+         :empty? (empty? files)}))))

--- a/src/dvergr/substrate/paths.clj
+++ b/src/dvergr/substrate/paths.clj
@@ -59,6 +59,7 @@
 (defn db-dir           "Chat/KB/code Datahike file store (datahike makes it)." [] (path "db"))
 (defn worktrees-dir    "Git worktrees container (git makes <branch> under it)." [] (dir "worktrees"))
 (defn workspace-dir    "Agent code workspace — a dedicated git repo, the SCI sandbox's load root." [] (dir "workspace"))
+(defn workspace-store  "Fallback Geschichte repository store (Datahike creates it)." [] (path "geschichte-workspace"))
 (defn system-db-dir    "System DB store: registry of parties/systems/rooms/grants (datahike makes it)." [] (path "system-db"))
 (defn systems-dir      "Per-system store container (each KB/repo scope gets a child under it)." [] (dir "systems"))
 (defn transcripts-dir  "Intake transcript cache (files under it)." [] (dir "transcripts"))

--- a/src/dvergr/system/rooms.clj
+++ b/src/dvergr/system/rooms.clj
@@ -64,28 +64,46 @@
   [path]
   (java.util.UUID/nameUUIDFromBytes (.getBytes ^String path)))
 
-(defn- store-cfg [path]
-  ;; keep-history? true so the store can branch with its room (fork/merge).
+(defn- store-cfg
+  "ONE config for every datom store a room owns — messages, KB, agent `:data`.
+   Uniform on purpose: any of them may grow to hold any combination of a room's
+   content, so none of them may be missing a create-time-fixed flag that a later
+   use would need.
+
+   `:crypto-hash? true` makes every index-node address a content hash and every
+   commit-id a UUID-5 over the merkle roots, so `datahike.audit/verify-chain`
+   can verify the store end to end. That is what makes a room's books — and its
+   wiki, chat and code — tamper-evident under one mechanism.
+
+   datahike REQUIRES `:commit-graph? true` alongside it (the audit chain verifies
+   the persisted commit chain), and the commit graph is also what
+   `datahike.versioning/branch-history` walks, so fork/merge ancestry comes from
+   here. (There is no `:branch-history?` option in datahike — a config carrying
+   one is silently ignoring it.)
+
+   `:keep-history? true` is for the PRODUCT's history: wiki edits, chat, ledger
+   rows. It is NOT needed for branching, contrary to what this comment used to
+   claim — `d/branch!` needs commit records, not temporal indices.
+
+   All of these are fixed at CREATION: `ensure-stored-config-consistency`
+   consistency-checks the STORED config on connect, so an existing store can
+   never adopt one. Changing anything here means re-creating rooms."
+  [path]
   {:store {:backend :file :path path :id (store-id path)}
    :keep-history? true
+   :crypto-hash? true
+   :commit-graph? true
+   :index-config {:diff-buf-size sdh/diff-buf-size}
    :schema-flexibility :write})
 
 (def ^:private kb-cfg store-cfg)
 
-(defn- msgs-cfg
-  "The ROOM store — the survivor of the per-room store collapse, so it is where the
-   kontor book comes to live. That requires `:crypto-hash? true`, and datahike fixes
-   it at CREATION: `ensure-stored-config-consistency` adopts/consistency-checks the
-   STORED config on connect, so an existing store can never adopt it — enabling it
-   later means re-creating rooms. datahike also rejects `:crypto-hash?` together with
-   `:commit-graph? false` (the audit chain verifies the persisted commit chain), so
-   both flags go on together.
-
-   Only this store gets them. Crypto-hash makes each index-node address a content
-   hash, which disables locality squuids and address reuse, so the KB and agent
-   `:data` stores keep the cheaper layout — they hold no sealed financial records."
-  [path]
-  (assoc (store-cfg path) :crypto-hash? true :commit-graph? true))
+(def ^:private msgs-cfg
+  "The room's messages store. Was the only store carrying `:crypto-hash?` +
+   `:commit-graph?`, back when it alone was expected to hold the kontor book;
+   those flags are now in `store-cfg` for every datom store, so this is a plain
+   alias kept for call-site readability."
+  store-cfg)
 
 (def ^:private data-cfg store-cfg)
 

--- a/src/dvergr/system/rooms.clj
+++ b/src/dvergr/system/rooms.clj
@@ -321,12 +321,27 @@
   (when-let [r (sdb/room-by-slug slug)]
     (room-msgs-conn (:room/id r))))
 
-(defn room-kb-conn
-  "Fork-aware conn to a room's OWN (writable) KB — where `knowledge_add` writes."
+(defn writable-kbs
+  "The room's writable KBs, `:owner` first — every one `knowledge_add` MAY
+   target, not just the one it does by default."
   [room-id]
-  (some->> (room-kbs room-id)
-           (filter #(#{:owner :read-write} (:permission %)))
-           first :path kb-system-name ygg/system :conn))
+  (filterv #(#{:owner :read-write} (:permission %)) (room-kbs room-id)))
+
+(defn room-kb-conn
+  "Fork-aware conn to a room's writable KB — where `knowledge_add` writes.
+
+   With no `slug`, the default is the highest-precedence writable KB, which is
+   the room's own. That default is the reason a room's wiki could be invisible
+   to its agent: a room whose knowledge actually lives in an ATTACHED KB still
+   wrote into its own empty one, and nothing said so. Passing a slug names the
+   target explicitly; `writable-kbs` lists what is nameable."
+  ([room-id] (room-kb-conn room-id nil))
+  ([room-id slug]
+   (let [kbs (writable-kbs room-id)]
+     (some-> (if slug
+               (first (filter #(= slug (:slug %)) kbs))
+               (first kbs))
+             :path kb-system-name ygg/system :conn))))
 
 (defn room-kb-conns
   "All KB conns a room may READ (own + attached), each `{:conn :permission :slug}` —

--- a/src/dvergr/system/rooms.clj
+++ b/src/dvergr/system/rooms.clj
@@ -24,7 +24,8 @@
             [dvergr.search.secondary :as search-secondary]
             [dvergr.scheduler.schema :as sched-schema]
             [dvergr.runtime.ctx :as rctx]
-            [dvergr.substrate.git :as git]
+            [dvergr.substrate.geschichte :as geschichte]
+            [geschichte.workspace :as gworkspace]
             [dvergr.substrate.paths :as paths]
             [dvergr.substrate.datahike :as sdh]
             [org.replikativ.spindel.yggdrasil :as ygg]
@@ -52,15 +53,40 @@
 
 (defn- scope-path [scope] (str (io/file (paths/systems-dir) scope)))
 
+(defn store-id
+  "Konserve store id for a room store `path`. Deterministic in the path, so the
+   id is stable across restarts and derivable without touching the store.
+
+   Public because it is the konserve-sync SCOPE: a consumer that collapses its
+   own per-room database onto the room store (simmis binds
+   `:room/content-db-scope` to it) must name the same store the writer uses, and
+   must not re-derive the formula on its own."
+  [path]
+  (java.util.UUID/nameUUIDFromBytes (.getBytes ^String path)))
+
 (defn- store-cfg [path]
   ;; keep-history? true so the store can branch with its room (fork/merge).
-  {:store {:backend :file :path path
-           :id (java.util.UUID/nameUUIDFromBytes (.getBytes ^String path))}
+  {:store {:backend :file :path path :id (store-id path)}
    :keep-history? true
    :schema-flexibility :write})
 
 (def ^:private kb-cfg store-cfg)
-(def ^:private msgs-cfg store-cfg)
+
+(defn- msgs-cfg
+  "The ROOM store — the survivor of the per-room store collapse, so it is where the
+   kontor book comes to live. That requires `:crypto-hash? true`, and datahike fixes
+   it at CREATION: `ensure-stored-config-consistency` adopts/consistency-checks the
+   STORED config on connect, so an existing store can never adopt it — enabling it
+   later means re-creating rooms. datahike also rejects `:crypto-hash?` together with
+   `:commit-graph? false` (the audit chain verifies the persisted commit chain), so
+   both flags go on together.
+
+   Only this store gets them. Crypto-hash makes each index-node address a content
+   hash, which disables locality squuids and address reuse, so the KB and agent
+   `:data` stores keep the cheaper layout — they hold no sealed financial records."
+  [path]
+  (assoc (store-cfg path) :crypto-hash? true :commit-graph? true))
+
 (def ^:private data-cfg store-cfg)
 
 (defn- connect-data-store
@@ -123,8 +149,8 @@
                    :system-name (msgs-system-name msgs-path)})
   (sdh/provision! {:cfg (kb-cfg kb-path) :schema? false
                    :system-name (kb-system-name kb-path)})
-  (ygg/register! (git/create-git-system :repo-path repo-path
-                                        :system-name (repo-system-name repo-path))))
+  (ygg/register! (geschichte/create-system :scope repo-path
+                                           :system-name (repo-system-name repo-path))))
 
 (defn- register-system-into-current!
   "Register one registry system (`{:system/type :system/scope}`) into the bound
@@ -136,8 +162,8 @@
                              :system-name (msgs-system-name scope)})
       :kb   (sdh/provision! {:cfg (kb-cfg scope) :schema? false
                              :system-name (kb-system-name scope)})
-      :repo (ygg/register! (git/create-git-system :repo-path scope
-                                                  :system-name (repo-system-name scope)))
+      :repo (ygg/register! (geschichte/create-system :scope scope
+                                                     :system-name (repo-system-name scope)))
       ;; agent-created data DBs (see create-room-db!) — re-register so they survive
       ;; restart, same as the room's own KB/msgs. Custom connect (schema-flexibility
       ;; fallback), so pass the conn; never impose dvergr schema on agent stores.
@@ -191,7 +217,7 @@
       (let [repo-path (scope-path (str (random-uuid)))
             kb-path   (scope-path (str (random-uuid)))
             msgs-path (scope-path (str (random-uuid)))
-            _         (git/ensure-repo! repo-path)
+            _         (geschichte/ensure-repository! repo-path)
             ;; KB store carries ONLY the knowledge schema (not the chat schema).
             _         (sdh/provision! {:cfg (kb-cfg kb-path) :schema? false
                                        :extra-schema (kbs/knowledge-datahike-schema)
@@ -250,13 +276,25 @@
   [room-id]
   (resolve-type room-id :msgs))
 
+(defn room-msgs-path
+  "Filesystem path of a room's OWN (writable) messages store, or nil."
+  [room-id]
+  (some->> (room-msgs room-id)
+           (filter #(#{:owner :read-write} (:permission %)))
+           first :path))
+
+(defn room-msgs-store-id
+  "Konserve store id of a room's OWN messages store — the sync scope a consumer
+   binds to when it collapses its per-room database onto the room store. nil if
+   the room isn't provisioned."
+  [room-id]
+  (some-> (room-msgs-path room-id) store-id))
+
 (defn room-msgs-conn
   "Fork-aware conn to a room's OWN messages store — where the room store writes
    conversation. nil if the room isn't provisioned / not registered in this ctx."
   [room-id]
-  (some->> (room-msgs room-id)
-           (filter #(#{:owner :read-write} (:permission %)))
-           first :path msgs-system-name ygg/system :conn))
+  (some-> (room-msgs-path room-id) msgs-system-name ygg/system :conn))
 
 (defn msgs-conn-for-slug
   "Fork-aware conn to the OWN messages store of the system-DB room with `slug`,
@@ -336,25 +374,27 @@
           conn))))
 
 (defn gc-orphan-fork-branches!
-  "Boot-time GC for abandoned fork worktrees/branches (P3). Fork rooms are in-memory
-   only — none survive a daemon restart — so on boot EVERY fork branch (`*-fork-*`,
-   from spindel's `<branch>-<fork-id>` naming) is an orphan with no live handle.
-   Prune them per room repo via the yggdrasil git adapter, reclaiming the leaked
-   worktree dirs + branches. Returns the total count pruned. Best-effort per room.
-   (Datahike fork-branch GC is a separate follow-up; git worktrees are the big leak.)
-   Must run under a bound ctx whose rooms are hydrated."
+  "Boot-time GC for abandoned virtual Geschichte workspace branches. Room forks
+  are in-memory and do not survive restart, so every non-canonical Datahike
+  workspace branch is orphaned after hydration."
   []
-  (let [prune (requiring-resolve 'yggdrasil.adapters.git/prune-orphan-branches!)
-        fork? (fn [b] (re-find #"-fork-" (str b)))]
-    (reduce
-     (fn [n {:room/keys [id]}]
-       (binding [ec/*execution-context* (or (room-ctx-for id) (ec/current-execution-context))]
-         (+ n (reduce (fn [m {:keys [path]}]
-                        (if-let [sys (ygg/system (repo-system-name path))]
-                          (+ m (count (try (prune sys fork?) (catch Throwable _ nil))))
-                          m))
-                      0 (room-repos id)))))
-     0 (sdb/all-rooms))))
+  (reduce
+   (fn [n {:room/keys [id]}]
+     (binding [ec/*execution-context* (or (room-ctx-for id)
+                                          (ec/current-execution-context))]
+       (+ n
+          (reduce
+           (fn [m {:keys [path]}]
+             (if-let [system (ygg/system (repo-system-name path))]
+               (let [conn (geschichte/gy-connection system)
+                     branches (gworkspace/list conn)]
+                 (doseq [branch branches]
+                   (try (gworkspace/remove! conn branch)
+                        (catch Throwable _ nil)))
+                 (+ m (count branches)))
+               m))
+           0 (room-repos id)))))
+   0 (sdb/all-rooms)))
 
 (defn gc-stores!
   "Reclaim unreachable storage across EVERY persistent store: the system-db plus
@@ -446,12 +486,20 @@
               (room-msgs room-id)))))
 
 (defn room-load-roots
-  "Ordered repo WORKTREES (fork-aware) for the SCI load-fn — own first, attached
-   after. Bind `dvergr.sandbox.workspace/*workspace-roots*` to this for a turn."
+  "Ordered virtual Geschichte roots for the SCI load-fn — own first, attached
+  after. Each descriptor is fork-aware and contains a Muschel FS, not a host
+  filesystem path."
   [room-id]
   (->> (room-repos room-id)
        (keep (fn [{:keys [path]}]
-               (some-> (ygg/system (repo-system-name path)) git/worktree-path)))
+               (when-let [system (ygg/system (repo-system-name path))]
+                 (let [conn (geschichte/gy-connection system)]
+                   {:id (geschichte/gy-workspace-id system)
+                    :root "/"
+                    :fs (geschichte/filesystem
+                         {:system system :conn conn
+                          :id (geschichte/gy-workspace-id system)
+                          :repository {:conn conn :config (:config @conn)}})}))))
        vec))
 
 (defn roots-for-slug
@@ -468,13 +516,18 @@
     (room-kb-conn (:room/id r))))
 
 (defn room-mount-spec
-  "muschel composite-fs mount data for a room: `[[mount-path worktree read-only?] …]`,
-   own repo first; `:read` grants mounted read-only. Fork-aware worktrees via ygg."
+  "Virtual Geschichte mount data for attached room repositories."
   [room-id]
   (->> (room-repos room-id)
        (keep (fn [{:keys [slug path permission]}]
-               (when-let [wt (some-> (ygg/system (repo-system-name path)) git/worktree-path)]
-                 [(str "/" slug) wt (= permission :read)])))
+               (when-let [system (ygg/system (repo-system-name path))]
+                 [(str "/" slug)
+                  (geschichte/filesystem
+                   (let [conn (geschichte/gy-connection system)]
+                     {:system system :conn conn
+                      :id (geschichte/gy-workspace-id system)
+                      :repository {:conn conn :config (:config @conn)}}))
+                  (= permission :read)])))
        vec))
 
 (defn- delete-tree! [path]
@@ -497,6 +550,7 @@
       (doseq [{:system/keys [type scope]} owned]
         (case type
           :repo (do (ygg/unregister! (repo-system-name scope))
+                    (geschichte/delete-repository! scope)
                     (delete-tree! scope))
           :kb   (do (ygg/unregister! (kb-system-name scope))
                     (try (when (d/database-exists? (kb-cfg scope))

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -10,6 +10,7 @@
             [dvergr.code.index :as idx]
             [dvergr.tools.structural :as structural]
             [dvergr.chat.compaction :as compaction]
+            [muschel.fs :as mfs]
             [org.replikativ.spindel.engine.core :as rtc])
   (:import [java.util.concurrent TimeUnit]))
 
@@ -131,6 +132,15 @@
 ;; role lattice. A "role" is therefore just a reusable tool-set you name in agent
 ;; config (plain data), should you want one.
 
+(defn- resolve-default-workspace []
+  (try
+    (when-let [workspace ((requiring-resolve
+                           'dvergr.substrate.geschichte/current-workspace))]
+      {:workspace workspace
+       :filesystem ((requiring-resolve 'dvergr.substrate.geschichte/filesystem)
+                    workspace)})
+    (catch Throwable _ nil)))
+
 (defn- resolve-default-cwd
   "Working directory for tool calls when none is supplied. Priority:
 
@@ -141,7 +151,8 @@
 
    Failures (no ctx bound, no git system) fall through silently."
   []
-  (or (try
+  (or (when (resolve-default-workspace) "/")
+      (try
         ((requiring-resolve 'dvergr.substrate.git/current-worktree-path))
         (catch Throwable _ nil))
       ;; no git system in scope → the isolated .dvergr/workspace clone, NEVER the
@@ -166,16 +177,72 @@
                       When :native, clojure_eval uses real Clojure eval instead of SCI
    - :eval-ns       - Atom holding current namespace for native eval (default: user)
    - :execution-ctx - Spindel execution context (for spawn_agent tool)"
-  [{:keys [cwd sci-ctx db-conn chat-ctx tools isolation eval-ns execution-ctx]}]
-  {:cwd (or cwd (resolve-default-cwd))
-   :sci-ctx sci-ctx
-   :db-conn db-conn
-   :chat-ctx chat-ctx
-   :tools tools  ; Authoritative tool allowlist (see execute); nil = unrestricted
-   :isolation isolation
-   :eval-ns (or eval-ns (atom (the-ns 'user)))
-   :execution-ctx execution-ctx
-   :abort (atom false)})
+  [{:keys [cwd workspace filesystem sci-ctx db-conn chat-ctx tools isolation
+           eval-ns execution-ctx] :as options}]
+  (let [virtual (when-not (or workspace filesystem)
+                  (resolve-default-workspace))]
+    (merge options
+           {:cwd (or cwd (when (or filesystem virtual) "/") (resolve-default-cwd))
+            :workspace (or workspace (:workspace virtual))
+            :filesystem (or filesystem (:filesystem virtual))
+            :sci-ctx sci-ctx
+            :db-conn db-conn
+            :chat-ctx chat-ctx
+            :tools tools  ; Authoritative tool allowlist (see execute); nil = unrestricted
+            :isolation isolation
+            :eval-ns (or eval-ns (atom (the-ns 'user)))
+            :execution-ctx execution-ctx
+            :abort (or (:abort options) (atom false))})))
+
+(defn- tool-path [{:keys [filesystem cwd]} path]
+  (if filesystem
+    (or (mfs/resolve filesystem
+                     (if (str/starts-with? (str path) "/")
+                       path
+                       (str (str/replace (or cwd "/") #"/$" "") "/" path)))
+        (throw (ex-info "Path escapes the virtual workspace" {:path path})))
+    (str (if (fs/absolute? path) (fs/file path) (fs/file cwd path)))))
+
+(defn- workspace-read [ctx path]
+  (let [path (tool-path ctx path)]
+    (if-let [filesystem (:filesystem ctx)]
+      (mfs/read-file filesystem path)
+      (slurp path))))
+
+(defn- workspace-write! [ctx path content]
+  (let [path (tool-path ctx path)]
+    (if-let [filesystem (:filesystem ctx)]
+      (do
+        (loop [parent (subs path 0 (max 1 (.lastIndexOf ^String path "/")))
+               pending []]
+          (if (or (= parent "/") (mfs/exists? filesystem parent))
+            (doseq [directory (reverse pending)] (mfs/mkdir filesystem directory))
+            (recur (subs parent 0 (max 1 (.lastIndexOf ^String parent "/")))
+                   (conj pending parent))))
+        (mfs/write-string! filesystem path (str content) false))
+      (do (fs/create-dirs (fs/parent path)) (spit path content)))
+    path))
+
+(defn- virtual-walk [filesystem root]
+  (letfn [(walk [path]
+            (cons path
+                  (when (= :dir (:type (mfs/stat filesystem path)))
+                    (mapcat #(walk (str (str/replace path #"/$" "") "/" (:name %)))
+                            (mfs/list-dir filesystem path)))))]
+    (walk root)))
+
+(defn- workspace-glob [{:keys [filesystem cwd]} pattern]
+  (if filesystem
+    (let [root (tool-path {:filesystem filesystem :cwd cwd} ".")
+          prefix (str (str/replace root #"/$" "") "/")
+          matcher (.getPathMatcher (java.nio.file.FileSystems/getDefault)
+                                   (str "glob:" pattern))]
+      (->> (virtual-walk filesystem root)
+           (remove #{root})
+           (map #(if (str/starts-with? % prefix) (subs % (count prefix)) %))
+           (filter #(.matches matcher (java.nio.file.Paths/get % (make-array String 0))))
+           vec))
+    (fs/glob cwd pattern)))
 
 (defn execute
   "Execute a tool by name with given input and context.
@@ -265,19 +332,22 @@
                :properties {:path {:type "string"
                                    :description "The absolute or relative path to the file"}}
                :required ["path"]}
-  :execute (fn [{:keys [path]} {:keys [cwd]}]
-             (let [file (if (fs/absolute? path)
-                          (fs/file path)
-                          (fs/file cwd path))]
-               (if (fs/exists? file)
-                 (if (fs/directory? file)
+  :execute (fn [{:keys [path]} ctx]
+             (let [file (tool-path ctx path)
+                   stat (if-let [filesystem (:filesystem ctx)]
+                          (mfs/stat filesystem file)
+                          (when (fs/exists? file)
+                            {:type (if (fs/directory? file) :dir :file)
+                             :size (fs/size file)}))]
+               (if stat
+                 (if (= :dir (:type stat))
                    {:type :error
                     :error (str "Path is a directory, not a file: " path)
                     :suggestion "Use glob to list directory contents"}
                    {:type :success
-                    :content (slurp file)
+                    :content (workspace-read ctx path)
                     :metadata {:path (str file)
-                               :size (fs/size file)}})
+                               :size (:size stat)}})
                  {:type :error
                   :error (str "File not found: " path)
                   :suggestion "Check if the path is correct. Use glob to find files."})))})
@@ -291,12 +361,8 @@
                             :content {:type "string"
                                       :description "The content to write"}}
                :required ["path" "content"]}
-  :execute (fn [{:keys [path content]} {:keys [cwd session-id]}]
-             (let [file (if (fs/absolute? path)
-                          (fs/file path)
-                          (fs/file cwd path))]
-               (fs/create-dirs (fs/parent file))
-               (spit file content)
+  :execute (fn [{:keys [path content]} {:keys [session-id] :as ctx}]
+             (let [file (workspace-write! ctx path content)]
                 ;; Auto-index if Clojure file
                (index-file-if-clojure! file content session-id)
                {:type :success
@@ -315,12 +381,13 @@
                             :new_string {:type "string"
                                          :description "The replacement string"}}
                :required ["path" "old_string" "new_string"]}
-  :execute (fn [{:keys [path old_string new_string]} {:keys [cwd session-id]}]
-             (let [file (if (fs/absolute? path)
-                          (fs/file path)
-                          (fs/file cwd path))]
-               (if (fs/exists? file)
-                 (let [content (slurp file)
+  :execute (fn [{:keys [path old_string new_string]} {:keys [session-id] :as ctx}]
+             (let [file (tool-path ctx path)
+                   exists? (if-let [filesystem (:filesystem ctx)]
+                             (mfs/exists? filesystem file)
+                             (fs/exists? file))]
+               (if exists?
+                 (let [content (workspace-read ctx path)
                        occurrences (count (re-seq (re-pattern (java.util.regex.Pattern/quote old_string)) content))]
                    (cond
                      (zero? occurrences)
@@ -335,7 +402,7 @@
 
                      :else
                      (let [new-content (str/replace-first content old_string new_string)]
-                       (spit file new-content)
+                       (workspace-write! ctx path new-content)
                         ;; Auto-index if Clojure file
                        (index-file-if-clojure! file new-content session-id)
                        {:type :success
@@ -353,8 +420,8 @@
                :properties {:pattern {:type "string"
                                       :description "Glob pattern (e.g., '**/*.clj', 'src/*.md')"}}
                :required ["pattern"]}
-  :execute (fn [{:keys [pattern]} {:keys [cwd]}]
-             (let [matches (fs/glob cwd pattern)]
+  :execute (fn [{:keys [pattern]} ctx]
+             (let [matches (workspace-glob ctx pattern)]
                {:type :success
                 :content (str/join "\n" (map str matches))
                 :metadata {:count (count matches)
@@ -377,22 +444,37 @@
                             :-i {:type "boolean"
                                  :description "Case-insensitive search"}}
                :required ["pattern"]}
-  :execute (fn [{:keys [pattern glob -i]} {:keys [cwd]}]
-             (let [cmd (cond-> ["grep" "-rn" "--color=never"]
-                         -i (conj "-i")
-                         true (conj pattern ".")
-                         glob (into ["--include" glob]))
-                   pb (ProcessBuilder. cmd)
-                   _ (.directory pb (io/file cwd))
-                   proc (.start pb)
-                   stdout (slurp (.getInputStream proc))
-                   _ (.waitFor proc)]
-               {:type :success
-                :content (if (str/blank? stdout)
-                           "No matches found"
-                           stdout)
-                :metadata {:pattern pattern
-                           :matches (count (str/split-lines stdout))}}))})
+  :execute (fn [{:keys [pattern glob -i]} {:keys [cwd filesystem] :as ctx}]
+             (if filesystem
+               (let [flags (if -i java.util.regex.Pattern/CASE_INSENSITIVE 0)
+                     re (java.util.regex.Pattern/compile pattern flags)
+                     paths (workspace-glob ctx (or glob "**"))
+                     lines (for [path paths
+                                 :when (= :file (:type (mfs/stat filesystem
+                                                                 (tool-path ctx path))))
+                                 [line-number line] (map-indexed vector
+                                                                 (str/split-lines
+                                                                  (workspace-read ctx path)))
+                                 :when (.find (.matcher re line))]
+                             (str path ":" (inc line-number) ":" line))]
+                 {:type :success
+                  :content (if (seq lines) (str/join "\n" lines) "No matches found")
+                  :metadata {:pattern pattern :matches (count lines)}})
+               (let [cmd (cond-> ["grep" "-rn" "--color=never"]
+                           -i (conj "-i")
+                           true (conj pattern ".")
+                           glob (into ["--include" glob]))
+                     pb (ProcessBuilder. cmd)
+                     _ (.directory pb (io/file cwd))
+                     proc (.start pb)
+                     stdout (slurp (.getInputStream proc))
+                     _ (.waitFor proc)]
+                 {:type :success
+                  :content (if (str/blank? stdout)
+                             "No matches found"
+                             stdout)
+                  :metadata {:pattern pattern
+                             :matches (count (str/split-lines stdout))}})))})
 
 (defn- native-eval
   "Evaluate Clojure code natively (not in SCI sandbox).
@@ -665,15 +747,20 @@
                             :new_source {:type "string"
                                          :description "New Clojure source code"}}
                :required ["file_path" "form_type" "form_name" "operation" "new_source"]}
-  :execute (fn [{:keys [file_path form_type form_name operation new_source]} {:keys [cwd session-id]}]
-             (let [full-path (if (fs/absolute? file_path)
-                               file_path
-                               (str cwd "/" file_path))
+  :execute (fn [{:keys [file_path form_type form_name operation new_source]}
+                {:keys [session-id] :as ctx}]
+             (let [full-path (tool-path ctx file_path)
                    op-keyword (keyword operation)
-                   result (structural/edit-clojure-form full-path form_type form_name op-keyword new_source)]
+                   result (if (:filesystem ctx)
+                            (if-let [source (workspace-read ctx file_path)]
+                              (structural/edit-clojure-source source form_type form_name
+                                                              op-keyword new_source)
+                              {:success false :error (str "File not found: " file_path)})
+                            (structural/edit-clojure-form full-path form_type form_name
+                                                          op-keyword new_source))]
                (if (:success result)
                  (do
-                   (spit full-path (:content result))
+                   (workspace-write! ctx file_path (:content result))
                     ;; Auto-index (always Clojure file)
                    (index-file-if-clojure! full-path (:content result) session-id)
                    {:type :success

--- a/src/dvergr/tools/structural.clj
+++ b/src/dvergr/tools/structural.clj
@@ -112,6 +112,27 @@
       {:success false
        :error (str "Error editing form: " (.getMessage e))})))
 
+(defn edit-clojure-source
+  "The storage-independent form of `edit-clojure-form`. Edits an in-memory
+  source string so callers backed by virtual/versioned filesystems do not need
+  to materialize a temporary native file."
+  [source form-type form-name operation new-source]
+  (try
+    (let [zloc (z/of-string source)
+          found (find-top-level-form zloc form-type form-name)]
+      (if-not found
+        {:success false
+         :error (str "Form not found: " form-type " " form-name)}
+        {:success true
+         :content (case operation
+                    :replace (replace-form found new-source)
+                    :insert-before (insert-before-form found new-source)
+                    :insert-after (insert-after-form found new-source))
+         :old-form (z/string found)}))
+    (catch Exception e
+      {:success false
+       :error (str "Error editing form: " (.getMessage e))})))
+
 ;; ---------------------------------------------------------------------------
 ;; Validation
 ;; ---------------------------------------------------------------------------

--- a/src/dvergr/web/apps.clj
+++ b/src/dvergr/web/apps.clj
@@ -13,11 +13,11 @@
    GET-only, path-canonicalized to the app root (symlink escape included), no
    dotfiles. The daemon web binds loopback by default; publishing to third
    parties is a separate, explicit step (auth boundary TBD)."
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [dvergr.substrate.git :as git]
+  (:require [clojure.string :as str]
+            [dvergr.substrate.geschichte :as geschichte]
             [dvergr.system.db :as sdb]
             [dvergr.system.rooms :as srooms]
+            [muschel.fs :as mfs]
             [org.replikativ.spindel.engine.core :as ec]))
 
 (def ^:private content-types
@@ -48,34 +48,33 @@
        "application/octet-stream"))
 
 (defn app-root
-  "The room's app directory — `<current worktree>/app` resolved fork-aware
-   under the room's OWN execution context. nil when the room has no ctx/repo."
+  "The room's virtual `app/` directory, resolved fork-aware under the room's
+  own execution context. nil when the room has no Geschichte workspace."
   [room-id]
   (when-let [room-ctx (srooms/room-ctx-for room-id)]
     (binding [ec/*execution-context* room-ctx]
-      (when-let [wt (git/current-worktree-path)]
-        (io/file wt "app")))))
+      (when-let [workspace (geschichte/current-workspace)]
+        {:fs (geschichte/filesystem workspace) :root "/app"}))))
 
 (defn app-exists?
   "True when the room has an app/index.html to serve (used by the room page
    to decide whether to show the app link)."
   [room-id]
-  (boolean (some-> (app-root room-id) (io/file "index.html") .isFile)))
+  (when-let [{:keys [fs root]} (app-root room-id)]
+    (= :file (:type (mfs/stat fs (str root "/index.html"))))))
 
-(defn- safe-file
-  "Resolve `rel` under `root`, canonicalized — nil unless the canonical result
-   stays inside the canonical root (rejects .., absolute paths, symlink escape)
-   and no path segment is a dotfile."
-  [^java.io.File root rel]
-  (when (and root (.isDirectory root))
+(defn- safe-path
+  "Resolve `rel` inside a virtual app root. Geschichte/Muschel perform the
+  canonical traversal and symlink containment check; dotfiles stay private."
+  [{:keys [fs root]} rel]
+  (when (and fs root (= :dir (:type (mfs/stat fs root))))
     (let [rel (str/replace (or rel "") #"^/+" "")]
       (when-not (some #(str/starts-with? % ".") (str/split rel #"/"))
-        (let [f (io/file root rel)
-              canon (.getCanonicalPath f)
-              root-canon (.getCanonicalPath root)]
-          (when (or (= canon root-canon)
-                    (str/starts-with? canon (str root-canon java.io.File/separator)))
-            f))))))
+        (let [path (mfs/resolve fs (str root "/" rel))]
+          (when (and path
+                     (not= :symlink (:type (mfs/stat fs path)))
+                     (or (= path root) (str/starts-with? path (str root "/"))))
+            path))))))
 
 (defn- not-found [slug]
   {:status 404
@@ -116,11 +115,12 @@
                   root (some-> room :room/id app-root)
                   rel  (if (str/blank? path) "index.html" path)
                   rel  (if (str/ends-with? rel "/") (str rel "index.html") rel)
-                  f    (safe-file root rel)]
-              (if (and f (.isFile f))
+                  path (when root (safe-path root rel))]
+              (if (and path (= :file (:type (mfs/stat (:fs root) path))))
                 {:status 200
-                 :headers {"Content-Type" (content-type (.getName f))
+                 :headers {"Content-Type" (content-type path)
                            ;; live-iterate loop: agents rewrite files, humans reload
                            "Cache-Control" "no-cache"}
-                 :body f}
+                 :body (java.io.ByteArrayInputStream.
+                        ^bytes (mfs/read-bytes (:fs root) path))}
                 (not-found slug)))))))))

--- a/test/dvergr/discourse/definitions_test.clj
+++ b/test/dvergr/discourse/definitions_test.clj
@@ -2,7 +2,8 @@
   "Unit tests for the unified file-driven definition loader (skills + agents)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [dvergr.discourse.definitions :as defs]))
+            [dvergr.discourse.definitions :as defs]
+            [muschel.fs.geschichte :as gfs]))
 
 (deftest parse-frontmatter-basics
   (testing "frontmatter is parsed and the body is returned separately"
@@ -121,6 +122,23 @@
         (finally
           (let [sk (java.io.File. dir "skills")]
             (.delete (java.io.File. sk "demo.md")) (.delete sk) (.delete dir)))))))
+
+(deftest virtual-author-then-promote-roundtrip
+  (let [{:keys [close!] :as repository}
+        (gfs/memory-repository! {:name "definitions"})
+        root {:fs (gfs/make-root repository) :root "/"}]
+    (try
+      (defs/author! "skills" root "nested/demo"
+        {:description "virtual" :provides [:demo]} "the body")
+      (let [definition (get (defs/load-kind "skills" root) "nested/demo")]
+        (is (= :room (:scope definition)))
+        (is (= false (:vetted definition)))
+        (is (= "the body" (:content definition)))
+        (defs/promote! definition "reviewer" "2026-07-18")
+        (let [promoted (get (defs/load-kind "skills" root) "nested/demo")]
+          (is (= true (:vetted promoted)))
+          (is (= "reviewer" (:vetted-by promoted)))))
+      (finally (close!)))))
 
 (deftest room-scope-overlays-globals
   (testing "a room-dir adds the room's own definitions as the highest-precedence

--- a/test/dvergr/intake/bash_isolation_test.clj
+++ b/test/dvergr/intake/bash_isolation_test.clj
@@ -1,169 +1,108 @@
 (ns dvergr.intake.bash-isolation-test
-  "End-to-end isolation tests for the agent's bash surface.
-
-   Verifies that `dvergr.intake.bash` correctly threads the workspace
-   path through yggdrasil's fork-context machinery, so a fork-context
-   gives the bash session an isolated git worktree, and merge / discard
-   plumbing works as advertised."
+  "End-to-end validation of the fully virtual Geschichte sandbox."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [dvergr.orchestration.daemon :as daemon]
-            [dvergr.substrate.git :as dgit]
+            [datahike.api :as dh]
             [dvergr.intake.bash :as b]
+            [dvergr.orchestration.daemon :as daemon]
+            [dvergr.substrate.geschichte :as g]
+            [muschel.fs :as mfs]
             [org.replikativ.spindel.engine.core :as ec]
-            [org.replikativ.spindel.yggdrasil :as ygg]
-            [yggdrasil.protocols :as yp]))
+            [org.replikativ.spindel.yggdrasil :as ygg]))
 
-;; ============================================================================
-;; Sandbox repo helpers
-;; ============================================================================
-
-(defn- run-shell [& cmd-parts]
-  (let [pb (-> (ProcessBuilder. ^java.util.List (vec cmd-parts))
-               (.redirectErrorStream true))
-        proc (.start pb)
-        exit (.waitFor proc)]
-    {:exit exit
-     :out (slurp (.getInputStream proc))}))
-
-(defn- init-sandbox-repo!
-  "Create a one-commit git repo at `path`. Idempotent — wipes any
-   existing dir at `path` first."
-  [path]
-  (run-shell "rm" "-rf" path)
-  (.mkdirs (io/file path))
-  (let [script (str "cd " path
-                    " && git init -q -b main"
-                    " && git config user.email test@example.com"
-                    " && git config user.name test"
-                    " && echo seed > README.md"
-                    " && git add . && git commit -q -m seed")
-        r (run-shell "bash" "-c" script)]
-    (when (not= 0 (:exit r))
-      (throw (ex-info "sandbox-init failed" r)))))
-
-(defn- chat-on
-  "Build a thin chat-ctx whose :spindel-ctx is the given execution
-   context. Enough for `intake.bash` — the fancier fields
-   (messages/budget signals) aren't read by the bash surface."
-  [spindel-ctx]
+(defn- chat-on [spindel-ctx]
   {:spindel-ctx spindel-ctx :chat-id (random-uuid) :title "test"})
 
-(defn- bash [chat-ctx cmd]
-  (let [r (b/run chat-ctx cmd)]
-    {:exit (:exit r)
-     :stdout (str/trim (or (:stdout r) ""))
-     :stderr (str/trim (or (:stderr r) ""))
-     :cwd (:cwd r)}))
+(defn- bash [chat-ctx command]
+  (let [result (b/run chat-ctx command)]
+    {:exit (:exit result)
+     :stdout (str/trim (or (:stdout result) ""))
+     :stderr (str/trim (or (:stderr result) ""))
+     :cwd (:cwd result)}))
 
-;; A unique sandbox per test run so tests can run in parallel and
-;; nothing leaks between runs.
-(def ^:dynamic *sandbox-dir* nil)
+(def ^:dynamic *scope* nil)
 (def ^:dynamic *base-ctx* nil)
 
 (defn- with-sandbox [test-fn]
-  (let [dir (str "/tmp/dvergr-bash-iso-" (System/nanoTime))]
+  (let [parent (.toFile (java.nio.file.Files/createTempDirectory
+                         "dvergr-virtual-"
+                         (make-array java.nio.file.attribute.FileAttribute 0)))
+        scope (.getPath (io/file parent "store"))
+        ctx (daemon/create-shared-context :repo-path scope
+                                          :with-git? true
+                                          :with-datahike? false)]
     (try
-      (init-sandbox-repo! dir)
-      (let [ctx (daemon/create-shared-context
-                 :repo-path dir
-                 :worktrees-dir (str dir "/.worktrees")
-                 :with-git? true
-                 :with-datahike? false)]
-        (binding [*sandbox-dir* dir
-                  *base-ctx* ctx]
-          (test-fn)))
+      (binding [*scope* scope *base-ctx* ctx] (test-fn))
       (finally
-        (run-shell "rm" "-rf" dir)))))
+        (when-let [system (binding [ec/*execution-context* ctx]
+                            (g/current-system))]
+          (dh/release (g/gy-connection system)))
+        (try (g/delete-repository! scope) (catch Throwable _))))))
 
 (use-fixtures :each with-sandbox)
 
-;; ============================================================================
-;; Tests
-;; ============================================================================
-
-(deftest workspace-resolves-to-registered-git-worktree
-  ;; Without a fork, bash in a chat-ctx attached to base-ctx should run
-  ;; with workspace = the registered git repo path.
-  (let [chat (chat-on *base-ctx*)]
-    (is (= *sandbox-dir*
-           (binding [ec/*execution-context* *base-ctx*]
-             (dgit/current-worktree-path))))
+(deftest room-shell-is-a-virtual-geschichte-root
+  (let [chat (chat-on *base-ctx*)
+        workspace (binding [ec/*execution-context* *base-ctx*]
+                    (g/current-workspace))]
+    (is (some? workspace))
     (is (= "main" (:stdout (bash chat "git branch --show-current"))))
-    (is (= "README.md" (:stdout (bash chat "ls"))))))
+    (is (nil? (mfs/physical-path (g/filesystem workspace) "/")))
+    (is (re-find #"AGENTS.md|README" (:stdout (bash chat "ls"))))))
 
-(deftest fork-gives-bash-a-fresh-worktree-on-a-fresh-branch
+(deftest fork-has-an-independent-virtual-workspace-on-the-same-logical-branch
   (let [parent (chat-on *base-ctx*)
-        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
-        child  (chat-on (:child-ctx fork))
-        parent-branch (:stdout (bash parent "git branch --show-current"))
-        child-branch  (:stdout (bash child  "git branch --show-current"))
-        child-cwd     (:cwd (bash child "pwd"))]
-    (testing "parent stays on main"
-      (is (= "main" parent-branch)))
-    (testing "fork's bash is on a different, fork-named branch"
-      (is (not= parent-branch child-branch))
-      ;; yggdrasil 0.3 names an overlay-fork branch `overlay-<uuid>` (the unified
-      ;; overlay naming). dvergr doesn't depend on the git branch name — forks are
-      ;; event-driven and the room slug is dvergr's own — so just assert a fresh fork.
-      (is (str/starts-with? child-branch "overlay-")))
-    (testing "fork's bash cwd is the sandbox root (its own worktree, mounted at
-              \"/\" via make-host's :mount-at; muschel ≥ 0.2.16 cwd is
-              sandbox-relative, not a real host path — fork isolation at the FS
-              level is covered by writes-in-fork-do-not-leak-to-parent)"
-      (is (= "/" child-cwd)))))
+        fork (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child (chat-on (:child-ctx fork))
+        parent-id (binding [ec/*execution-context* *base-ctx*]
+                    (:id (g/current-workspace)))
+        child-id (binding [ec/*execution-context* (:child-ctx fork)]
+                   (:id (g/current-workspace)))]
+    (is (= "main" (:stdout (bash parent "git branch --show-current"))))
+    (is (= "main" (:stdout (bash child "git branch --show-current"))))
+    (is (not= parent-id child-id))
+    (is (= "/" (:cwd (bash child "pwd"))))))
 
 (deftest writes-in-fork-do-not-leak-to-parent
   (let [parent (chat-on *base-ctx*)
-        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
-        child  (chat-on (:child-ctx fork))]
-    ;; Fork writes a file
+        fork (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child (chat-on (:child-ctx fork))]
     (is (= 0 (:exit (bash child "echo hello > side.txt"))))
     (is (= "hello" (:stdout (bash child "cat side.txt"))))
-    ;; Parent can't see it
-    (let [r (bash parent "cat side.txt")]
-      (is (not= 0 (:exit r)))
-      (is (re-find #"No such file" (:stderr r))))))
+    (is (not= 0 (:exit (bash parent "cat side.txt"))))))
 
-(deftest writes-in-parent-do-not-leak-to-fork
+(deftest parent-writes-after-fork-are-not-visible-in-frozen-child
   (let [parent (chat-on *base-ctx*)
-        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
-        child  (chat-on (:child-ctx fork))]
-    (is (= 0 (:exit (bash parent "echo p > parent.txt"))))
-    (let [r (bash child "cat parent.txt")]
-      (is (not= 0 (:exit r))))))
+        fork (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child (chat-on (:child-ctx fork))]
+    (is (= 0 (:exit (bash parent "echo parent > parent.txt"))))
+    (is (not= 0 (:exit (bash child "cat parent.txt"))))))
 
-(deftest merge-fork-propagates-commits-to-parent
+(deftest merge-publishes-child-commit-to-parent
   (let [parent (chat-on *base-ctx*)
-        fork   (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
-        child  (chat-on (:child-ctx fork))]
-    ;; Fork writes + commits
-    (is (= 0 (:exit (bash child "echo merged > m.txt && git add . && git commit -m wip"))))
-    ;; Before merge: parent doesn't see m.txt
-    (is (not (re-find #"m.txt" (:stdout (bash parent "ls")))))
-    ;; Merge from parent's context
-    (binding [ec/*execution-context* *base-ctx*]
-      (ygg/merge-fork! fork))
-    ;; After merge: parent sees m.txt
-    (is (= "merged" (:stdout (bash parent "cat m.txt"))))))
+        fork (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+        child (chat-on (:child-ctx fork))]
+    (is (= 0 (:exit
+              (bash child "echo merged > merged.txt && git add . && git commit -m wip"))))
+    (is (not= 0 (:exit (bash parent "cat merged.txt"))))
+    (binding [ec/*execution-context* *base-ctx*] (ygg/merge-fork! fork))
+    (is (= "merged" (:stdout (bash parent "cat merged.txt"))))))
 
-(deftest discard-fork-drops-the-worktree
-  (let [fork  (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
+(deftest discard-removes-the-datahike-workspace
+  (let [fork (binding [ec/*execution-context* *base-ctx*] (ygg/fork!))
         child (chat-on (:child-ctx fork))
-        wt    (binding [ec/*execution-context* (:child-ctx fork)]
-                (dgit/current-worktree-path))]
-    (is (= 0 (:exit (bash child "echo throwaway > t.txt && git add . && git commit -m wip"))))
-    (is (.exists (io/file wt)))
-    (binding [ec/*execution-context* *base-ctx*]
-      (ygg/discard-fork! fork))
-    (is (not (.exists (io/file wt)))
-        "discard-fork! must remove the worktree directory from disk")))
+        branch (binding [ec/*execution-context* (:child-ctx fork)]
+                 (second (:id (g/current-workspace))))
+        parent-conn (binding [ec/*execution-context* *base-ctx*]
+                      (:conn (g/current-workspace)))]
+    (is (= 0 (:exit
+              (bash child "echo throwaway > t.txt && git add . && git commit -m wip"))))
+    (is (contains? (set (dh/branches parent-conn)) branch))
+    (binding [ec/*execution-context* *base-ctx*] (ygg/discard-fork! fork))
+    (is (not (contains? (set (dh/branches parent-conn)) branch)))))
 
-(deftest container-refuses-paths-outside-worktree
-  ;; Even though the parent's underlying FS is a real DiskFS, paths
-  ;; outside the sandbox root are rejected.
-  (let [parent (chat-on *base-ctx*)]
-    (let [r (bash parent "cat /etc/passwd")]
-      (is (not= 0 (:exit r)))
-      (is (re-find #"No such file" (:stderr r))))))
+(deftest virtual-root-refuses-host-paths
+  (let [result (bash (chat-on *base-ctx*) "cat /etc/passwd")]
+    (is (not= 0 (:exit result)))
+    (is (re-find #"No such file" (:stderr result)))))

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -6,9 +6,7 @@
    - merge-room emits :dvergr/fork-merged
    - discard emits :dvergr/fork-discarded
    - pending-proposals scans a room's log"
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [dvergr.runtime.bus :as bus]
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.discourse :as d]
@@ -27,27 +25,14 @@
     (.waitFor proc)
     {:out (slurp (.getInputStream proc))}))
 
-(defn- init-sandbox-repo! [path]
-  (run-shell "rm" "-rf" path)
-  (.mkdirs (io/file path))
-  (run-shell "bash" "-c"
-             (str "cd " path
-                  " && git init -q -b main"
-                  " && git config user.email t@e.com"
-                  " && git config user.name t"
-                  " && echo seed > README.md"
-                  " && git add . && git commit -q -m seed")))
-
 (def ^:dynamic *sandbox-dir* nil)
 (def ^:dynamic *base-ctx* nil)
 
 (defn- with-sandbox [test-fn]
   (let [dir (str "/tmp/dvergr-pb-" (System/nanoTime))]
     (try
-      (init-sandbox-repo! dir)
       (let [ctx (daemon/create-shared-context
-                 :repo-path dir
-                 :worktrees-dir (str dir "/.worktrees")
+                 :repo-path (str dir "/repository")
                  :with-git? true
                  :with-datahike? false)]
         (binding [*sandbox-dir* dir
@@ -94,8 +79,7 @@
         (is (= 1 (count evts)) "exactly one fork-created event")
         (is (= (:id fork) (:dvergr/origin (first evts))))
         (is (= :parent (:dvergr/parent (first evts))))
-        (is (str/starts-with? (:worktree-path (first evts))
-                              (str *sandbox-dir* "/.worktrees/")))))))
+        (is (vector? (:workspace-id (first evts))))))))
 
 (deftest propose-merge!-emits-event-and-tagged-message
   (binding [ec/*execution-context* *base-ctx*]

--- a/test/dvergr/sandbox/mirror_policy_test.clj
+++ b/test/dvergr/sandbox/mirror_policy_test.clj
@@ -1,0 +1,91 @@
+(ns dvergr.sandbox.mirror-policy-test
+  "The host-namespace mirror policy is a trust boundary: agents read untrusted
+   input (mail, web, chat), so anything reachable from `(require …)` inside the
+   sandbox is reachable by prompt injection.
+
+   These tests pin the boundary's POLARITY. The policy used to be a denylist,
+   which meant every namespace nobody thought to name was reachable — and
+   `ensure-mirrored!` copies every public var of whatever it mirrors, so that
+   included the host's credentials and live database connections."
+  (:require [clojure.test :refer [deftest testing is]]
+            [dvergr.sandbox.deps :as deps]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.core :as rtc]))
+
+(defmacro with-ctx
+  "Policy WRITES go through the spindel execution context (so a forked room
+   carries its own policy), which needs one bound. Reads deliberately do not —
+   they fall back to the built-in defaults, which deny."
+  [& body]
+  `(binding [rtc/*execution-context* (ctx/create-execution-context)]
+     ~@body))
+
+(deftest denies-by-default
+  (testing "a namespace nobody enumerated is NOT mirrorable"
+    ;; The regression that matters: this must fail closed, not open.
+    (is (not (deps/namespace-mirrorable? 'com.example.nobody.thought.of.this)))
+    (is (not (deps/namespace-mirrorable? 'some.new.dvergr.subsystem)))))
+
+(deftest denies-credential-bearing-namespaces
+  (testing "host config / auth namespaces are unreachable"
+    ;; dvergr.substrate.config exposes github-token / telegram-token;
+    ;; is.simm.runtimes.auth-config exposes the JWT signing secret as a public var.
+    (doseq [ns- '[dvergr.substrate.config
+                  is.simm.runtimes.auth-config
+                  is.simm.model.access]]
+      (is (not (deps/namespace-mirrorable? ns-)) (str ns- " must not be mirrorable")))))
+
+(deftest denies-cross-tenant-data-access
+  (testing "system DB and room registries are unreachable"
+    ;; Reaching these yields conns to OTHER rooms and to the shared system DB,
+    ;; which is a cross-tenant boundary, not just a dvergr-internals boundary.
+    (doseq [ns- '[is.simm.model.system-db
+                  dvergr.system.db
+                  dvergr.system.rooms
+                  dvergr.room.registry]]
+      (is (not (deps/namespace-mirrorable? ns-)) (str ns- " must not be mirrorable")))))
+
+(deftest denies-governance-and-substrate
+  (testing "datahike.tx-preds stays unreachable"
+    ;; The accounting governor is a per-store tx-predicate enforced inside
+    ;; datahike's writer, which is what makes it hold even for a raw d/transact
+    ;; on a conn the agent legitimately owns. Mirroring this namespace exposes
+    ;; unregister-tx-pred! — one call and that guarantee is gone.
+    (is (not (deps/namespace-mirrorable? 'datahike.tx-preds))))
+  (testing "raw datahike/konserve/kabel stay unreachable"
+    ;; dvergr.sandbox.ns.datahike injects the data-ops while keeping
+    ;; create/connect/delete room-guarded; mirroring the raw API would undo it.
+    (doseq [ns- '[datahike.api datahike.connector konserve.core kabel.peer]]
+      (is (not (deps/namespace-mirrorable? ns-)) (str ns- " must not be mirrorable"))))
+  (testing "sci's own internals stay unreachable"
+    (is (not (deps/namespace-mirrorable? 'sci.core))))
+  (testing "host filesystem/process access stays unreachable"
+    ;; The agent gets muschel's virtual FS; clojure.java.io would bypass it.
+    (doseq [ns- '[clojure.java.io clojure.java.shell]]
+      (is (not (deps/namespace-mirrorable? ns-)) (str ns- " must not be mirrorable")))))
+
+(deftest allows-the-curated-library-surface
+  (testing "pure data/format libraries remain available"
+    (doseq [ns- '[cheshire.core clojure.data.xml clojure.zip clojure.test babashka.fs]]
+      (is (deps/namespace-mirrorable? ns-) (str ns- " should stay mirrorable")))))
+
+(deftest add-libs-provenance-widens-but-not-past-the-hard-denylist
+  (with-ctx
+    (testing "an approved add-libs makes its own namespaces requirable"
+      (deps/allow-added-lib-namespaces! '[org.clojure/data.csv])
+      (is (deps/namespace-mirrorable? 'clojure.data.csv)))
+    (testing "provenance cannot be used to reach the host application"
+      ;; A coord whose name collides with a denied prefix must not open it up.
+      (deps/allow-added-lib-namespaces! '[is.simm/model my.group/tx-preds])
+      (is (not (deps/namespace-mirrorable? 'is.simm.model.system-db)))
+      (is (not (deps/namespace-mirrorable? 'datahike.tx-preds))))))
+
+(deftest caller-allowlist-cannot-widen-past-the-hard-denylist
+  (with-ctx
+    (testing "set-namespace-allowlist! is bounded by the hard denylist"
+      (deps/set-namespace-allowlist! [".*"])            ; maximally permissive
+      (is (not (deps/namespace-mirrorable? 'is.simm.runtimes.auth-config)))
+      (is (not (deps/namespace-mirrorable? 'datahike.tx-preds)))
+      (is (not (deps/namespace-mirrorable? 'sci.core)))
+      ;; ...and the curated surface still resolves under the wide allowlist
+      (is (deps/namespace-mirrorable? 'cheshire.core)))))

--- a/test/dvergr/sandbox/security_test.clj
+++ b/test/dvergr/sandbox/security_test.clj
@@ -3,10 +3,65 @@
    2026-06 security audit. (Replaces the original sandbox_shell_test.clj, which
    tested the pre-refactor fs/proc API and was stale since the project's first
    commit.)"
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [sci.core :as sci]
             [dvergr.sandbox.ns.io :as io]
-            [dvergr.intake.bash :as bash]))
+            [dvergr.intake.bash :as bash]
+            [dvergr.tools :as tools]
+            [muschel.fs :as mfs]
+            [muschel.fs.geschichte :as gfs]))
+
+(deftest structured-tools-use-the-virtual-workspace
+  (let [{:keys [conn close!] :as repository}
+        (gfs/memory-repository! {:name "structured-tools"})
+        filesystem (gfs/make-root repository)
+        ctx (tools/make-context {:cwd "/" :filesystem filesystem})]
+    (try
+      (is (= :success (:type (tools/execute "write_file"
+                                            {:path "src/demo.clj"
+                                             :content "(ns demo)\n(defn answer [] 41)\n"}
+                                            ctx))))
+      (is (= :success (:type (tools/execute "edit_file"
+                                            {:path "src/demo.clj"
+                                             :old_string "41" :new_string "42"}
+                                            ctx))))
+      (is (= :success (:type (tools/execute "clojure_edit"
+                                            {:file_path "src/demo.clj"
+                                             :form_type "defn" :form_name "answer"
+                                             :operation "replace"
+                                             :new_source "(defn answer [] :virtual)"}
+                                            ctx))))
+      (is (str/includes? (:content (tools/execute "read_file"
+                                                  {:path "src/demo.clj"} ctx))
+                         ":virtual"))
+      (is (= :file (:type (mfs/stat filesystem "/src/demo.clj"))))
+      (is (= :error (:type (tools/execute "read_file"
+                                          {:path "../../etc/passwd"} ctx))))
+      (finally (close!)))))
+
+(deftest sci-files-and-git-share-a-virtual-geschichte-workspace
+  (let [{:keys [conn close!] :as repository}
+        (gfs/memory-repository! {:name "sci-virtual"})
+        workspace {:conn conn :id [(get-in @conn [:config :store :id]) :db]
+                   :repository repository}
+        filesystem (gfs/make-root repository)
+        ctx (sci/init {})]
+    (try
+      (io/add-fs-ns! ctx :filesystem filesystem)
+      (io/add-git-ns! ctx :workspace workspace)
+      (is (= "src/demo.clj"
+             (sci/eval-string* ctx
+                               "(spit \"src/demo.clj\" \"(ns demo)\\n\")")))
+      (is (= "(ns demo)\n" (sci/eval-string* ctx "(slurp \"src/demo.clj\")")))
+      (is (= ["src/demo.clj"]
+             (sci/eval-string* ctx
+                               "(require '[babashka.fs :as fs]) (fs/glob \"**/*.clj\")")))
+      (is (= ["src/demo.clj"]
+             (:untracked (sci/eval-string* ctx "(git/status)"))))
+      (is (= :ok (sci/eval-string* ctx "(git/add \".\")")))
+      (is (string? (sci/eval-string* ctx "(git/commit \"SCI virtual\")")))
+      (finally (close!)))))
 
 (deftest sensitive-path-policy-blocks-secrets
   (testing "known-sensitive OS paths are rejected"

--- a/test/dvergr/substrate/geschichte_test.clj
+++ b/test/dvergr/substrate/geschichte_test.clj
@@ -1,28 +1,89 @@
 (ns dvergr.substrate.geschichte-test
   (:require [clojure.java.io :as io]
-            [clojure.test :refer [deftest is]]
+            [clojure.java.shell :as shell]
+            [clojure.test :refer [deftest is testing]]
             [datahike.api :as d]
             [dvergr.substrate.geschichte :as g]
             [geschichte.repo :as repo]
             [geschichte.yggdrasil :as gy]
             [muschel.fs :as fs]))
 
-(deftest persistent-system-exposes-a-virtual-workspace
-  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
-                      "dvergr-geschichte-"
-                      (make-array java.nio.file.attribute.FileAttribute 0)))
+(defn- temp-dir [prefix]
+  (.toFile (java.nio.file.Files/createTempDirectory
+            prefix (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(defn- native-source-repo!
+  "A one-commit native Git repository, built by the test.
+
+   The seed path under test imports a NATIVE repository, so the fixture has to
+   be one; `dvergr.substrate.git` already drives `git` exactly this way.
+   Building it here rather than pointing at `../dvergr-sandbox` is the
+   difference between a test that passes on a developer's machine and one that
+   passes anywhere: the sibling checkout is absent in CI, `source-file` still
+   resolves the path (it canonicalises without checking existence), and the
+   import throws \"not a native Git repository\" — so the run fell through to
+   `fallback-workspace!` and only the upstream-remote assertion noticed.
+
+   `-c user.*` is passed per-invocation because a CI container has no global
+   git identity and `commit` refuses without one."
+  [^java.io.File dir]
+  (let [git (fn [& args]
+              ;; `shell/sh` reports a failure in its return value rather than
+              ;; throwing. Unchecked, a broken fixture would surface as the
+              ;; import failing and the upstream assertion going nil — the same
+              ;; confusing symptom this rewrite is fixing.
+              (let [{:keys [exit err]} (apply shell/sh "git" "-C" (.getPath dir) args)]
+                (when-not (zero? exit)
+                  (throw (ex-info "git fixture command failed"
+                                  {:args args :exit exit :err err})))))]
+    (git "init" "-q" "-b" "main")
+    (spit (io/file dir "seed.clj") "(ns seed)\n(def answer 42)\n")
+    (git "add" "-A")
+    (git "-c" "user.email=test@dvergr.local" "-c" "user.name=dvergr test"
+         "commit" "-q" "-m" "seed")
+    (.getCanonicalPath dir)))
+
+(defn- with-workspace
+  "Open a persistent Geschichte repository seeded from `source`, hand
+   `[conn filesystem]` to `f`, and always release + delete."
+  [source f]
+  (let [dir (temp-dir "dvergr-geschichte-")
         scope (.getPath (io/file dir "store"))
         system (g/create-system :scope scope :system-name "room-repo-test"
-                                :source (.getPath (io/file "../dvergr-sandbox")))
+                                :source source)
         conn (gy/connection system)
         filesystem (g/filesystem {:system system :conn conn
                                   :id (gy/workspace-id system)
                                   :repository {:conn conn
                                                :config (:config @conn)}})]
     (try
-      (is (seq (repo/files conn)))
-      (is (nil? (fs/physical-path filesystem "/")))
-      (is (some? (get (repo/configuration conn) "remote.upstream.url")))
+      (f conn filesystem)
       (finally
         (d/release conn)
         (g/delete-repository! scope)))))
+
+(deftest persistent-system-exposes-a-virtual-workspace
+  (let [source (native-source-repo! (temp-dir "dvergr-git-source-"))]
+    (with-workspace
+      source
+      (fn [conn filesystem]
+        (testing "the seed's content is in the workspace"
+          (is (seq (repo/files conn))))
+        (testing "and it is VIRTUAL — no host path backs it"
+          (is (nil? (fs/physical-path filesystem "/"))))
+        (testing "the seed source is recorded as the upstream remote"
+          (is (= source (get (repo/configuration conn) "remote.upstream.url"))))))))
+
+(deftest unreachable-seed-still-yields-a-usable-workspace
+  ;; `fallback-workspace!` is what kept CI green everywhere except the upstream
+  ;; assertion, so pin it deliberately rather than reaching it by accident: an
+  ;; unreachable seed must still leave a committed workspace, not a
+  ;; half-initialised repository.
+  (with-workspace
+    (.getPath (io/file (temp-dir "dvergr-git-absent-") "definitely-not-a-repo"))
+    (fn [conn filesystem]
+      (is (seq (repo/files conn))
+          "the fallback commits a starter file, so the workspace is not empty")
+      (is (nil? (fs/physical-path filesystem "/")))
+      (is (nil? (get (repo/configuration conn) "remote.upstream.url"))
+          "nothing was imported, so there is no upstream to point at"))))

--- a/test/dvergr/substrate/geschichte_test.clj
+++ b/test/dvergr/substrate/geschichte_test.clj
@@ -1,0 +1,28 @@
+(ns dvergr.substrate.geschichte-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [dvergr.substrate.geschichte :as g]
+            [geschichte.repo :as repo]
+            [geschichte.yggdrasil :as gy]
+            [muschel.fs :as fs]))
+
+(deftest persistent-system-exposes-a-virtual-workspace
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "dvergr-geschichte-"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))
+        scope (.getPath (io/file dir "store"))
+        system (g/create-system :scope scope :system-name "room-repo-test"
+                                :source (.getPath (io/file "../dvergr-sandbox")))
+        conn (gy/connection system)
+        filesystem (g/filesystem {:system system :conn conn
+                                  :id (gy/workspace-id system)
+                                  :repository {:conn conn
+                                               :config (:config @conn)}})]
+    (try
+      (is (seq (repo/files conn)))
+      (is (nil? (fs/physical-path filesystem "/")))
+      (is (some? (get (repo/configuration conn) "remote.upstream.url")))
+      (finally
+        (d/release conn)
+        (g/delete-repository! scope)))))

--- a/test/dvergr/web/apps_test.clj
+++ b/test/dvergr/web/apps_test.clj
@@ -4,43 +4,44 @@
    cover the pure parts: canonicalized containment, dotfile/symlink rejection,
    method/uri gating."
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.java.io :as io]
-            [dvergr.web.apps :as apps])
-  (:import [java.nio.file Files]
-           [java.nio.file.attribute FileAttribute]))
+            [dvergr.web.apps :as apps]
+            [muschel.fs :as mfs]
+            [muschel.fs.geschichte :as gfs]))
 
-(def ^:private safe-file @#'apps/safe-file)
+(def ^:private safe-path @#'apps/safe-path)
 (def ^:private content-type @#'apps/content-type)
 
 (defn- tmp-app-root []
-  (let [dir (.toFile (Files/createTempDirectory "dvergr-app-test" (make-array FileAttribute 0)))]
-    (spit (io/file dir "index.html") "<h1>hi</h1>")
-    (.mkdirs (io/file dir "js"))
-    (spit (io/file dir "js" "app.js") "1")
-    dir))
+  (let [{:keys [close!] :as repository} (gfs/memory-repository! {:name "app-test"})
+        fs (gfs/make-root repository)]
+    (mfs/mkdir fs "/app")
+    (mfs/write-string! fs "/app/index.html" "<h1>hi</h1>" false)
+    (mfs/mkdir fs "/app/js")
+    (mfs/write-string! fs "/app/js/app.js" "1" false)
+    {:root {:fs fs :root "/app"} :close! close!}))
 
 (deftest safe-file-containment
-  (let [root (tmp-app-root)]
-    (testing "normal paths resolve"
-      (is (.isFile (safe-file root "index.html")))
-      (is (.isFile (safe-file root "js/app.js"))))
-    (testing "leading slashes are stripped, not treated as absolute"
-      (is (.isFile (safe-file root "/index.html"))))
-    (testing "raw traversal is rejected by canonicalization"
-      (is (nil? (safe-file root "../../../etc/passwd")))
-      (is (nil? (safe-file root "js/../../outside.txt"))))
-    (testing "dotfiles and dot-dirs are rejected in any segment"
-      (is (nil? (safe-file root ".git/config")))
-      (is (nil? (safe-file root "js/.hidden")))
-      (is (nil? (safe-file root "..")))) ; pure dot segment
-    (testing "symlink pointing outside the root is rejected"
-      (let [link (io/file root "leak.txt")]
-        (Files/createSymbolicLink (.toPath link) (.toPath (io/file "/etc/hostname"))
-                                  (make-array FileAttribute 0))
-        (is (nil? (safe-file root "leak.txt")))))
-    (testing "nil/missing root yields nil"
-      (is (nil? (safe-file nil "index.html")))
-      (is (nil? (safe-file (io/file root "nonexistent-dir") "index.html"))))))
+  (let [{:keys [root close!]} (tmp-app-root)]
+    (try
+      (testing "normal paths resolve"
+        (is (= "/app/index.html" (safe-path root "index.html")))
+        (is (= "/app/js/app.js" (safe-path root "js/app.js"))))
+      (testing "leading slashes are stripped, not treated as absolute"
+        (is (= "/app/index.html" (safe-path root "/index.html"))))
+      (testing "raw traversal is rejected by canonicalization"
+        (is (nil? (safe-path root "../../../etc/passwd")))
+        (is (nil? (safe-path root "js/../../outside.txt"))))
+      (testing "dotfiles and dot-dirs are rejected in any segment"
+        (is (nil? (safe-path root ".git/config")))
+        (is (nil? (safe-path root "js/.hidden")))
+        (is (nil? (safe-path root ".."))))
+      (testing "symlink pointing outside the root is rejected"
+        (mfs/symlink (:fs root) "/outside" "/app/leak.txt")
+        (is (nil? (safe-path root "leak.txt"))))
+      (testing "nil/missing root yields nil"
+        (is (nil? (safe-path nil "index.html")))
+        (is (nil? (safe-path (assoc root :root "/missing") "index.html"))))
+      (finally (close!)))))
 
 (deftest content-types
   (is (= "text/html; charset=utf-8" (content-type "index.html")))


### PR DESCRIPTION
## What

Replaces dvergr's native-git / host-filesystem substrate with **Geschichte**
(git-in-Datahike) behind Muschel's virtual filesystem, and settles the
**room-store identity** question the room-DB collapse depends on.

### Geschichte substrate
New `dvergr.substrate.geschichte` provisions a persistent Geschichte repository per
room scope and exposes it as a Muschel MountFS, replacing `dvergr.substrate.git`'s
shell/JGit worktrees:

- agent file tools (`read_file`/`write_file`/`edit_file`/`glob`/`grep`) and the `shell`
  intake now resolve against the **same** virtual filesystem — closing the split-brain
  where tools used host `babashka.fs` while the shell used a mount;
- `git` in the sandbox is Muschel's Geschichte-backed builtin instead of a guarded
  real-process passthrough (fallback allowlist drops to `#{}`);
- fork/merge review (`diff-since-fork`) works off Geschichte workspaces rather than
  host worktree paths.

The native path remains as a fallback for room-less/test/sidecar use; fully removing
`substrate.git` is follow-up.

## ⚠️ Breaking: existing rooms must be re-created

`msgs-cfg` — the room store, and the agreed survivor of the per-room store collapse —
now sets **`:crypto-hash? true :commit-graph? true`**, because it will hold the kontor
book and needs a tamper-evident chain.

Both flags are fixed **at creation**. datahike consistency-checks the *stored* config
and **refuses** a mismatched connect (`:config-does-not-match-stored-db`) — it does
**not** silently adopt (verified against datahike 0.8.1744):

- **existing rooms will fail to connect until re-created**;
- **do not** use `:allow-unsafe-config true` — that runs a crypto-hash-configured
  connection against a non-hashed store, precisely the auditability lie the flag
  prevents.

Only the room store gets these flags. Crypto-hash makes each index-node address a
content hash, disabling locality squuids and address reuse, so the KB and agent
`:data` stores keep the cheaper layout — they hold no sealed financial records.

## Dependencies — aligned with simmis #13

| dep | version |
|---|---|
| geschichte | **0.1.10** (Maven; was a local root) |
| datahike | **0.8.1744** |
| konserve | **0.9.363** |
| hasch | 0.4.101 |

geschichte 0.1.10 carries code-search (#6) and the native-release CI fix (#5), so no
worktree is needed. datahike/konserve match what simmis #13 merged, keeping the
client-sync set on one coordinated version.

## Unblocked: muschel 0.2.18

`muschel.fs.geschichte` — the Geschichte-workspace mount API this branch is built
on (isolated worktrees, checkout semantics delegated to Geschichte, Git served from
a virtual GeschichteFS base) — is released as **0.2.18** and the pin now points at
it. No `:local/root` override is needed to build or merge this branch; the `:local`
alias stays an optional convenience for parallel muschel work.

Verified `../muschel` is content-identical to the `0.2.18` tag (`git diff 0.2.18
HEAD` is empty), so the released jar is what the branch was developed against.

## Also in this branch

The substrate commit was the first of a stack; the rest were held back while
muschel was unreleased. All are in the same area (room stores, the sandbox's view
of them) and simmis's landed store-unification work depends on several:

| commit | what |
|---|---|
| `afd8b6d` | sandbox host-namespace mirror policy becomes an allowlist (+ tests) |
| `18a2204` | keep user media out of fork/merge review |
| `7c595d7` | one store config for every datom store; geschichte differs by one flag |
| `4f41811` | make the KB write target explicit and enumerable |
| `58f5bfe` | KB reads span every readable KB and both bindings |
| `22ec1e7` | keep var metadata in the sandbox overview so signatures show |
| `623fd67` | the muschel 0.2.18 pin |

`main` is merged in, so #42 (scheduler discoverability + arity rejection) is
included and there is nothing to rebase.

## Testing

`380 tests, 1482 assertions, 0 failures` on the released stack — geschichte 0.1.10 /
datahike 0.8.1744 / konserve 0.9.363 / **muschel 0.2.18 from Maven**, no local
overrides (classpath checked: `muschel-0.2.18.jar`). `cljfmt` clean.
