### PR TITLE
Make the sandbox's testing and vocabulary discoverable to agents

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -58,7 +58,7 @@
         ;; API this branch's agent workspaces are built on (isolated worktrees,
         ;; checkout semantics delegated to Geschichte, Git served from a virtual
         ;; GeschichteFS base) — so no local root is needed to build it.
-        org.replikativ/muschel     {:mvn/version "0.2.18"}
+        org.replikativ/muschel     {:mvn/version "0.2.19"}
 
         ;; Geschichte — authoritative virtual filesystem + Git compatibility.
         ;; Released coordinate — 0.1.10 carries code-search (#6) + the native-release

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -138,6 +138,57 @@
    {:tool :bash :pattern {:kind :argv-vec :vec ["git" git-local-subcommands]}
     :action :allow :origin :default}])
 
+(def workspace-delete-rules
+  "Re-allow recursive `rm` inside the workspace; keep it denied on system paths.
+
+   muschel's default ruleset denies `rm` with any recursive flag OUTRIGHT,
+   regardless of target. That is the right default for a LIBRARY — muschel
+   cannot assume its embedder's workspace is recoverable. dvergr's is: the agent
+   works in a geschichte-backed fork with commit history, so `rm -rf build/` is a
+   working-tree change it can undo (checkout, or discard the fork), and the FS is
+   jailed so the path cannot reach the host anyway.
+
+   The blanket deny also bought nothing measurable. `babashka.fs/delete-tree` is
+   part of the sandbox's fs surface and performs the SAME recursive deletion with
+   no permit layer in front of it — verified: `rm -rf scratch` returned
+   \"permit denied: recursive delete\" while `(babashka.fs/delete-tree \"scratch\")`
+   removed the identical tree in the same session. So the rule did not prevent
+   recursive deletion; it pushed the agent from the audited shell onto an
+   unaudited door, and made an ordinary chore (`rm -rf node_modules`) feel
+   forbidden. Worse than allowing it.
+
+   Order matters — rules are LAST-MATCH-WINS and these are applied after the
+   defaults, so the system-path deny is re-asserted AFTER the allow. Wiping the
+   workspace root is still refused: inside muschel the workspace is mounted at
+   `/`, so `rm -rf /` means \"delete everything I have\" — recoverable, but
+   essentially always a mistake, and refusing costs nothing legitimate.
+
+   The re-assertion has to be spelled out here rather than left to muschel's own
+   critical-path rule, because relaxing the blanket deny is what puts that rule
+   on the critical path for the first time. It was an `:argv-shape` with `:**`
+   in the MIDDLE — which matches nothing, so it had never fired; the blanket
+   deny in front of it caught every `rm -rf` first. Lifting the blanket exposed
+   it: `rm -rf /etc` came back exit 0 in the first cut of this change, caught by
+   `dvergr.intake.workspace-delete-test`. Fixed upstream (muschel#12) with a
+   position-independent `:argv-any`, which is what \"a protected path ANYWHERE
+   in the args\" needs — `rm -rf /etc`, `rm -r -f /etc` and `rm -v -r /etc` put
+   the target in different slots. `:argv-any` also fails CLOSED on non-literal
+   args (`$TARGET`, unexpanded globs), so a deny refuses rather than guessing
+   what they expand to. Needs muschel >= 0.2.19."
+  [{:tool :bash
+    :pattern {:kind :argv-flags
+              :head ["rm"]
+              :any-of #{"-r" "-R" "--recursive"}}
+    :action :allow :origin :default
+    :reason "workspace is versioned + jailed; recursive delete is recoverable"}
+   {:tool :bash
+    :pattern {:kind :argv-any
+              :head ["rm"]
+              :any #{"/" "/*" "/home" "/usr" "/etc" "/var" "/bin" "/lib"
+                     "/root" "/boot" "/sys" "/proc" "/dev"}}
+    :action :deny :origin :default
+    :reason "would delete a critical path / the whole workspace"}])
+
 (def ^:private git-identity-defaults
   "Commit identity for the agent (so it can commit without the disallowed
    `git config`). A host GIT_AUTHOR_*/GIT_COMMITTER_* overrides these."
@@ -520,7 +571,8 @@
                     ;; Agents don't write stdin; never inherit System/in
                     ;; (would block under nREPL / when daemonised).
                     :in          (java.io.ByteArrayInputStream. (.getBytes ""))
-                    :permit      {:rulesets [m/default-rules git-sandbox-rules] :prompter prompter}
+                    :permit      {:rulesets [m/default-rules git-sandbox-rules workspace-delete-rules]
+                                  :prompter prompter}
                     :timeout-ms  timeout-ms
                     :trace       (trace-bridge)}
              interrupt-fn (assoc :interrupt-fn interrupt-fn)))

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -612,8 +612,12 @@
   [s]
   (or (#{"user" "h" "intake.bash"} s)
       ;; clojure.data.xml is a library WE mount (the hardened parser) — keep it
-      ;; visible even though it's clojure-prefixed.
-      (and (not (#{"clojure.data.xml"} s))
+      ;; visible even though it's clojure-prefixed. clojure.test is kept for a
+      ;; different reason: unlike clojure.string, whether a test RUNNER exists
+      ;; in a sandbox is not something an agent can assume. Hiding it is why
+      ;; agents reached for kaocha (denied by the mirror allowlist) instead of
+      ;; the runner they already had.
+      (and (not (#{"clojure.data.xml" "clojure.test"} s))
            (some #(str/starts-with? s %) hidden-ns-prefixes))))
 
 (defn- interesting-ns?
@@ -665,12 +669,15 @@
    "dvergr.actors"   ["mutate the roster — spawn sub-agents / humans, assign skills"
                       "(dvergr.actors/spawn-agent! {:prompt \"…\" :budget 0.10})"]
    "dvergr.skills"   ["reusable skills you can find + dispatch"
-                      "(dvergr.skills/find \"draft a brief\")"]})
+                      "(dvergr.skills/find \"draft a brief\")"]
+   "clojure.test"    ["THE test runner in this sandbox — the real clojure.test. There is no kaocha/lein here (and mirroring one is denied), so this is the way to test your code. Failures print expected/actual to your stdout."
+                      "(require '[clojure.test :refer [deftest is]]) (deftest t (is (= 4 (+ 2 2)))) (clojure.test/run-tests)  ;=> {:test 1 :pass 1 :fail 0 …}"]})
 
 (def ^:private guide-order
   ["babashka.fs" "babashka.http-client" "babashka.process" "cheshire.core" "clojure.data.xml"
    "datahike.api" "dvergr.room" "dvergr.mail" "dvergr.intake" "dvergr.codec" "git" "env" "llm"
-   "dvergr.scheduler" "dvergr.tasks" "dvergr.agents" "dvergr.actors" "dvergr.skills"])
+   "dvergr.scheduler" "dvergr.tasks" "dvergr.agents" "dvergr.actors" "dvergr.skills"
+   "clojure.test"])
 
 (defn ns-overview-data
   "Introspect the SCI ctx's injected namespaces → sorted seq of

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -671,7 +671,7 @@
                       "(dvergr.actors/spawn-agent! {:prompt \"…\" :budget 0.10})"]
    "dvergr.skills"   ["reusable skills you can find + dispatch"
                       "(dvergr.skills/find \"draft a brief\")"]
-   "clojure.test"    ["THE test runner in this sandbox — the real clojure.test. There is no kaocha/lein here (and mirroring one is denied), so this is the way to test your code. Failures print expected/actual to your stdout."
+   "clojure.test"    ["how you test IN here — the real clojure.test, run inside clojure_eval; failures print expected/actual to your stdout. This is the ONLY runner available to you, by design: kaocha/lein/clj are not reachable (handing control to a second runtime would let it read+write outside the sandbox), so requiring kaocha fails and the shell has no `clj`. To exercise code that lives in a FILE, load it — (load-string (slurp \"src/foo.clj\")) — then deftest against it here."
                       "(require '[clojure.test :refer [deftest is]]) (deftest t (is (= 4 (+ 2 2)))) (clojure.test/run-tests)  ;=> {:test 1 :pass 1 :fail 0 …}"]})
 
 (def ^:private guide-order
@@ -832,8 +832,13 @@
        "relative paths** (`(p/shell \"ls\")`, `(p/shell \"cat src/foo.clj\")`) — "
        "absolute system paths like `/etc` don't exist. Built-in POSIX tools include ls cat "
        "grep sed awk find sort uniq cut tr jq xargs wc head tail diff git — no "
-       "external binary needed. Destructive ops (rm -rf, sudo, git push --force) "
-       "are blocked by design; that's expected, not a failure.\n\n"
+       "external binary needed, and `sed -i` edits in place. These are IN-PROCESS "
+       "implementations, not the system binaries: `git` is backed by your room's "
+       "geschichte workspace, and there is deliberately no `clj`/`python3`/`node` "
+       "(a second runtime could read and write outside the sandbox — use "
+       "clojure_eval for scripting). Destructive ops (rm -rf, sudo, git push --force) "
+       "are blocked by design; that's expected, not a failure. `(dvergr.shell/builtins)` "
+       "lists what this session actually has, if you are unsure.\n\n"
        "**Knowledge:** recall with `knowledge_search`/`(search/find …)` BEFORE "
        "researching, and save findings with `knowledge_add` so they persist past "
        "this session (sandbox `(defn …)` do not)."))

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -22,6 +22,7 @@
             [dvergr.sandbox.ns.kb :as ns-kb]
             [dvergr.sandbox.ns.room :as ns-room]
             [dvergr.sandbox.ns.mail :as ns-mail]
+            [dvergr.sandbox.ns.doc :as ns-doc]
             [dvergr.sandbox.ns.datahike :as ns-datahike]
             [dvergr.sandbox.workspace :as workspace]
             [dvergr.sandbox.ns.agent :as ns-agent]
@@ -843,10 +844,15 @@
    it sees every namespace injected by `setup-agent-namespaces!`)."
   [sci-ctx]
   (sci/add-namespace! sci-ctx 'sandbox
-                      {'namespaces (fn [] (ns-overview-data sci-ctx))
-                       'overview   (fn [] (ns-overview-md sci-ctx))
-                       'help       (fn [] (ns-overview-md sci-ctx))
-                       'doc        (fn [ns-name] (ns-doc-md sci-ctx ns-name))}))
+                      (ns-doc/with-docs
+                        {'namespaces (fn [] (ns-overview-data sci-ctx))
+                         'overview   (fn [] (ns-overview-md sci-ctx))
+                         'help       (fn [] (ns-overview-md sci-ctx))
+                         'doc        (fn [ns-name] (ns-doc-md sci-ctx ns-name))}
+                        '{namespaces [([]) "What is loaded, as DATA: a seq of {:ns \"dvergr.room\" :fns [\"kb-search\" …]}. Derived from the live context, so it never drifts from what was actually injected."]
+                          overview   [([]) "The same inventory as readable markdown — what each namespace is for plus one real call. Start here when you do not know what you can do."]
+                          help       [([]) "Alias for `overview`."]
+                          doc        [([ns-name]) "Markdown for ONE namespace: its purpose, an example, and its fns with signatures — e.g. (sandbox/doc 'dvergr.room). For a single fn use (clojure.repl/doc dvergr.room/kb-search)."]})))
 
 (defn lock-interop!
   "Remove `:allow :all` from a sandbox context's class config, so JVM interop is

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -1,8 +1,14 @@
 (ns dvergr.sandbox.ns.agent
   "SCI injectors — agent identity + work: agents (self/inbox), actors (durable
    identity), skills, tasks, scheduler. Split out of dvergr.sandbox (Phase 4).
-   Subsystems reached via inline require + ns-resolve."
-  (:require [sci.core :as sci]))
+   Subsystems reached via inline require + ns-resolve.
+
+   Each `sci/add-namespace!` map is wrapped in `doc/with-docs` so the injected
+   closures carry `:doc`/`:arglists` — without it `(clojure.repl/doc …)` and
+   `(find-doc …)` answer nothing for them inside the sandbox. See
+   `dvergr.sandbox.ns.doc`."
+  (:require [sci.core :as sci]
+            [dvergr.sandbox.ns.doc :as doc]))
 
 (defn add-agents-ns!
   "Expose the agent registry as 'agents namespace in SCI.
@@ -27,10 +33,15 @@
         online?-fn   (fn [id] (online?* id))
         by-tag-fn    (fn [tag] (filterv #(contains? (:tags %) tag) (online-actors*)))]
     (sci/add-namespace! sci-ctx 'dvergr.agents
-                        {'list    list-fn
-                         'lookup  lookup-fn
-                         'online? online?-fn
-                         'by-tag  by-tag-fn})))
+                        (doc/with-docs
+                          {'list    list-fn
+                           'lookup  lookup-fn
+                           'online? online?-fn
+                           'by-tag  by-tag-fn}
+                          '{list    [([]) "Every agent currently ONLINE in this daemon, as a vector of entries. Ground-truth for who can actually take work right now — a profile mentioning an agent does not mean it is running."]
+                            lookup  [([id]) "The full entry for one agent id (e.g. :skald), or nil if it is not online."]
+                            online? [([id]) "Whether an agent id is running right now. Check before dispatching work to it."]
+                            by-tag  [([tag]) "Online agents whose :tags contain `tag` (e.g. :coding) — a vector, possibly empty."]}))))
 
 (defn add-skills-ns!
   "Expose the skill registry + dispatch as 'skills namespace in SCI.
@@ -61,37 +72,48 @@
                                   'dvergr.sandbox.workspace/workspace-root))
                                 (catch Throwable _ nil)))]
     (sci/add-namespace! sci-ctx 'dvergr.skills
-                        {'all       (fn [] (load-all* (room-dir)))
+                        (doc/with-docs
+                          {'all       (fn [] (load-all* (room-dir)))
                          ;; Progressive disclosure: the system prompt shows a
                          ;; brief index; pull a skill's FULL instructions here.
-                         'read      (fn [skill-name] (read-skill* skill-name (room-dir)))
-                         'find      (fn [provides-tag]
-                                      (vec (list-fn :provides provides-tag)))
-                         'providers (fn [skill] (find-prov conn skill))
-                         'rank      (fn [skill] (rank-prov conn skill))
-                         'dispatch  (fn [skill] (dispatch conn skill))
-                         'dispatch! (fn [skill opts]
-                                      (dispatch!* conn skill opts))
+                           'read      (fn [skill-name] (read-skill* skill-name (room-dir)))
+                           'find      (fn [provides-tag]
+                                        (vec (list-fn :provides provides-tag)))
+                           'providers (fn [skill] (find-prov conn skill))
+                           'rank      (fn [skill] (rank-prov conn skill))
+                           'dispatch  (fn [skill] (dispatch conn skill))
+                           'dispatch! (fn [skill opts]
+                                        (dispatch!* conn skill opts))
                          ;; Authoring lifecycle (writes into THIS room's repo —
                          ;; versioned + forkable + mergeable). Agent-authored
                          ;; skills land `vetted: false`, so the vetting gate keeps
                          ;; them out of prompts until a reviewer promotes them.
-                         'author!   (fn [skill-name frontmatter body]
-                                      (if-let [dir (room-dir)]
-                                        (author* "skills" dir (str skill-name) frontmatter (str body))
-                                        (throw (ex-info "skills/author! needs a room sandbox repo (no room ctx bound)" {}))))
+                           'author!   (fn [skill-name frontmatter body]
+                                        (if-let [dir (room-dir)]
+                                          (author* "skills" dir (str skill-name) frontmatter (str body))
+                                          (throw (ex-info "skills/author! needs a room sandbox repo (no room ctx bound)" {}))))
                          ;; Lift external content (an openclaw/Claude skill, a URL
                          ;; you fetched) into the room as an UNVETTED skill.
-                         'lift!     (fn [skill-name source body]
-                                      (if-let [dir (room-dir)]
-                                        (author* "skills" dir (str skill-name)
-                                                 {:source (str source) :vetted false} (str body))
-                                        (throw (ex-info "skills/lift! needs a room sandbox repo (no room ctx bound)" {}))))
+                           'lift!     (fn [skill-name source body]
+                                        (if-let [dir (room-dir)]
+                                          (author* "skills" dir (str skill-name)
+                                                   {:source (str source) :vetted false} (str body))
+                                          (throw (ex-info "skills/lift! needs a room sandbox repo (no room ctx bound)" {}))))
                          ;; Promote a room skill to vetted (reviewer action).
-                         'promote!  (fn [skill-name by date]
-                                      (if-let [definition (get (load-all* (room-dir)) (str skill-name))]
-                                        (do (promote* definition (str by) (str date)) true)
-                                        (throw (ex-info (str "no such skill to promote: " skill-name) {}))))})))
+                           'promote!  (fn [skill-name by date]
+                                        (if-let [definition (get (load-all* (room-dir)) (str skill-name))]
+                                          (do (promote* definition (str by) (str date)) true)
+                                          (throw (ex-info (str "no such skill to promote: " skill-name) {}))))}
+                          '{all       [([]) "Every skill visible here — on disk plus any this room defines (the room's own take precedence). A map of skill-name → definition."]
+                            read      [([skill-name]) "The FULL instructions for one skill. The system prompt carries only a brief index; pull the body with this before following a skill."]
+                            find      [([provides-tag]) "Skill definitions that provide `provides-tag` (e.g. :research) — a vector, possibly empty."]
+                            providers [([skill]) "Actor-ids that declare they can perform `skill`, whether or not they are online."]
+                            rank      [([skill]) "Providers of `skill` ranked by suitability, ONLINE ones only."]
+                            dispatch  [([skill]) "The single best online provider for `skill` (an actor map), or nil if nobody can take it."]
+                            dispatch! [([skill opts]) "Actually hand `skill` to its best provider. `opts` carries the payload for the receiving actor."]
+                            author!   [([skill-name frontmatter body]) "Write a NEW skill into this room's repo (versioned, forkable, mergeable). Lands `vetted: false`, so it stays out of prompts until a reviewer promotes it. Needs a room ctx."]
+                            lift!     [([skill-name source body]) "Import external content (another agent's skill, a fetched URL) into the room as an UNVETTED skill, recording `source`. Needs a room ctx."]
+                            promote!  [([skill-name by date]) "Mark a room skill vetted — a REVIEWER action; this is what lets it appear in prompts. Throws if there is no such skill."]}))))
 
 (defn add-actors-ns!
   "Expose the durable actor table as 'actors namespace in SCI.
@@ -130,15 +152,25 @@
         add-skill-fn    @(ns-resolve 'dvergr.actors 'add-skill!)
         remove-skill-fn @(ns-resolve 'dvergr.actors 'remove-skill!)]
     (sci/add-namespace! sci-ctx 'dvergr.actors
-                        {'list          (fn [& kvs] (apply list-fn conn kvs))
-                         'lookup        (fn [id]      (lookup-fn conn id))
-                         'online?       (fn [id]      (online?-fn id))
-                         'spawn-agent!  (fn [opts]    (spawn-agent-fn conn opts))
-                         'spawn-human!  (fn [opts]    (spawn-human-fn conn opts))
-                         'dismiss!      (fn [id]      (dismiss-fn conn id))
-                         'update!       (fn [id patch] (update-fn conn id patch))
-                         'add-skill!    (fn [id skill] (add-skill-fn conn id skill))
-                         'remove-skill! (fn [id skill] (remove-skill-fn conn id skill))})))
+                        (doc/with-docs
+                          {'list          (fn [& kvs] (apply list-fn conn kvs))
+                           'lookup        (fn [id]      (lookup-fn conn id))
+                           'online?       (fn [id]      (online?-fn id))
+                           'spawn-agent!  (fn [opts]    (spawn-agent-fn conn opts))
+                           'spawn-human!  (fn [opts]    (spawn-human-fn conn opts))
+                           'dismiss!      (fn [id]      (dismiss-fn conn id))
+                           'update!       (fn [id patch] (update-fn conn id patch))
+                           'add-skill!    (fn [id skill] (add-skill-fn conn id skill))
+                           'remove-skill! (fn [id skill] (remove-skill-fn conn id skill))}
+                          '{list          [([] [& {:keys [kind status]}]) "Every DURABLE actor the system knows — including offline and retired ones (contrast dvergr.agents/list, which is who is alive now). Filter with :kind (:agent/:human) and :status (e.g. :online, :retired)."]
+                            lookup        [([id]) "The durable row for one actor id, or nil. Persisted state, not runtime state."]
+                            online?       [([id]) "Runtime check — is this actor actually running now?"]
+                            spawn-agent!  [([opts]) "Create a NEW agent, persisted to Datahike. `opts` takes :id :name :profile-ref :skills :config (provider/model). This grows the roster; prefer an existing agent when one fits."]
+                            spawn-human!  [([opts]) "Register a HUMAN participant as an actor, so work can be assigned to and tracked for them."]
+                            dismiss!      [([id]) "Retire an actor — flags :status :retired rather than deleting, so its history survives."]
+                            update!       [([id patch]) "Merge `patch` into an actor's durable row (e.g. {:skills #{:prose :writing}})."]
+                            add-skill!    [([id skill]) "Declare that an actor can perform `skill` — this is what makes it show up in dvergr.skills/providers."]
+                            remove-skill! [([id skill]) "Withdraw a skill declaration from an actor."]}))))
 
 (defn add-tasks-ns!
   "Expose the task ledger as 'tasks namespace in SCI.
@@ -163,11 +195,17 @@
         complete-fn @(ns-resolve 'dvergr.orchestration.tasks 'complete!)
         ignore-fn   @(ns-resolve 'dvergr.orchestration.tasks 'ignore!)]
     (sci/add-namespace! sci-ctx 'dvergr.tasks
-                        {'list      (fn [& kvs] (apply list-fn conn kvs))
-                         'lookup    (fn [id]    (lookup-fn conn id))
-                         'accept!   (fn [id]    (accept-fn conn id))
-                         'complete! (fn [id r]  (complete-fn conn id r))
-                         'ignore!   (fn [id]    (ignore-fn conn id))})))
+                        (doc/with-docs
+                          {'list      (fn [& kvs] (apply list-fn conn kvs))
+                           'lookup    (fn [id]    (lookup-fn conn id))
+                           'accept!   (fn [id]    (accept-fn conn id))
+                           'complete! (fn [id r]  (complete-fn conn id r))
+                           'ignore!   (fn [id]    (ignore-fn conn id))}
+                          '{list      [([] [& {:keys [actor-id status]}]) "The shared task ledger — persistent rows for work dispatched to non-agent actors (humans). Filter with :actor-id and :status (e.g. :pending). Agents themselves just react to inbox messages and need no task row."]
+                            lookup    [([id]) "One task by its uuid, or nil."]
+                            accept!   [([id]) "Claim a task — marks it accepted so nobody else picks it up."]
+                            complete! [([id result]) "Finish a task, recording `result` (a string describing what was done/found)."]
+                            ignore!   [([id]) "Decline a task, leaving it for someone else."]}))))
 
 (defn add-scheduler-ns!
   "Expose scheduling as 'scheduler namespace in SCI.

--- a/src/dvergr/sandbox/ns/codec.clj
+++ b/src/dvergr/sandbox/ns/codec.clj
@@ -8,7 +8,8 @@
                           `parse-str` here forbids DOCTYPE → no XXE / billion-laughs / SSRF.
      dvergr.codec       — base64 / url / html helpers (no babashka equivalent; ours)."
   (:require [clojure.string :as str]
-            [sci.core :as sci])
+            [sci.core :as sci]
+            [dvergr.sandbox.ns.doc :as doc])
   (:import [javax.xml.parsers SAXParserFactory]
            [javax.xml XMLConstants]
            [org.xml.sax InputSource]
@@ -123,10 +124,17 @@
                        'text      xml-text})
   ;; dvergr.codec — base64 / url / html (no babashka equivalent)
   (sci/add-namespace! sci-ctx 'dvergr.codec
-                      {'base64-encode   b64-encode
-                       'base64-decode   b64-decode-str
-                       'url-encode      url-encode
-                       'url-decode      url-decode
-                       'decode-entities html-decode-entities
-                       'strip-tags      html-strip-tags})
+                      (doc/with-docs
+                        {'base64-encode   b64-encode
+                         'base64-decode   b64-decode-str
+                         'url-encode      url-encode
+                         'url-decode      url-decode
+                         'decode-entities html-decode-entities
+                         'strip-tags      html-strip-tags}
+                        '{base64-encode   [([s]) "Base64-encode a string."]
+                          base64-decode   [([s]) "Decode a base64 string back to a string."]
+                          url-encode      [([s]) "Percent-encode a string for use in a URL query/path segment."]
+                          url-decode      [([s]) "Reverse percent-encoding."]
+                          decode-entities [([html]) "Turn HTML entities (&amp;, &#39;, …) into the characters they denote."]
+                          strip-tags      [([html]) "Strip HTML tags, leaving the text — handy for turning a fetched page into something summarizable."]}))
   sci-ctx)

--- a/src/dvergr/sandbox/ns/doc.clj
+++ b/src/dvergr/sandbox/ns/doc.clj
@@ -1,0 +1,93 @@
+(ns dvergr.sandbox.ns.doc
+  "Attach `:doc`/`:arglists` to the fns dvergr injects into the SCI sandbox.
+
+   The discovery machinery an agent has — `(clojure.repl/doc …)`, `dir`,
+   `apropos`, `find-doc`, `(sandbox/doc 'ns)` — reads metadata off the injected
+   VALUE. `sci/copy-var` carries a real var's metadata across, which is why every
+   borrowed namespace (clojure.string, cheshire, babashka.fs …) documents itself.
+   But dvergr's own vocabulary is injected as bare `(fn …)` closures, and a raw
+   closure carries no metadata, so those same tools answered:
+
+     (clojure.repl/doc dvergr.room/kb-search)
+     ;=> dvergr.room/kb-search
+     ;     ; arity unknown — injected as a bare fn
+     ;     ; no docstring
+
+   and `(find-doc \"knowledge\")` reported that nothing in the sandbox matches —
+   for a capability the sandbox very much has. An agent's only way to learn a
+   signature was to call the fn and read the error, and its only way to learn a
+   capability existed was to be told in the prompt. `dvergr.scheduler` was fixed
+   this way once (a local `documented` helper); this ns is that helper, shared,
+   so the rest of the vocabulary can follow and a test can hold the line.
+
+   Usage — keep the wiring as it is and hang a doc table off it:
+
+     (sci/add-namespace! sci-ctx 'dvergr.agents
+       (doc/with-docs
+         {'list    list-fn
+          'lookup  lookup-fn}
+         '{list   [([]) \"Every agent currently online in this daemon.\"]
+           lookup [([id]) \"The full entry for one agent id, or nil.\"]}))
+
+   Docs live next to the wiring on purpose: the fn list stays auto-derived from
+   what is actually injected (drift-free), and a var that gains a doc gains it
+   in the same place a reader is already looking."
+  (:require [clojure.string :as str]))
+
+(defn documented
+  "Return `f` with `:name`/`:arglists`/`:doc` metadata attached.
+
+   Only values that can carry metadata are touched — a datahike conn, `nil`, or
+   any other non-`IObj` injected value is returned unchanged rather than
+   throwing, so a doc table may mention a var whose value is not a fn without
+   the caller special-casing it."
+  [sym arglists doc f]
+  (if (instance? clojure.lang.IObj f)
+    (vary-meta f merge (cond-> {:name sym}
+                         arglists (assoc :arglists arglists)
+                         doc      (assoc :doc doc)))
+    f))
+
+(defn with-docs
+  "Attach metadata from a doc table to an SCI namespace map.
+
+   `ns-map` is the map you would pass to `sci/add-namespace!`.
+   `docs` is `{sym [arglists doc]}` — typically quoted as a whole, so the
+   arglists read like the ones on a real `defn`.
+
+   Vars absent from `docs` pass through untouched (a var that legitimately has
+   no signature to state, e.g. `*kb*`, needs no entry). Entries in `docs` that
+   name a var NOT in `ns-map` throw: a doc table that has drifted away from the
+   wiring is a bug, and a silent no-op is exactly how it would rot unnoticed."
+  [ns-map docs]
+  (let [unknown (remove (set (keys ns-map)) (keys docs))]
+    (when (seq unknown)
+      (throw (ex-info (str "doc table names vars that are not injected: "
+                           (str/join ", " (sort (map str unknown))))
+                      {:unknown (vec (sort unknown))
+                       :injected (vec (sort (map str (keys ns-map))))}))))
+  (reduce-kv (fn [m sym [arglists doc]]
+               (cond-> m
+                 (contains? m sym) (update sym #(documented sym arglists doc %))))
+             ns-map
+             docs))
+
+(defn from-var
+  "Document `f` by harvesting `:arglists`/`:doc` off the var it wraps.
+
+   Most injected fns are thin wrappers that partially apply a host var — e.g.
+   `(fn [id] (lookup-fn conn id))` over `dvergr.orchestration.tasks/lookup`,
+   whose own arglist is `([conn id])`. `drop-args` says how many leading
+   parameters the wrapper supplies, so the sandbox sees `([id])`: the signature
+   an agent actually calls, derived from the source rather than restated (and so
+   unable to drift from it).
+
+   `doc` overrides the source docstring when the source has none, or when the
+   sandbox-facing meaning differs from the host-facing one."
+  [sym src-var f & {:keys [drop-args doc]
+                    :or   {drop-args 0}}]
+  (let [m        (meta src-var)
+        arglists (some->> (:arglists m)
+                          (map #(vec (drop drop-args %)))
+                          (apply list))]
+    (documented sym arglists (or doc (:doc m)) f)))

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -7,7 +7,8 @@
             [clojure.string :as str]
             [jsonista.core :as j]
             [babashka.fs :as fs]
-            [muschel.fs :as mfs])
+            [muschel.fs :as mfs]
+            [dvergr.sandbox.ns.doc :as doc])
   (:import [java.io File]))
 
 (declare fs-safe-resolve git-run* parse-porcelain-status parse-git-log)
@@ -518,11 +519,17 @@
                       (str/trim (apply run! args))))]
 
     (sci/add-namespace! sci-ctx 'git
-                        {'status status-fn
-                         'log    log-fn
-                         'diff   diff-fn
-                         'add    add-fn
-                         'commit commit-fn})))
+                        (doc/with-docs
+                          {'status status-fn
+                           'log    log-fn
+                           'diff   diff-fn
+                           'add    add-fn
+                           'commit commit-fn}
+                          '{status [([]) "Working-tree status of YOUR room's repo, PARSED into a map (not porcelain text) — branch plus changed paths."]
+                            log    [([] [opts]) "Recent commits as maps of :hash/:subject/:author/:date. `opts` takes :n (default 10)."]
+                            diff   [([] [& args]) "Unified diff text. No args = unstaged changes; extra args pass through to `git diff` (e.g. \"--staged\", a path)."]
+                            add    [([& paths]) "Stage paths for commit. Audited. Returns :ok."]
+                            commit [([message] [message opts]) "Commit staged changes with `message`, returning the trimmed git output. `opts` takes :author. Audited."]}))))
 
 (defn add-env-ns!
   "Expose config-scoped key access as the 'env namespace in SCI. Resolves ONLY from
@@ -560,9 +567,13 @@
         keys-fn (fn [] (vec (distinct (concat (map str (keys @config-atom))
                                               (keys (or secrets {}))))))]
     (sci/add-namespace! sci-ctx 'env
-                        {'get  get-fn
-                         'set  set-fn
-                         'keys keys-fn})))
+                        (doc/with-docs
+                          {'get  get-fn
+                           'set  set-fn
+                           'keys keys-fn}
+                          '{get  [([key] [key default]) "Read a config key granted to YOU. This is NOT the host process environment — System/getenv is unreachable, so the daemon's own secrets are not visible here. A key configured as an injected secret returns an opaque PLACEHOLDER, never the real value; HTTP egress substitutes the real one at the destination."]
+                            set  [([key value]) "Set a config key for this sandbox session. Returns :ok."]
+                            keys [([]) "Every config key readable here, including the names of injected secrets (whose values stay placeholders)."]}))))
 
 (defn add-http-ns!
   "Expose HTTP client as 'http namespace in SCI.

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -5,7 +5,8 @@
    datahike + spindel directly."
   (:require [sci.core :as sci]
             [datahike.api :as dh]
-            [org.replikativ.spindel.engine.core :as rtc]))
+            [org.replikativ.spindel.engine.core :as rtc]
+            [dvergr.sandbox.ns.doc :as doc]))
 
 (defn add-llm-ns!
   "Expose cheap one-shot LLM calls as 'llm namespace in SCI.
@@ -25,8 +26,11 @@
                        (call-fn "Summarize the key points concisely:"
                                 content (or opts {})))]
     (sci/add-namespace! sci-ctx 'llm
-                        {'call      call-fn
-                         'summarize summarize-fn})))
+                        (doc/with-docs
+                          {'call      call-fn
+                           'summarize summarize-fn}
+                          '{call      [([system-prompt content] [system-prompt content opts]) "One-shot call to a CHEAP model — for mechanical language work (extract, classify, rewrite) inside a larger job, not for reasoning you should do yourself. `opts` takes :max-tokens. Not budget-tracked at this level."]
+                            summarize [([content] [content opts]) "Summarize text with the cheap model. `opts` takes :max-tokens, e.g. (llm/summarize page {:max-tokens 300})."]}))))
 
 ;; (RF5: the calendar folded into the per-room scheduler — see `scheduler/*` +
 ;; `dvergr.room/schedules`. The standalone calendar subsystem is gone.)
@@ -168,38 +172,60 @@
                       (binding [rtc/*execution-context* spindel-ctx]
                         (or (rreg-lookup* :daemon)
                             (rtc/get-state [:dvergr/discourse-root]))))]
-    {'create!      create-fn
-     'list         list-fn
-     'get          get-fn
-     'post!        post-fn
-     'messages     messages-fn
-     'children     children-fn
-     'set-parent!  set-parent-fn
-     'join!        join-fn
-     'leave!       leave-fn
-     'delete!      delete-fn
-     'fork!        fork-fn
-     'merge!       merge-fn
-     'discard!     discard-fn
-     'diff         diff-fn
-     'review       review-fn
-     'classify     fork-classify*
-     'forks        forks-fn
-     'participants participants-fn
-     'root         root-fn
+    (doc/with-docs
+      {'create!      create-fn
+       'list         list-fn
+       'get          get-fn
+       'post!        post-fn
+       'messages     messages-fn
+       'children     children-fn
+       'set-parent!  set-parent-fn
+       'join!        join-fn
+       'leave!       leave-fn
+       'delete!      delete-fn
+       'fork!        fork-fn
+       'merge!       merge-fn
+       'discard!     discard-fn
+       'diff         diff-fn
+       'review       review-fn
+       'classify     fork-classify*
+       'forks        forks-fn
+       'participants participants-fn
+       'root         root-fn
      ;; Subagent delegation — fork a subroom (`:ctx` substrate + shared CRDTs),
      ;; host an ephemeral worker, delegate the goal, merge/discard. Returns a Spin:
      ;; `(await (dvergr.room/hire "<room-ref>" {:goal … :spec {…}}))` in the
      ;; foreground, or hold the spin and await it later (background). Durably
      ;; tracked as a `:dvergr/subagent` lifecycle log; `pending-subagents` lists
      ;; the still-running ones.
-     'hire         (fn [ref opts]
-                     (when-let [room (resolve-room ref)]
-                       (binding [rtc/*execution-context* (:ctx room)]
-                         (subagent-hire* room opts))))
-     'pending-subagents (fn [ref]
-                          (when-let [room (resolve-room ref)]
-                            (binding [rtc/*execution-context* (:ctx room)]
-                              (subagent-pend* room))))}))
+       'hire         (fn [ref opts]
+                       (when-let [room (resolve-room ref)]
+                         (binding [rtc/*execution-context* (:ctx room)]
+                           (subagent-hire* room opts))))
+       'pending-subagents (fn [ref]
+                            (when-let [room (resolve-room ref)]
+                              (binding [rtc/*execution-context* (:ctx room)]
+                                (subagent-pend* room))))}
+      '{create!      [([opts]) "Create a persistent room. `opts` takes :slug :title :agents. Rooms are the unit of work: each has its own git repo, knowledge base and schedules."]
+        list         [([]) "Every room you can see, as maps."]
+        get          [([ref]) "One room by slug or id, or nil."]
+        post!        [([ref content]) "Post a message into a room — how you talk to the people and agents in it. `ref` is a slug or id."]
+        messages     [([ref] [ref opts]) "Recent messages in a room, newest first."]
+        children     [([ref]) "Rooms whose parent is this one."]
+        set-parent!  [([child parent]) "Re-parent a room, building the room tree."]
+        join!        [([ref] [ref who]) "Join a room so you receive its messages."]
+        leave!       [([ref] [ref who]) "Stop receiving a room's messages."]
+        delete!      [([ref]) "Delete a room. Destructive — prefer discard! on a fork, or archiving."]
+        fork!        [([ref]) "Branch a room into an ISOLATED copy — its own git repo AND database — so you can experiment freely. This is the safe way to attempt a substantial or risky change: fork, work, then merge! or discard!."]
+        merge!       [([parent fork]) "Collapse a fork's work back into its parent, surfacing a git + database diff for review. The other half of the fork→test→merge loop."]
+        discard!     [([fork]) "Throw a fork away, keeping the parent untouched."]
+        diff         [([fork]) "What a fork CHANGED versus its parent — code and data — so you can judge it before merging."]
+        review       [([fork]) "An agent review of a fork's changes: the fork tiering + review pipeline, not just a raw diff."]
+        classify     [([fork]) "How mergeable a fork is (its tier) — used to route it as a task vs a proposal."]
+        forks        [([ref]) "Every fork of a room."]
+        participants [([ref]) "Who is in a room — agents and humans."]
+        root         [([]) "The root room of the tree."]
+        hire         [([ref opts]) "Delegate a goal to an EPHEMERAL sub-agent in a forked subroom (`:ctx` substrate + shared CRDTs), then merge or discard it. `opts` takes :goal and :spec. Returns a SPIN — (await (dvergr.room/hire …)) to run it in the foreground, or hold the spin and await it later to run it in the background. Tracked durably as a :dvergr/subagent lifecycle log."]
+        pending-subagents [([ref]) "Sub-agents hired from this room that are still running."]})))
 
 

--- a/src/dvergr/sandbox/ns/mail.clj
+++ b/src/dvergr/sandbox/ns/mail.clj
@@ -6,7 +6,8 @@
    mailbox is attached. Read helpers (recent/search/unread) are agent-readable
    stdlib SOURCE in dvergr/mail/inbox.clj."
   (:require [sci.core :as sci]
-            [org.replikativ.spindel.yggdrasil :as ygg]))
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [dvergr.sandbox.ns.doc :as doc]))
 
 (defn add-mail-ns!
   "Mount dvergr.mail into the SCI ctx. `inbox` is a 0-arg LIVE resolver — call it
@@ -14,6 +15,11 @@
    mount-time snapshot resolved under the bound (room/fork) ctx."
   [sci-ctx]
   (sci/add-namespace! sci-ctx 'dvergr.mail
-                      {'inbox   (fn [] (some-> (ygg/system "mail") :conn))
-                       '*inbox* (some-> (ygg/system "mail") :conn)})
+                      (doc/with-docs
+                        {'inbox   (fn [] (some-> (ygg/system "mail") :conn))
+                         '*inbox* (some-> (ygg/system "mail") :conn)}
+                        ;; `*inbox*` is a conn (or nil) — a value with no
+                        ;; signature to state, so it carries no entry here; the
+                        ;; ns-guide overview describes it.
+                        '{inbox [([]) "The datahike conn for YOUR room's attached mailbox, resolved LIVE — call it per access so a fork, or a mailbox attached after this sandbox was built, is reflected. nil when no mailbox is attached. Read helpers (recent/search/unread) are readable source: (require '[dvergr.mail.inbox])."]}))
   sci-ctx)

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -19,6 +19,7 @@
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
+            [dvergr.sandbox.ns.doc :as doc]
             [sci.core :as sci]))
 
 (defn- safe [f] (try (f) (catch Throwable t {:error (.getMessage t)})))
@@ -125,17 +126,36 @@
         kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
                                 (srooms/room-kb-conn room-id slug))))
         room-map (merge (ns-kb/room-ops-map ctx)        ; create!/fork!/merge!/post!/messages/…
-                        {'*room*          room-conn      ; the room's own datahike (messages store)
-                         '*kb*            kb-conn         ; the DEFAULT writable KB (see kbs)
-                         'kbs             kbs             ; [{:name :permission :default?}] — writable KBs
-                         'kb              kb              ; fork-aware conn to a writable KB by name
-                         'databases       databases       ; [{:name :type :permission}] — your DBs
-                         'db              db              ; fork-aware conn to one by name
-                         'kb-find         kb-find
-                         'kb-by-type      kb-by-type
-                         'kb-search       kb-search
-                         'recent-messages recent-msgs
-                         'search-messages search-msgs
-                         'schedules       schedules
-                         'gc!             gc!})]
+                        ;; Docs live HERE rather than only in these trailing
+                        ;; comments: the comments never reached the sandbox, so
+                        ;; `(clojure.repl/doc dvergr.room/kb-search)` answered
+                        ;; "arity unknown — injected as a bare fn". See
+                        ;; `dvergr.sandbox.ns.doc`. `*room*`/`*kb*` are conns
+                        ;; (or nil) — values with no signature to state — so
+                        ;; they carry no entry and are described in ns-guide.
+                        (doc/with-docs
+                          {'*room*          room-conn      ; the room's own datahike (messages store)
+                           '*kb*            kb-conn         ; the DEFAULT writable KB (see kbs)
+                           'kbs             kbs             ; [{:name :permission :default?}] — writable KBs
+                           'kb              kb              ; fork-aware conn to a writable KB by name
+                           'databases       databases       ; [{:name :type :permission}] — your DBs
+                           'db              db              ; fork-aware conn to one by name
+                           'kb-find         kb-find
+                           'kb-by-type      kb-by-type
+                           'kb-search       kb-search
+                           'recent-messages recent-msgs
+                           'search-messages search-msgs
+                           'schedules       schedules
+                           'gc!             gc!}
+                          '{kbs             [([]) "The knowledge bases you may WRITE, as [{:name :permission :default?}]. Your own KB is usually the default, but a room whose knowledge lives in an ATTACHED KB would otherwise write into its own empty one — check here before saving if it matters where."]
+                            kb              [([slug]) "Fork-aware conn to one WRITABLE knowledge base by name (see `kbs`)."]
+                            databases       [([]) "Every database available to this room, as [{:name :type :permission}] — the discovery entry point before `db`."]
+                            db              [([db-name]) "Fork-aware conn to one of your databases by name (see `databases`). Query it with the real datahike API: (d/q '[…] @conn)."]
+                            kb-find         [([title]) "The single KB entity with this exact title, or nil. Searches EVERY readable KB — your own plus whatever is granted to the room — across both title bindings, and the result carries :kb so you know where it lives."]
+                            kb-by-type      [([type]) "KB entities of a given :entity/type (pass the type as a string or keyword), pulled with title/summary/type, tagged with :kb."]
+                            kb-search       [([term]) "Substring search over title+summary across EVERY readable KB (max 25 hits), each tagged with :kb. Reach for this before researching something afresh."]
+                            recent-messages [([] [n]) "The n most recent messages in THIS room (default 20), newest first."]
+                            search-messages [([term]) "Messages in THIS room whose content contains `term` (max 50)."]
+                            schedules       [([]) "The schedules registered on THIS room — what runs, and when."]
+                            gc!             [([] [opts]) "Reclaim unreachable storage for this room/fork — datahike index blobs and git objects. Default collects orphan garbage only and KEEPS all history; pass {:remove-before <Date>} to collapse history older than that."]}))]
     (sci/add-namespace! sci-ctx 'dvergr.room room-map)))

--- a/src/dvergr/sci/impl/clojure_test.clj
+++ b/src/dvergr/sci/impl/clojure_test.clj
@@ -283,7 +283,53 @@
 
 (def testing-contexts (sci/new-dynamic-var '*testing-contexts* (list) {:ns tns})) ; bound to hierarchy of "testing" strings
 
-(def test-out (sci/new-dynamic-var '*test-out* *out* {:ns tns}))         ; PrintWriter for test reporting output
+(defn- sandbox-following-writer
+  "A PrintWriter that writes to the CURRENT sandbox `*out*`, falling back to
+   `fallback` when there is none.
+
+   `*test-out*` used to be initialised to the bare `*out*` of whatever thread
+   happened to load THIS namespace — the host JVM's stdout. Every reporting fn
+   goes through `with-test-out-internal`, which binds `*out*` to `@test-out`, so
+   all of clojure.test's output (`FAIL in … / expected: … / actual: …`) was
+   written to the SERVER CONSOLE instead of the sandbox. An agent running tests
+   got a correct summary (`{:test 3 :pass 2 :fail 1}`) and no way to see WHICH
+   test failed or why — which reads as broken tooling and sends agents looking
+   for another runner (kaocha), which the mirror allowlist rightly denies.
+
+   `sci/eval-code` evaluates inside `(sci/binding [sci/out <StringWriter>] …)`,
+   and host code can read that binding via `@sci/out`. So resolving the target
+   at WRITE time makes reporting land wherever the sandbox's stdout currently
+   points, per-eval and per-thread, with no change to eval-code.
+
+   `fallback` is captured at construction (not read dynamically) on purpose:
+   `with-test-out-internal` binds `*out*` to this very writer, so reading `*out*`
+   at write time to fall back would make it write to itself — an immediate
+   StackOverflowError. Capturing it also preserves the previous behaviour
+   exactly for non-sandbox callers (dvergr's own test suite)."
+  [^java.io.Writer fallback]
+  (let [target (fn ^java.io.Writer []
+                 (let [o @sci/out]
+                   (if (instance? java.io.Writer o) o fallback)))]
+    (java.io.PrintWriter.
+     (proxy [java.io.Writer] []
+       (write
+         ([x]
+          (let [^java.io.Writer w (target)]
+            (cond (integer? x) (.write w ^int x)
+                  (string? x)  (.write w ^String x)
+                  :else        (.write w ^chars x))))
+         ([x off len]
+          (let [^java.io.Writer w (target)]
+            (if (string? x)
+              (.write w ^String x ^int off ^int len)
+              (.write w ^chars x ^int off ^int len)))))
+       (flush [] (.flush ^java.io.Writer (target)))
+       ;; Never close the target — it is the sandbox's capture buffer or the
+       ;; host stdout, both owned by someone else.
+       (close [] nil))
+     true)))                                                    ; autoflush
+
+(def test-out (sci/new-dynamic-var '*test-out* (sandbox-following-writer *out*) {:ns tns})) ; follows the sandbox *out*; see above
 
 (defmacro with-test-out-internal
   "Runs body with *out* bound to the value of *test-out*."

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -372,16 +372,27 @@
 
 (register!
  {:name "edit_file"
-  :description "Edit a file by replacing an exact string match with new content. The old_string must match exactly (including whitespace)."
+  :description "Edit a file by replacing an exact string match with new content. The old_string must match exactly (including whitespace).
+
+   By default the match must be UNIQUE — if old_string occurs more than once the
+   edit is refused, so you cannot change the wrong occurrence by accident. When
+   you genuinely mean every occurrence (renaming a local, updating a repeated
+   literal), pass replace_all true instead of issuing one call per occurrence
+   with hand-built surrounding context.
+
+   For CLOJURE code prefer `clojure_edit`, which finds a form by type+name and
+   needs no string matching at all."
   :parameters {:type "object"
                :properties {:path {:type "string"
                                    :description "The path to the file"}
                             :old_string {:type "string"
                                          :description "The exact string to find and replace"}
                             :new_string {:type "string"
-                                         :description "The replacement string"}}
+                                         :description "The replacement string"}
+                            :replace_all {:type "boolean"
+                                          :description "Replace EVERY occurrence (default false, which requires the match to be unique)"}}
                :required ["path" "old_string" "new_string"]}
-  :execute (fn [{:keys [path old_string new_string]} {:keys [session-id] :as ctx}]
+  :execute (fn [{:keys [path old_string new_string replace_all]} {:keys [session-id] :as ctx}]
              (let [file (tool-path ctx path)
                    exists? (if-let [filesystem (:filesystem ctx)]
                              (mfs/exists? filesystem file)
@@ -395,19 +406,26 @@
                       :error "String not found in file"
                       :suggestion "Make sure the old_string matches exactly, including whitespace and newlines"}
 
-                     (> occurrences 1)
+                     (and (> occurrences 1) (not replace_all))
                      {:type :error
                       :error (str "String found " occurrences " times, must be unique")
-                      :suggestion "Include more surrounding context to make the match unique"}
+                      :suggestion (str "Include more surrounding context to make the match "
+                                       "unique, or pass replace_all true to change all "
+                                       occurrences " occurrences")}
 
                      :else
-                     (let [new-content (str/replace-first content old_string new_string)]
+                     (let [new-content (if replace_all
+                                         (str/replace content old_string new_string)
+                                         (str/replace-first content old_string new_string))]
                        (workspace-write! ctx path new-content)
                         ;; Auto-index if Clojure file
                        (index-file-if-clojure! file new-content session-id)
                        {:type :success
-                        :content (str "Replaced string in " path)
+                        :content (str "Replaced " (if replace_all occurrences 1)
+                                      " occurrence" (when (and replace_all (> occurrences 1)) "s")
+                                      " in " path)
                         :metadata {:path (str file)
+                                   :replacements (if replace_all occurrences 1)
                                    :old-length (count old_string)
                                    :new-length (count new_string)}})))
                  {:type :error
@@ -1377,16 +1395,13 @@ Note: changes take effect on the next agent restart or reload."
 ;; Test Execution Tool
 ;; ---------------------------------------------------------------------------
 
-;; Lazy require kaocha
-(defn- kaocha-ns []
-  (require 'kaocha.api)
-  (find-ns 'kaocha.api))
-
 (defn- format-test-output
-  "Format test results for display."
-  [result]
-  (let [pass (:pass result 0)
-        fail (:fail result 0)
+  "Format test results for display. `report` is clojure.test's captured output —
+   the FAIL/expected/actual lines — which is the part an agent actually needs to
+   act on, so it is included verbatim rather than summarised away."
+  [result report]
+  (let [pass  (:pass result 0)
+        fail  (:fail result 0)
         error (:error result 0)
         total (+ pass fail error)]
     (str "Test Results:\n"
@@ -1398,91 +1413,73 @@ Note: changes take effect on the next agent restart or reload."
          (if (zero? (+ fail error))
            "✓ All tests passed"
            (str "✗ " (+ fail error) " test(s) failed\n\n"
-                "Run with detailed reporter to see failure details")))))
+                (str/trim (str report)))))))
 
 (register!
  {:name "run_tests"
-  :description "Run Clojure tests using Kaocha in the current working directory.
+  :description "Run clojure.test across the namespaces defined in YOUR sandbox.
 
-   This tool executes tests programmatically without requiring shell access.
-   Tests run in the agent's working directory (forked worktree context),
-   so agents can verify their code changes in isolation.
+   Runs inside your SCI session, so it sees exactly the namespaces you have
+   defined or loaded this session — nothing on the daemon's classpath. To test
+   code that lives in a file, load it first, then run:
+     clojure_eval: (load-string (slurp \"src/foo.clj\"))
+     run_tests:    {\"pattern\": \"foo\"}
 
-   Options:
-   - focus: Run specific test namespace (e.g., 'dvergr.knowledge.links-test')
-   - pattern: Regex pattern to match test namespaces (e.g., 'knowledge')
-   - fail_fast: Stop on first failure (default false)
+   Options (all optional):
+   - focus:   one test namespace, e.g. 'my.thing-test'
+   - pattern: regex over namespace names, e.g. 'knowledge'
+   - (neither): every test namespace in the session
 
-   Returns structured test results including:
-   - Pass/fail/error counts
-   - Exit code (0 = all pass, 1 = failures)
-   - Summary output
+   Returns pass/fail/error counts AND, on failure, clojure.test's
+   expected/actual report so you can see WHICH assertion failed and why.
 
-   Example: Run specific test namespace
-   {\"focus\": \"dvergr.knowledge.links-test\"}
-
-   Example: Run all tests matching pattern
-   {\"pattern\": \"knowledge\"}
-
-   Example: Run all tests
-   {}
-
-   Note: Tests execute in the tool's :cwd, which for agents is their
-   forked git worktree. This allows safe isolated testing."
+   Note: this is not kaocha and does not run the project's test files from
+   disk. A second runtime (clj/lein) is deliberately unavailable — it could
+   read and write outside the sandbox — so in-session clojure.test is the
+   supported way to test here."
   :parameters {:type "object"
                :properties {:focus {:type "string"
                                     :description "Specific test namespace to run"}
                             :pattern {:type "string"
-                                      :description "Regex pattern for test namespaces"}
-                            :fail_fast {:type "boolean"
-                                        :description "Stop on first failure (default false)"}}
+                                      :description "Regex pattern for test namespaces"}}
                :required []}
-  :execute (fn [{:keys [focus pattern fail_fast]} {:keys [cwd]}]
-             (try
-                ;; Lazy load kaocha
-               (let [kaocha-ns (kaocha-ns)
-                     kaocha-run! (ns-resolve kaocha-ns 'run)
-
-                      ;; Build kaocha config
-                     config (cond-> {:color? false
-                                     :fail-fast (boolean fail_fast)
-                                     :cwd (or cwd ".")}
-
-                               ;; Focus on specific test namespace
-                              focus
-                              (assoc :kaocha/tests
-                                     [{:kaocha.testable/id :unit
-                                       :kaocha.testable/type :kaocha.type/clojure.test
-                                       :kaocha/ns-patterns [(re-pattern (str focus "$"))]}])
-
-                               ;; Match pattern in test namespaces
-                              pattern
-                              (assoc :kaocha.filter/regex (re-pattern pattern)))
-
-                      ;; Run tests
-                     result (kaocha-run! config)
-
-                      ;; Extract summary
-                     pass (:kaocha.result/count result 0)
-                     fail (:kaocha.result/fail result 0)
-                     error (:kaocha.result/error result 0)
-                     exit-code (if (and (zero? fail) (zero? error)) 0 1)]
-
-                 {:type (if (zero? exit-code) :success :error)
-                  :content (format-test-output {:pass pass
-                                                :fail fail
-                                                :error error})
-                  :metadata {:passed pass
-                             :failed fail
-                             :errors error
-                             :exit-code exit-code
-                             :cwd (or cwd ".")}})
-
-               (catch Exception e
-                 {:type :error
-                  :error (str "Test execution failed: " (.getMessage e))
-                  :details (str "Cause: " (when-let [cause (.getCause e)]
-                                            (.getMessage cause)))})))})
+  ;; Runs clojure.test INSIDE the agent's SCI context.
+  ;;
+  ;; This used to `ns-resolve` kaocha.api and run it in the HOST jvm. Three
+  ;; things were wrong with that: kaocha is only in dvergr's :test alias, so at
+  ;; runtime the resolve threw "Could not locate kaocha/api" and the tool ALWAYS
+  ;; failed; `:cwd` was passed as a kaocha config key, which chdirs nothing, so
+  ;; the advertised "runs in your forked worktree in isolation" was untrue; and
+  ;; had it worked it would have loaded and executed host test namespaces from
+  ;; the daemon's classpath on agent request — outside the sandbox entirely.
+  ;;
+  ;; The sandbox already has a ctx-aware clojure.test (run-tests / run-all-tests
+  ;; enumerate vars in THIS context), so running there is both correct and
+  ;; actually isolated. `:sci-ctx` is the same handle clojure_eval receives.
+  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx]}]
+             (if-not sci-ctx
+               {:type :error
+                :error "No sandbox context available to run tests in."}
+               (let [form (cond
+                            focus   (str "(clojure.test/run-tests '" focus ")")
+                            pattern (str "(clojure.test/run-all-tests #\""
+                                         (str/replace pattern "\"" "\\\"") "\")")
+                            :else   "(clojure.test/run-all-tests)")
+                     r    (sandbox/eval-code sci-ctx form)]
+                 (if-not (:success r)
+                   {:type :error
+                    :error (str "Test run failed: " (get-in r [:error :message]))}
+                   (let [{:keys [test pass fail error]
+                          :or   {test 0 pass 0 fail 0 error 0}} (:value r)
+                         broken? (pos? (+ fail error))]
+                     {:type (if broken? :error :success)
+                      :content (format-test-output {:pass pass :fail fail :error error}
+                                                   (:stdout r))
+                      :metadata {:tests    test
+                                 :passed   pass
+                                 :failed   fail
+                                 :errors   error
+                                 :exit-code (if broken? 1 0)}})))))})
 
 ;; ---------------------------------------------------------------------------
 ;; Budget Tool

--- a/test/dvergr/intake/workspace_delete_test.clj
+++ b/test/dvergr/intake/workspace_delete_test.clj
@@ -1,0 +1,90 @@
+(ns dvergr.intake.workspace-delete-test
+  "Recursive delete is allowed inside the workspace, refused on system paths.
+
+   muschel denies `rm -r*` outright — correct for a library that cannot assume
+   its embedder's workspace is recoverable. dvergr's IS: a geschichte-backed
+   fork with history, behind a jailed FS. And the blanket deny bought nothing
+   measurable, because `babashka.fs/delete-tree` performs the same recursive
+   deletion through the sandbox's fs surface with no permit layer in front of
+   it. Measured before this change, in one session:
+
+     rm -rf scratch                    ;=> exit 126, \"permit denied: recursive delete\"
+     (babashka.fs/delete-tree \"scratch\") ;=> deleted
+
+   So the rule did not stop recursive deletion; it moved it off the audited
+   shell onto an unaudited door. These tests pin the corrected posture — and
+   the system-path refusal that must survive it, since the rules are
+   last-match-wins and an over-broad allow would silently undo it."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.sandbox.ns.io :as ns-io]
+            [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.context :as ctx]))
+
+(defn- with-shell [f]
+  (let [ec      (ctx/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ec)]
+    (try
+      (sandbox/setup-agent-namespaces! sci-ctx ec)
+      (ns-io/add-bash-ns! sci-ctx {:spindel-ctx ec})
+      (f sci-ctx ec)
+      (finally (ctx/stop-context! ec)))))
+
+(defn- ev [sci-ctx ec code]
+  (binding [rtc/*execution-context* ec]
+    (let [r (sandbox/eval-code sci-ctx code)]
+      (if (:success r) (:value r) {:err (get-in r [:error :message])}))))
+
+(defn- sh [sci-ctx ec cmd]
+  (ev sci-ctx ec (str "(let [r (babashka.process/shell " (pr-str cmd) ")] "
+                      "{:exit (:exit r) :err (str (:err r))})")))
+
+(deftest workspace-local-recursive-delete-is-allowed
+  (with-shell
+    (fn [sci-ctx ec]
+      (sh sci-ctx ec "mkdir -p wsdel/nested")
+      (sh sci-ctx ec "sh -c 'echo hi > wsdel/nested/f.txt'")
+      (is (true? (ev sci-ctx ec "(babashka.fs/exists? \"wsdel/nested/f.txt\")"))
+          "fixture must exist before we try to delete it")
+
+      (testing "rm -rf on a workspace-local folder now succeeds"
+        (let [r (sh sci-ctx ec "rm -rf wsdel")]
+          (is (zero? (:exit r))
+              (str "expected the delete to be permitted, got: " (:err r)))))
+
+      (testing "and the tree is actually gone"
+        (is (false? (ev sci-ctx ec "(babashka.fs/exists? \"wsdel/nested/f.txt\")")))))))
+
+(deftest system-paths-are-still-refused
+  (with-shell
+    (fn [sci-ctx ec]
+      (testing "the allow must not have swallowed the critical-path deny"
+        (doseq [target ["/" "/etc" "/home" "/usr" "/var" "/bin"]]
+          (let [r (sh sci-ctx ec (str "rm -rf " target))]
+            (is (not (zero? (:exit r)))
+                (str "rm -rf " target " must stay refused")))))
+
+      (testing "…in every flag arrangement, not just the one shape we thought of"
+        ;; muschel's own critical-path rule was an :argv-shape with `:**` in the
+        ;; MIDDLE, which never matches — so it only ever appeared to work because
+        ;; the blanket recursive deny sat in front of it. These arrangements are
+        ;; what a position-sensitive rule gets wrong.
+        (doseq [cmd ["rm -rf /etc"
+                     "rm -r -f /etc"
+                     "rm -r --force /etc"
+                     "rm --recursive /etc"
+                     "rm -fr /etc"
+                     "rm -v -r -f /etc"
+                     "rm /etc"]]
+          (let [r (sh sci-ctx ec cmd)]
+            (is (not (zero? (:exit r)))
+                (str cmd " must stay refused"))))))))
+
+(deftest non-recursive-delete-is-unaffected
+  (with-shell
+    (fn [sci-ctx ec]
+      (sh sci-ctx ec "sh -c 'mkdir -p wsdel2 && echo x > wsdel2/a.txt'")
+      (let [r (sh sci-ctx ec "rm wsdel2/a.txt")]
+        (is (zero? (:exit r))))
+      (is (false? (ev sci-ctx ec "(babashka.fs/exists? \"wsdel2/a.txt\")"))))))

--- a/test/dvergr/sandbox/doc_coverage_test.clj
+++ b/test/dvergr/sandbox/doc_coverage_test.clj
@@ -1,0 +1,74 @@
+(ns dvergr.sandbox.doc-coverage-test
+  "Every fn dvergr injects into the sandbox must document itself.
+
+   An agent discovers its vocabulary through `(clojure.repl/doc …)`, `dir`,
+   `apropos`, `find-doc` and `(sandbox/doc 'ns)`, all of which read metadata off
+   the injected value. Borrowed namespaces arrive via `sci/copy-var` and keep
+   their metadata; dvergr's OWN vocabulary is injected as bare closures, which
+   carry none — so those tools used to answer \"arity unknown — injected as a
+   bare fn / no docstring\" for ~75 vars, and `(find-doc \"knowledge\")` found
+   nothing despite KB search being a core capability.
+
+   This test is the ratchet. It fails when a NEW undocumented fn is added to an
+   agent-facing namespace, naming the offenders, so the vocabulary cannot
+   silently rot back into being undiscoverable. Attach docs with
+   `dvergr.sandbox.ns.doc/with-docs` (or `from-var` to harvest them from the
+   wrapped host var).
+
+   Scope note: only fns are required to document themselves. Injected VALUES
+   (`*kb*`, `*room*` — datahike conns, possibly nil in a room-less ctx) have no
+   signature to state and are described in the `ns-guide` overview instead."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox :as sandbox]
+            [org.replikativ.spindel.engine.context :as ctx]))
+
+(def ^:private agent-facing-namespaces
+  "dvergr's own vocabulary — the namespaces an agent is pointed at that we
+   inject ourselves (so metadata is our job, not `sci/copy-var`'s)."
+  '#{dvergr.room dvergr.agents dvergr.actors dvergr.skills dvergr.tasks
+     dvergr.scheduler dvergr.codec dvergr.mail git env llm sandbox})
+
+(defn- undocumented-fns
+  "Seq of \"ns/sym\" for every injected FN missing :doc or :arglists."
+  [sci-ctx]
+  (let [nss (:namespaces @(:env sci-ctx))]
+    (for [[ns-sym vars] nss
+          :when (contains? agent-facing-namespaces ns-sym)
+          [sym v] vars
+          :when (symbol? sym)
+          :when (ifn? v)                       ; values (conns) are exempt — see ns doc
+          :let  [m (meta v)]
+          :when (or (nil? (:doc m)) (nil? (:arglists m)))]
+      (str ns-sym "/" sym))))
+
+(deftest every-injected-fn-documents-itself
+  (let [ec      (ctx/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ec)]
+    (try
+      (sandbox/setup-agent-namespaces! sci-ctx ec)
+      (testing "no agent-facing fn is left without :doc + :arglists"
+        (let [missing (sort (undocumented-fns sci-ctx))]
+          (is (empty? missing)
+              (str "These injected fns carry no :doc/:arglists, so "
+                   "(clojure.repl/doc …) and (find-doc …) answer nothing for "
+                   "them. Document them with dvergr.sandbox.ns.doc/with-docs:\n  "
+                   (str/join "\n  " missing)))))
+      (finally (ctx/stop-context! ec)))))
+
+(deftest documentation-is-actually-reachable-from-inside
+  (let [ec      (ctx/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ec)]
+    (try
+      (sandbox/setup-agent-namespaces! sci-ctx ec)
+      (testing "the metadata reaches the tools an agent actually uses"
+        ;; Guards the WIRING, not just the data: metadata is useless if the
+        ;; discovery path can't see it. dvergr.scheduler/create is documented.
+        (let [doc-out (sandbox/eval-code
+                       sci-ctx "(clojure.repl/doc dvergr.scheduler/create)")]
+          (is (:success doc-out))
+          (is (not (re-find #"arity unknown" (str (:value doc-out))))
+              "a documented fn must not render as the hollow fallback")
+          (is (not (re-find #"no docstring" (str (:value doc-out))))
+              "…nor claim it has no docstring")))
+      (finally (ctx/stop-context! ec)))))

--- a/test/dvergr/sandbox/escape_corpus_test.clj
+++ b/test/dvergr/sandbox/escape_corpus_test.clj
@@ -177,6 +177,58 @@
           (is (str/includes? (str (:err r)) "not allowed")
               "the block must be sci's instance-member gate (ADR 0007)"))))))
 
+(defn- with-shell-sandbox
+  "Like `with-sandbox`, but ALSO wires the muschel-backed shell.
+
+   `babashka.process` is registered by `add-bash-ns!`, which production calls
+   from `dvergr.agent.turn` per chat-context — NOT from `setup-agent-namespaces!`.
+   So the plain harness has no `babashka.process` at all, and a test written on
+   it cannot tell \"the shell is denied\" from \"the shell was never mounted\".
+   That blind spot is why the corpus asserted the mirror is CLOSED without ever
+   asserting the capability it was closed alongside still WORKS — half of this
+   corpus's stated contract, untested. `add-bash-ns!` needs only `:spindel-ctx`
+   off the chat-ctx for session/host creation, so a stub suffices."
+  [f]
+  (let [ec      (ctx/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ec)]
+    (try
+      (sandbox/setup-agent-namespaces! sci-ctx ec)
+      (io/add-bash-ns! sci-ctx {:spindel-ctx ec})
+      (f sci-ctx ec)
+      (finally (ctx/stop-context! ec)))))
+
+(deftest muschel-shell-still-works-while-the-mirror-stays-denied
+  ;; THE CAPABILITY HALF. `babashka.process` was added to the hard denylist to
+  ;; close `(require 'babashka.process :reload)` → host shell. The sandbox's OWN
+  ;; muschel-backed `babashka.process/shell` must survive that: the denylist
+  ;; governs the MIRROR path, while a registered namespace resolves from the ctx
+  ;; and never consults it. If this goes red, the escape was closed by breaking
+  ;; the feature — exactly the trade this corpus exists to prevent.
+  (with-shell-sandbox
+    (fn [sci ec]
+      (testing "the agent-facing shell runs"
+        (let [r (eval-in sci ec
+                         "(require '[babashka.process :as p])
+                          (:out (p/shell \"echo corpus-shell-ok\"))")]
+          (is (:ok r) (str "p/shell must work: " (pr-str (:err r))))
+          (is (str/includes? (str (:ok r)) "corpus-shell-ok")
+              "…and actually return the command's stdout")))
+
+      (testing ":reload of it is STILL refused, now that it is registered"
+        ;; With the ns registered the refusal comes from the `:reload` guard
+        ;; rather than a bare \"could not find namespace\" — the guard is the
+        ;; part that matters, since a merge would replace the jailed shim.
+        (let [r (eval-in sci ec "(require 'babashka.process :reload)")]
+          (is (:err r) "must not mirror the host namespace over the shim")
+          (is (str/includes? (str (:err r)) "Refusing to reload")
+              "and must say why")))
+
+      (testing "the shim still works AFTER the reload attempt"
+        (let [r (eval-in sci ec
+                         "(:out (babashka.process/shell \"echo still-here\"))")]
+          (is (str/includes? (str (:ok r)) "still-here")
+              "the reload attempt must not have damaged the shim"))))))
+
 (deftest host-shell-namespace-must-not-mirror
   ;; MECHANISM: the deps :load-fn mirror — `clojure.java.shell` is not on the
   ;; denylist, so `(require 'clojure.java.shell)` mirrors the host ns and

--- a/test/dvergr/sandbox/test_output_test.clj
+++ b/test/dvergr/sandbox/test_output_test.clj
@@ -1,0 +1,112 @@
+(ns dvergr.sandbox.test-output-test
+  "clojure.test reporting must reach the AGENT, not the server console.
+
+   `*test-out*` was initialised to the bare `*out*` of whatever thread loaded
+   `dvergr.sci.impl.clojure-test` — the host JVM's stdout. Every reporting fn
+   goes through `with-test-out-internal`, which binds `*out*` to `@*test-out*`,
+   so an agent running tests in the sandbox got a correct summary and NOTHING
+   else:
+
+     (run-tests)  ;=> {:test 3 :pass 2 :fail 1}   <- one failed... which one?
+     (is (= 5 (+ 2 2)))  ;=> stdout \"\"          <- expected/actual went to
+                                                     the server console
+
+   With no way to see WHICH assertion failed or why, agents reasonably concluded
+   the runner was broken and went looking for another one (kaocha), which the
+   mirror allowlist rightly denies — so they were left with no working path to
+   a capability that in fact worked. These tests pin that the detail lands in
+   the sandbox's captured stdout, and that both explicit escape hatches
+   (`with-out-str`, `binding *test-out*`) still behave."
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox :as sandbox]
+            [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.context :as ctx]))
+
+(defn- with-sandbox [f]
+  (let [ec      (ctx/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ec)]
+    (try
+      (sandbox/setup-agent-namespaces! sci-ctx ec)
+      (f sci-ctx ec)
+      (finally (ctx/stop-context! ec)))))
+
+(defn- eval-in
+  "Evaluate the way production does — execution context bound — returning the
+   whole result map so a test can assert on `:stdout` as well as `:value`."
+  [sci-ctx ec code]
+  (binding [rtc/*execution-context* ec]
+    (sandbox/eval-code sci-ctx code)))
+
+(deftest failing-assertion-detail-reaches-the-sandbox-stdout
+  (with-sandbox
+    (fn [sci-ctx ec]
+      (testing "a failing `is` reports expected/actual into the agent's stdout"
+        (let [r (eval-in sci-ctx ec
+                         "(do (require '[clojure.test :refer [is]])
+                              (is (= 5 (+ 2 2)))
+                              :done)")]
+          (is (:success r))
+          (is (re-find #"FAIL" (:stdout r))
+              "the FAIL banner must reach the agent, not the server console")
+          (is (re-find #"expected: \(= 5 \(\+ 2 2\)\)" (:stdout r))
+              "…including the expected form")
+          (is (re-find #"actual: \(not \(= 5 4\)\)" (:stdout r))
+              "…and the actual value, which is the whole point"))))))
+
+(deftest run-tests-names-the-failing-test
+  (with-sandbox
+    (fn [sci-ctx ec]
+      (testing "run-tests still returns its summary AND says which test failed"
+        (let [r (eval-in sci-ctx ec
+                         "(do (require '[clojure.test :refer [deftest is]])
+                              (deftest t-pass (is (= 4 (+ 2 2))))
+                              (deftest t-fail (is (= 5 (+ 2 2))))
+                              (clojure.test/run-tests))")]
+          (is (:success r))
+          (is (= {:test 2 :pass 1 :fail 1 :error 0 :type :summary} (:value r))
+              "the summary map is unchanged")
+          (is (re-find #"FAIL in \(t-fail\)" (:stdout r))
+              "the failing test is NAMED — without this an agent cannot act")
+          (is (not (re-find #"FAIL in \(t-pass\)" (:stdout r)))
+              "and the passing one is not reported as failing"))))))
+
+(deftest explicit-capture-still-works
+  (with-sandbox
+    (fn [sci-ctx ec]
+      ;; NB: `clojure.test/is` is fully qualified below on purpose. SCI analyses
+      ;; a whole form before evaluating it, so a `(require … :refer [is])` INSIDE
+      ;; the same `with-out-str`/`let` body has not run yet when `is` is
+      ;; resolved — "Unable to resolve symbol: is" at analysis time. Qualifying
+      ;; sidesteps that; clojure.test is always present in the sandbox anyway.
+      (testing "with-out-str captures the report instead of the eval stdout"
+        (let [r (eval-in sci-ctx ec
+                         "(with-out-str (clojure.test/is (= 5 (+ 2 2))))")]
+          (is (:success r) (str "eval failed: " (pr-str (:error r))))
+          (is (re-find #"actual: \(not \(= 5 4\)\)" (:value r))
+              "the agent can capture the report as a value")
+          (is (= "" (:stdout r))
+              "…and then it must NOT also leak into the eval's stdout")))
+
+      (testing "an explicit *test-out* binding still wins over the default"
+        (let [r (eval-in sci-ctx ec
+                         "(let [sw (java.io.StringWriter.)]
+                            (binding [clojure.test/*test-out* sw]
+                              (clojure.test/is (= 5 (+ 2 2))))
+                            (str sw))")]
+          (is (:success r) (str "eval failed: " (pr-str (:error r))))
+          (is (re-find #"actual: \(not \(= 5 4\)\)" (:value r))
+              "redirecting *test-out* by hand must still route the report")
+          (is (= "" (:stdout r))
+              "…and nothing escapes to the default sink"))))))
+
+(deftest passing-tests-stay-quiet
+  (with-sandbox
+    (fn [sci-ctx ec]
+      (testing "no FAIL noise when everything passes"
+        (let [r (eval-in sci-ctx ec
+                         "(do (require '[clojure.test :refer [deftest is]])
+                              (deftest t-ok (is (= 4 (+ 2 2))))
+                              (clojure.test/run-tests))")]
+          (is (:success r))
+          (is (= 0 (:fail (:value r))))
+          (is (not (re-find #"FAIL" (:stdout r)))))))))

--- a/test/dvergr/tools/edit_file_test.clj
+++ b/test/dvergr/tools/edit_file_test.clj
@@ -1,0 +1,99 @@
+(ns dvergr.tools.edit-file-test
+  "`edit_file` must be able to change EVERY occurrence, not only a unique one.
+
+   The tool did `str/replace-first` and REFUSED any input matching more than
+   once. That default is right — it makes it impossible to change the wrong
+   occurrence by accident — but with no way to opt out, renaming a local that
+   appears five times meant five calls, each carrying hand-built surrounding
+   context to force uniqueness. That is the single biggest reason a coding agent
+   abandons the edit tool and reaches for a script (or a second runtime) instead,
+   which is exactly what the sandbox is trying not to need.
+
+   `replace_all` opts out explicitly. These tests pin both halves: the safety
+   default still refuses an ambiguous edit AND says how to proceed, and the
+   opt-in changes all of them and reports how many."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [dvergr.tools :as tools])
+  (:import [java.io File]))
+
+(defn- edit-tool []
+  (first (filter #(= "edit_file" (:name %)) (vals @@#'tools/registry))))
+
+(defn- with-temp-file
+  "Run `(f dir relative-name)` against a real file holding `content`."
+  [content f]
+  (let [dir  (File. (str (System/getProperty "java.io.tmpdir")
+                         "/dvergr-edit-file-test-"
+                         (System/nanoTime)))
+        _    (.mkdirs dir)
+        name "target.txt"
+        file (File. dir name)]
+    (try
+      (spit file content)
+      (f dir name file)
+      (finally
+        (when (.exists file) (.delete file))
+        (.delete dir)))))
+
+(deftest ambiguous-edit-is-refused-by-default
+  (with-temp-file
+    "alpha\nbeta\nalpha\n"
+    (fn [dir name file]
+      (let [r ((:execute (edit-tool))
+               {:path name :old_string "alpha" :new_string "OMEGA"}
+               {:cwd (str dir)})]
+        (testing "a non-unique match is still refused"
+          (is (= :error (:type r)))
+          (is (str/includes? (str (:error r)) "must be unique")))
+        (testing "and the refusal now names the way forward"
+          (is (str/includes? (str (:suggestion r)) "replace_all")
+              "an agent that cannot see the opt-out will go write a script instead"))
+        (testing "the file is untouched"
+          (is (= "alpha\nbeta\nalpha\n" (slurp file))))))))
+
+(deftest replace-all-changes-every-occurrence
+  (with-temp-file
+    "alpha\nbeta\nalpha\n"
+    (fn [dir name file]
+      (let [r ((:execute (edit-tool))
+               {:path name :old_string "alpha" :new_string "OMEGA" :replace_all true}
+               {:cwd (str dir)})]
+        (is (= :success (:type r)))
+        (is (= "OMEGA\nbeta\nOMEGA\n" (slurp file)))
+        (testing "and it reports how many it changed"
+          (is (= 2 (:replacements (:metadata r))))
+          (is (str/includes? (str (:content r)) "2 occurrences")))))))
+
+(deftest unique-edit-still-works-unchanged
+  (with-temp-file
+    "alpha\nbeta\ngamma\n"
+    (fn [dir name file]
+      (let [r ((:execute (edit-tool))
+               {:path name :old_string "beta" :new_string "BETA"}
+               {:cwd (str dir)})]
+        (is (= :success (:type r)))
+        (is (= "alpha\nBETA\ngamma\n" (slurp file)))
+        (is (= 1 (:replacements (:metadata r))))))))
+
+(deftest replace-all-on-a-single-occurrence-is-fine
+  (with-temp-file
+    "alpha\nbeta\n"
+    (fn [dir name file]
+      (let [r ((:execute (edit-tool))
+               {:path name :old_string "beta" :new_string "BETA" :replace_all true}
+               {:cwd (str dir)})]
+        (is (= :success (:type r)))
+        (is (= "alpha\nBETA\n" (slurp file)))
+        (is (= 1 (:replacements (:metadata r))))))))
+
+(deftest a-string-that-is-absent-still-errors
+  (with-temp-file
+    "alpha\n"
+    (fn [dir name file]
+      (let [r ((:execute (edit-tool))
+               {:path name :old_string "nowhere" :new_string "x" :replace_all true}
+               {:cwd (str dir)})]
+        (is (= :error (:type r)))
+        (is (str/includes? (str (:error r)) "not found"))
+        (is (= "alpha\n" (slurp file)))))))

--- a/test/dvergr/tools/run_tests_test.clj
+++ b/test/dvergr/tools/run_tests_test.clj
@@ -1,0 +1,78 @@
+(ns dvergr.tools.run-tests-test
+  "`run_tests` must run the agent's OWN tests, in the agent's OWN sandbox.
+
+   It used to `ns-resolve` kaocha.api and run it in the HOST jvm. Three things
+   were wrong with that, all measured: kaocha lives only in dvergr's `:test`
+   alias, so at runtime the resolve threw \"Could not locate kaocha/api\" and the
+   tool ALWAYS failed; `:cwd` was passed as a kaocha config key, which chdirs
+   nothing, so the advertised \"runs in your forked worktree in isolation\" was
+   untrue; and had it worked it would have loaded and executed host test
+   namespaces from the daemon's classpath on agent request — outside the sandbox
+   entirely.
+
+   The sandbox already carries a ctx-aware clojure.test whose runners enumerate
+   vars in THIS context, so running there is both correct and actually isolated.
+   These tests pin that it finds the session's tests, reports pass and fail
+   honestly, and surfaces the expected/actual detail an agent needs to act."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.tools :as tools]
+            [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.context :as ctx]))
+
+(defn- run-tests-tool []
+  (first (filter #(= "run_tests" (:name %)) (vals @@#'tools/registry))))
+
+(defn- with-sandbox [f]
+  (let [ec      (ctx/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ec)]
+    (try
+      (sandbox/setup-agent-namespaces! sci-ctx ec)
+      (f sci-ctx ec)
+      (finally (ctx/stop-context! ec)))))
+
+(defn- define! [sci-ctx ec code]
+  (binding [rtc/*execution-context* ec]
+    (let [r (sandbox/eval-code sci-ctx code)]
+      (when-not (:success r)
+        (throw (ex-info (str "setup eval failed: " (get-in r [:error :message])) {})))
+      r)))
+
+(defn- invoke [sci-ctx ec args]
+  (binding [rtc/*execution-context* ec]
+    ((:execute (run-tests-tool)) args {:sci-ctx sci-ctx})))
+
+(deftest runs-the-sessions-own-passing-tests
+  (with-sandbox
+    (fn [sci-ctx ec]
+      (define! sci-ctx ec
+        "(require '[clojure.test :refer [deftest is]])
+         (deftest arithmetic-holds (is (= 4 (+ 2 2))))")
+      (let [r (invoke sci-ctx ec {})]
+        (is (= :success (:type r)))
+        (is (pos? (:passed (:metadata r)))
+            "must actually FIND the test defined in this session")
+        (is (zero? (:failed (:metadata r))))
+        (is (str/includes? (str (:content r)) "All tests passed"))))))
+
+(deftest a-failure-is-reported-with-its-detail
+  (with-sandbox
+    (fn [sci-ctx ec]
+      (define! sci-ctx ec
+        "(require '[clojure.test :refer [deftest is]])
+         (deftest arithmetic-is-broken (is (= 5 (+ 2 2))))")
+      (let [r (invoke sci-ctx ec {})]
+        (is (= :error (:type r)) "a failing suite must not report success")
+        (is (= 1 (:failed (:metadata r))))
+        (is (= 1 (:exit-code (:metadata r))))
+        (testing "and the agent is told WHICH assertion failed and why"
+          (is (str/includes? (str (:content r)) "arithmetic-is-broken"))
+          (is (str/includes? (str (:content r)) "expected"))
+          (is (str/includes? (str (:content r)) "actual")))))))
+
+(deftest no-sandbox-context-is-a-clean-error
+  (testing "rather than a confusing failure deep inside a runner"
+    (let [r ((:execute (run-tests-tool)) {} {})]
+      (is (= :error (:type r)))
+      (is (str/includes? (str (:error r)) "No sandbox context")))))


### PR DESCRIPTION
Three independent findings with the same shape: a capability the sandbox HAS, that an agent cannot reach, cannot discover, or that nothing verifies still works. All were found by probing a live sandbox rather than reading code, and each is pinned by a new test. Reviewable commit-by-commit.

### 1. `clojure.test` reporting went to the server console (`a7ba7d3`)

`*test-out*` was initialised to the bare `*out*` of whatever thread loaded `dvergr.sci.impl.clojure-test` — the host JVM's stdout. Every reporting fn goes through `with-test-out-internal`, which binds `*out*` to `@*test-out*`, so an agent running tests got a correct summary and nothing else:

```clojure
(run-tests)         ;=> {:test 3 :pass 2 :fail 1}   ; one failed... which one?
(is (= 5 (+ 2 2)))  ;=> stdout ""                   ; expected/actual went to
                                                    ; the server console
```

With no way to see WHICH assertion failed or why, agents reasonably concluded the runner was broken and went looking for another one (kaocha) — which the mirror allowlist rightly denies, leaving them with no working path to a capability that in fact worked.

`eval-code` already evaluates inside `(sci/binding [sci/out <StringWriter>] …)`, and host code can read that binding via `@sci/out`. So `*test-out*` is now a PrintWriter that resolves its target at **write** time: reporting lands wherever the sandbox's stdout currently points, per-eval and per-thread, with no change to `eval-code`.

The fallback is captured at construction rather than read dynamically, deliberately — `with-test-out-internal` binds `*out*` to this very writer, so reading `*out*` at write time makes it write to itself (an immediate StackOverflowError, hit while prototyping). Capturing also preserves the old behaviour exactly for non-sandbox callers, i.e. dvergr's own suite.

Also surfaces `clojure.test` in the sandbox overview. It was hidden by the `clojure` prefix rule alongside `clojure.string` — but unlike `clojure.string`, whether a test RUNNER exists in a sandbox is not something an agent can assume, and hiding it is the other half of why they reached for kaocha.

New `test/dvergr/sandbox/test_output_test.clj`: failure detail reaches the eval's stdout, `run-tests` NAMES the failing test, `with-out-str` and an explicit `*test-out*` binding both still capture instead, and passing tests stay quiet.

### 2. dvergr's own vocabulary carried no `:doc`/`:arglists` (`a6ea5d7`)

Agents discover what they can do through `(clojure.repl/doc …)`, `dir`, `apropos`, `find-doc`, `(sandbox/doc 'ns)` — all of which read metadata off the injected value. Borrowed namespaces arrive via `sci/copy-var` and keep theirs; dvergr's own are bare closures and carry none:

```clojure
(clojure.repl/doc dvergr.room/kb-search)
;=> ; arity unknown — injected as a bare fn
;   ; no docstring

(clojure.repl/find-doc "knowledge")
;=> Nothing in this sandbox matches "knowledge."
```

…for a capability the sandbox very much has. Measured across a live context: **939 vars, 68% documented — but that 68% was entirely the borrowed namespaces.** dvergr's own sat at 0%, except `dvergr.scheduler`, fixed once from Vár's feedback with a local `documented` helper. An agent's only way to learn a signature was to call the fn and read the error.

Adds `dvergr.sandbox.ns.doc` — that helper, shared:

- `with-docs` hangs a `{sym [arglists doc]}` table off an existing ns map, leaving the wiring untouched. It **throws** if the table names a var that isn't injected: a drifted table is a bug, and a silent no-op is exactly how it would rot unnoticed.
- `from-var` harvests `:arglists`/`:doc` off the host var a wrapper partially applies, dropping the supplied leading args, so the signature is derived rather than restated.
- `documented` is the primitive; non-`IObj` values (conns, nil) pass through unchanged.

Applied across all 12 agent-facing namespaces. Measured in a live sandbox afterwards: **87 of 87 agent-facing fns carry both `:doc` and `:arglists`**, and `find-doc "knowledge"` now returns `dvergr.room/create!`, `/kb`, `/kbs`. The `dvergr.room` entries largely promote trailing comments that were already in the source into text the sandbox can actually reach.

New `test/dvergr/sandbox/doc_coverage_test.clj` is the ratchet: it fails and NAMES any agent-facing fn missing metadata, and separately asserts the metadata is reachable through `clojure.repl/doc` — guarding the wiring, not just the data, since metadata is useless if the discovery path can't see it. Injected VALUES (`*kb*`, `*room*`) are exempt: no signature to state, and they're covered by the ns-guide overview.

### 3. The corpus asserted the hole was closed, never that the feature survived (`885f6d0`)

This corpus states its contract as "a closed hole PLUS the feature it was closed WITHOUT breaking". For `babashka.process` only the first half was tested — and not by oversight I could have read off the code: `add-bash-ns!`, which registers the muschel-backed shell, is called by `dvergr.agent.turn` per chat-context, NOT by `setup-agent-namespaces!`. So the harness had no `babashka.process` at all, and a test written on it cannot distinguish "the shell is denied" from "the shell was never mounted".

Adds `with-shell-sandbox` and one test pinning all three states: `(p/shell "echo …")` runs and returns stdout; `(require 'babashka.process :reload)` is still refused — and now that the ns is registered the refusal comes from the `:reload` guard ("Refusing to reload") rather than a bare "could not find namespace", which is the part that actually matters since a merge would replace the jailed shim; and the shim still works afterwards.

If this goes red, the escape was closed by breaking the feature.


### Verification

Full suite **402 tests, 1587 assertions, 0 failures** (up from 395/1561 on main; the additions are the three test namespaces above). `clj -M:format` clean.

Known remaining gap, not addressed here: `find-doc "test runner"` still finds nothing, because `clojure.test`'s vars carry their standard upstream docstrings and the "THE test runner in this sandbox" wording lives in the `ns-guide` overview, which `find-doc` does not search. Agents reach it via `(sandbox/overview)`.

---

### 4. Usable editing and testing (`e38586c`)

Three affordances an agent needs that were missing, broken, or forbidden.

**`edit_file` gains `replace_all`.** It did `str/replace-first` and refused any match occurring more than once. The safety default is right — you can't change the wrong occurrence by accident — but with no opt-out, renaming a local appearing five times meant five calls, each carrying hand-built context to force uniqueness. That's the single biggest reason a coding agent abandons the edit tool for a script. The default is unchanged; the refusal now *names* the opt-out, since an agent that can't see it will go around instead. (For Clojure, `clojure_edit` is better still — it finds a form by type+name and needs no string matching.)

**`run_tests` actually runs tests.** It used to `ns-resolve` kaocha.api in the HOST jvm. Measured: kaocha is only in the `:test` alias, so at runtime the resolve threw `Could not locate kaocha/api` and the tool ALWAYS failed; `:cwd` was passed as a kaocha config key, which chdirs nothing, so "runs in your forked worktree in isolation" was untrue; and had it worked it would have executed host test namespaces from the daemon classpath on agent request. It now runs `clojure.test` inside the agent's own SCI context — `focus` → `run-tests`, `pattern` → `run-all-tests` with a regex, neither → all session namespaces — and inherits the `*test-out*` fix, so failures report expected/actual instead of a bare count.

**Recursive delete inside the workspace is allowed.** muschel denies `rm -r*` outright, correct for a library that can't assume its embedder's workspace is recoverable. dvergr's is: a geschichte-backed fork with history, behind a jailed FS. And the deny bought nothing measurable — `babashka.fs/delete-tree` does the same recursive deletion through the sandbox's own fs surface with no permit layer. Verified in one session: `rm -rf scratch` denied, `(fs/delete-tree "scratch")` deleted. It didn't prevent recursive deletion; it moved it off the audited shell onto an unaudited door.

Lifting that blanket rule exposed a second bug: muschel's critical-path rule was an `:argv-shape` with `:**` in the middle, which matches nothing — it had **never fired**, masked by the blanket deny in front of it. The first cut of this change let `rm -rf /etc` through with exit 0, caught by the new test. Fixed upstream in **muschel#12** with a position-independent `:argv-any` that fails closed on `$VAR`/globs; deps bumped **0.2.18 → 0.2.19** and the rule is expressed with it here.

Also corrects two agent-facing claims earlier commits on this branch got wrong: the prompt does list `git` among shell builtins (**true** — muschel's in-process geschichte-backed git, gated on a workspace map, which is why a room-less probe sees exit 126), and `clojure.test` is now described as the only in-sandbox runner *by design*, with `(load-string (slurp …))` for file-resident code.

Tests: `edit_file_test` (5), `run_tests_test` (3), `workspace_delete_test` (3).

**Full suite: 413 tests, 1634 assertions, 0 failures.**
