### PR TITLE
feat(rooms): persist actor assignments and response policies

### DIFF
--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -617,6 +617,56 @@
     :db/doc "EDN-encoded map {skill-kw → int-priority}; overrides kind default"}])
 
 ;; ============================================================================
+;; Room Assignment Schema (actor participation + dispatch policy)
+;; ============================================================================
+
+(def assignment-schema
+  "A durable actor assignment to a room. Assignment is intentionally richer
+   than presence: it records why an actor is in the room and when an inbound
+   message should wake it. Runtime presence and run state are projections over
+   this relation, not fields on it.
+
+   `:assignment/config` is EDN so clients can add actor- or role-specific
+   settings without creating a second application-owned assignment record."
+  [{:db/ident :assignment/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :assignment/room
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc "Assigned room, identified by :room/id"}
+
+   {:db/ident :assignment/actor
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc "Assigned actor, identified by :actor/id"}
+
+   {:db/ident :assignment/role
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc ":lead | :specialist | :reviewer | :observer"}
+
+   {:db/ident :assignment/response-policy
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc ":always | :mention | :manual"}
+
+   {:db/ident :assignment/config
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "EDN-encoded assignment-specific configuration"}
+
+   {:db/ident :assignment/created-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :assignment/updated-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}])
+
+;; ============================================================================
 ;; Task Schema (skill dispatches to humans / externals)
 ;; ============================================================================
 
@@ -701,6 +751,7 @@
                task-schema
                room-schema
                actor-schema
+               assignment-schema
                task-dispatch-schema)))
 
 ;; ============================================================================

--- a/src/dvergr/rooms.clj
+++ b/src/dvergr/rooms.clj
@@ -271,27 +271,43 @@
 
 (defn join-agent!
   "Join `agent-id` to `room-ref` (a Room, room-id keyword, or slug):
-   - Persists the agent in the system-db registry (`:room/agent-ids`).
+   - Persists a first-class room assignment in the system-db and maintains
+     `:room/agent-ids` as a compatibility projection.
    - If the agent is running AND the discourse Room is registered, clones its
      Participant via `:factory` and joins it so it actually receives messages.
 
-   Returns {:joined? true :discourse-joined? <bool>} for inspection."
-  [room-ref agent-id]
-  (let [slug (->slug room-ref)
-        agent-id (if (keyword? agent-id) agent-id (keyword agent-id))]
-    (when slug (sdb/add-room-agent! slug agent-id))
-    (let [room (when slug (rreg/lookup (rstore/slug->room-id slug)))
-          d-joined? (discourse-join! room agent-id)]
-      {:joined? true :discourse-joined? d-joined? :agent-id agent-id
-       :room (:id room)})))
+   Optional assignment opts are `:role`, `:response-policy` and `:config`.
+   Returns the durable assignment alongside the runtime join result."
+  ([room-ref agent-id]
+   (join-agent! room-ref agent-id {}))
+  ([room-ref agent-id assignment-opts]
+   (let [slug (->slug room-ref)
+         agent-id (if (keyword? agent-id) agent-id (keyword agent-id))
+         assignment (when slug
+                      (try
+                        (sdb/assign-room-actor! slug agent-id assignment-opts)
+                        (catch clojure.lang.ExceptionInfo e
+                          ;; Historical callers could record a not-yet-running
+                          ;; agent id before its actor row existed. Preserve that
+                          ;; boot ordering as a compatibility membership; it is
+                          ;; exposed as `:assignment/legacy?` until materialized.
+                          (if (= "Cannot assign an unknown actor" (.getMessage e))
+                            (do (sdb/add-room-agent! slug agent-id)
+                                (sdb/assignment-for slug agent-id))
+                            (throw e)))))
+         room (when slug (rreg/lookup (rstore/slug->room-id slug)))
+         d-joined? (discourse-join! room agent-id)]
+     {:joined? true :discourse-joined? d-joined? :agent-id agent-id
+      :assignment assignment :room (:id room)})))
 
 (defn leave-agent!
-  "Remove `agent-id` from `room-ref`'s registry membership (`:room/agent-ids`).
+  "Remove `agent-id` from `room-ref`'s assignment and compatibility membership.
    (Discourse-level leave is not automatic — the Participant stays joined until
    the daemon restarts.)"
   [room-ref agent-id]
   (when-let [slug (->slug room-ref)]
-    (sdb/remove-room-agent! slug (if (keyword? agent-id) agent-id (keyword agent-id)))))
+    (sdb/unassign-room-actor!
+     slug (if (keyword? agent-id) agent-id (keyword agent-id)))))
 
 (defn set-parent!
   "Set the parent of `child-ref` to `parent-ref` (Rooms, room-ids, or slugs) in

--- a/src/dvergr/system/db.clj
+++ b/src/dvergr/system/db.clj
@@ -9,6 +9,7 @@
    - `:system/*`  — the registry of attachable yggdrasil systems (KBs, repos, …),
                     each carrying its own store *scope*.
    - `:room/*`    — rooms as top-level projects (own message-DB scope + owner).
+   - `:assignment/*` — actor roles and response policies within rooms.
    - `:grant/*`   — room↔system attachment edges, each with a permission.
 
    A room defaults to owning its own KB + repo (a `:grant` with `:owner`).
@@ -16,9 +17,12 @@
    on the fly — the durable record lives here; the live runtime attach/detach
    happens on the room's yggdrasil composite (spindel `register!` / `detach!`).
    Generalises simmis's `is.simm.model.system-db` from `:kb/*` to any `:system/*`."
-  (:require [datahike.api :as d]
+  (:require [clojure.edn :as edn]
+            [datahike.api :as d]
             [dvergr.chat.schema :as cschema]
-            [dvergr.substrate.paths :as paths]))
+            [dvergr.substrate.paths :as paths])
+  (:import [java.nio.charset StandardCharsets]
+           [java.util UUID]))
 
 ;; ---------------------------------------------------------------------------
 ;; Schema
@@ -81,6 +85,12 @@
 ;; S5 reconciles the two.
 (def actor-schema cschema/actor-schema)
 
+;; --- Assignments: room-specific actor role + response policy ---
+;; This is the canonical participation relation. `:room/agent-ids` remains as a
+;; compatibility projection for existing room hydration and clients while they
+;; move to assignments.
+(def assignment-schema cschema/assignment-schema)
+
 ;; --- Pricing: the global model price list ---
 ;; RF5 S3: pricing is truly-global, read-mostly config (a model's price is the
 ;; same in every room), so it belongs in system-db. The live price source today
@@ -117,7 +127,8 @@
       (let [c (cfg)]
         (when-not (d/database-exists? c) (d/create-database c))
         (let [conn (d/connect c)]
-          (d/transact conn (vec (concat schema actor-schema pricing-schema task-schema)))
+          (d/transact conn (vec (concat schema actor-schema assignment-schema
+                                        pricing-schema task-schema)))
           (reset! conn-atom conn)))))
 
 (defn reset-conn!
@@ -203,15 +214,192 @@
        @(get-conn) (long telegram-chat-id)))
 
 (defn add-room-agent!
-  "Add `agent-id` (keyword) to a room's `:room/agent-ids` set (by slug)."
+  "Add `agent-id` to the legacy `:room/agent-ids` compatibility projection.
+   New code should call `assign-room-actor!`, which writes both models."
   [slug agent-id]
   (d/transact (get-conn) [{:room/slug slug :room/agent-ids agent-id}]))
 
 (defn remove-room-agent!
-  "Remove `agent-id` from a room's `:room/agent-ids` set (by slug)."
+  "Remove `agent-id` from the legacy `:room/agent-ids` compatibility projection.
+   New code should call `unassign-room-actor!`, which retracts both models."
   [slug agent-id]
   (when-let [eid (d/q '[:find ?e . :in $ ?s :where [?e :room/slug ?s]] @(get-conn) slug)]
     (d/transact (get-conn) [[:db/retract eid :room/agent-ids agent-id]])))
+
+;; ---------------------------------------------------------------------------
+;; Room assignments
+;; ---------------------------------------------------------------------------
+
+(def assignment-roles
+  "Roles understood by the generic room assignment contract."
+  #{:lead :specialist :reviewer :observer})
+
+(def response-policies
+  "Automatic response policies. `:manual` actors remain addressable but are
+   never awakened merely because a message was posted."
+  #{:always :mention :manual})
+
+(defn- assignment-id
+  [room-id actor-id]
+  (UUID/nameUUIDFromBytes
+   (.getBytes (str "dvergr/assignment:" room-id ":" actor-id)
+              StandardCharsets/UTF_8)))
+
+(defn- read-config [config]
+  (cond
+    (map? config) config
+    (string? config) (let [parsed (edn/read-string config)]
+                       (if (map? parsed)
+                         parsed
+                         (throw (ex-info "Assignment config EDN must decode to a map"
+                                         {:config config :decoded parsed}))))
+    (nil? config) {}
+    :else (throw (ex-info "Assignment config must be a map or EDN map string"
+                          {:config config}))))
+
+(defn- normalize-assignment [assignment]
+  (when assignment
+    {:assignment/id (:assignment/id assignment)
+     :assignment/room-id (get-in assignment [:assignment/room :room/id])
+     :assignment/room-slug (get-in assignment [:assignment/room :room/slug])
+     :assignment/actor-id (get-in assignment [:assignment/actor :actor/id])
+     :assignment/actor-name (get-in assignment [:assignment/actor :actor/name])
+     :assignment/actor-kind (get-in assignment [:assignment/actor :actor/kind])
+     :assignment/role (:assignment/role assignment)
+     :assignment/response-policy (:assignment/response-policy assignment)
+     :assignment/config (read-config (:assignment/config assignment))
+     :assignment/created-at (:assignment/created-at assignment)
+     :assignment/updated-at (:assignment/updated-at assignment)}))
+
+(def ^:private assignment-pull
+  [:assignment/id :assignment/role :assignment/response-policy
+   :assignment/config :assignment/created-at :assignment/updated-at
+   {:assignment/room [:room/id :room/slug]}
+   {:assignment/actor [:actor/id :actor/name :actor/kind]}])
+
+(defn- persisted-room-assignments [conn slug]
+  (->> (d/q '[:find [(pull ?assignment ?pull) ...]
+              :in $ ?slug ?pull
+              :where
+              [?room :room/slug ?slug]
+              [?assignment :assignment/room ?room]]
+            @conn slug assignment-pull)
+       (map normalize-assignment)))
+
+(defn room-assignments
+  "Return every actor assignment for room `slug`, sorted by actor id.
+
+   A pre-assignment `:room/agent-ids` member is returned as a read-only
+   `:assignment/legacy? true` default (`:specialist`/`:always`). This keeps
+   existing rooms dispatch-compatible without an eager migration. The first
+   assignment edit materializes the canonical row."
+  [slug]
+  (let [conn (get-conn)
+        room (room-by-slug slug)
+        persisted (persisted-room-assignments conn slug)
+        by-actor (into {} (map (juxt :assignment/actor-id identity)) persisted)
+        legacy (for [actor-id (:room/agent-ids room)
+                     :when (not (contains? by-actor actor-id))
+                     :let [actor (d/q '[:find (pull ?actor [:actor/id :actor/name :actor/kind]) .
+                                        :in $ ?id
+                                        :where [?actor :actor/id ?id]]
+                                      @conn actor-id)]]
+                 {:assignment/id (assignment-id (:room/id room) actor-id)
+                  :assignment/room-id (:room/id room)
+                  :assignment/room-slug slug
+                  :assignment/actor-id actor-id
+                  :assignment/actor-name (:actor/name actor)
+                  :assignment/actor-kind (:actor/kind actor)
+                  :assignment/role :specialist
+                  :assignment/response-policy :always
+                  :assignment/config {}
+                  :assignment/legacy? true})]
+    (->> (concat persisted legacy)
+         (sort-by (comp str :assignment/actor-id))
+         vec)))
+
+(defn assignment-for
+  "The canonical or compatibility assignment for `[room-slug actor-id]`."
+  [slug actor-id]
+  (some #(when (= actor-id (:assignment/actor-id %)) %)
+        (room-assignments slug)))
+
+(defn assign-room-actor!
+  "Create or update one room assignment and maintain `:room/agent-ids` as a
+   compatibility projection. `opts` may contain `:role`, `:response-policy`
+   and `:config`; omitted values preserve an existing canonical assignment or
+   default to `:specialist`, `:always` and `{}`.
+
+   The room and actor must already exist. Returns the normalized assignment."
+  [slug actor-id {:keys [role response-policy config] :as opts}]
+  (let [conn (get-conn)
+        room (room-by-slug slug)
+        actor (d/q '[:find (pull ?actor [:actor/id]) .
+                     :in $ ?id
+                     :where [?actor :actor/id ?id]]
+                   @conn actor-id)]
+    (when-not room
+      (throw (ex-info "Cannot assign an actor to an unknown room"
+                      {:room-slug slug :actor-id actor-id})))
+    (when-not actor
+      (throw (ex-info "Cannot assign an unknown actor"
+                      {:room-slug slug :actor-id actor-id})))
+    (let [existing (some #(when (and (= actor-id (:assignment/actor-id %))
+                                     (not (:assignment/legacy? %))) %)
+                         (persisted-room-assignments conn slug))
+          role (or role (:assignment/role existing) :specialist)
+          response-policy (or response-policy
+                              (:assignment/response-policy existing)
+                              :always)
+          config (if (contains? opts :config)
+                   (read-config config)
+                   (or (:assignment/config existing) {}))
+          timestamp (now)
+          id (assignment-id (:room/id room) actor-id)]
+      (when-not (contains? assignment-roles role)
+        (throw (ex-info "Unknown room assignment role"
+                        {:role role :allowed assignment-roles})))
+      (when-not (contains? response-policies response-policy)
+        (throw (ex-info "Unknown room response policy"
+                        {:response-policy response-policy
+                         :allowed response-policies})))
+      (d/transact conn
+                  [(cond-> {:assignment/id id
+                            :assignment/room [:room/id (:room/id room)]
+                            :assignment/actor [:actor/id actor-id]
+                            :assignment/role role
+                            :assignment/response-policy response-policy
+                            :assignment/config (pr-str config)
+                            :assignment/updated-at timestamp}
+                     (nil? existing) (assoc :assignment/created-at timestamp))
+                   {:room/slug slug :room/agent-ids actor-id}])
+      (assignment-for slug actor-id))))
+
+(defn unassign-room-actor!
+  "Remove the canonical assignment and its legacy room membership projection.
+   Idempotent; returns true when either representation existed."
+  [slug actor-id]
+  (let [conn (get-conn)
+        room (room-by-slug slug)
+        assignment (assignment-for slug actor-id)
+        room-eid (when room
+                   (d/q '[:find ?room . :in $ ?id :where [?room :room/id ?id]]
+                        @conn (:room/id room)))
+        actor-eid (d/q '[:find ?actor . :in $ ?id :where [?actor :actor/id ?id]]
+                       @conn actor-id)
+        assignment-eid (when (and room-eid actor-eid)
+                         (d/q '[:find ?assignment .
+                                :in $ ?room ?actor
+                                :where
+                                [?assignment :assignment/room ?room]
+                                [?assignment :assignment/actor ?actor]]
+                              @conn room-eid actor-eid))
+        tx (cond-> []
+             assignment-eid (conj [:db/retractEntity assignment-eid])
+             (and room-eid assignment)
+             (conj [:db/retract room-eid :room/agent-ids actor-id]))]
+    (when (seq tx) (d/transact conn tx))
+    (boolean assignment)))
 
 (defn set-room-parent!
   "Set a room's parent (by slugs)."

--- a/test/dvergr/system/assignment_test.clj
+++ b/test/dvergr/system/assignment_test.clj
@@ -1,0 +1,116 @@
+(ns dvergr.system.assignment-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [dvergr.actors :as actors]
+            [dvergr.rooms :as rooms]
+            [dvergr.system.db :as sdb]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(def ^:dynamic *conn* nil)
+
+(defn- memory-system-db [f]
+  (let [config {:store {:backend :memory :id (random-uuid)}
+                :schema-flexibility :write
+                :keep-history? false}]
+    (d/create-database config)
+    (let [conn (d/connect config)
+          execution-context (context/create-execution-context)]
+      (d/transact conn (vec (concat sdb/schema sdb/actor-schema
+                                    sdb/assignment-schema)))
+      (binding [*conn* conn
+                ec/*execution-context* execution-context]
+        (with-redefs [sdb/get-conn (constantly conn)]
+          (try
+            (f)
+            (finally
+              (d/release conn)
+              (d/delete-database config))))))))
+
+(use-fixtures :each memory-system-db)
+
+(deftest legacy-membership-is-a-compatible-assignment
+  (sdb/create-room! {:slug "old-room" :name "Old room"
+                     :agent-ids #{:not-yet-running}})
+  (is (= [{:assignment/actor-id :not-yet-running
+           :assignment/role :specialist
+           :assignment/response-policy :always
+           :assignment/legacy? true}]
+         (mapv #(select-keys % [:assignment/actor-id :assignment/role
+                                :assignment/response-policy :assignment/legacy?])
+               (sdb/room-assignments "old-room")))))
+
+(deftest assignment-roundtrip-and-partial-update
+  (actors/spawn-agent! *conn* {:id :researcher :name "Researcher"})
+  (sdb/create-room! {:slug "product" :name "Product"})
+  (let [created (sdb/assign-room-actor!
+                 "product" :researcher
+                 {:role :lead
+                  :response-policy :mention
+                  :config {:budget-dollars 4 :focus :customers}})
+        updated (sdb/assign-room-actor!
+                 "product" :researcher {:response-policy :manual})]
+    (testing "the canonical relation carries role, policy, actor and config"
+      (is (uuid? (:assignment/id created)))
+      (is (= :researcher (:assignment/actor-id created)))
+      (is (= "Researcher" (:assignment/actor-name created)))
+      (is (= :lead (:assignment/role created)))
+      (is (= :mention (:assignment/response-policy created)))
+      (is (= {:budget-dollars 4 :focus :customers}
+             (:assignment/config created))))
+    (testing "an omitted role/config survives a policy-only update"
+      (is (= (:assignment/id created) (:assignment/id updated)))
+      (is (= (:assignment/created-at created) (:assignment/created-at updated)))
+      (is (= :lead (:assignment/role updated)))
+      (is (= :manual (:assignment/response-policy updated)))
+      (is (= (:assignment/config created) (:assignment/config updated))))
+    (testing "legacy membership is maintained but not duplicated on reads"
+      (is (= #{:researcher}
+             (set (:room/agent-ids (sdb/room-by-slug "product")))))
+      (is (= [updated] (sdb/room-assignments "product"))))))
+
+(deftest assignment-input-is-validated
+  (actors/spawn-agent! *conn* {:id :reviewer})
+  (sdb/create-room! {:slug "review" :name "Review"})
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown room"
+                        (sdb/assign-room-actor! "missing" :reviewer {})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown actor"
+                        (sdb/assign-room-actor! "review" :missing {})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"assignment role"
+                        (sdb/assign-room-actor! "review" :reviewer
+                                                {:role :wizard})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"response policy"
+                        (sdb/assign-room-actor! "review" :reviewer
+                                                {:response-policy :sometimes})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"config must be"
+                        (sdb/assign-room-actor! "review" :reviewer
+                                                {:config [:not :a :map]})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"decode to a map"
+                        (sdb/assign-room-actor! "review" :reviewer
+                                                {:config "[:still :not-a-map]"}))))
+
+(deftest unassign-retracts-both-representations
+  (actors/spawn-agent! *conn* {:id :observer})
+  (sdb/create-room! {:slug "ops" :name "Ops"})
+  (sdb/assign-room-actor! "ops" :observer
+                          {:role :observer :response-policy :manual})
+  (is (true? (sdb/unassign-room-actor! "ops" :observer)))
+  (is (empty? (sdb/room-assignments "ops")))
+  (is (empty? (:room/agent-ids (sdb/room-by-slug "ops"))))
+  (is (false? (sdb/unassign-room-actor! "ops" :observer))))
+
+(deftest join-agent-materializes-when-identity-is-available
+  (sdb/create-room! {:slug "dispatch" :name "Dispatch"})
+  (testing "boot ordering remains compatible before an actor row exists"
+    (let [result (rooms/join-agent! "dispatch" :late-agent)]
+      (is (not (:discourse-joined? result)))
+      (is (true? (get-in result [:assignment :assignment/legacy?])))))
+  (testing "joining again materializes the assignment with explicit policy"
+    (actors/spawn-agent! *conn* {:id :late-agent :name "Late"})
+    (let [result (rooms/join-agent! "dispatch" :late-agent
+                                    {:role :reviewer
+                                     :response-policy :mention})]
+      (is (= :reviewer (get-in result [:assignment :assignment/role])))
+      (is (= :mention
+             (get-in result [:assignment :assignment/response-policy])))
+      (is (nil? (get-in result [:assignment :assignment/legacy?]))))))


### PR DESCRIPTION
## Summary

- add canonical room assignments with role, response policy, config, and stable identity
- preserve `:room/agent-ids` as a compatibility projection during rollout
- expose legacy memberships as synthetic `:specialist` / `:always` assignments until first edit
- extend `join-agent!` and `leave-agent!` to materialize/retract assignments without breaking actor-late boot ordering

## Why

Room membership currently cannot express whether an actor is a lead, reviewer, observer, always-on responder, mention-only responder, or manually invoked participant. Simmis needs this durable substrate before replacing its unsafe mention fallback and adding multi-agent room controls.

## Verification

- `clj -M:ffix`
- `clj -M:format`
- focused assignment contract: 5 tests, 29 assertions, 0 failures
- full suite: 418 tests, 1663 assertions; the only failure is the existing jail fixture checking for `deps.edn` inside the default workspace when run from the isolated `/tmp` worktree
- that jail test passes when the branch source is run from dvergr's normal workspace, confirming the failure is worktree-path dependent
