### PR TITLE
fix(scheduler): make the sandbox API discoverable, and reject bad arity clearly

### DIFF
--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -183,7 +183,15 @@
      (scheduler/list)"
   [sci-ctx]
   (require 'dvergr.scheduler.core)
-  (let [sched-create  @(ns-resolve 'dvergr.scheduler.core 'create-schedule!)
+  (let [documented
+        ;; `dvergr.sandbox` already reports `:arglists`/`:doc` off each injected
+        ;; value, and `dev/doc` prints them — but a raw `(fn …)` carries no
+        ;; metadata, so everything below contributed nothing and the docstring
+        ;; on THIS function never reached the sandbox. An agent's only way to
+        ;; learn a signature was to call it and read the error.
+        (fn [sym arglists doc f]
+          (vary-meta f merge {:name sym :arglists arglists :doc doc}))
+        sched-create  @(ns-resolve 'dvergr.scheduler.core 'create-schedule!)
         sched-cancel  @(ns-resolve 'dvergr.scheduler.core 'cancel-schedule!)
         sched-list    @(ns-resolve 'dvergr.scheduler.core 'list-schedules)
         current-room  @(ns-resolve 'dvergr.scheduler.core 'current-room)
@@ -192,17 +200,42 @@
                             (throw (ex-info "No current room — schedules are per-room" {}))))
 
         every-fn (fn [period & args]
-                   (let [[opts agent-id task]
-                         (cond
-                           (and (keyword? (first args)) (string? (second args)))
-                           [{:every period :on (first args) :at (second args)}
-                            (nth args 2) (nth args 3)]
-                           (string? (first args))
-                           [{:every period :at (first args)} (second args) (nth args 2)]
-                           (keyword? (first args))
-                           [{:every period} (first args) (second args)]
-                           :else
-                           (throw (ex-info "Invalid schedule args" {:period period :args args})))]
+                   ;; Dispatch on ARITY, not on the types of the first two args.
+                   ;;
+                   ;; The type-based cond could not tell `(every :day :var "task")`
+                   ;; from `(every :week :monday "14:00" :agent "task")` — both open
+                   ;; (keyword, string) — so the 4-arg branch swallowed the 2-arg
+                   ;; form and then ran `(nth args 2)` off the end. That surfaced as
+                   ;; a bare IndexOutOfBoundsException with a nil message, and with
+                   ;; no arglists to consult an agent reasonably concluded the
+                   ;; function was broken. It was not: both documented forms work.
+                   ;; The 2-arg form was genuinely unreachable, and is now reachable.
+                   (let [n (count args)
+                         wrong (fn []
+                                 (throw (ex-info
+                                         (str "scheduler/every: cannot read these "
+                                              n " argument(s) after the period. Expected one of:\n"
+                                              "  (every period agent-id task)\n"
+                                              "  (every period \"HH:MM\" agent-id task)\n"
+                                              "  (every period :day-of-week \"HH:MM\" agent-id task)\n"
+                                              "where agent-id is a keyword and task a string.")
+                                         {:period period :args (vec args)})))
+                         [opts agent-id task]
+                         (case n
+                           2 [{:every period} (first args) (second args)]
+                           3 [{:every period :at (first args)} (second args) (nth args 2)]
+                           4 [{:every period :on (first args) :at (second args)}
+                              (nth args 2) (nth args 3)]
+                           (wrong))]
+                     ;; Check the SHAPE, not just the count. Arity alone still lets
+                     ;; `(every :day "07:00" :var)` through as agent-id "07:00" and
+                     ;; task :var, which only fails later against create-schedule!'s
+                     ;; `(keyword? agent-id)` precondition — an AssertionError naming
+                     ;; neither the caller nor what it should have passed.
+                     (when-not (and (keyword? agent-id) (string? task)
+                                    (or (not (:at opts)) (string? (:at opts)))
+                                    (or (not (:on opts)) (keyword? (:on opts))))
+                       (wrong))
                      (sched-create (room!)
                                    {:agent-id agent-id
                                     :task task
@@ -223,9 +256,26 @@
                                      :interval-ms ms
                                      :description (str "Every " (/ ms 60000.0) " minutes")}))]
     (sci/add-namespace! sci-ctx 'dvergr.scheduler
-                        {'every    every-fn
-                         'at       at-fn
-                         'interval interval-fn
+                        {'every
+                         (documented 'every
+                                     '([period agent-id task]
+                                       [period at agent-id task]
+                                       [period day-of-week at agent-id task])
+                                     (str "Recurring schedule in THIS room. `period` is :day/:week/…, "
+                                          "`at` is \"HH:MM\" wall-clock, `day-of-week` a keyword like "
+                                          ":monday. e.g. (every :day \"09:00\" :huginn \"Morning sweep\").")
+                                     every-fn)
+                         'at
+                         (documented 'at
+                                     '([iso-datetime agent-id task])
+                                     (str "One-shot at a FULL ISO datetime — \"2026-04-01T09:00\", not "
+                                          "\"09:00\". For a daily wall-clock time use `every` instead.")
+                                     at-fn)
+                         'interval
+                         (documented 'interval
+                                     '([ms agent-id task])
+                                     "Repeat every `ms` milliseconds."
+                                     interval-fn)
                          ;; CODE schedules — the durable-pipeline primitive:
                          ;; the form evals in YOUR sandbox on each fire
                          ;; (deterministic, no LLM turn). Put the fns in a
@@ -239,8 +289,23 @@
                          ;; :n multiplies :minute/:hour/:day/:week into a fixed
                          ;; interval), {:every-ms N}, {:at \"ISO\" :once true}.
                          ;; Unknown keys are REJECTED (no silent wrong cadence).
-                         'create   (fn [cfg] (sched-create (room!) cfg))
-                         'cancel   (fn [id] (sched-cancel (room!) id))
-                         'list     (fn [] (sched-list (room!)))})))
+                         'create
+                         (documented 'create
+                                     '([cfg])
+                                     (str "Richest form. cfg = {:agent-id kw :task \"…\" | :code \"…\" "
+                                          ":schedule {…} | :interval-ms N :description \"…\"}. `:code` "
+                                          "evals in your sandbox on each fire with no LLM turn. "
+                                          "Unknown keys are REJECTED.")
+                                     (fn [cfg] (sched-create (room!) cfg)))
+                         'cancel
+                         (documented 'cancel
+                                     '([schedule-id])
+                                     "Deactivate a schedule BY ID — the uuid itself, not the map `list` returns."
+                                     (fn [id] (sched-cancel (room!) id)))
+                         'list
+                         (documented 'list
+                                     '([])
+                                     "Active schedules in this room, as maps carrying :id :kind :next-fire …"
+                                     (fn [] (sched-list (room!))))})))
 
 


### PR DESCRIPTION
An agent reported `dvergr.scheduler` as broken. Most of the report turned out to be **wrong** — but it was wrong for a reason worth fixing, so this PR is deliberately narrow.

## What was actually true

**The docs never reached the sandbox.** `dvergr.sandbox` already reports `:arglists`/`:doc` off every injected value, and `dev/doc` prints them — but these were raw `(fn …)`s, which carry no metadata. The documentation existed the whole time, in `add-scheduler-ns!`'s own docstring, and none of it was visible from inside SCI.

So the agent reverse-engineered all six verbs by calling them and reading errors. Every other complaint in its report follows from that: `at`'s ISO format is documented (line 180) but unreachable; `cancel` taking an id rather than a map is correct but undiscoverable.

Verified after the change:

```
every     arglists=([period agent-id task] [period at agent-id task] [period day-of-week at agent-id task])
at        arglists=([iso-datetime agent-id task])
interval  arglists=([ms agent-id task])
create    arglists=([cfg])
cancel    arglists=([schedule-id])
list      arglists=([])
```

## `every` was not broken

Worth stating plainly, because the report said it was and acting on that would have removed a working function. Both documented forms worked:

```clojure
(every :day "09:00" :huginn "task")          ; => ok
(every :week :monday "14:00" :analyst "task"); => ok
```

The `cond` dispatched on the **types of the first two args**, and could not distinguish `(every :day :var "task")` from the four-arg day-of-week form — both open `(keyword, string)`. The four-arg branch therefore swallowed two-arg calls and ran `(nth args 2)` off the end, producing a bare `IndexOutOfBoundsException` with a **nil message**. With no arglists to consult, "broken" was a reasonable inference.

Dispatch is now on arity. That also makes the two-arg form reachable — it was written but permanently shadowed by the type-based branch.

## Arity alone was not enough

`(every :day "07:00" :var)` is *two* args after the period, so an arity-only fix would sail it through as `agent-id "07:00"`, `task :var` — failing later against `create-schedule!`'s `(keyword? agent-id)` precondition with an `AssertionError` naming neither the caller nor the expected shape. The shape is now checked where it is known, and the error lists the three accepted forms.

```
(every :week :monday "14:00" :analyst "task") → ok
(every :day "09:00" :huginn "task")           → ok
(every :day :var "task")                      → ok   (previously threw)
(every :day "07:00" :var)                     → rejected, with the three forms listed
(every :day "09:00" "task" :huginn)           → rejected
```

## Behaviour change to flag

The two-arg `(every period agent-id task)` form now works where it previously threw. Everything that worked before works identically. Happy to gate that behind a separate commit if you'd rather keep this purely additive.

## Not in this PR

The report's most serious item — `:agent-id` "type mismatch" — is **not a dvergr bug**. `create-schedule!`'s precondition is `(keyword? agent-id)` and `:party/<uuid>` *is* a keyword, so it passes and is never reached. The real failure is that `:party/13d2d613-…` cannot be **read** — `clojure.core`, `clojure.edn` and SCI all reject it, because a keyword's name part may not begin with a digit. simmis was printing that literal into the system prompt and telling the agent to type it. Fixed on the simmis side.

## Tests

`scheduler.core`, `sandbox.overview`, `sandbox.ns-injector` — 10 tests, 32 assertions, 0 failures.