### PR TITLE
fix(room-store): preserve canonical message envelopes

### DIFF
--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -114,6 +114,20 @@
     :db/cardinality :db.cardinality/one
     :db/doc "Message role: :user :assistant :system :tool-result"}
 
+   ;; Discourse envelope identity. Actor ids are keywords throughout dvergr;
+   ;; keeping them as values (rather than refs into the system DB) is what lets
+   ;; per-room stores remain independent and later join through distributed
+   ;; index space.
+   {:db/ident :message/from
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc "Canonical actor id that authored the message"}
+
+   {:db/ident :message/to
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc "Canonical addressed actor id; absent means room broadcast"}
+
    ;; Content
    {:db/ident :message/content
     :db/valueType :db.type/string
@@ -133,6 +147,19 @@
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/one
     :db/doc "Optional reference to message this is a reply to"}
+
+   {:db/ident :message/in-reply-to
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/doc "Stable parent message id from the discourse envelope. Unlike the
+             legacy ref, this survives out-of-order import and replay."}
+
+   {:db/ident :message/metadata
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "EDN extension map from the discourse envelope. Query-critical
+             fields have dedicated attributes; this preserves attachment,
+             provenance and adapter extensions losslessly across replay."}
 
    ;; Mentions/References
    {:db/ident :message/mentions

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -50,8 +50,10 @@
   (-store-message! [this room-id message]
     "Persist a single Message. `message` is a discourse.Message record
      (with :id :from :to :content :ts :in-reply-to :metadata) OR a
-     map with the same keys. Implementations must be idempotent on
-     :id — re-stores are no-ops.")
+     map with the same keys. :from and non-nil :to are canonical keyword actor
+     ids; :in-reply-to is a stable message UUID and :metadata is structured
+     EDN. Implementations replay these envelope fields losslessly and must be
+     first-write-wins idempotent on :id — re-stores are no-ops.")
 
   (-list-messages [this room-id {:keys [limit since]}]
     "Return messages in chronological order. :limit caps result size

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -7,7 +7,8 @@
    The store maps a Room's keyword id ↔ a Datahike :chat/id UUID via
    the :room/slug attribute (`slug->room-id`/`room-id->slug` in
    `dvergr.room.store`)."
-  (:require [datahike.api :as dh]
+  (:require [clojure.edn :as edn]
+            [datahike.api :as dh]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.persist :as persist]
             [dvergr.room.store :as store]
@@ -16,6 +17,31 @@
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
+
+(defn- metadata->edn
+  "Encode envelope extensions only when they are readable EDN. A bad adapter
+   value must not make an otherwise valid message impossible to persist."
+  [metadata]
+  (when (seq metadata)
+    (let [encoded (pr-str metadata)]
+      (try
+        ;; Validate now so replay cannot discover an unreadable #object later.
+        (edn/read-string encoded)
+        encoded
+        (catch Throwable t
+          (tel/log! {:level :warn :id :room-store/unreadable-message-metadata
+                     :data {:error (.getMessage t)}}
+                    "message metadata is not EDN — structured fields still persist")
+          nil)))))
+
+(defn- edn->metadata [encoded]
+  (when encoded
+    (try
+      (edn/read-string encoded)
+      (catch Throwable t
+        (tel/log! {:level :warn :id :room-store/unreadable-stored-metadata
+                   :data {:error (.getMessage t)}})
+        nil))))
 
 (defn- room-by-slug
   [conn slug]
@@ -80,6 +106,7 @@
         msg-id       (:id msg)
         ts           (some-> (:ts msg) (java.util.Date.))
         metadata     (:metadata msg)
+        metadata-edn (metadata->edn metadata)
         role         (store/infer-role msg)
         source-user  (or (:source-user metadata)
                          (some-> (:from msg) name)
@@ -90,6 +117,10 @@
              :message/content    content
              :message/created-at (or ts (java.util.Date.))
              :message/source-user source-user}
+      (keyword? (:from msg)) (assoc :message/from (:from msg))
+      (keyword? (:to msg)) (assoc :message/to (:to msg))
+      (uuid? (:in-reply-to msg)) (assoc :message/in-reply-to (:in-reply-to msg))
+      metadata-edn (assoc :message/metadata metadata-edn)
       (:source-username metadata) (assoc :message/source-username (:source-username metadata))
       (:source-user-id  metadata) (assoc :message/source-user-id  (long (:source-user-id metadata)))
       ;; Structured tool-uses (already serialized component maps from the
@@ -156,16 +187,23 @@
   (-store-message! [_ room-id msg]
     (let [slug (store/room-id->slug room-id)]
       (if-let [ent (room-by-slug conn slug)]
-        (let [chat-id (:chat/id ent)
-              entity  (message->entity chat-id msg)]
-          ;; One durability policy (surface + retry-once + dead-letter) instead
-          ;; of the old catch-and-silently-drop — a lost message is now visible
-          ;; and recoverable, not swallowed at :warn.
-          (persist/persist-tx! conn
-                               [entity
-                                {:db/id [:chat/id chat-id]
-                                 :chat/updated-at (java.util.Date.)}]
-                               {:op :store-message :room-id room-id :msg-id (:id msg)}))
+        ;; PRoomStore promises first-write-wins idempotence. A lookup-identity
+        ;; upsert alone would silently overwrite content when an adapter retries
+        ;; the same id with a changed envelope.
+        (when-not (dh/q '[:find ?m .
+                          :in $ ?mid
+                          :where [?m :message/id ?mid]]
+                        @conn (:id msg))
+          (let [chat-id (:chat/id ent)
+                entity  (message->entity chat-id msg)]
+            ;; One durability policy (surface + retry-once + dead-letter) instead
+            ;; of the old catch-and-silently-drop — a lost message is now visible
+            ;; and recoverable, not swallowed at :warn.
+            (persist/persist-tx! conn
+                                 [entity
+                                  {:db/id [:chat/id chat-id]
+                                   :chat/updated-at (java.util.Date.)}]
+                                 {:op :store-message :room-id room-id :msg-id (:id msg)})))
         (tel/log! {:level :error :id :room-store/datahike-missing-room
                    :data {:room-id room-id :msg-id (:id msg)}}
                   "message for unknown room — not persisted (dropped)"))))
@@ -176,7 +214,9 @@
         (let [chat-id (:chat/id ent)
               base    (dh/q '[:find [(pull ?m [:message/id :message/role :message/content
                                                :message/created-at :message/source-user
-                                               :message/source-username :message/reasoning
+                                               :message/source-username :message/source-user-id
+                                               :message/from :message/to :message/in-reply-to
+                                               :message/metadata :message/reasoning
                                                {:message/tool-uses
                                                 [:tool-use/id :tool-use/name
                                                  {:tool-use/input [*]}]}]) ...]
@@ -196,22 +236,32 @@
           ;; see {:id :from :to :content :ts :role :metadata} regardless of
           ;; which store backs the room.
           (mapv (fn [m]
-                  (cond-> {:id        (:message/id m)
-                           :from      (some-> (:message/source-user m) keyword)
-                           :to        nil
-                           :content   (:message/content m)
-                           :ts        (some-> (:message/created-at m) .getTime)
-                           :role      (:message/role m)
-                           :metadata  {:source-user     (:message/source-user m)
-                                       :source-username (:message/source-username m)}}
+                  (let [stored-metadata (or (edn->metadata (:message/metadata m)) {})
+                        metadata (cond-> stored-metadata
+                                   (:message/source-user m)
+                                   (assoc :source-user (:message/source-user m))
+                                   (:message/source-username m)
+                                   (assoc :source-username (:message/source-username m))
+                                   (:message/source-user-id m)
+                                   (assoc :source-user-id (:message/source-user-id m)))]
+                    (cond-> {:id        (:message/id m)
+                             :from      (or (:message/from m)
+                                            (some-> (:message/source-user m) keyword))
+                             :to        (:message/to m)
+                             :content   (:message/content m)
+                             :ts        (some-> (:message/created-at m) .getTime)
+                             :role      (:message/role m)
+                             :metadata  metadata}
+                      (:message/in-reply-to m)
+                      (assoc :in-reply-to (:message/in-reply-to m))
                     ;; Surface structured tool-uses so rich frontends render an
                     ;; agent's tool activity inline (same as the chat-ctx view).
-                    (seq (:message/tool-uses m))
-                    (assoc :tool-uses (:message/tool-uses m))
+                      (seq (:message/tool-uses m))
+                      (assoc :tool-uses (:message/tool-uses m))
                     ;; Surface the interleaved-thinking trace so seeding can feed
                     ;; it back to reasoning models (MiniMax M2 / Kimi / DeepSeek).
-                    (seq (:message/reasoning m))
-                    (assoc :reasoning (:message/reasoning m))))
+                      (seq (:message/reasoning m))
+                      (assoc :reasoning (:message/reasoning m)))))
                 (vec (take-last (or limit 100) filtered))))))))
 
 (defn make

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -1,0 +1,35 @@
+(ns dvergr.room.store.contract
+  "Behavioral contract shared by every PRoomStore implementation."
+  (:require [clojure.test :refer [is testing]]
+            [dvergr.room.store :as store]))
+
+(defn assert-message-envelope!
+  "Exercise lossless envelope replay and first-write-wins idempotence."
+  [st room-id]
+  (testing "message envelope round-trips"
+    (let [parent-id (random-uuid)
+          child-id (random-uuid)
+          ts 1787860800123
+          metadata {:role :user
+                    :source-user "Alice"
+                    :attachment {:blob-id (random-uuid) :mime "audio/ogg"}
+                    :audience #{:agent/reviewer}
+                    :provenance {:mode :live :source :screen}}
+          parent {:id parent-id :from :party/alice :to nil
+                  :content "proposal" :ts (dec ts) :role :user
+                  :metadata {:role :user :source-user "Alice"}}
+          child {:id child-id :from :party/alice :to :agent/reviewer
+                 :content "please review" :ts ts :in-reply-to parent-id
+                 :role :user :metadata metadata}]
+      (store/-store-room! st room-id {:slug (name room-id) :title "Contract"})
+      ;; Imports and distributed replay may see a reply before its parent. The
+      ;; stable UUID field must not require the target entity to exist yet.
+      (store/-store-message! st room-id child)
+      (store/-store-message! st room-id parent)
+      ;; A retry carrying mutated data must not rewrite durable history.
+      (store/-store-message! st room-id (assoc child :content "mutated retry"))
+      (let [replayed (some #(when (= child-id (:id %)) %)
+                           (store/-list-messages st room-id {}))]
+        (is (= (select-keys child [:id :from :to :content :ts :in-reply-to :role])
+               (select-keys replayed [:id :from :to :content :ts :in-reply-to :role])))
+        (is (= metadata (:metadata replayed)))))))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -7,6 +7,7 @@
             [datahike.api :as dh]
             [dvergr.chat.schema :as schema]
             [dvergr.room.store :as store]
+            [dvergr.room.store.contract :as contract]
             [dvergr.room.store.datahike :as dhs]))
 
 (defn- mem-store []
@@ -17,6 +18,10 @@
     (let [conn (dh/connect cfg)]
       (schema/ensure-full-schema! conn)
       [conn (dhs/make conn)])))
+
+(deftest message-envelope-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-message-envelope! st :envelope-datahike)))
 
 (deftest tool-uses-round-trip
   (testing "the room store persists and returns structured :tool-uses"

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -1,0 +1,7 @@
+(ns dvergr.room.store.memory-test
+  (:require [clojure.test :refer [deftest]]
+            [dvergr.room.store.contract :as contract]
+            [dvergr.room.store.memory :as memory]))
+
+(deftest message-envelope-contract
+  (contract/assert-message-envelope! (memory/make) :envelope-memory))


### PR DESCRIPTION
## Summary

- persist canonical `:from`, `:to`, and stable UUID `:in-reply-to` fields in Datahike room stores
- round-trip structured EDN metadata, including attachments and provenance, while retaining legacy source fields
- make Datahike message persistence first-write-wins idempotent like the memory store
- add one behavioral `PRoomStore` contract exercised by both implementations

## Why

`PRoomStore` accepts the full discourse message envelope, but the Datahike implementation previously discarded audience, reply causality, and general structured metadata during replay. That prevented Simmis and other clients from using canonical dvergr messages without maintaining a second projection.

A REPL experiment also confirmed that a Datahike lookup ref fails when an imported reply arrives before its parent. The durable contract therefore stores the parent message UUID directly; the older ref attribute remains available to legacy chat APIs.

## Verification

- REPL contract run: 4 tests, 9 assertions, 0 failures
- `clj -M:format`
- focused Datahike tests: 3 tests, 7 assertions, 0 failures
- focused memory tests: 1 test, 2 assertions, 0 failures
- `clj -M:test --skip-meta :integration`: 415 tests, 1638 assertions, 0 failures