### PR TITLE
feat(models): register OpenAI models so an OPENAI_API_KEY can run a turn

### DIFF
--- a/doc/provider-setup.md
+++ b/doc/provider-setup.md
@@ -155,11 +155,14 @@ model `:codex-subscription-cli` / `"codex-subscription-cli"`.
 | Fireworks account | `FIREWORKS_API_KEY` | `:fireworks` / `"accounts/fireworks/models/minimax-m2p7"` |
 | OpenAI API account | `OPENAI_API_KEY`, plus an OpenAI registry entry | `:openai` / the registered model id |
 
-The built-in registry currently carries Anthropic, Claude Code, Codex
-subscription, and Fireworks models. Public OpenAI API models can be loaded with
-`(registry/refresh-from-models-dev! #{:openai})` or declared in
-`resources/models.edn`; the API key alone registers the transport but does not
-invent model metadata.
+The built-in registry carries Anthropic, Claude Code, Codex subscription, five
+native OpenAI Chat models, and the curated Fireworks registry in
+`resources/models.edn`. `OPENAI_API_KEY` can therefore run one of the built-in
+OpenAI models immediately. `(registry/refresh-from-models-dev! #{:openai})` is
+an opt-in runtime overlay: it can add current models and replace its mapped
+limits/rates in this process, but does not rewrite a resource or source file.
+Declare a model in `resources/models.edn` when it is a dvergr-maintained
+configuration rather than a live overlay.
 
 For a custom or local OpenAI-compatible endpoint, register both its credentials
 and at least one model. A credential-free local endpoint still receives an
@@ -224,7 +227,11 @@ Opus/Sonnet/Haiku plus Claude-Code and Codex-subscription models, defined in
 `model/registry.clj`).
 
 `(registry/refresh-from-models-dev! #{:anthropic …})` is an opt-in, network call
-that overlays live pricing/context from <https://models.dev>.
+that overlays live pricing/context from <https://models.dev> into process state
+only. It is not a build or release generator and does not persist a downloaded
+snapshot. Built-in OpenAI rate fields are a separately documented dated
+snapshot in `model/registry.clj`; `resources/models.edn` is a distinct curated
+registry.
 
 **Vision models** carry `:vision` in `:capabilities`. `dvergr.media.vision`
 (image describe/extract) picks the registry's vision default, overridable with

--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -310,6 +310,9 @@
 (def ^:private default-openai-base-url "https://api.openai.com/v1")
 (def ^:private default-fireworks-base-url "https://api.fireworks.ai/inference/v1")
 
+(defn- normalize-base-url [base-url]
+  (str/replace base-url #"/+$" ""))
+
 (defn- system-env [env-key]
   (System/getenv env-key))
 
@@ -328,7 +331,8 @@
                      (env-lookup "OPENAI_API_KEY"))
          custom-base-url (or (:base-url config)
                              (env-lookup "OPENAI_BASE_URL"))
-         base-url (or custom-base-url default-openai-base-url)
+         base-url (normalize-base-url
+                   (or custom-base-url default-openai-base-url))
          provider-id (or (:provider-id config) :openai)
          credentials (or (:credentials config)
                          (when api-key
@@ -343,11 +347,11 @@
           (dissoc :api-key)
           (assoc :base-url base-url
                  :provider-id provider-id
-                 ;; A supplied base URL is an OpenAI-compatible endpoint, even if
-                 ;; it happens to equal a known provider URL. Provider identity and
-                 ;; native request capabilities are configuration, not URL guesses.
+                 ;; The documented explicit canonical URL is semantically the same
+                 ;; as omitting it. Other URLs are compatible endpoints and do not
+                 ;; inherit OpenAI-specific request roles or model workarounds.
                  :native-openai? (and (= :openai provider-id)
-                                      (nil? custom-base-url))
+                                      (= default-openai-base-url base-url))
                  :credentials credentials))))))
 
 (defn create-if-available

--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -65,8 +65,11 @@
           ;; that needs both belongs on the Responses API, which this
           ;; provider does not speak. Only for models carrying the quirk:
           ;; gpt-5.5 and older take tools and reasoning together, and
-          ;; forcing "none" there would quietly make them dumber.
-          effort-none? (and (seq tools)
+          ;; forcing "none" there would quietly make them dumber. Compatible
+          ;; endpoints do not get the native workaround merely because they
+          ;; share this adapter.
+          effort-none? (and (:native-openai? config)
+                            (seq tools)
                             (registry/get-quirk (:model opts) :chat-tools-need-effort-none?))]
       {:url (str (or (:base-url config) "https://api.openai.com/v1") "/chat/completions")
        :headers (merge {"Content-Type" "application/json"}
@@ -285,6 +288,12 @@
 ;; Constructors
 ;; ============================================================================
 
+(def ^:private default-openai-base-url "https://api.openai.com/v1")
+(def ^:private default-fireworks-base-url "https://api.fireworks.ai/inference/v1")
+
+(defn- system-env [env-key]
+  (System/getenv env-key))
+
 (defn create
   "Create an OpenAI provider instance.
 
@@ -293,29 +302,44 @@
    - :base-url      - API base URL (default: https://api.openai.com/v1)
    - :provider-id   - Override provider ID (default: :openai)
    - :extra-headers - Additional HTTP headers"
-  [config]
-  (let [api-key (or (:api-key config)
-                    (System/getenv "OPENAI_API_KEY"))]
-    (when-not (or api-key (:credentials config))
-      (throw (ex-info "OpenAI API key required" {:env "OPENAI_API_KEY"})))
-    (let [base-url (or (:base-url config)
-                       (System/getenv "OPENAI_BASE_URL")
-                       "https://api.openai.com/v1")
-          credentials (or (:credentials config)
-                          (gateway/static-credentials
-                           :openai-api-key
-                           {"Authorization" (str "Bearer " api-key)}
-                           #{(gateway/request-origin base-url)}))]
-      (->OpenAIProvider (-> config
-                            (dissoc :api-key)
-                            (assoc :base-url base-url
-                                   :credentials credentials))))))
+  ([config]
+   (create config system-env))
+  ([config env-lookup]
+   (let [api-key (or (:api-key config)
+                     (env-lookup "OPENAI_API_KEY"))
+         custom-base-url (or (:base-url config)
+                             (env-lookup "OPENAI_BASE_URL"))
+         base-url (or custom-base-url default-openai-base-url)
+         provider-id (or (:provider-id config) :openai)
+         credentials (or (:credentials config)
+                         (when api-key
+                           (gateway/static-credentials
+                            :openai-api-key
+                            {"Authorization" (str "Bearer " api-key)}
+                            #{(gateway/request-origin base-url)})))]
+     (when-not credentials
+       (throw (ex-info "OpenAI API key required" {:env "OPENAI_API_KEY"})))
+     (->OpenAIProvider
+      (-> config
+          (dissoc :api-key)
+          (assoc :base-url base-url
+                 :provider-id provider-id
+                 ;; A supplied base URL is an OpenAI-compatible endpoint, even if
+                 ;; it happens to equal a known provider URL. Provider identity and
+                 ;; native request capabilities are configuration, not URL guesses.
+                 :native-openai? (and (= :openai provider-id)
+                                      (nil? custom-base-url))
+                 :credentials credentials))))))
 
 (defn create-if-available
   "Create OpenAI provider if API key is available, otherwise nil."
-  [config]
-  (when (or (:api-key config) (System/getenv "OPENAI_API_KEY"))
-    (create config)))
+  ([config]
+   (create-if-available config system-env))
+  ([config env-lookup]
+   (when (or (:credentials config)
+             (:api-key config)
+             (env-lookup "OPENAI_API_KEY"))
+     (create config env-lookup))))
 
 ;; ============================================================================
 ;; Fireworks Provider (OpenAI-compatible)
@@ -328,29 +352,37 @@
    - :api-key       - Fireworks API key (or from env)
    - :base-url      - API base URL (default: Fireworks endpoint)
    - :extra-headers - Additional HTTP headers"
-  [config]
-  (let [api-key (or (:api-key config)
-                    (System/getenv "FIREWORKS_API_KEY"))
-        base-url (or (:base-url config)
-                     (System/getenv "FIREWORKS_BASE_URL")
-                     "https://api.fireworks.ai/inference/v1")]
-    (when-not (or api-key (:credentials config))
-      (throw (ex-info "Fireworks API key required"
-                      {:env "FIREWORKS_API_KEY"})))
-    (let [credentials (or (:credentials config)
-                          (gateway/static-credentials
-                           :fireworks-api-key
-                           {"Authorization" (str "Bearer " api-key)}
-                           #{(gateway/request-origin base-url)}))]
-      (->OpenAIProvider (-> config
-                            (dissoc :api-key)
-                            (assoc :credentials credentials
-                                   :base-url base-url
-                                   :provider-id :fireworks))))))
+  ([config]
+   (create-fireworks config system-env))
+  ([config env-lookup]
+   (let [api-key (or (:api-key config)
+                     (env-lookup "FIREWORKS_API_KEY"))
+         base-url (or (:base-url config)
+                      (env-lookup "FIREWORKS_BASE_URL")
+                      default-fireworks-base-url)
+         credentials (or (:credentials config)
+                         (when api-key
+                           (gateway/static-credentials
+                            :fireworks-api-key
+                            {"Authorization" (str "Bearer " api-key)}
+                            #{(gateway/request-origin base-url)})))]
+     (when-not credentials
+       (throw (ex-info "Fireworks API key required"
+                       {:env "FIREWORKS_API_KEY"})))
+     (->OpenAIProvider
+      (-> config
+          (dissoc :api-key)
+          (assoc :credentials credentials
+                 :base-url base-url
+                 :provider-id :fireworks
+                 :native-openai? false))))))
 
 (defn create-fireworks-if-available
   "Create Fireworks provider if API key is available, otherwise nil."
-  [config]
-  (when (or (:api-key config)
-            (System/getenv "FIREWORKS_API_KEY"))
-    (create-fireworks config)))
+  ([config]
+   (create-fireworks-if-available config system-env))
+  ([config env-lookup]
+   (when (or (:credentials config)
+             (:api-key config)
+             (env-lookup "FIREWORKS_API_KEY"))
+     (create-fireworks config env-lookup))))

--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -57,7 +57,17 @@
   (api-type [_] :openai-chat)
 
   (build-request [_ messages opts]
-    (let [tools (:tools opts)]
+    (let [tools (:tools opts)
+          ;; GPT-5.6: /v1/chat/completions refuses function tools unless
+          ;; reasoning_effort is "none" — "To use function tools, use
+          ;; /v1/responses or set reasoning_effort to 'none'". Sending it
+          ;; buys tool use at the cost of server-side reasoning; a model
+          ;; that needs both belongs on the Responses API, which this
+          ;; provider does not speak. Only for models carrying the quirk:
+          ;; gpt-5.5 and older take tools and reasoning together, and
+          ;; forcing "none" there would quietly make them dumber.
+          effort-none? (and (seq tools)
+                            (registry/get-quirk (:model opts) :chat-tools-need-effort-none?))]
       {:url (str (or (:base-url config) "https://api.openai.com/v1") "/chat/completions")
        :headers (merge {"Content-Type" "application/json"}
                        (:extra-headers config))
@@ -73,7 +83,8 @@
                (:top-p opts) (assoc :top_p (:top-p opts))
                ;; Top-k if specified — a Fireworks extension param (MiniMax M2: 40)
                (:top-k opts) (assoc :top_k (:top-k opts))
-               (seq tools) (assoc :tools (p/format-tools _ tools)))}))
+               (seq tools) (assoc :tools (p/format-tools _ tools))
+               effort-none? (assoc :reasoning_effort "none"))}))
 
   (create-accumulator [_ model-def]
     {:current-blocks {}

--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -17,9 +17,10 @@
 (defn- format-message
   "Format a single message for OpenAI API.
    Preserves tool_calls on assistant messages and tool_call_id on tool messages."
-  [msg]
+  [msg instruction-role]
   (let [role (:role msg)
-        role-str (if (keyword? role) (name role) role)]
+        role-str (if (keyword? role) (name role) role)
+        role-str (if (= "system" role-str) instruction-role role-str)]
     (cond-> {:role role-str
              :content (:content msg)}
       ;; Preserve tool_calls on assistant messages
@@ -29,20 +30,32 @@
       ;; Preserve interleaved-thinking state fed back to the model
       (:reasoning_content msg) (assoc :reasoning_content (:reasoning_content msg)))))
 
-(defn- with-system
-  "Prepend a system message from the `:system` opt when one isn't already present
-   in the list. Parity with the Anthropic provider (which reads `:system` from
-   opts); OpenAI-compatible APIs take the system prompt as the first message."
-  [messages system]
+(defn- with-instructions
+  "Prepend product instructions from `:system` when the message list does not
+   already contain an instruction message. Native o1-and-newer OpenAI models use
+   `developer`; compatible endpoints retain the broadly supported `system` role."
+  [messages system instruction-role]
   (if (and system (not (str/blank? system))
-           (not (some #(let [r (:role %)] (= "system" (if (keyword? r) (name r) r))) messages)))
-    (into [{:role "system" :content system}] (vec messages))
+           (not (some #(let [r (:role %)
+                             r (if (keyword? r) (name r) r)]
+                         (#{"system" "developer"} r))
+                      messages)))
+    (into [{:role instruction-role :content system}] (vec messages))
     (vec messages)))
 
 (defn- format-messages
   "Format messages for OpenAI API."
-  [messages]
-  (mapv format-message messages))
+  [messages instruction-role]
+  (mapv #(format-message % instruction-role) messages))
+
+(defn- product-instruction-role
+  "Wire role for product instructions. This is model metadata, not an ID guess,
+   and is native-only because compatible services need not implement OpenAI's
+   o1-and-newer developer-message contract."
+  [config model]
+  (if (:native-openai? config)
+    (name (registry/instruction-role model))
+    "system"))
 
 ;; ============================================================================
 ;; Provider Record
@@ -58,6 +71,7 @@
 
   (build-request [_ messages opts]
     (let [tools (:tools opts)
+          instruction-role (product-instruction-role config (:model opts))
           ;; GPT-5.6: /v1/chat/completions refuses function tools unless
           ;; reasoning_effort is "none" — "To use function tools, use
           ;; /v1/responses or set reasoning_effort to 'none'". Sending it
@@ -79,7 +93,9 @@
                       :max_completion_tokens (:max-tokens opts 8192)
                       :stream true
                       :stream_options {:include_usage true}
-                      :messages (format-messages (with-system messages (:system opts)))}
+                      :messages (format-messages
+                                 (with-instructions messages (:system opts) instruction-role)
+                                 instruction-role)}
                ;; Temperature if specified (some models like Kimi K2.5 require specific values)
                (:temperature opts) (assoc :temperature (:temperature opts))
                ;; Top-p if specified (Kimi / MiniMax M2 use 0.95)
@@ -248,7 +264,8 @@
   (format-messages [_ messages model]
     ;; OpenAI/Fireworks: tool results as separate "tool" messages with tool_call_id
     ;; Kimi K2 quirk: rewrite tool IDs to functions.{name}:{idx}
-    (let [messages (if (registry/has-quirk? model :kimi-tool-id-format?)
+    (let [instruction-role (product-instruction-role config model)
+          messages (if (registry/has-quirk? model :kimi-tool-id-format?)
                      (quirks/rewrite-kimi-tool-ids messages)
                      messages)]
       (mapv (fn [msg]
@@ -278,7 +295,9 @@
                                                                            (tool-schema/input-entity->args (:tool-use/input tu)))}})
                                                  tool-uses)}
                         (seq reasoning) (assoc :reasoning_content reasoning))
-                      (cond-> {:role (name role)
+                      (cond-> {:role (if (= role :system)
+                                       instruction-role
+                                       (name role))
                                :content (:message/content msg)}
                         (and (= role :assistant) (seq reasoning))
                         (assoc :reasoning_content reasoning)))))))

--- a/src/dvergr/model/providers.clj
+++ b/src/dvergr/model/providers.clj
@@ -155,9 +155,10 @@
    resources/models.edn; the others are passed through to the provider."
   {:anthropic   "claude-sonnet-4-6"
    :fireworks   "accounts/fireworks/models/minimax-m2p7"
-   ;; gpt-5.5, not the newer 5.6 line: 5.6 gives up reasoning the moment a
-   ;; turn carries tools (registry quirk :chat-tools-need-effort-none?), and
-   ;; every agent turn here carries tools.
+   ;; GPT-5.5 is documented independently with medium reasoning by default and
+   ;; supports function calling on Chat Completions. Unlike GPT-5.6, it does not
+   ;; carry :chat-tools-need-effort-none?; that absence is not itself evidence
+   ;; of reasoning behavior — the explicit registry default is.
    :openai      "gpt-5.5"
    :claude-code "claude-code-sonnet"
    :codex-subscription "codex-subscription"

--- a/src/dvergr/model/providers.clj
+++ b/src/dvergr/model/providers.clj
@@ -151,7 +151,10 @@
    resources/models.edn; the others are passed through to the provider."
   {:anthropic   "claude-sonnet-4-6"
    :fireworks   "accounts/fireworks/models/minimax-m2p7"
-   :openai      "gpt-4o"
+   ;; gpt-5.5, not the newer 5.6 line: 5.6 gives up reasoning the moment a
+   ;; turn carries tools (registry quirk :chat-tools-need-effort-none?), and
+   ;; every agent turn here carries tools.
+   :openai      "gpt-5.5"
    :claude-code "claude-code-sonnet"
    :codex-subscription "codex-subscription"
    :codex-subscription-cli "codex-subscription-cli"})

--- a/src/dvergr/model/providers.clj
+++ b/src/dvergr/model/providers.clj
@@ -83,57 +83,59 @@
 (defn init-defaults!
   "Initialize default providers from environment variables.
    Only registers providers that have API keys available."
-  []
-  ;; Anthropic
-  (when-let [provider (anthropic/create-if-available {})]
-    (register! :anthropic provider)
-    (tel/log! {:id :providers/registered :data {:provider :anthropic}} "Registered provider"))
+  ([]
+   (init-defaults! #(System/getenv %)))
+  ([env-lookup]
+   ;; Anthropic
+   (when-let [provider (anthropic/create-if-available {})]
+     (register! :anthropic provider)
+     (tel/log! {:id :providers/registered :data {:provider :anthropic}} "Registered provider"))
 
-  ;; OpenAI
-  (when-let [provider (openai/create-if-available {})]
-    (register! :openai provider)
-    (tel/log! {:id :providers/registered :data {:provider :openai}} "Registered provider"))
+   ;; OpenAI
+   (when-let [provider (openai/create-if-available {} env-lookup)]
+     (register! :openai provider)
+     (tel/log! {:id :providers/registered :data {:provider :openai}} "Registered provider"))
 
-  ;; Fireworks
-  (when-let [provider (openai/create-fireworks-if-available {})]
-    (register! :fireworks provider)
-    (tel/log! {:id :providers/registered :data {:provider :fireworks}} "Registered provider"))
+   ;; Fireworks
+   (when-let [provider (openai/create-fireworks-if-available {} env-lookup)]
+     (register! :fireworks provider)
+     (tel/log! {:id :providers/registered :data {:provider :fireworks}} "Registered provider"))
 
-  ;; Claude Code CLI
-  (when-let [provider (claude-code/create-if-available {})]
-    (register! :claude-code provider)
-    (tel/log! {:id :providers/registered :data {:provider :claude-code}} "Registered provider"))
+   ;; Claude Code CLI
+   (when-let [provider (claude-code/create-if-available {})]
+     (register! :claude-code provider)
+     (tel/log! {:id :providers/registered :data {:provider :claude-code}} "Registered provider"))
 
-  ;; Native OpenAI Codex Responses transport via a file-backed ChatGPT login.
-  (when-let [provider (codex-subscription/create-if-available {})]
-    (register! :codex-subscription provider)
-    (tel/log! {:id :providers/registered :data {:provider :codex-subscription}}
-              "Registered provider"))
+   ;; Native OpenAI Codex Responses transport via a file-backed ChatGPT login.
+   (when-let [provider (codex-subscription/create-if-available {})]
+     (register! :codex-subscription provider)
+     (tel/log! {:id :providers/registered :data {:provider :codex-subscription}}
+               "Registered provider"))
 
-  ;; Compatibility path for keyring-only logins or upstream wire changes.
-  (when-let [provider (codex-subscription/create-cli-if-available {})]
-    (register! :codex-subscription-cli provider)
-    (tel/log! {:id :providers/registered :data {:provider :codex-subscription-cli}}
-              "Registered provider"))
+   ;; Compatibility path for keyring-only logins or upstream wire changes.
+   (when-let [provider (codex-subscription/create-cli-if-available {})]
+     (register! :codex-subscription-cli provider)
+     (tel/log! {:id :providers/registered :data {:provider :codex-subscription-cli}}
+               "Registered provider"))
 
-  ;; Load extra models from resources/models.edn
-  (try
-    (when-let [n (registry/load-models-resource!)]
-      (tel/log! {:id :providers/models-loaded :data {:count n}} "Loaded models"))
-    (catch Exception e
-      (tel/log! {:level :warn :id :providers/models-load-failed :data {:error (.getMessage e)}}
-                "Failed to load models.edn")))
+   ;; Load extra models from resources/models.edn
+   (try
+     (when-let [n (registry/load-models-resource!)]
+       (tel/log! {:id :providers/models-loaded :data {:count n}} "Loaded models"))
+     (catch Exception e
+       (tel/log! {:level :warn :id :providers/models-load-failed :data {:error (.getMessage e)}}
+                 "Failed to load models.edn")))
 
-  ;; Loud boot warning when NOTHING registered — the common fresh-machine failure
-  ;; is a missing API key, which otherwise only surfaces later as every turn
-  ;; failing with a confusing model/provider error.
-  (when (empty? @providers)
-    (tel/log! {:level :warn :id :providers/none-registered :data {}}
-              (str "No LLM providers registered — set ANTHROPIC_API_KEY, "
-                   "OPENAI_API_KEY, or FIREWORKS_API_KEY, or sign in with "
-                   "the Claude Code or Codex CLI.")))
+   ;; Loud boot warning when NOTHING registered — the common fresh-machine failure
+   ;; is a missing API key, which otherwise only surfaces later as every turn
+   ;; failing with a confusing model/provider error.
+   (when (empty? @providers)
+     (tel/log! {:level :warn :id :providers/none-registered :data {}}
+               (str "No LLM providers registered — set ANTHROPIC_API_KEY, "
+                    "OPENAI_API_KEY, or FIREWORKS_API_KEY, or sign in with "
+                    "the Claude Code or Codex CLI.")))
 
-  (tel/log! {:id :providers/init-complete :data {:count (count @providers)}} "Providers ready"))
+   (tel/log! {:id :providers/init-complete :data {:count (count @providers)}} "Providers ready")))
 
 (defn clear-all!
   "Clear all registered providers."
@@ -142,9 +144,11 @@
 
 (defn ensure-initialized!
   "Ensure providers are initialized. Safe to call multiple times."
-  []
-  (when (empty? @providers)
-    (init-defaults!)))
+  ([]
+   (ensure-initialized! #(System/getenv %)))
+  ([env-lookup]
+   (when (empty? @providers)
+     (init-defaults! env-lookup))))
 
 (def ^:private preferred-default-model
   "Best default model per provider for auto-config. Fireworks ids must exist in
@@ -172,11 +176,13 @@
    encodes \"what this machine can actually run\". Lets a coder default to
    Anthropic where ANTHROPIC_API_KEY is set and Fireworks where it isn't, with no
    hardcoded provider in the persona."
-  []
-  (ensure-initialized!)
-  (let [available (set (keys @providers))]
-    (when-let [p (some available provider-preference)]
-      {:provider p :model (preferred-default-model p)})))
+  ([]
+   (default-spec #(System/getenv %)))
+  ([env-lookup]
+   (ensure-initialized! env-lookup)
+   (let [available (set (keys @providers))]
+     (when-let [p (some available provider-preference)]
+       {:provider p :model (preferred-default-model p)}))))
 
 ;; ============================================================================
 ;; Custom Provider Registration

--- a/src/dvergr/model/registry.clj
+++ b/src/dvergr/model/registry.clj
@@ -39,15 +39,12 @@
      :cache-write   — 5-minute prompt-cache write (1.25× input)
      :cache-write-1h— 1-hour prompt-cache write (2× input), where available
 
-   Snapshot date: 2026-08-22. Anthropic prices: claude.com/pricing. OpenAI
-   identities, limits, reasoning levels, and capabilities are checked against
-   <https://developers.openai.com/api/docs/models>; the static OpenAI rate fields
-   below are a <https://models.dev> snapshot. In particular, gpt-5.6-sol
-   intentionally remains at that snapshot's base rate here. Promotional and
-   context/service-tier accounting belongs in the billing change; OpenAI's
-   `GET /models/{model}` response does not contain a rate card.
+   Anthropic prices: claude.com/pricing. OpenAI identities, limits, reasoning
+   levels, capabilities, and rate fields checked 2026-08-28 against OpenAI model
+   documentation and <https://models.dev/api.json>.
+   Base rates exclude long-context, service-tier, and account-specific billing.
 
-   `refresh-from-models-dev!` reads the same third-party source live."
+   `refresh-from-models-dev!` reads models.dev live."
   {;; ── Claude Opus 4.x ──────────────────────────────────────────────
    "claude-opus-4-7"
    {:id "claude-opus-4-7"
@@ -170,7 +167,7 @@
     :reasoning-efforts ["none" "low" "medium" "high" "xhigh" "max"]
     :default-reasoning-effort "medium"
     :instruction-role :developer
-    :pricing {:input 5.0 :output 30.0 :cache-read 0.50 :cache-write 6.25}
+    :pricing {:input 4.0 :output 20.0 :cache-read 0.40 :cache-write 5.0}
     :quirks {:chat-tools-need-effort-none? true}}
 
    "gpt-5.6-terra"

--- a/src/dvergr/model/registry.clj
+++ b/src/dvergr/model/registry.clj
@@ -17,7 +17,7 @@
     :vision          ; Image input
     :thinking        ; Extended thinking/reasoning
     :streaming       ; SSE streaming
-    :system-prompt   ; Separate system prompt field
+    :system-prompt   ; Product/provider instructions (wire role may be developer)
     :cache-control   ; Prompt caching
     :json-mode})     ; Structured JSON output
 
@@ -39,9 +39,15 @@
      :cache-write   — 5-minute prompt-cache write (1.25× input)
      :cache-write-1h— 1-hour prompt-cache write (2× input), where available
 
-   Snapshot date: 2026-08-22. Anthropic prices: claude.com/pricing.
-   OpenAI prices/limits: models.dev (the same source
-   `refresh-from-models-dev!` reads live)."
+   Snapshot date: 2026-08-22. Anthropic prices: claude.com/pricing. OpenAI
+   identities, limits, reasoning levels, and capabilities are checked against
+   <https://developers.openai.com/api/docs/models>; the static OpenAI rate fields
+   below are a <https://models.dev> snapshot. In particular, gpt-5.6-sol
+   intentionally remains at that snapshot's base rate here. Promotional and
+   context/service-tier accounting belongs in the billing change; OpenAI's
+   `GET /models/{model}` response does not contain a rate card.
+
+   `refresh-from-models-dev!` reads the same third-party source live."
   {;; ── Claude Opus 4.x ──────────────────────────────────────────────
    "claude-opus-4-7"
    {:id "claude-opus-4-7"
@@ -161,6 +167,9 @@
     :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
     :context 1050000
     :max-output 128000
+    :reasoning-efforts ["none" "low" "medium" "high" "xhigh" "max"]
+    :default-reasoning-effort "medium"
+    :instruction-role :developer
     :pricing {:input 5.0 :output 30.0 :cache-read 0.50 :cache-write 6.25}
     :quirks {:chat-tools-need-effort-none? true}}
 
@@ -172,6 +181,9 @@
     :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
     :context 1050000
     :max-output 128000
+    :reasoning-efforts ["none" "low" "medium" "high" "xhigh" "max"]
+    :default-reasoning-effort "medium"
+    :instruction-role :developer
     :pricing {:input 2.0 :output 12.0 :cache-read 0.20 :cache-write 2.50}
     :quirks {:chat-tools-need-effort-none? true}}
 
@@ -183,12 +195,15 @@
     :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
     :context 1050000
     :max-output 128000
+    :reasoning-efforts ["none" "low" "medium" "high" "xhigh" "max"]
+    :default-reasoning-effort "medium"
+    :instruction-role :developer
     :pricing {:input 0.20 :output 1.20 :cache-read 0.02 :cache-write 0.25}
     :quirks {:chat-tools-need-effort-none? true}}
 
    ;; ── OpenAI GPT-5.5 / 5.4 ─────────────────────────────────────────
-   ;; Tools AND reasoning on chat/completions, no quirk needed. This is why
-   ;; gpt-5.5 is the OpenAI default in `providers/preferred-default-model`.
+   ;; GPT-5.5 has its own documented reasoning contract: medium is the default
+   ;; and max is not supported. It does not inherit the GPT-5.6 Chat tool quirk.
    "gpt-5.5"
    {:id "gpt-5.5"
     :name "GPT-5.5"
@@ -197,6 +212,9 @@
     :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
     :context 1050000
     :max-output 128000
+    :reasoning-efforts ["none" "low" "medium" "high" "xhigh"]
+    :default-reasoning-effort "medium"
+    :instruction-role :developer
     :pricing {:input 5.0 :output 30.0 :cache-read 0.50}
     :quirks {}}
 
@@ -208,6 +226,9 @@
     :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
     :context 400000
     :max-output 128000
+    :reasoning-efforts ["none" "low" "medium" "high" "xhigh"]
+    :default-reasoning-effort "none"
+    :instruction-role :developer
     :pricing {:input 0.75 :output 4.50 :cache-read 0.075}
     :quirks {}}
 
@@ -395,6 +416,21 @@
   [model-id]
   (:max-output (get-model model-id)))
 
+(defn reasoning-efforts
+  "Get the supported reasoning_effort values for a model."
+  [model-id]
+  (or (:reasoning-efforts (get-model model-id)) []))
+
+(defn default-reasoning-effort
+  "Get the documented default reasoning_effort for a model."
+  [model-id]
+  (:default-reasoning-effort (get-model model-id)))
+
+(defn instruction-role
+  "Get the provider-native role used for product instructions."
+  [model-id]
+  (or (:instruction-role (get-model model-id)) :system))
+
 ;; ============================================================================
 ;; EDN Loading
 ;; ============================================================================
@@ -480,6 +516,10 @@
   [provider-id mid m]
   (let [cost  (:cost m)
         limit (:limit m)
+        reasoning-efforts (some (fn [option]
+                                  (when (= "effort" (:type option))
+                                    (vec (:values option))))
+                                (:reasoning_options m))
         caps  (cond-> #{:streaming}
                 (:tool_call m)       (conj :tools)
                 (:reasoning m)       (conj :thinking)
@@ -487,20 +527,21 @@
                 (conj :vision)
                 true                 (conj :system-prompt)
                 (some? (:cache_read cost)) (conj :cache-control))]
-    {:id (name mid)
-     :name (or (:name m) (name mid))
-     :provider provider-id
-     :api-type (case provider-id
-                 :anthropic :anthropic-messages
-                 :openai    :openai-chat
-                 :openai-chat)
-     :capabilities caps
-     :context (:context limit)
-     :max-output (:output limit)
-     :pricing (cond-> {:input  (:input cost)
-                       :output (:output cost)}
-                (:cache_read cost)  (assoc :cache-read (:cache_read cost))
-                (:cache_write cost) (assoc :cache-write (:cache_write cost)))}))
+    (cond-> {:id (name mid)
+             :name (or (:name m) (name mid))
+             :provider provider-id
+             :api-type (case provider-id
+                         :anthropic :anthropic-messages
+                         :openai    :openai-chat
+                         :openai-chat)
+             :capabilities caps
+             :context (:context limit)
+             :max-output (:output limit)
+             :pricing (cond-> {:input  (:input cost)
+                               :output (:output cost)}
+                        (:cache_read cost)  (assoc :cache-read (:cache_read cost))
+                        (:cache_write cost) (assoc :cache-write (:cache_write cost)))}
+      (seq reasoning-efforts) (assoc :reasoning-efforts reasoning-efforts))))
 
 (defn refresh-from-models-dev!
   "Fetch <https://models.dev/api.json> and overlay all entries from the
@@ -521,14 +562,17 @@
                :when (some? prov)
                [mid m] models]
          (let [entry (coerce-models-dev-model prov-key mid m)]
-           ;; QUIRKS SURVIVE THE OVERLAY. models.dev carries pricing and
-           ;; limits, not the per-model API workarounds we discovered by
-           ;; being 400'd — dropping them here would silently re-break tool
-           ;; calls on the GPT-5.6 line the moment someone refreshed prices.
+           ;; NATIVE CONTRACT SURVIVES THE OVERLAY. models.dev carries live
+           ;; limits, rates, and reasoning options, but not dvergr's Chat
+           ;; compatibility quirks, the official default effort, or the
+           ;; o1-and-newer instruction role. Dropping those built-in fields
+           ;; would silently change the wire payload after a metadata refresh.
            (swap! registry update (:id entry)
                   (fn [existing]
-                    (cond-> entry
-                      (seq (:quirks existing)) (assoc :quirks (:quirks existing)))))
+                    (merge (select-keys existing
+                                        [:quirks :reasoning-efforts
+                                         :default-reasoning-effort :instruction-role])
+                           entry)))
            (swap! n inc)))
        @n))))
 
@@ -540,6 +584,8 @@
   aliases (atom {"sonnet" "claude-sonnet-4-6"
                  "opus"   "claude-opus-4-7"
                  "haiku"  "claude-haiku-4-5"
+                 ;; Official OpenAI family alias: routes to GPT-5.6 Sol.
+                 "gpt-5.6"  "gpt-5.6-sol"
                  "gpt"      "gpt-5.5"
                  "gpt-mini" "gpt-5.4-mini"
                  "sol"      "gpt-5.6-sol"

--- a/src/dvergr/model/registry.clj
+++ b/src/dvergr/model/registry.clj
@@ -39,7 +39,9 @@
      :cache-write   — 5-minute prompt-cache write (1.25× input)
      :cache-write-1h— 1-hour prompt-cache write (2× input), where available
 
-   Snapshot date: 2026-05-24. See claude.com/pricing for live prices."
+   Snapshot date: 2026-08-22. Anthropic prices: claude.com/pricing.
+   OpenAI prices/limits: models.dev (the same source
+   `refresh-from-models-dev!` reads live)."
   {;; ── Claude Opus 4.x ──────────────────────────────────────────────
    "claude-opus-4-7"
    {:id "claude-opus-4-7"
@@ -141,6 +143,72 @@
     :context 200000
     :max-output 32000
     :pricing {:input 0 :output 0}
+    :quirks {}}
+
+   ;; ── OpenAI GPT-5.6 ───────────────────────────────────────────────
+   ;; The whole 5.6 line carries :chat-tools-need-effort-none? — on
+   ;; /v1/chat/completions these models refuse function tools unless
+   ;; reasoning_effort is "none" ("To use function tools, use /v1/responses
+   ;; or set reasoning_effort to 'none'"). The openai adapter sends it for
+   ;; them whenever tools are present, which trades server-side reasoning
+   ;; for tool use. An agent that needs BOTH wants the Responses API, which
+   ;; this provider does not speak yet — pick gpt-5.5 until it does.
+   "gpt-5.6-sol"
+   {:id "gpt-5.6-sol"
+    :name "GPT-5.6 Sol"
+    :provider :openai
+    :api-type :openai-chat
+    :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
+    :context 1050000
+    :max-output 128000
+    :pricing {:input 5.0 :output 30.0 :cache-read 0.50 :cache-write 6.25}
+    :quirks {:chat-tools-need-effort-none? true}}
+
+   "gpt-5.6-terra"
+   {:id "gpt-5.6-terra"
+    :name "GPT-5.6 Terra"
+    :provider :openai
+    :api-type :openai-chat
+    :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
+    :context 1050000
+    :max-output 128000
+    :pricing {:input 2.0 :output 12.0 :cache-read 0.20 :cache-write 2.50}
+    :quirks {:chat-tools-need-effort-none? true}}
+
+   "gpt-5.6-luna"
+   {:id "gpt-5.6-luna"
+    :name "GPT-5.6 Luna"
+    :provider :openai
+    :api-type :openai-chat
+    :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
+    :context 1050000
+    :max-output 128000
+    :pricing {:input 0.20 :output 1.20 :cache-read 0.02 :cache-write 0.25}
+    :quirks {:chat-tools-need-effort-none? true}}
+
+   ;; ── OpenAI GPT-5.5 / 5.4 ─────────────────────────────────────────
+   ;; Tools AND reasoning on chat/completions, no quirk needed. This is why
+   ;; gpt-5.5 is the OpenAI default in `providers/preferred-default-model`.
+   "gpt-5.5"
+   {:id "gpt-5.5"
+    :name "GPT-5.5"
+    :provider :openai
+    :api-type :openai-chat
+    :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
+    :context 1050000
+    :max-output 128000
+    :pricing {:input 5.0 :output 30.0 :cache-read 0.50}
+    :quirks {}}
+
+   "gpt-5.4-mini"
+   {:id "gpt-5.4-mini"
+    :name "GPT-5.4 mini"
+    :provider :openai
+    :api-type :openai-chat
+    :capabilities #{:tools :vision :thinking :streaming :system-prompt :cache-control}
+    :context 400000
+    :max-output 128000
+    :pricing {:input 0.75 :output 4.50 :cache-read 0.075}
     :quirks {}}
 
    ;; Native Codex Responses models (via an existing ChatGPT subscription). These ids are
@@ -443,7 +511,7 @@
    last release.
 
    Returns the number of models registered (or nil on network failure)."
-  ([] (refresh-from-models-dev! #{:anthropic}))
+  ([] (refresh-from-models-dev! #{:anthropic :openai}))
   ([providers]
    (when-let [data (models-dev-fetch)]
      (let [n (atom 0)]
@@ -453,7 +521,14 @@
                :when (some? prov)
                [mid m] models]
          (let [entry (coerce-models-dev-model prov-key mid m)]
-           (swap! registry assoc (:id entry) entry)
+           ;; QUIRKS SURVIVE THE OVERLAY. models.dev carries pricing and
+           ;; limits, not the per-model API workarounds we discovered by
+           ;; being 400'd — dropping them here would silently re-break tool
+           ;; calls on the GPT-5.6 line the moment someone refreshed prices.
+           (swap! registry update (:id entry)
+                  (fn [existing]
+                    (cond-> entry
+                      (seq (:quirks existing)) (assoc :quirks (:quirks existing)))))
            (swap! n inc)))
        @n))))
 
@@ -465,6 +540,11 @@
   aliases (atom {"sonnet" "claude-sonnet-4-6"
                  "opus"   "claude-opus-4-7"
                  "haiku"  "claude-haiku-4-5"
+                 "gpt"      "gpt-5.5"
+                 "gpt-mini" "gpt-5.4-mini"
+                 "sol"      "gpt-5.6-sol"
+                 "terra"    "gpt-5.6-terra"
+                 "luna"     "gpt-5.6-luna"
                  "opus-4-6" "claude-opus-4-6"
                  "opus-4-5" "claude-opus-4-5"
                  "sonnet-4-5" "claude-sonnet-4-5"

--- a/test/dvergr/model/openai_test.clj
+++ b/test/dvergr/model/openai_test.clj
@@ -133,6 +133,19 @@
     (is (= "system" (get-in body [:messages 0 :role])))
     (is (not (contains? body :reasoning_effort)))))
 
+(deftest explicit-canonical-base-url-keeps-native-chat-behavior
+  (let [request (provider/build-request
+                 (openai/create {:api-key "test-openai-key"
+                                 :base-url "https://api.openai.com/v1/"}
+                                {})
+                 [{:role :system :content "Product policy"}
+                  {:role :user :content "Use the tool"}]
+                 {:model "gpt-5.6-sol"
+                  :tools [test-tool]})]
+    (is (= "https://api.openai.com/v1/chat/completions" (:url request)))
+    (is (= "developer" (get-in request [:body :messages 0 :role])))
+    (is (= "none" (get-in request [:body :reasoning_effort])))))
+
 (deftest models-dev-overlay-preserves-built-in-native-contract
   (let [overlay {:openai
                  {:models

--- a/test/dvergr/model/openai_test.clj
+++ b/test/dvergr/model/openai_test.clj
@@ -70,9 +70,9 @@
           (is (= efforts (registry/reasoning-efforts id)))
           (is (= default (registry/default-reasoning-effort id)))
           (is (= :developer (registry/instruction-role id))))))
-    (is (= {:input 5.0 :output 30.0 :cache-read 0.50 :cache-write 6.25}
+    (is (= {:input 4.0 :output 20.0 :cache-read 0.40 :cache-write 5.0}
            (registry/pricing-of "gpt-5.6-sol"))
-        "DVG-02 must not silently replace the static models.dev Sol rate")
+        "GPT-5.6 Sol pricing must match the current documented base rate")
     (doseq [id ["gpt-5.6-sol" "gpt-5.6-terra" "gpt-5.6-luna"]]
       (is (true? (registry/get-quirk id :chat-tools-need-effort-none?))))
     (is (nil? (registry/get-quirk "gpt-5.5" :chat-tools-need-effort-none?))

--- a/test/dvergr/model/openai_test.clj
+++ b/test/dvergr/model/openai_test.clj
@@ -1,0 +1,254 @@
+(ns dvergr.model.openai-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [dvergr.model.api.openai :as openai]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.provider :as provider]
+            [dvergr.model.providers :as providers]
+            [dvergr.model.registry :as registry]
+            [hato.client :as hc]
+            [jsonista.core :as json])
+  (:import [java.io ByteArrayInputStream]))
+
+(def ^:private test-tool
+  {:name "lookup"
+   :description "Look up a value"
+   :parameters {:type "object"
+                :properties {:query {:type "string"}}
+                :required ["query"]}})
+
+(def ^:private gpt-capabilities
+  #{:tools :vision :thinking :streaming :system-prompt :cache-control})
+
+(def ^:private gpt-5p6-efforts
+  ["none" "low" "medium" "high" "xhigh" "max"])
+
+(def ^:private gpt-5p5-efforts
+  ["none" "low" "medium" "high" "xhigh"])
+
+(def ^:private models-dev-fetch-var
+  (ns-resolve 'dvergr.model.registry 'models-dev-fetch))
+
+(use-fixtures
+  :each
+  (fn [f]
+    (let [before-providers @providers/providers
+          before-models @registry/registry
+          before-aliases @registry/aliases]
+      (try
+        (reset! providers/providers {})
+        (registry/reset-to-defaults!)
+        (f)
+        (finally
+          (reset! providers/providers before-providers)
+          (reset! registry/registry before-models)
+          (reset! registry/aliases before-aliases))))))
+
+(defn- native-provider []
+  (openai/create {:api-key "test-openai-key"} {}))
+
+(defn- compatible-provider []
+  (openai/create {:api-key "test-compatible-key"
+                  :base-url "https://compatible.example.test/v1"}
+                 {}))
+
+(deftest gpt-registry-contract
+  (let [expected {"gpt-5.6-sol"   {:context 1050000 :default "medium" :efforts gpt-5p6-efforts}
+                  "gpt-5.6-terra" {:context 1050000 :default "medium" :efforts gpt-5p6-efforts}
+                  "gpt-5.6-luna"  {:context 1050000 :default "medium" :efforts gpt-5p6-efforts}
+                  "gpt-5.5"       {:context 1050000 :default "medium" :efforts gpt-5p5-efforts}
+                  "gpt-5.4-mini"  {:context 400000 :default "none" :efforts gpt-5p5-efforts}}]
+    (doseq [[id {:keys [context default efforts]}] expected]
+      (testing id
+        (let [model (registry/get-model! id)]
+          (is (= id (:id model)))
+          (is (= :openai (:provider model)))
+          (is (= :openai-chat (:api-type model)))
+          (is (= gpt-capabilities (:capabilities model)))
+          (is (= context (:context model)))
+          (is (= 128000 (:max-output model)))
+          (is (= efforts (registry/reasoning-efforts id)))
+          (is (= default (registry/default-reasoning-effort id)))
+          (is (= :developer (registry/instruction-role id))))))
+    (is (= {:input 5.0 :output 30.0 :cache-read 0.50 :cache-write 6.25}
+           (registry/pricing-of "gpt-5.6-sol"))
+        "DVG-02 must not silently replace the static models.dev Sol rate")
+    (doseq [id ["gpt-5.6-sol" "gpt-5.6-terra" "gpt-5.6-luna"]]
+      (is (true? (registry/get-quirk id :chat-tools-need-effort-none?))))
+    (is (nil? (registry/get-quirk "gpt-5.5" :chat-tools-need-effort-none?))
+        "GPT-5.5 is verified independently and does not inherit the 5.6 restriction")))
+
+(deftest gpt-aliases-resolve-to-selected-chat-entries
+  (is (= "gpt-5.6-sol" (registry/resolve-alias "gpt-5.6"))
+      "OpenAI's documented GPT-5.6 alias routes to Sol")
+  (is (= "gpt-5.6-sol" (registry/resolve-alias "sol")))
+  (is (= "gpt-5.6-terra" (registry/resolve-alias "terra")))
+  (is (= "gpt-5.6-luna" (registry/resolve-alias "luna")))
+  (is (= "gpt-5.5" (registry/resolve-alias "gpt")))
+  (is (= "gpt-5.4-mini" (registry/resolve-alias "gpt-mini"))))
+
+(deftest native-gpt-5p6-function-tool-request-is-exact-chat-json
+  (let [request (provider/build-request
+                 (native-provider)
+                 [{:role :user :content "Use the tool"}]
+                 {:model "gpt-5.6-sol"
+                  :max-tokens 321
+                  :system "Product policy"
+                  :tools [test-tool]})
+        expected-json (str "{\"model\":\"gpt-5.6-sol\","
+                           "\"max_completion_tokens\":321,"
+                           "\"stream\":true,"
+                           "\"stream_options\":{\"include_usage\":true},"
+                           "\"messages\":["
+                           "{\"role\":\"developer\",\"content\":\"Product policy\"},"
+                           "{\"role\":\"user\",\"content\":\"Use the tool\"}],"
+                           "\"tools\":[{\"type\":\"function\",\"function\":{"
+                           "\"name\":\"lookup\",\"description\":\"Look up a value\","
+                           "\"parameters\":{\"type\":\"object\",\"properties\":{"
+                           "\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]}}}],"
+                           "\"reasoning_effort\":\"none\"}")]
+    (is (= "https://api.openai.com/v1/chat/completions" (:url request)))
+    (is (= expected-json (json/write-value-as-string (:body request))))))
+
+(deftest native-gpt-5p5-keeps-its-own-reasoning-contract
+  (let [body (:body (provider/build-request
+                     (native-provider)
+                     [{:role :system :content "Product policy"}
+                      {:role :user :content "Use the tool"}]
+                     {:model "gpt-5.5"
+                      :tools [test-tool]}))]
+    (is (= "medium" (registry/default-reasoning-effort "gpt-5.5")))
+    (is (= gpt-5p5-efforts (registry/reasoning-efforts "gpt-5.5")))
+    (is (= "developer" (get-in body [:messages 0 :role])))
+    (is (not (contains? body :reasoning_effort))
+        "GPT-5.5 must not inherit the GPT-5.6 function-tool restriction")))
+
+(deftest custom-base-url-gates-native-chat-behavior
+  (let [body (:body (provider/build-request
+                     (compatible-provider)
+                     [{:role :system :content "Product policy"}
+                      {:role :user :content "Use the tool"}]
+                     {:model "gpt-5.6-sol"
+                      :tools [test-tool]}))]
+    (is (= "system" (get-in body [:messages 0 :role])))
+    (is (not (contains? body :reasoning_effort)))))
+
+(deftest models-dev-overlay-preserves-built-in-native-contract
+  (let [overlay {:openai
+                 {:models
+                  {:gpt-5.6-sol
+                   {:name "GPT-5.6 Sol overlay"
+                    :tool_call true
+                    :reasoning true
+                    :reasoning_options [{:type "effort"
+                                         :values ["none" "low" "medium" "high" "xhigh" "max"]}]
+                    :modalities {:input ["text" "image"]}
+                    :limit {:context 900000 :output 64000}
+                    :cost {:input 99.0 :output 199.0}}}}}]
+    (with-redefs-fn
+      {models-dev-fetch-var (constantly overlay)}
+      #(is (= 1 (registry/refresh-from-models-dev! #{:openai}))))
+    (let [model (registry/get-model! "gpt-5.6-sol")]
+      (is (= 900000 (:context model)) "overlay still refreshes limits")
+      (is (= {:input 99.0 :output 199.0} (:pricing model))
+          "overlay still refreshes its third-party rate fields")
+      (is (= gpt-5p6-efforts (:reasoning-efforts model)))
+      (is (= "medium" (:default-reasoning-effort model)))
+      (is (= :developer (:instruction-role model)))
+      (is (= {:chat-tools-need-effort-none? true} (:quirks model)))
+      (is (= "gpt-5.6-sol" (registry/resolve-alias "gpt-5.6"))
+          "aliases remain valid after overlay"))))
+
+(defn- sse-body [events]
+  (let [wire (str (str/join "" (map #(str "data: "
+                                          (json/write-value-as-string %)
+                                          "\n\n")
+                                    events))
+                  "data: [DONE]\n\n")]
+    (ByteArrayInputStream. (.getBytes wire "UTF-8"))))
+
+(deftest streamed-gpt-tool-call-assembles-and-accounts-usage
+  (let [captured (atom nil)
+        events [{:id "chatcmpl-test"
+                 :model "gpt-5.6-sol"
+                 :choices [{:index 0
+                            :delta {:role "assistant"
+                                    :tool_calls [{:index 0
+                                                  :id "call_123"
+                                                  :type "function"
+                                                  :function {:name "lookup"
+                                                             :arguments "{"}}]}
+                            :finish_reason nil}]}
+                {:id "chatcmpl-test"
+                 :model "gpt-5.6-sol"
+                 :choices [{:index 0
+                            :delta {:tool_calls [{:index 0
+                                                  :function {:arguments "\"query\":\"Toronto\"}"}}]}
+                            :finish_reason nil}]}
+                {:id "chatcmpl-test"
+                 :model "gpt-5.6-sol"
+                 :choices [{:index 0 :delta {} :finish_reason "tool_calls"}]}
+                {:id "chatcmpl-test"
+                 :model "gpt-5.6-sol"
+                 :choices []
+                 :usage {:prompt_tokens 42
+                         :completion_tokens 7
+                         :total_tokens 49}}]
+        openai-provider (native-provider)]
+    (providers/register! :openai openai-provider)
+    (with-redefs [hc/request (fn [request]
+                               (reset! captured request)
+                               {:status 200 :headers {} :body (sse-body events)})]
+      (let [response (model-chat/chat
+                      [{:role :system :content "Product policy"}
+                       {:role :user :content "Find Toronto"}]
+                      {:provider :openai
+                       :model "gpt-5.6-sol"
+                       :tools [test-tool]})
+            sent-body (json/read-value (:body @captured)
+                                       json/keyword-keys-object-mapper)]
+        (is (= "developer" (get-in sent-body [:messages 0 :role])))
+        (is (= "none" (:reasoning_effort sent-body)))
+        (is (= [{:id "call_123"
+                 :name "lookup"
+                 :input {:query "Toronto"}}]
+               (:tool-calls response)))
+        (is (= {:input-tokens 42 :output-tokens 7} (:usage response))
+            "the final choices=[] usage frame must still be accumulated")
+        (is (= :tool_calls (:stop-reason response)))
+        (is (= "gpt-5.6-sol" (:model response)))
+        (is (= "chatcmpl-test" (:id response)))))))
+
+(deftest tool-result-continuation-replays-chat-tool-protocol
+  (let [openai-provider (native-provider)
+        api-messages (provider/format-messages
+                      openai-provider
+                      [{:message/role :system
+                        :message/content "Product policy"}
+                       {:message/role :user
+                        :message/content "Find Toronto"}
+                       {:message/role :assistant
+                        :message/content "Calling lookup"
+                        :message/tool-uses [{:tool-use/id "call_123"
+                                             :tool-use/name "lookup"
+                                             :tool-use/input {:query "Toronto"}}]}
+                       {:message/role :tool-result
+                        :message/tool-use-id "call_123"
+                        :message/content "18 C"}]
+                      "gpt-5.6-sol")
+        body (:body (provider/build-request
+                     openai-provider
+                     api-messages
+                     {:model "gpt-5.6-sol"
+                      :tools [test-tool]}))]
+    (is (= [{:role "developer" :content "Product policy"}
+            {:role "user" :content "Find Toronto"}
+            {:role "assistant"
+             :content "Calling lookup"
+             :tool_calls [{:id "call_123"
+                           :type "function"
+                           :function {:name "lookup"
+                                      :arguments "{\"query\":\"Toronto\"}"}}]}
+            {:role "tool" :tool_call_id "call_123" :content "18 C"}]
+           (:messages body)))
+    (is (= "none" (:reasoning_effort body)))))

--- a/test/dvergr/model/openai_test.clj
+++ b/test/dvergr/model/openai_test.clj
@@ -3,10 +3,10 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [dvergr.model.api.openai :as openai]
             [dvergr.model.chat :as model-chat]
+            [dvergr.model.gateway :as gateway]
             [dvergr.model.provider :as provider]
             [dvergr.model.providers :as providers]
             [dvergr.model.registry :as registry]
-            [hato.client :as hc]
             [jsonista.core :as json])
   (:import [java.io ByteArrayInputStream]))
 
@@ -196,9 +196,9 @@
                          :total_tokens 49}}]
         openai-provider (native-provider)]
     (providers/register! :openai openai-provider)
-    (with-redefs [hc/request (fn [request]
-                               (reset! captured request)
-                               {:status 200 :headers {} :body (sse-body events)})]
+    (binding [gateway/*request-fn* (fn [request]
+                                     (reset! captured request)
+                                     {:status 200 :headers {} :body (sse-body events)})]
       (let [response (model-chat/chat
                       [{:role :system :content "Product policy"}
                        {:role :user :content "Find Toronto"}]

--- a/test/dvergr/model/providers_test.clj
+++ b/test/dvergr/model/providers_test.clj
@@ -1,0 +1,145 @@
+(ns dvergr.model.providers-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [dvergr.model.api.anthropic :as anthropic]
+            [dvergr.model.api.claude-code :as claude-code]
+            [dvergr.model.api.openai :as openai]
+            [dvergr.model.provider :as provider]
+            [dvergr.model.providers :as providers]
+            [dvergr.model.registry :as registry]))
+
+(def ^:private openai-url "https://api.openai.com/v1/chat/completions")
+(def ^:private fireworks-base-url "https://api.fireworks.ai/inference/v1")
+(def ^:private fireworks-url (str fireworks-base-url "/chat/completions"))
+(def ^:private test-tool
+  {:name "lookup"
+   :description "Look up a value"
+   :parameters {:type "object" :properties {}}})
+
+(use-fixtures
+  :each
+  (fn [f]
+    (let [before @providers/providers]
+      (try
+        (providers/clear-all!)
+        (f)
+        (finally
+          (reset! providers/providers before))))))
+
+(defn- with-provider-env [env f]
+  ;; Keep this contract test independent of the developer machine's Anthropic
+  ;; key and local Claude CLI; only OpenAI and Fireworks are under test here.
+  (with-redefs [anthropic/create-if-available (constantly nil)
+                claude-code/create-if-available (constantly nil)
+                registry/load-models-resource! (constantly nil)]
+    (providers/init-defaults! env)
+    (f)))
+
+(defn- request-for [provider-key]
+  (provider/build-request
+   (providers/get-provider! provider-key)
+   [{:role :user :content "test"}]
+   {:model "gpt-5.6-sol"
+    :tools [test-tool]}))
+
+(defn- bearer [request]
+  (get-in request [:headers "Authorization"]))
+
+(defn- assert-default-provider [env expected]
+  (let [{:keys [provider]} (providers/default-spec env)]
+    (is (= expected provider))
+    (is (providers/registered? provider)
+        "auto-selection must return a registered provider")))
+
+(deftest no-provider-credentials
+  (with-provider-env
+    {}
+    (fn []
+      (is (empty? (providers/list-providers)))
+      (is (nil? (providers/default-spec {})))
+      (is (= "OPENAI_API_KEY"
+             (:env (ex-data (try
+                              (openai/create {} {})
+                              (catch clojure.lang.ExceptionInfo e e))))))
+      (is (= "FIREWORKS_API_KEY"
+             (:env (ex-data (try
+                              (openai/create-fireworks {} {})
+                              (catch clojure.lang.ExceptionInfo e e)))))))))
+
+(deftest openai-only-configuration
+  (let [env {"OPENAI_API_KEY" "openai-only-credential"}]
+    (with-provider-env
+      env
+      (fn []
+        (is (= #{:openai} (set (providers/list-providers))))
+        (assert-default-provider env :openai)
+        (let [request (request-for :openai)]
+          (is (= :openai (provider/provider-id (providers/get-provider! :openai))))
+          (is (= openai-url (:url request)))
+          (is (= "Bearer openai-only-credential" (bearer request)))
+          (is (= "none" (get-in request [:body :reasoning_effort]))
+              "native OpenAI keeps its model-specific request workaround"))))))
+
+(deftest openai-custom-base-configuration
+  (let [base-url "https://compatible.example.test/v1"
+        env {"OPENAI_API_KEY" "openai-custom-credential"
+             "OPENAI_BASE_URL" base-url}]
+    (with-provider-env
+      env
+      (fn []
+        (is (= #{:openai} (set (providers/list-providers))))
+        (assert-default-provider env :openai)
+        (let [request (request-for :openai)]
+          (is (= :openai (provider/provider-id (providers/get-provider! :openai))))
+          (is (= (str base-url "/chat/completions") (:url request)))
+          (is (= "Bearer openai-custom-credential" (bearer request)))
+          (is (not (contains? (:body request) :reasoning_effort))
+              "a compatible endpoint must not receive an OpenAI-native field"))))))
+
+(deftest fireworks-only-configuration
+  (let [env {"FIREWORKS_API_KEY" "fireworks-only-credential"}]
+    (with-provider-env
+      env
+      (fn []
+        (is (= #{:fireworks} (set (providers/list-providers))))
+        (assert-default-provider env :fireworks)
+        (let [request (request-for :fireworks)]
+          (is (= :fireworks (provider/provider-id (providers/get-provider! :fireworks))))
+          (is (= fireworks-url (:url request)))
+          (is (= "Bearer fireworks-only-credential" (bearer request)))
+          (is (not (contains? (:body request) :reasoning_effort))))))))
+
+(deftest both-provider-credentials
+  (let [env {"OPENAI_API_KEY" "openai-both-credential"
+             "FIREWORKS_API_KEY" "fireworks-both-credential"}]
+    (with-provider-env
+      env
+      (fn []
+        (is (= #{:openai :fireworks} (set (providers/list-providers))))
+        (assert-default-provider env :fireworks)
+        (let [openai-request (request-for :openai)
+              fireworks-request (request-for :fireworks)]
+          (is (= openai-url (:url openai-request)))
+          (is (= "Bearer openai-both-credential" (bearer openai-request)))
+          (is (= fireworks-url (:url fireworks-request)))
+          (is (= "Bearer fireworks-both-credential" (bearer fireworks-request))))))))
+
+(deftest identical-base-urls-keep-provider-scope
+  (let [env {"OPENAI_API_KEY" "openai-shared-url-credential"
+             "OPENAI_BASE_URL" fireworks-base-url
+             "FIREWORKS_API_KEY" "fireworks-shared-url-credential"}]
+    (with-provider-env
+      env
+      (fn []
+        (is (= #{:openai :fireworks} (set (providers/list-providers))))
+        (assert-default-provider env :fireworks)
+        (let [openai-provider (providers/get-provider! :openai)
+              fireworks-provider (providers/get-provider! :fireworks)
+              openai-request (request-for :openai)
+              fireworks-request (request-for :fireworks)]
+          (is (= :openai (provider/provider-id openai-provider)))
+          (is (= :fireworks (provider/provider-id fireworks-provider)))
+          (is (= (:url openai-request) (:url fireworks-request) fireworks-url))
+          (is (= "Bearer openai-shared-url-credential" (bearer openai-request)))
+          (is (= "Bearer fireworks-shared-url-credential" (bearer fireworks-request)))
+          (is (not (contains? (:body openai-request) :reasoning_effort)))
+          (is (not (contains? (:body fireworks-request) :reasoning_effort))))))))

--- a/test/dvergr/model/providers_test.clj
+++ b/test/dvergr/model/providers_test.clj
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [dvergr.model.api.anthropic :as anthropic]
             [dvergr.model.api.claude-code :as claude-code]
+            [dvergr.model.api.codex-subscription :as codex-subscription]
             [dvergr.model.api.openai :as openai]
+            [dvergr.model.gateway :as gateway]
             [dvergr.model.provider :as provider]
             [dvergr.model.providers :as providers]
             [dvergr.model.registry :as registry]))
@@ -30,6 +32,8 @@
   ;; key and local Claude CLI; only OpenAI and Fireworks are under test here.
   (with-redefs [anthropic/create-if-available (constantly nil)
                 claude-code/create-if-available (constantly nil)
+                codex-subscription/create-if-available (constantly nil)
+                codex-subscription/create-cli-if-available (constantly nil)
                 registry/load-models-resource! (constantly nil)]
     (providers/init-defaults! env)
     (f)))
@@ -42,7 +46,12 @@
     :tools [test-tool]}))
 
 (defn- bearer [request]
-  (get-in request [:headers "Authorization"]))
+  (let [seen (atom nil)]
+    (binding [gateway/*request-fn* (fn [authorized]
+                                     (reset! seen authorized)
+                                     {:status 200})]
+      (gateway/request! request))
+    (get-in @seen [:headers "Authorization"])))
 
 (defn- assert-default-provider [env expected]
   (let [{:keys [provider]} (providers/default-spec env)]


### PR DESCRIPTION
## Overview

This branch makes native OpenAI available through dvergr's existing Chat Completions adapter. It registers public OpenAI models, resolves aliases and defaults, serializes requests, handles streamed text and tool calls, replays tool results, and records terminal usage. It deliberately does not add a Responses API adapter.

Audited against `main` at `b20925aaba100dacb7227a6ff00ff969d5487e74` (`feat(orchestration): add durable agent run lifecycle (#56)`), branch head `161fd93f98189578151979a1cc190df8d117e0d7`.

### Provider configuration

| Environment | Registered providers | Automatic default | Endpoint |
|---|---|---|---|
| no provider keys | none | none | none |
| `OPENAI_API_KEY` | OpenAI | OpenAI / `gpt-5.5` | `https://api.openai.com/v1/chat/completions` |
| `OPENAI_API_KEY` + `OPENAI_BASE_URL` | OpenAI-compatible configuration | OpenAI / `gpt-5.5` | `<OPENAI_BASE_URL>/chat/completions` |
| `FIREWORKS_API_KEY` | Fireworks | Fireworks | `https://api.fireworks.ai/inference/v1/chat/completions` |
| both keys | OpenAI and Fireworks | Fireworks | provider-specific |

OpenAI and Fireworks retain distinct identity, credentials, and endpoints even if their configured URLs happen to match. Provider construction takes an injectable `env-lookup`, so the registration matrix above is asserted from fixtures rather than from the machine's environment.

Credentials never enter a provider request map. `create` and `create-fireworks` `dissoc` the key and attach a `gateway/static-credentials` capability confined to the endpoint's origin; `build-request` emits only `Content-Type`, the configured extra headers, and `:credentials`. `gateway/request!` injects `Authorization` at the last moment. This is `main`'s boundary from #52 and the branch adopts it rather than working around it.

### Built-in OpenAI catalog

| Model | Aliases | Context / max output | Base input / output per MTok | Reasoning efforts (default) |
|---|---|---:|---:|---|
| `gpt-5.6-sol` | `gpt-5.6`, `sol` | 1,050,000 / 128,000 | $4 / $20 | none, low, medium, high, xhigh, max (medium) |
| `gpt-5.6-terra` | `terra` | 1,050,000 / 128,000 | $2 / $12 | none, low, medium, high, xhigh, max (medium) |
| `gpt-5.6-luna` | `luna` | 1,050,000 / 128,000 | $0.20 / $1.20 | none, low, medium, high, xhigh, max (medium) |
| `gpt-5.5` | `gpt` | 1,050,000 / 128,000 | $5 / $30 | none, low, medium, high, xhigh (medium) |
| `gpt-5.4-mini` | `gpt-mini` | 400,000 / 128,000 | $0.75 / $4.50 | none, low, medium, high, xhigh (none) |

The catalog records provider model facts. Each entry uses the `:openai-chat` adapter and native OpenAI product instructions use the `developer` role. These entries sit alongside `main`'s `codex-subscription*` entries, which are a different provider on the `:openai-responses` adapter and keep their own ids, aliases, credentials, and endpoint. Adapter request semantics are specified and tested separately below.

### Chat adapter behavior

- Native OpenAI uses `developer` for product instructions; custom compatible bases retain `system`. The role comes from registry metadata gated on `:native-openai?`, never from an id guess.
- Native GPT-5.6 requests with function tools send `reasoning_effort: "none"`; tool-free GPT-5.6 requests omit it. GPT-5.5 function-tool requests leave the provider default unchanged. A configured compatible endpoint never receives the native workaround merely because it shares this adapter.
- Streaming requests use `stream_options.include_usage`; the parser retains usage-only terminal frames and joins fragmented tool calls.
- Tool continuation replays the assistant tool-call message followed by the matching `tool` result message.

Chat Completions is the tested boundary. A Responses adapter requires separate request/event/continuation/state handling and remains separate work, tracked in #60.

### Where this sits in the current lifecycle

`main` now owns participant lifecycle (#55), thread-aware room attention (#54), and a durable agent run lifecycle (#56). This branch changes none of it. Its diff against `main` is six files — `registry.clj`, `providers.clj`, `api/openai.clj`, their two tests, and `doc/provider-setup.md` — and touches nothing under `discourse`, `agent/`, `room/`, or `chat/`.

The path is: environment → `providers/init-defaults!` registration → registry entry and alias → adapter selection by `:api-type` → `build-request` → `gateway/request!`. Everything above that line — which participant is created, joined, observed and retired, which thread an agent attends to, which run a turn belongs to, when terminal usage is attached — is `main`'s, unmodified. A provider swap is invisible to it, which is why the lifecycle suites are green unchanged.

### Catalog maintenance and provenance

`default-models` is a manually maintained static fallback, not generated build output. The current OpenAI facts and base rates were checked on 2026-08-28 against [OpenAI model documentation](https://developers.openai.com/api/docs/models/gpt-5.6-sol) and [models.dev API data](https://models.dev/api.json). GPT-5.6 Sol is $4 input, $0.40 cached input, $20 output, and $5 cache write per million tokens. Base rates exclude long-context, service-tier, and account-specific billing.

`refresh-from-models-dev!` is an opt-in network overlay, defaulting to `#{:anthropic :openai}`. It can add models and replace mapped limits, reasoning options, and rate fields in process state while preserving dvergr-owned quirks, instruction roles, aliases, and explicit defaults. It does not write a resource or source file. `resources/models.edn` is a separate curated registry, primarily for configured Fireworks models.

### Verification

- `clojure -M:test --focus dvergr.model.providers-test --focus dvergr.model.openai-test` — 14 tests, 123 assertions, 0 failures.
- `clojure -M:test --focus dvergr.discourse-test --focus dvergr.discourse.llm-test --focus dvergr.agent.run-test --focus dvergr.repl-meta-harness-test` — 54 tests, 193 assertions, 0 failures. Covers participant lifecycle, thread-aware attention, durable runs, and `silent-failure-does-not-repost-stale-reply`.
- `clojure -M:test` — **476 tests, 2000 assertions, 0 failures.**
- `clojure -M:format` — all source files formatted correctly.
- `git diff --check` — clean.
- Secret scan over the added lines — no key-shaped literals; no raw key reaches a request map or a log.

Minimal live check against the real API, one short prompt each:

- `gpt-5.5`, `:max-tokens 256` → text `"ok"`, usage `{:input-tokens 17 :output-tokens 25}`, stop `:stop`, model echo `gpt-5.5-2026-04-23`.
- `gpt-5.6-luna` with one tool, `:max-tokens 64` → parsed tool call, usage `{:input-tokens 126 :output-tokens 12}`, stop `:tool_calls`.

This branch is also the substrate for replikativ/simmis#2, which exercises the same path through room settings, model selection, and a live agent turn.

### Primary references

- [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
- [GPT-5.6 Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
- [GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna)
- [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5)
- [GPT-5.4 mini](https://developers.openai.com/api/docs/models/gpt-5.4-mini)
- [Chat Completions create](https://developers.openai.com/api/reference/cli/resources/chat/subresources/completions/methods/create)
