### PR TITLE
chore(deps): follow the Geschichte adapter into Yggdrasil

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -61,9 +61,10 @@
         org.replikativ/muschel     {:mvn/version "0.2.19"}
 
         ;; Geschichte — authoritative virtual filesystem + Git compatibility.
-        ;; Released coordinate — 0.1.10 carries code-search (#6) + the native-release
-        ;; CI fix (#5); no local root needed.
-        org.replikativ/geschichte  {:mvn/version "0.1.10"}
+        ;; 0.1.12 is the release where the Yggdrasil adapter MOVED OUT (#8), so
+        ;; there is exactly one GeschichteSystem record on the classpath — the
+        ;; one in yggdrasil.adapters.geschichte. No local root needed.
+        org.replikativ/geschichte  {:mvn/version "0.1.12"}
 
         ;; rewrite-clj for structural editing
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
@@ -72,8 +73,11 @@
         org.replikativ/datahike    {:mvn/version "0.8.1744"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
-        ;; 0.2.27 carries composite Mergeable diff + conflicts (PR #3).
-        org.replikativ/yggdrasil   {:mvn/version "0.3.36"}
+        ;; 0.3.38 adopts the Geschichte adapter (yggdrasil.adapters.geschichte,
+        ;; PR #16) and gives it the p/Mergeable it never had, so a room repo can
+        ;; finally produce a FILE diff instead of a datom count over
+        ;; Geschichte's internal schema.
+        org.replikativ/yggdrasil   {:mvn/version "0.3.38"}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
         org.replikativ/scriptum    {:mvn/version "0.1.27"}

--- a/src/dvergr/substrate/geschichte.clj
+++ b/src/dvergr/substrate/geschichte.clj
@@ -14,11 +14,11 @@
             [geschichte.git.http :as git-http]
             [geschichte.git.local :as git-local]
             [geschichte.repo :as repo]
-            [geschichte.yggdrasil :as gy]
             [muschel.fs.geschichte :as mgeschichte]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [taoensso.telemere :as tel]
+            [yggdrasil.adapters.geschichte :as gy]
             [yggdrasil.protocols :as p]))
 
 (def sandbox-repo-url

--- a/test/dvergr/substrate/geschichte_test.clj
+++ b/test/dvergr/substrate/geschichte_test.clj
@@ -5,8 +5,8 @@
             [datahike.api :as d]
             [dvergr.substrate.geschichte :as g]
             [geschichte.repo :as repo]
-            [geschichte.yggdrasil :as gy]
-            [muschel.fs :as fs]))
+            [muschel.fs :as fs]
+            [yggdrasil.adapters.geschichte :as gy]))
 
 (defn- temp-dir [prefix]
   (.toFile (java.nio.file.Files/createTempDirectory


### PR DESCRIPTION
Follow-up to [replikativ/yggdrasil#16](https://github.com/replikativ/yggdrasil/pull/16) (released **0.3.38**) and [replikativ/geschichte#8](https://github.com/replikativ/geschichte/pull/8) (released **0.1.12**).

The geschichte↔yggdrasil adapter used to live in geschichte, pointing the dependency edge backwards. It now sits with the other backends as `yggdrasil.adapters.geschichte`.

## Changes

- `yggdrasil` `0.3.36` → `0.3.38`
- `geschichte` `0.1.10` → `0.1.12`
- two requires repointed: `src/dvergr/substrate/geschichte.clj`, `test/dvergr/substrate/geschichte_test.clj`

Everything else goes through the `gy/` alias, so **no call sites move**.

## Why the geschichte bump is not optional

0.1.10 still ships its own `geschichte.yggdrasil`. Pairing it with yggdrasil 0.3.38 would put **two `GeschichteSystem` record types on the classpath** — a protocol-dispatch hazard. Verified the 0.1.12 jar contains zero `yggdrasil` entries.

## What 0.3.38 adds

The adapter gained `p/Mergeable` (`diff` / `conflicts` / `merge!`), which a Geschichte-backed system never had — it implemented `SystemIdentity`/`Snapshotable`/`Branchable`/`Graphable` only, so a room repo had **no `diff` at all** and its `capabilities` advertised `mergeable false`. No consumer in this repo uses it yet; it unblocks reviewable code forks downstream in simmis.

`hasch 0.4.101` and `konserve 0.9.363` were already pinned at or above what 0.3.38 needs, so nothing else moves.

## Verification

Full suite: **413 tests / 1634 assertions, 0 failures**. `clj -M:format` clean.