### PR TITLE
Store message metadata as typed datoms

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -70,7 +70,7 @@
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        org.replikativ/datahike    {:mvn/version "0.8.1744"}
+        org.replikativ/datahike    {:mvn/version "0.8.1819"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.3.38 adopts the Geschichte adapter (yggdrasil.adapters.geschichte,
@@ -80,7 +80,7 @@
         org.replikativ/yggdrasil   {:mvn/version "0.3.38"}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
-        org.replikativ/scriptum    {:mvn/version "0.1.27"}
+        org.replikativ/scriptum    {:mvn/version "0.1.30"}
 
         ;; Briefkasten (local IMAP mirror) is OPTIONAL — it backs dvergr.intake.mail
         ;; only, and pulls the jakarta-mail tree, so it lives in the
@@ -89,11 +89,13 @@
         ;; Kabel — WebSocket peer-to-peer transport. 0.3.98 pins javac --release 11
         ;; (0.3.97 shipped Java-25 bytecode → UnsupportedClassVersionError on JDK <25).
         org.replikativ/kabel       {:mvn/version "0.3.98"}
+        ;; Compatibility alignment: Yggdrasil 0.3.38 still loads
+        ;; hasch.benc.HashRef, which was removed in Hasch 0.4.102. Drop this
+        ;; override when Yggdrasil moves to the new reference representation.
         org.replikativ/hasch       {:mvn/version "0.4.101"}
-        org.replikativ/incognito   {:mvn/version "0.3.69"}
-        org.replikativ/konserve    {:mvn/version "0.9.363"}
-        org.replikativ/kabel-auth  {:mvn/version "0.1.19"}
-        org.replikativ/superv.async {:mvn/version "0.3.50"}
+        ;; Dvergr's drive blob store uses Konserve directly. Keep this aligned
+        ;; with Datahike rather than relying on Datahike's transitive API.
+        org.replikativ/konserve    {:mvn/version "0.9.385"}
 
         ;; Distributed-scope — remote function invocation over Kabel
         is.simm/distributed-scope  {:mvn/version "0.1.2"}

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -154,12 +154,80 @@
     :db/doc "Stable parent message id from the discourse envelope. Unlike the
              legacy ref, this survives out-of-order import and replay."}
 
-   {:db/ident :message/metadata
+   ;; Structured envelope metadata. These are ordinary datoms on the message:
+   ;; clients can query/sync them independently and never need to parse an
+   ;; opaque EDN string. Actor ids remain keyword values for the same reason as
+   ;; :message/from/:message/to: room stores do not depend on system-db refs.
+   {:db/ident :message/audience
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/many
+    :db/doc "Canonical actor ids intended to observe or act on this message"}
+
+   {:db/ident :message/mention-handles
     :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/many
+    :db/doc "Presentation handles explicitly mentioned in the message"}
+
+   {:db/ident :message/metadata-kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/context-from
+    :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one
-    :db/doc "EDN extension map from the discourse envelope. Query-critical
-             fields have dedicated attributes; this preserves attachment,
-             provenance and adapter extensions losslessly across replay."}
+    :db/doc "Logical initiator carried by delegated/background work"}
+
+   ;; Attachments may name an object through Datahike's GC-aware store-ref, or
+   ;; carry a foreign CAS id (the current dvergr drive uses SHA-256 strings in a
+   ;; separately configured blob store). A message uses at most one form.
+   {:db/ident :message/attachment-store-ref
+    :db/valueType :db.type/store-ref
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/attachment-blob-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/attachment-node-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/attachment-mime
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/attachment-name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/attachment-size
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/provenance-mode
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/provenance-source
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   ;; Background-task notification envelope.
+   {:db/ident :message/notification-type
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/notification-agent
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/notification-task
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :message/notification-elapsed
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
 
    ;; Mentions/References
    {:db/ident :message/mentions

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -177,6 +177,16 @@
     :db/cardinality :db.cardinality/one
     :db/doc "Logical initiator carried by delegated/background work"}
 
+   {:db/ident :message/source
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc "Subsystem that originated the message, such as :scheduler"}
+
+   {:db/ident :message/schedule-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/doc "Schedule whose firing produced this message"}
+
    ;; Attachments may name an object through Datahike's GC-aware store-ref, or
    ;; carry a foreign CAS id (the current dvergr drive uses SHA-256 strings in a
    ;; separately configured blob store). A message uses at most one form.

--- a/src/dvergr/discourse/background.clj
+++ b/src/dvergr/discourse/background.clj
@@ -80,7 +80,9 @@
      :timeout-ms   — give up if the agent doesn't reply in this window.
                      Posts a :task-failed notification with content
                      '[timed out]'. Default 300000 (5 min).
-     :metadata     — extra metadata merged into the notification.
+     :metadata     — extra typed durable metadata merged into the notification;
+                     keys must belong to
+                     `dvergr.room.store/durable-message-metadata-keys`.
 
    Returns a TASK HANDLE map (the spawned spin is held alive by spindel's spawn
    keep-alive until its body resolves, so the task survives GC while suspended):

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -51,9 +51,12 @@
     "Persist a single Message. `message` is a discourse.Message record
      (with :id :from :to :content :ts :in-reply-to :metadata) OR a
      map with the same keys. :from and non-nil :to are canonical keyword actor
-     ids; :in-reply-to is a stable message UUID and :metadata is structured
-     EDN. Implementations replay these envelope fields losslessly and must be
-     first-write-wins idempotent on :id — re-stores are no-ops.")
+     ids; :in-reply-to is a stable message UUID and :metadata uses dvergr's
+     typed durable vocabulary (role/source, audience/mentions, attachment,
+     provenance, notification, tool-use and reasoning fields). Implementations
+     replay these envelope fields losslessly and must be first-write-wins
+     idempotent on :id — re-stores are no-ops. Unknown durable metadata is an
+     error: extend the typed schema rather than adding an opaque encoding.")
 
   (-list-messages [this room-id {:keys [limit since]}]
     "Return messages in chronological order. :limit caps result size
@@ -63,6 +66,53 @@
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
+
+(def durable-message-metadata-keys
+  "The top-level metadata keys that every PRoomStore implementation accepts.
+   New durable extensions must add typed storage in persistent implementations
+   before being added here."
+  #{:role :source-user :source-username :source-user-id
+    :audience :mentions :attachment :provenance
+    :tool-uses :reasoning :kind :from
+    :notification/type :notification/agent :notification/task
+    :notification/elapsed})
+
+(def ^:private attachment-metadata-keys #{:blob-id :node-id :mime :name :size})
+(def ^:private provenance-metadata-keys #{:mode :source})
+
+(defn- reject-unknown-metadata! [kind allowed value]
+  (let [unknown (seq (remove allowed (keys (or value {}))))]
+    (when unknown
+      (throw (ex-info (str "Unknown durable message " kind " keys")
+                      {:type :room-store/unknown-message-metadata
+                       :kind kind
+                       :unknown (set unknown)
+                       :allowed allowed})))))
+
+(defn validate-message-metadata!
+  "Validate the typed durable message metadata vocabulary and return `metadata`.
+   Kept at the protocol boundary so ephemeral and persistent stores reject the
+   same accidental, unmodelled extensions."
+  [metadata]
+  (when metadata
+    (when-not (map? metadata)
+      (throw (ex-info "Durable message metadata must be a map"
+                      {:type :room-store/invalid-message-metadata
+                       :value metadata})))
+    (reject-unknown-metadata! :metadata durable-message-metadata-keys metadata)
+    (when-let [attachment (:attachment metadata)]
+      (when-not (map? attachment)
+        (throw (ex-info "Message attachment metadata must be a map"
+                        {:type :room-store/invalid-message-metadata
+                         :attachment attachment})))
+      (reject-unknown-metadata! :attachment attachment-metadata-keys attachment))
+    (when-let [provenance (:provenance metadata)]
+      (when-not (map? provenance)
+        (throw (ex-info "Message provenance metadata must be a map"
+                        {:type :room-store/invalid-message-metadata
+                         :provenance provenance})))
+      (reject-unknown-metadata! :provenance provenance-metadata-keys provenance)))
+  metadata)
 
 (defn message-shape?
   "True if `msg` looks like a Message (has the required keys). Used by

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -73,7 +73,7 @@
    before being added here."
   #{:role :source-user :source-username :source-user-id
     :audience :mentions :attachment :provenance
-    :tool-uses :reasoning :kind :from
+    :tool-uses :reasoning :kind :from :source :schedule-id
     :notification/type :notification/agent :notification/task
     :notification/elapsed})
 

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -7,8 +7,7 @@
    The store maps a Room's keyword id ↔ a Datahike :chat/id UUID via
    the :room/slug attribute (`slug->room-id`/`room-id->slug` in
    `dvergr.room.store`)."
-  (:require [clojure.edn :as edn]
-            [datahike.api :as dh]
+  (:require [datahike.api :as dh]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.persist :as persist]
             [dvergr.room.store :as store]
@@ -17,31 +16,6 @@
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
-
-(defn- metadata->edn
-  "Encode envelope extensions only when they are readable EDN. A bad adapter
-   value must not make an otherwise valid message impossible to persist."
-  [metadata]
-  (when (seq metadata)
-    (let [encoded (pr-str metadata)]
-      (try
-        ;; Validate now so replay cannot discover an unreadable #object later.
-        (edn/read-string encoded)
-        encoded
-        (catch Throwable t
-          (tel/log! {:level :warn :id :room-store/unreadable-message-metadata
-                     :data {:error (.getMessage t)}}
-                    "message metadata is not EDN — structured fields still persist")
-          nil)))))
-
-(defn- edn->metadata [encoded]
-  (when encoded
-    (try
-      (edn/read-string encoded)
-      (catch Throwable t
-        (tel/log! {:level :warn :id :room-store/unreadable-stored-metadata
-                   :data {:error (.getMessage t)}})
-        nil))))
 
 (defn- room-by-slug
   [conn slug]
@@ -105,8 +79,10 @@
   (let [content      (str (:content msg))
         msg-id       (:id msg)
         ts           (some-> (:ts msg) (java.util.Date.))
-        metadata     (:metadata msg)
-        metadata-edn (metadata->edn metadata)
+        metadata     (store/validate-message-metadata! (:metadata msg))
+        attachment   (:attachment metadata)
+        provenance   (:provenance metadata)
+        blob-id      (:blob-id attachment)
         role         (store/infer-role msg)
         source-user  (or (:source-user metadata)
                          (some-> (:from msg) name)
@@ -120,9 +96,31 @@
       (keyword? (:from msg)) (assoc :message/from (:from msg))
       (keyword? (:to msg)) (assoc :message/to (:to msg))
       (uuid? (:in-reply-to msg)) (assoc :message/in-reply-to (:in-reply-to msg))
-      metadata-edn (assoc :message/metadata metadata-edn)
       (:source-username metadata) (assoc :message/source-username (:source-username metadata))
       (:source-user-id  metadata) (assoc :message/source-user-id  (long (:source-user-id metadata)))
+      (seq (:audience metadata)) (assoc :message/audience (set (:audience metadata)))
+      (seq (:mentions metadata)) (assoc :message/mention-handles
+                                        (set (map str (:mentions metadata))))
+      (:kind metadata) (assoc :message/metadata-kind (:kind metadata))
+      (:from metadata) (assoc :message/context-from (:from metadata))
+      (uuid? blob-id) (assoc :message/attachment-store-ref blob-id)
+      (and blob-id (not (uuid? blob-id)))
+      (assoc :message/attachment-blob-id (str blob-id))
+      (:node-id attachment) (assoc :message/attachment-node-id
+                                   (str (:node-id attachment)))
+      (:mime attachment) (assoc :message/attachment-mime (:mime attachment))
+      (:name attachment) (assoc :message/attachment-name (:name attachment))
+      (:size attachment) (assoc :message/attachment-size (long (:size attachment)))
+      (:mode provenance) (assoc :message/provenance-mode (:mode provenance))
+      (:source provenance) (assoc :message/provenance-source (:source provenance))
+      (:notification/type metadata)
+      (assoc :message/notification-type (:notification/type metadata))
+      (:notification/agent metadata)
+      (assoc :message/notification-agent (:notification/agent metadata))
+      (:notification/task metadata)
+      (assoc :message/notification-task (:notification/task metadata))
+      (:notification/elapsed metadata)
+      (assoc :message/notification-elapsed (long (:notification/elapsed metadata)))
       ;; Structured tool-uses (already serialized component maps from the
       ;; chat-ctx in-memory signal — :tool-use/id is plain string, not
       ;; unique, so re-transacting creates fresh components). This is how a
@@ -216,7 +214,21 @@
                                                :message/created-at :message/source-user
                                                :message/source-username :message/source-user-id
                                                :message/from :message/to :message/in-reply-to
-                                               :message/metadata :message/reasoning
+                                               :message/reasoning
+                                               :message/audience :message/mention-handles
+                                               :message/metadata-kind :message/context-from
+                                               :message/attachment-store-ref
+                                               :message/attachment-blob-id
+                                               :message/attachment-node-id
+                                               :message/attachment-mime
+                                               :message/attachment-name
+                                               :message/attachment-size
+                                               :message/provenance-mode
+                                               :message/provenance-source
+                                               :message/notification-type
+                                               :message/notification-agent
+                                               :message/notification-task
+                                               :message/notification-elapsed
                                                {:message/tool-uses
                                                 [:tool-use/id :tool-use/name
                                                  {:tool-use/input [*]}]}]) ...]
@@ -236,14 +248,58 @@
           ;; see {:id :from :to :content :ts :role :metadata} regardless of
           ;; which store backs the room.
           (mapv (fn [m]
-                  (let [stored-metadata (or (edn->metadata (:message/metadata m)) {})
-                        metadata (cond-> stored-metadata
+                  (let [attachment (cond-> {}
+                                     (or (:message/attachment-store-ref m)
+                                         (:message/attachment-blob-id m))
+                                     (assoc :blob-id
+                                            (or (:message/attachment-store-ref m)
+                                                (:message/attachment-blob-id m)))
+                                     (:message/attachment-node-id m)
+                                     (assoc :node-id (:message/attachment-node-id m))
+                                     (:message/attachment-mime m)
+                                     (assoc :mime (:message/attachment-mime m))
+                                     (:message/attachment-name m)
+                                     (assoc :name (:message/attachment-name m))
+                                     (:message/attachment-size m)
+                                     (assoc :size (:message/attachment-size m)))
+                        provenance (cond-> {}
+                                     (:message/provenance-mode m)
+                                     (assoc :mode (:message/provenance-mode m))
+                                     (:message/provenance-source m)
+                                     (assoc :source (:message/provenance-source m)))
+                        metadata (cond-> {:role (:message/role m)}
                                    (:message/source-user m)
                                    (assoc :source-user (:message/source-user m))
                                    (:message/source-username m)
                                    (assoc :source-username (:message/source-username m))
                                    (:message/source-user-id m)
-                                   (assoc :source-user-id (:message/source-user-id m)))]
+                                   (assoc :source-user-id (:message/source-user-id m))
+                                   (seq (:message/audience m))
+                                   (assoc :audience (set (:message/audience m)))
+                                   (seq (:message/mention-handles m))
+                                   (assoc :mentions (set (:message/mention-handles m)))
+                                   (seq attachment) (assoc :attachment attachment)
+                                   (seq provenance) (assoc :provenance provenance)
+                                   (:message/metadata-kind m)
+                                   (assoc :kind (:message/metadata-kind m))
+                                   (:message/context-from m)
+                                   (assoc :from (:message/context-from m))
+                                   (:message/notification-type m)
+                                   (assoc :notification/type
+                                          (:message/notification-type m))
+                                   (:message/notification-agent m)
+                                   (assoc :notification/agent
+                                          (:message/notification-agent m))
+                                   (:message/notification-task m)
+                                   (assoc :notification/task
+                                          (:message/notification-task m))
+                                   (:message/notification-elapsed m)
+                                   (assoc :notification/elapsed
+                                          (:message/notification-elapsed m))
+                                   (seq (:message/tool-uses m))
+                                   (assoc :tool-uses (:message/tool-uses m))
+                                   (seq (:message/reasoning m))
+                                   (assoc :reasoning (:message/reasoning m)))]
                     (cond-> {:id        (:message/id m)
                              :from      (or (:message/from m)
                                             (some-> (:message/source-user m) keyword))

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -103,6 +103,8 @@
                                         (set (map str (:mentions metadata))))
       (:kind metadata) (assoc :message/metadata-kind (:kind metadata))
       (:from metadata) (assoc :message/context-from (:from metadata))
+      (:source metadata) (assoc :message/source (:source metadata))
+      (:schedule-id metadata) (assoc :message/schedule-id (:schedule-id metadata))
       (uuid? blob-id) (assoc :message/attachment-store-ref blob-id)
       (and blob-id (not (uuid? blob-id)))
       (assoc :message/attachment-blob-id (str blob-id))
@@ -217,6 +219,7 @@
                                                :message/reasoning
                                                :message/audience :message/mention-handles
                                                :message/metadata-kind :message/context-from
+                                               :message/source :message/schedule-id
                                                :message/attachment-store-ref
                                                :message/attachment-blob-id
                                                :message/attachment-node-id
@@ -284,6 +287,10 @@
                                    (assoc :kind (:message/metadata-kind m))
                                    (:message/context-from m)
                                    (assoc :from (:message/context-from m))
+                                   (:message/source m)
+                                   (assoc :source (:message/source m))
+                                   (:message/schedule-id m)
+                                   (assoc :schedule-id (:message/schedule-id m))
                                    (:message/notification-type m)
                                    (assoc :notification/type
                                           (:message/notification-type m))

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -37,7 +37,9 @@
                (let [v (or existing [])]
                  (if (some #(= (:id %) msg-id) v)
                    v
-                   (conj v msg)))))
+                   (do
+                     (store/validate-message-metadata! (:metadata msg))
+                     (conj v msg))))))
       (swap! state update-in [:rooms room-id]
              (fn [m] (when m (assoc m :updated-at (java.util.Date.)))))))
 

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -133,6 +133,27 @@
               :notification/elapsed 1234}
              (:metadata (first (store/-list-messages st room-id {}))))))))
 
+(deftest scheduler-metadata-round-trip
+  (testing "scheduled messages retain their typed origin and correlation id"
+    (let [[conn st] (mem-store)
+          room-id :scheduled-message
+          message-id (random-uuid)
+          schedule-id (random-uuid)]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (store/-store-message!
+       st room-id
+       {:id message-id :from :scheduler :to :agent/planner :content "run"
+        :metadata {:source :scheduler :schedule-id schedule-id}})
+      (is (= {:message/source :scheduler
+              :message/schedule-id schedule-id}
+             (dh/pull @conn [:message/source :message/schedule-id]
+                      [:message/id message-id])))
+      (is (= {:role :assistant
+              :source-user "scheduler"
+              :source :scheduler
+              :schedule-id schedule-id}
+             (:metadata (first (store/-list-messages st room-id {}))))))))
+
 (deftest tool-uses-round-trip
   (testing "the room store persists and returns structured :tool-uses"
     (let [[_conn st] (mem-store)

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -23,6 +23,116 @@
   (let [[_conn st] (mem-store)]
     (contract/assert-message-envelope! st :envelope-datahike)))
 
+(deftest metadata-is-typed-and-queryable
+  (testing "durable metadata is datoms, with UUID blobs marked as store refs"
+    (let [[conn st] (mem-store)
+          room-id :typed-metadata
+          message-id (random-uuid)
+          blob-id (random-uuid)]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (store/-store-message!
+       st room-id
+       {:id message-id :from :party/alice :to :agent/reviewer
+        :content "review" :ts 1787860800123
+        :metadata {:role :user
+                   :mentions #{"reviewer"}
+                   :audience #{:agent/reviewer}
+                   :attachment {:blob-id blob-id :mime "audio/ogg"}
+                   :provenance {:mode :live :source :screen}}})
+      (let [stored (dh/pull @conn
+                            [:message/audience :message/mention-handles
+                             :message/attachment-store-ref :message/attachment-mime
+                             :message/provenance-mode :message/provenance-source]
+                            [:message/id message-id])]
+        (is (= #{:agent/reviewer} (set (:message/audience stored))))
+        (is (= #{"reviewer"} (set (:message/mention-handles stored))))
+        (is (= blob-id (:message/attachment-store-ref stored)))
+        (is (= {:message/attachment-mime "audio/ogg"
+                :message/provenance-mode :live
+                :message/provenance-source :screen}
+               (select-keys stored [:message/attachment-mime
+                                    :message/provenance-mode
+                                    :message/provenance-source]))))
+      (is (nil? (dh/q '[:find ?a .
+                        :where [?a :db/ident :message/metadata]]
+                      @conn))
+          "the opaque EDN attribute is absent from fresh schema"))))
+
+(deftest unknown-metadata-must-extend-the-schema
+  (testing "unknown extensions fail instead of silently becoming opaque data"
+    (let [[_conn st] (mem-store)
+          room-id :unknown-metadata]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Unknown durable message"
+           (store/-store-message!
+            st room-id
+            {:id (random-uuid) :from :alice :content "hi"
+             :metadata {:role :user :unmodelled/value 1}}))))))
+
+(deftest foreign-content-addressed-blob-id-round-trip
+  (testing "non-UUID IDs from a separately configured blob CAS remain strings"
+    (let [[conn st] (mem-store)
+          room-id :foreign-blob
+          message-id (random-uuid)
+          blob-id "sha256:9e107d9d372bb6826bd81d3542a419d6"]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (store/-store-message!
+       st room-id
+       {:id message-id :from :party/alice :content "file"
+        :metadata {:role :user
+                   :attachment {:blob-id blob-id
+                                :node-id "drive-node-1"
+                                :name "proposal.pdf"
+                                :size 4096}}})
+      (let [stored (dh/pull @conn
+                            [:message/attachment-store-ref
+                             :message/attachment-blob-id]
+                            [:message/id message-id])
+            replayed (first (store/-list-messages st room-id {}))]
+        (is (= {:message/attachment-blob-id blob-id} stored))
+        (is (= {:blob-id blob-id
+                :node-id "drive-node-1"
+                :name "proposal.pdf"
+                :size 4096}
+               (get-in replayed [:metadata :attachment])))))))
+
+(deftest notification-metadata-round-trip
+  (testing "background notification correlation fields remain queryable"
+    (let [[conn st] (mem-store)
+          room-id :notification
+          message-id (random-uuid)
+          task-id (random-uuid)]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (store/-store-message!
+       st room-id
+       {:id message-id :from :agent/planner :to :party/alice :content "done"
+        :metadata {:role :assistant
+                   :from :background
+                   :notification/type :task-complete
+                   :notification/agent :agent/planner
+                   :notification/task task-id
+                   :notification/elapsed 1234}})
+      (is (= {:message/context-from :background
+              :message/notification-type :task-complete
+              :message/notification-agent :agent/planner
+              :message/notification-task task-id
+              :message/notification-elapsed 1234}
+             (dh/pull @conn
+                      [:message/context-from :message/notification-type
+                       :message/notification-agent :message/notification-task
+                       :message/notification-elapsed]
+                      [:message/id message-id])))
+      (is (= {:role :assistant
+              :source-user "planner"
+              :from :background
+              :notification/type :task-complete
+              :notification/agent :agent/planner
+              :notification/task task-id
+              :notification/elapsed 1234}
+             (:metadata (first (store/-list-messages st room-id {}))))))))
+
 (deftest tool-uses-round-trip
   (testing "the room store persists and returns structured :tool-uses"
     (let [[_conn st] (mem-store)

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -1,7 +1,19 @@
 (ns dvergr.room.store.memory-test
-  (:require [clojure.test :refer [deftest]]
+  (:require [clojure.test :refer [deftest is]]
             [dvergr.room.store.contract :as contract]
+            [dvergr.room.store :as store]
             [dvergr.room.store.memory :as memory]))
 
 (deftest message-envelope-contract
   (contract/assert-message-envelope! (memory/make) :envelope-memory))
+
+(deftest rejects-unmodelled-durable-metadata
+  (let [st (memory/make)]
+    (store/-store-room! st :strict-memory {:slug "strict-memory"})
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Unknown durable message"
+         (store/-store-message!
+          st :strict-memory
+          {:id (random-uuid) :from :alice :content "hi"
+           :metadata {:unmodelled/value 1}})))))


### PR DESCRIPTION
## Summary

- replace the just-added opaque `:message/metadata` EDN string with explicit, queryable Datahike datoms
- use `:db.type/store-ref` for UUID attachment blobs while preserving foreign content-addressed string IDs used by Dvergr's separate blob store
- make unknown durable metadata fail closed across Datahike and memory stores, so extensions must deliberately extend the typed schema
- bump Datahike to 0.8.1819 and align Konserve/Scriptum; remove obsolete `kabel-auth` and unused direct Incognito/Superv pins

This intentionally has no decoder for the short-lived EDN-string representation: this is the immediate correction requested before that format accumulates compatibility obligations.

## Verification

- `clj -M:test --focus dvergr.room.store.datahike-test` — 7 tests, 17 assertions, 0 failures
- `clj -M:test --focus dvergr.room.store.memory-test` — 2 tests, 3 assertions, 0 failures
- direct memory-store check for first-write-wins retries plus unknown-metadata rejection
- `clj -M:format`
- `git diff --check`

The complete 496-test suite was not run locally because the host had only 3.7 GiB available and swap was exhausted after a recent system OOM; CI should run the full non-integration suite.
