### PR TITLE
feat(models): add native Codex subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ reactive runtime), [Datahike](https://github.com/replikativ/datahike)
 - 🔐 **Boundary credential handling** — intakes that need an API key get a *placeholder*
   in the sandbox; the gated HTTP egress swaps in the real key only at the bound domain
   and scrubs it from the response, so **the agent uses keys it never sees** ([design](doc/boundary-secret-injection.md))
-- 🔌 **Multiple LLM providers** — Anthropic (incl. the local `claude` CLI, zero-key),
-  OpenAI, Fireworks, or any OpenAI-compatible endpoint — swappable per agent
+- 🔌 **Multiple LLM providers** — Anthropic API/Claude Code, a native Codex
+  subscription transport, OpenAI API, Fireworks, or any OpenAI-compatible
+  endpoint — swappable per agent
 - 🪙 **Budgets & accounting** — every turn is metered in microdollars against a
   per-agent budget; an agent hits a checkpoint and can escalate `:directive/raise-budget`
   for more, with all spend recorded in a ledger — so cost stays bounded
@@ -94,18 +95,24 @@ Pick a provider by exporting its API key (or set it in `config.local.edn`):
 # no key needed with a Claude Code subscription)
 export ANTHROPIC_API_KEY=sk-ant-...
 
-# OpenAI, or any OpenAI-compatible endpoint
+# OpenAI API (usage-based; distinct from a ChatGPT/Codex subscription)
 export OPENAI_API_KEY=sk-...
-export OPENAI_BASE_URL=https://api.openai.com/v1     # optional; override for compatibles
+# export OPENAI_BASE_URL=https://api.openai.com/v1  # optional override
 
 # Fireworks (OpenAI-compatible; the bundled model registry is Fireworks)
 export FIREWORKS_API_KEY=fw-...
+# export FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
+
+# OpenAI Codex subscription — no API key; choose Sign in with ChatGPT
+codex login
 ```
 
 > The shipped default config leaves the agent's provider **unpinned**, so it
-> auto-selects the best provider you have a key for (preference: Anthropic →
-> Fireworks → OpenAI → the local `claude` CLI) and its default model. **Set any
-> one of the keys above and it works** — you don't have to match a specific
+> auto-selects the best provider available (preference: Anthropic →
+> Fireworks → OpenAI → native Codex subscription → isolated Codex CLI →
+> the local `claude` CLI) and its
+> default model. **Set one of the keys above or log into a supported CLI and it
+> works** — you don't have to match a specific
 > provider. Pin `:provider`/`:model` in `config.local.edn` to force one. If no
 > provider key is set at all, the daemon still boots but logs a warning and agent
 > turns fail at call time.
@@ -213,11 +220,18 @@ The standalone, runnable scenarios these import live in [`examples/`](examples/)
 ```clojure
 (require '[dvergr.model.providers :as providers])
 
-;; Auto-registers from env: ANTHROPIC_API_KEY, OPENAI_API_KEY, FIREWORKS_API_KEY
+;; Auto-registers API keys, Claude Code, and a logged-in Codex subscription.
 (providers/ensure-initialized!)
+
+;; Verify what this process can use and what an unpinned agent will select.
+(vec (providers/list-providers))
+(providers/default-spec)
 
 ;; Anthropic via the local `claude` CLI (no API key needed)
 ;; Auto-detected if `claude` is on PATH.
+
+;; OpenAI via a Codex/ChatGPT subscription (no API key needed).
+;; Run `codex login` once, then select :codex-subscription / "codex-subscription".
 
 ;; Any OpenAI-compatible provider
 (providers/register-openai-compatible!

--- a/config.example.edn
+++ b/config.example.edn
@@ -59,11 +59,18 @@
  ;; (or `~/.dvergr/agents/`, `./.dvergr/agents/`, or a room's sandbox repo) with
  ;; `autostart: true` + `vetted: true` boots itself and joins its `rooms:`. The
  ;; shipped `var.md` (Vár, the secretary) autostarts that way with its provider
- ;; unpinned → env auto-select (anthropic → fireworks → openai → claude-code CLI).
+ ;; unpinned → auto-select (anthropic → fireworks → openai → codex
+ ;; subscription native → codex CLI compatibility → claude-code CLI).
  ;;
  ;; To OVERRIDE per deployment — pin a provider/model, or declare an agent you
  ;; don't want as a committed file — add an optional `:agents` map, e.g.:
  ;;   :agents {:my-bot {:provider :fireworks :model "…"}}
+ ;; Codex subscription native transport (after `codex login`):
+ ;;   :agents {:my-bot {:provider :codex-subscription
+ ;;                     :model "codex-subscription"}}
+ ;; Explicit isolated CLI compatibility path:
+ ;;   :agents {:my-bot {:provider :codex-subscription-cli
+ ;;                     :model "codex-subscription-cli"}}
 
  ;; ============================================================
  ;; Secrets — boundary key injection (doc/boundary-secret-injection.md)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -43,7 +43,8 @@ workspace + Datahike message/knowledge stores); a thin global **system-db**
   each room's workspace; only `intake/bash` (the muschel shell) and `intake/mail` remain
   in-tree.
 - **L5 — agent execution**: the turn loop (`chat/agent`), context compaction, model
-  abstraction (`model/*` + provider impls for Anthropic/OpenAI/Claude-Code), the
+  abstraction (`model/*` + provider impls for Anthropic/OpenAI, native Codex
+  subscription, and CLI compatibility paths), the
   LLM-backed participant factory (`discourse/llm`), the shared turn mechanics
   (`agent/turn`), the system-prompt assembler (`agent/prompt`), and process
   checkpoint/resume (`agent/process`).
@@ -225,7 +226,7 @@ graph TD
 | `sandbox` + `sandbox/{deps,workspace}` + `sandbox/ns/*` | L4 | SCI runtime (ctx/eval/limits); gated add-libs; the workspace load-root; the injected namespaces (`io`/`data`/`datahike`/`agent`/`kb`/`room`/`mail`/`codec`/`dev`/`intake`) |
 | `intake/{bash,mail}` | L4 | the only in-tree intakes — muschel-jailed shell + briefkasten mail (all other data sources live in the dvergr-sandbox stdlib repo) |
 | `channels/{core,telegram,telegram_commands,telegram_send}` | L4/L6 | channel framework; Telegram Bot API (polling/old dispatch); `dvergr.ops` slash-command binding; outbound Markdown→HTML rendering + chunking |
-| `model/{provider,providers,registry,chat,quirks}` + `model/api/{anthropic,openai,claude_code}` | L5 | provider protocol + registry + metadata; streaming chat over SSE; provider quirks; the three provider impls |
+| `model/{provider,providers,registry,chat,quirks,gateway}` + `model/api/{anthropic,openai,claude_code,codex_subscription,codex_auth}` | L5 | provider protocol + registry + metadata; origin-confined credential injection; HTTP/SSE, native Codex subscription, and CLI compatibility transports; provider quirks |
 | `agent/{turn,prompt,process,tool_commands,persona,ops,fields}` | L5/L6 | shared turn mechanics; system-prompt assembler; checkpoint/resume process; tool commands; persona resolution; agent-management ops + field spec |
 | `orchestration/{daemon,skills,tasks,stats}` | L6 | the runtime daemon (lifecycle/registry/turn loop/sessions/Telegram); skill registry; task ledger; stats cache |
 | `actors` + `actors/transport` | L6 | durable actor identity table; PActorTransport impls |

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -76,8 +76,9 @@ Priority: `(paths/set-home! …)` → `$DVERGR_HOME` → `./.dvergr`. Layout:
 **Core** — `DVERGR_CONFIG` (config path) · `DVERGR_HOME` (state root) ·
 `TELEGRAM_BOT_TOKEN` · `GITHUB_DVERGR_TOKEN` · `SLACK_USER_TOKEN`.
 
-**Models** — `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `GROQ_API_KEY` (providers &
-ASR) · `DVERGR_VISION_MODEL` (override the vision model). See
+**Models** — `ANTHROPIC_API_KEY` · `OPENAI_API_KEY` / `OPENAI_BASE_URL` ·
+`FIREWORKS_API_KEY` / `FIREWORKS_BASE_URL` · `CODEX_HOME` (providers) ·
+`GROQ_API_KEY` (ASR) · `DVERGR_VISION_MODEL` (override the vision model). See
 [provider-setup.md](provider-setup.md).
 
 **Media / voice** (see [media.md](media.md)) — `DVERGR_RECORD_CMD` (mic-capture

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -19,19 +19,47 @@ provider libraries automatically.
 
 ## Provider setup
 
-dvergr supports three provider classes out of the box:
+dvergr supports API, OpenAI-compatible, and subscription providers out of the
+box:
 
 ```clojure
 (require '[dvergr.model.providers :as providers])
 
 ;; Reads ANTHROPIC_API_KEY, OPENAI_API_KEY, FIREWORKS_API_KEY from env
-;; and auto-detects the local `claude` CLI if present.
+;; and auto-detects Claude Code plus a logged-in Codex subscription.
 (providers/ensure-initialized!)
 ```
 
 If you have a Claude Code subscription, the `claude-code` provider is
 the easiest way to get started — no API key needed. It uses `claude -p`
 under the hood.
+
+For an OpenAI Codex subscription, install Codex and run `codex login` with
+**Sign in with ChatGPT** once. Dvergr then reads the file-backed login through its trusted
+credential gateway and talks directly to the Codex Responses endpoint; the
+Codex agent harness is not involved. Select provider `:codex-subscription` and
+model `"codex-subscription"` (Sol by default).
+
+Verify the active provider from the REPL before constructing an agent:
+
+```clojure
+(require '[dvergr.model.chat :as chat])
+
+(vec (providers/list-providers))
+;; A file-backed ChatGPT login includes :codex-subscription.
+
+(providers/default-spec)
+;; => {:provider :codex-subscription, :model "codex-subscription"}
+
+(chat/quick-chat "Reply with DVERGR_OK" "codex")
+;; => "DVERGR_OK"
+```
+
+If only `:codex-subscription-cli` appears, use model
+`"codex-subscription-cli"`. This runs a locked-down, ephemeral `codex exec`
+process for each model turn while dvergr still owns history, tools, sandboxing,
+and persistence. See [Provider & model setup](provider-setup.md) for all provider
+paths and troubleshooting.
 
 ## Path A — try the CLI
 
@@ -200,7 +228,9 @@ Add the `:web` alias for the dashboard, e.g. `clojure -M:repl:web` or
 **Agent doesn't reply** — make sure the provider is configured.
 `(providers/ensure-initialized!)` must run before the first
 `llm-agent` is constructed. The `claude-code` provider needs the
-`claude` CLI on PATH.
+`claude` CLI on PATH. The native `codex-subscription` provider needs a
+file-backed ChatGPT login from `codex login`. Keyring-only Codex logins use the
+registered `:codex-subscription-cli` compatibility provider instead.
 
 **"namespace 'dvergr.X' not found"** — check `(:provider config)`
 matches a registered provider. List models with

--- a/doc/provider-setup.md
+++ b/doc/provider-setup.md
@@ -1,8 +1,12 @@
 # Provider & model setup
 
 dvergr talks to LLMs through pluggable **providers**, each resolved from a
-**model registry**. To run anything you need (1) at least one provider's API key
-and (2) a model in the registry pointing at that provider.
+**model registry**. To run anything you need (1) an API credential or supported
+subscription login and (2) a model in the registry pointing at it. Provider
+credentials are injected by the trusted in-process gateway only after the
+configured upstream origin has been validated. Credential-free local providers
+use the same boundary with an explicitly unauthenticated, origin-confined
+capability.
 
 ## Supported providers
 
@@ -12,10 +16,87 @@ and (2) a model in the registry pointing at that provider.
 | `:openai`     | `:openai-chat`      | `https://api.openai.com/v1`               | `model/api/openai.clj` |
 | `:fireworks`  | `:openai-chat`      | `https://api.fireworks.ai/inference/v1`   | `model/api/openai.clj` (OpenAI-compatible) |
 | `:claude-code`| `:claude-code-cli`  | local `claude -p` CLI (subscription)      | `model/api/claude_code.clj` |
+| `:codex-subscription` | `:openai-responses` | native ChatGPT Codex Responses transport | `model/api/codex_subscription.clj` |
+| `:codex-subscription-cli` | `:codex-cli` | isolated `codex exec` compatibility path | `model/api/codex_subscription.clj` |
 
 Providers self-register at startup (`providers/init-defaults!`) **only when
 their key is available** — so a missing key just means that provider is absent,
 not an error. If *nothing* registers, you get a loud boot warning.
+
+## Verify a provider from the REPL
+
+Start dvergr with the environment and CLI login you intend to use already in
+place, then inspect the registry before creating an agent:
+
+```clojure
+(require '[dvergr.model.chat :as chat]
+         '[dvergr.model.providers :as providers]
+         '[dvergr.model.registry :as registry])
+
+(providers/ensure-initialized!)
+(vec (providers/list-providers))
+(providers/default-spec)                    ; selection for an unpinned agent
+(mapv :id (registry/models-for-provider :codex-subscription))
+
+;; Exercise only the model transport, without constructing a room:
+(chat/quick-chat "Reply with DVERGR_OK" "codex")
+```
+
+Provider discovery is cached for the life of the process. Restart the REPL after
+changing an environment variable or logging a CLI in. An application may call
+`providers/clear-all!` followed by `providers/ensure-initialized!` during a
+controlled reconfiguration, but should not do that while turns are active.
+
+## Codex subscription quickstart
+
+OpenAI documents two distinct local Codex sign-in modes: ChatGPT subscription
+access and usage-based API-key access. Dvergr's `:codex-subscription` providers
+require the former.
+
+1. Install the Codex CLI and run `codex login`.
+2. Choose **Sign in with ChatGPT** and finish the browser flow.
+3. Confirm `codex login status` reports a ChatGPT login.
+4. Start dvergr, call `providers/ensure-initialized!`, and inspect
+   `providers/list-providers` as shown above.
+5. Use the native model alias `"codex"`, or pin an agent explicitly:
+
+```clojure
+{:agents
+ {:var {:provider :codex-subscription
+        :model "codex-subscription"}}}
+```
+
+The explicit native model choices are `"codex-subscription-sol"`,
+`"codex-subscription-terra"`, and `"codex-subscription-luna"`; their short
+aliases are `"codex-sol"`, `"codex-terra"`, and `"codex-luna"`.
+
+The native transport reads `$CODEX_HOME/auth.json`, falling back to
+`~/.codex/auth.json`. If you have configured
+`cli_auth_credentials_store = "keyring"` or `"auto"` and no file is present,
+dvergr cannot read the keyring directly. You have two options:
+
+- Select `:codex-subscription-cli` with model `"codex-subscription-cli"`. This
+  starts a locked-down, ephemeral `codex exec` for each turn.
+- Set `cli_auth_credentials_store = "file"` in `~/.codex/config.toml`, then run
+  `codex login` again to create the file needed by the native transport.
+
+Both providers leave agent state, context, tools, effects, and sandbox semantics
+in dvergr. The CLI path is compatibility isolation, not delegation of the agent
+runtime to Codex. Dvergr does not switch paths automatically: replaying a request
+after streaming or a tool call has begun could duplicate effects.
+
+Never copy `auth.json` into a project or container image. Dvergr injects its
+tokens only after validating the exact `https://chatgpt.com` origin, refreshes
+expiring tokens in the host process, and persists rotations back to the auth
+file with owner-only permissions where the filesystem supports them.
+
+The native route targets the private endpoint used by the open-source Codex
+client, not the stable public OpenAI API. Treat it as experimental compatibility
+machinery and keep the explicit CLI path available across upgrades.
+
+Official setup references: [Codex CLI](https://learn.chatgpt.com/docs/codex/cli),
+[authentication](https://learn.chatgpt.com/docs/auth), and the
+[`cli_auth_credentials_store` configuration](https://learn.chatgpt.com/docs/config-file/config-reference#configtoml).
 
 ## API keys (env vars)
 
@@ -26,16 +107,87 @@ Keys are read from environment variables (or passed in a config map to the
 export ANTHROPIC_API_KEY=sk-ant-…     # enables :anthropic
 export OPENAI_API_KEY=sk-…            # enables :openai
 export FIREWORKS_API_KEY=fw-…         # enables :fireworks
-# :fireworks also accepts OPENAI_API_KEY as a fallback
-# override the Fireworks/OpenAI base URL with OPENAI_BASE_URL
+export OPENAI_BASE_URL=https://api.openai.com/v1               # optional
+export FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1 # optional
 ```
 
-- **Fireworks** prefers `FIREWORKS_API_KEY`, then falls back to `OPENAI_API_KEY`;
-  base URL falls back to `OPENAI_BASE_URL` before the Fireworks default. This is
-  the default provider dvergr ships with.
+- **OpenAI and Fireworks are credential-scoped.** OpenAI reads only
+  `OPENAI_API_KEY` / `OPENAI_BASE_URL`; Fireworks reads only
+  `FIREWORKS_API_KEY` / `FIREWORKS_BASE_URL`. A key for one never registers or
+  authorizes the other. Fireworks is the default provider represented in
+  `resources/models.edn`.
 - **Claude Code** has **no API key** — it auto-detects by running `claude --version`.
   If the CLI exits 0, `:claude-code` registers and bills against your Claude
   subscription (model pricing is `0`).
+- **Codex subscription** has **no API key**. Run `codex login` and choose
+  **Sign in with ChatGPT**. For the default file-backed login, dvergr refreshes
+  OAuth credentials inside its trusted host boundary and sends dvergr-owned
+  history and native tool definitions directly to the ChatGPT Codex Responses
+  endpoint. The token is not placed in provider request maps or exposed to SCI.
+  A keyring-only login registers `:codex-subscription-cli` as a compatibility
+  path. Subscription model pricing is recorded as `0`, while normal plan limits
+  still apply.
+
+The subscription endpoint is an upstream Codex compatibility surface rather
+than the public OpenAI API. Keep `:codex-subscription-cli` available when
+upgrading Codex/dvergr so an upstream wire or authentication change has an
+immediate fallback.
+
+Pin an agent to the native subscription model with:
+
+```clojure
+:agents {:var {:provider :codex-subscription
+               :model "codex-subscription"}}
+```
+
+The optional aliases `codex-sol`, `codex-terra`, and `codex-luna` select an
+explicit subscription model. To force the compatibility path, use provider and
+model `:codex-subscription-cli` / `"codex-subscription-cli"`.
+
+### Provider recipes
+
+| You have | Setup | Provider / bundled model |
+|----------|-------|--------------------------|
+| Anthropic API account | `ANTHROPIC_API_KEY` | `:anthropic` / `"claude-sonnet-4-6"` |
+| Claude Code subscription | Logged-in `claude` on `PATH` | `:claude-code` / `"claude-code-sonnet"` |
+| ChatGPT Codex subscription | `codex login` with ChatGPT | `:codex-subscription` / `"codex-subscription"` |
+| Keyring-only Codex login | Logged-in `codex` on `PATH` | `:codex-subscription-cli` / `"codex-subscription-cli"` |
+| Fireworks account | `FIREWORKS_API_KEY` | `:fireworks` / `"accounts/fireworks/models/minimax-m2p7"` |
+| OpenAI API account | `OPENAI_API_KEY`, plus an OpenAI registry entry | `:openai` / the registered model id |
+
+The built-in registry currently carries Anthropic, Claude Code, Codex
+subscription, and Fireworks models. Public OpenAI API models can be loaded with
+`(registry/refresh-from-models-dev! #{:openai})` or declared in
+`resources/models.edn`; the API key alone registers the transport but does not
+invent model metadata.
+
+For a custom or local OpenAI-compatible endpoint, register both its credentials
+and at least one model. A credential-free local endpoint still receives an
+origin-confined capability, so it cannot accidentally acquire another
+provider's authorization header:
+
+```clojure
+(require '[dvergr.model.gateway :as gateway])
+
+(providers/register-openai-compatible!
+ :ollama
+ {:base-url "http://localhost:11434/v1"
+  :credentials (gateway/unauthenticated-credentials
+                #{"http://localhost:11434"})})
+
+(registry/register-model!
+ {:id "qwen3:8b"
+  :name "Qwen 3 8B (local)"
+  :provider :ollama
+  :api-type :openai-chat
+  :capabilities #{:tools :streaming :system-prompt}
+  :context 32768
+  :max-output 8192
+  :pricing {:input 0 :output 0}
+  :quirks {}})
+
+(chat/quick-chat "Reply with LOCAL_OK" "qwen3:8b")
+```
 
 > Provider keys are *not* in `config.local.edn` — they come from the env. Other
 > secrets (Telegram, GitHub, …) live in config; see `doc/configuration.md`.
@@ -68,7 +220,8 @@ startup and is also re-loadable via `(registry/load-models-resource!)`. Shape:
 **To add a model:** add an entry under `:models` keyed by its provider-side id,
 set `:provider` to a registered provider, list `:capabilities`, and (optionally)
 an alias. EDN entries merge over the built-in `default-models` (current Claude
-Opus/Sonnet/Haiku + Claude-Code models, defined in `model/registry.clj`).
+Opus/Sonnet/Haiku plus Claude-Code and Codex-subscription models, defined in
+`model/registry.clj`).
 
 `(registry/refresh-from-models-dev! #{:anthropic …})` is an opt-in, network call
 that overlays live pricing/context from <https://models.dev>.

--- a/src/dvergr/model/api/anthropic.clj
+++ b/src/dvergr/model/api/anthropic.clj
@@ -1,6 +1,7 @@
 (ns dvergr.model.api.anthropic
   "Anthropic Messages API implementation."
   (:require [dvergr.model.provider :as p]
+            [dvergr.model.gateway :as gateway]
             [dvergr.model.quirks :as quirks]
             [dvergr.chat.tool-schema :as tool-schema]
             [jsonista.core :as json]))
@@ -50,9 +51,9 @@
           msgs (remove-system-messages messages)
           tools (:tools opts)]
       {:url (str (or (:base-url config) "https://api.anthropic.com/v1") "/messages")
-       :headers {"x-api-key" (:api-key config)
-                 "anthropic-version" (or (:api-version config) "2023-06-01")
+       :headers {"anthropic-version" (or (:api-version config) "2023-06-01")
                  "content-type" "application/json"}
+       :credentials (:credentials config)
        :body (cond-> {:model (:model opts "claude-sonnet-4-5")
                       :max_tokens (:max-tokens opts 8192)
                       :stream true
@@ -244,9 +245,17 @@
   [config]
   (let [api-key (or (:api-key config)
                     (System/getenv "ANTHROPIC_API_KEY"))]
-    (when-not api-key
+    (when-not (or api-key (:credentials config))
       (throw (ex-info "Anthropic API key required" {:env "ANTHROPIC_API_KEY"})))
-    (->AnthropicProvider (assoc config :api-key api-key))))
+    (let [base-url (or (:base-url config) "https://api.anthropic.com/v1")
+          credentials (or (:credentials config)
+                          (gateway/static-credentials
+                           :anthropic-api-key
+                           {"x-api-key" api-key}
+                           #{(gateway/request-origin base-url)}))]
+      (->AnthropicProvider (-> config
+                               (dissoc :api-key)
+                               (assoc :credentials credentials))))))
 
 (defn create-if-available
   "Create Anthropic provider if API key is available, otherwise nil."

--- a/src/dvergr/model/api/codex_auth.clj
+++ b/src/dvergr/model/api/codex_auth.clj
@@ -1,0 +1,221 @@
+(ns dvergr.model.api.codex-auth
+  "ChatGPT subscription credentials for the native Codex transport.
+
+   This is intentionally a credential backend, not an agent runtime. It reads
+   Codex's file-backed login, refreshes expiring OAuth tokens, preserves rotated
+   refresh tokens, and only exposes request headers through model.gateway. A
+   keyring-backed Codex login is left to the CLI compatibility provider until
+   dvergr has a portable keyring backend."
+  (:require [clojure.java.io :as io]
+            [dvergr.model.gateway :as gateway]
+            [hato.client :as hc]
+            [jsonista.core :as json])
+  (:import [java.nio.charset StandardCharsets]
+           [java.nio.file AtomicMoveNotSupportedException CopyOption Files Path
+            StandardCopyOption]
+           [java.nio.file.attribute FileAttribute PosixFilePermission]
+           [java.security MessageDigest]
+           [java.time Instant]
+           [java.util Base64]))
+
+(def ^:private codex-origin "https://chatgpt.com")
+(def ^:private refresh-url "https://auth.openai.com/oauth/token")
+(def ^:private oauth-client-id "app_EMoamEEZ73f0CkXaXp7hrann")
+(def ^:private refresh-window-seconds (* 5 60))
+(def ^:private stale-refresh-seconds (* 8 24 60 60))
+(def ^:private auth-claims-key (keyword "https://api.openai.com/auth"))
+
+(defn default-auth-path []
+  (let [codex-home (or (System/getenv "CODEX_HOME")
+                       (str (System/getProperty "user.home") "/.codex"))]
+    (.toPath (io/file codex-home "auth.json"))))
+
+(defn- read-auth-file [^Path path]
+  (json/read-value (Files/readString path StandardCharsets/UTF_8)
+                   json/keyword-keys-object-mapper))
+
+(defn- posix-600! [^Path path]
+  (try
+    (Files/setPosixFilePermissions
+     path
+     #{PosixFilePermission/OWNER_READ PosixFilePermission/OWNER_WRITE})
+    (catch UnsupportedOperationException _ nil)))
+
+(defn- write-auth-file! [^Path path auth]
+  (let [parent (.getParent path)
+        _ (Files/createDirectories parent (make-array FileAttribute 0))
+        temp (Files/createTempFile parent ".dvergr-auth-" ".json"
+                                   (make-array FileAttribute 0))]
+    (try
+      (Files/writeString temp (json/write-value-as-string auth)
+                         StandardCharsets/UTF_8
+                         (make-array java.nio.file.OpenOption 0))
+      (posix-600! temp)
+      (try
+        (Files/move temp path
+                    (into-array CopyOption
+                                [StandardCopyOption/ATOMIC_MOVE
+                                 StandardCopyOption/REPLACE_EXISTING]))
+        (catch AtomicMoveNotSupportedException _
+          (Files/move temp path
+                      (into-array CopyOption
+                                  [StandardCopyOption/REPLACE_EXISTING]))))
+      (posix-600! path)
+      (finally
+        (Files/deleteIfExists temp)))))
+
+(defn- response-body-string [body]
+  (cond
+    (string? body) body
+    (nil? body) ""
+    :else (slurp body)))
+
+(defn- default-refresh-request [payload]
+  (let [response (hc/request {:method :post
+                              :url refresh-url
+                              :headers {"Content-Type" "application/json"
+                                        "originator" "dvergr"}
+                              :body (json/write-value-as-string payload)
+                              :as :string
+                              :throw-exceptions false})]
+    {:status (:status response)
+     :body (response-body-string (:body response))}))
+
+(defn- decode-jwt-payload [token]
+  (try
+    (let [[_ payload _] (.split ^String token "\\." 3)
+          bytes (.decode (Base64/getUrlDecoder) ^String payload)]
+      (json/read-value (String. bytes StandardCharsets/UTF_8)
+                       json/keyword-keys-object-mapper))
+    (catch Exception _ nil)))
+
+(defn- jwt-expiry [token]
+  (some-> (decode-jwt-payload token) :exp long Instant/ofEpochSecond))
+
+(defn- parse-instant [value]
+  (try
+    (when value (Instant/parse (str value)))
+    (catch Exception _ nil)))
+
+(defn- refresh-needed? [auth]
+  (let [now (Instant/now)
+        access (get-in auth [:tokens :access_token])]
+    (if-let [expiry (and access (jwt-expiry access))]
+      (not (.isAfter expiry (.plusSeconds now refresh-window-seconds)))
+      (when-let [last-refresh (parse-instant (:last_refresh auth))]
+        (.isBefore last-refresh (.minusSeconds now stale-refresh-seconds))))))
+
+(defn- token-version [token]
+  (let [digest (.digest (MessageDigest/getInstance "SHA-256")
+                        (.getBytes ^String token StandardCharsets/UTF_8))]
+    (apply str (map #(format "%02x" (bit-and (int %) 0xff)) (take 12 digest)))))
+
+(defn- chatgpt-auth? [auth]
+  (and (= "chatgpt" (some-> (:auth_mode auth) name))
+       (seq (get-in auth [:tokens :access_token]))
+       (seq (get-in auth [:tokens :refresh_token]))
+       (seq (or (get-in auth [:tokens :account_id])
+                (get-in (decode-jwt-payload (get-in auth [:tokens :id_token]))
+                        [auth-claims-key :chatgpt_account_id])))))
+
+(defn- refresh-auth! [auth load-auth save-auth refresh-request]
+  (let [refresh-token (get-in auth [:tokens :refresh_token])
+        response (refresh-request {:client_id oauth-client-id
+                                   :grant_type "refresh_token"
+                                   :refresh_token refresh-token})
+        body (try
+               (json/read-value (response-body-string (:body response))
+                                json/keyword-keys-object-mapper)
+               (catch Exception _ {}))]
+    (when-not (<= 200 (long (:status response 0)) 299)
+      (throw (ex-info "Codex subscription token refresh failed"
+                      {:status (:status response)
+                       :code (or (get-in body [:error :code]) (:code body))
+                       :message (or (get-in body [:error :message]) (:message body))})))
+    ;; Re-read immediately before persisting so unrelated fields changed by a
+    ;; concurrently upgraded Codex installation are retained.
+    (let [current (or (load-auth) auth)
+          updated (cond-> (assoc current :last_refresh (str (Instant/now)))
+                    (:id_token body) (assoc-in [:tokens :id_token] (:id_token body))
+                    (:access_token body) (assoc-in [:tokens :access_token] (:access_token body))
+                    (:refresh_token body) (assoc-in [:tokens :refresh_token] (:refresh_token body)))]
+      (save-auth updated)
+      updated)))
+
+(defn- auth-headers [auth]
+  (let [access (get-in auth [:tokens :access_token])
+        claims (decode-jwt-payload (get-in auth [:tokens :id_token]))
+        account-id (or (get-in auth [:tokens :account_id])
+                       (get-in claims [auth-claims-key :chatgpt_account_id]))
+        fedramp? (true? (get-in claims
+                                [auth-claims-key
+                                 :chatgpt_account_is_fedramp]))]
+    (cond-> {"Authorization" (str "Bearer " access)
+             "ChatGPT-Account-ID" account-id}
+      fedramp? (assoc "X-OpenAI-Fedramp" "true"))))
+
+(deftype CodexFileCredentials [load-auth save-auth refresh-request refresh-lock]
+  gateway/Credentials
+  (credential-kind [_] :codex-subscription)
+  (allowed-origins [_] #{codex-origin})
+  (resolve-auth! [_ _]
+    (locking refresh-lock
+      (let [loaded (load-auth)]
+        (when-not (chatgpt-auth? loaded)
+          (throw (ex-info "No usable file-backed Codex ChatGPT login"
+                          {:credential-kind :codex-subscription})))
+        (let [auth (if (refresh-needed? loaded)
+                     (refresh-auth! loaded load-auth save-auth refresh-request)
+                     loaded)
+              access (get-in auth [:tokens :access_token])]
+          {:headers (auth-headers auth)
+           :version (token-version access)}))))
+  (recover-auth! [_ _ prior-auth]
+    (locking refresh-lock
+      (let [loaded (load-auth)
+            loaded-version (some-> loaded (get-in [:tokens :access_token]) token-version)]
+        (if (and loaded-version (not= loaded-version (:version prior-auth)))
+          true
+          (try
+            (refresh-auth! loaded load-auth save-auth refresh-request)
+            true
+            (catch Exception refresh-error
+              ;; Another Codex process may have won a rotating-refresh-token
+              ;; race. Accept its newly persisted access token when present.
+              (let [reloaded (load-auth)
+                    reloaded-version (some-> reloaded
+                                             (get-in [:tokens :access_token])
+                                             token-version)]
+                (if (and reloaded-version
+                         (not= reloaded-version (:version prior-auth)))
+                  true
+                  (throw refresh-error)))))))))
+
+  Object
+  (toString [_] "#<CodexFileCredentials>"))
+
+(defn create
+  "Create file-backed Codex credentials.
+
+   Tests and alternative secure stores may inject :load-auth, :save-auth and
+   :refresh-request without exposing tokens to provider code."
+  [config]
+  (let [path (or (:auth-path config) (default-auth-path))
+        path (if (instance? Path path) path (.toPath (io/file path)))
+        load-auth (or (:load-auth config)
+                      #(read-auth-file path))
+        save-auth (or (:save-auth config)
+                      #(write-auth-file! path %))
+        refresh-request (or (:refresh-request config) default-refresh-request)]
+    (CodexFileCredentials. load-auth save-auth refresh-request (Object.))))
+
+(defn available?
+  "True when a usable file-backed ChatGPT login is available. Never logs token
+   material. Keyring-only logins deliberately return false for now."
+  [config]
+  (try
+    (let [path (or (:auth-path config) (default-auth-path))
+          path (if (instance? Path path) path (.toPath (io/file path)))
+          load-auth (or (:load-auth config) #(read-auth-file path))]
+      (boolean (chatgpt-auth? (load-auth))))
+    (catch Exception _ false)))

--- a/src/dvergr/model/api/codex_subscription.clj
+++ b/src/dvergr/model/api/codex_subscription.clj
@@ -1,0 +1,617 @@
+(ns dvergr.model.api.codex-subscription
+  "Native ChatGPT Codex subscription provider plus a CLI compatibility path.
+
+   The primary provider sends dvergr-owned history and tools directly to the
+   ChatGPT Codex Responses endpoint. The trusted gateway injects file-backed
+   subscription credentials. `create-cli` retains the earlier isolated
+   `codex exec` adapter for keyring logins and wire-compatibility fallback."
+  (:require [clojure.string :as str]
+            [dvergr.chat.tool-schema :as tool-schema]
+            [dvergr.model.api.codex-auth :as codex-auth]
+            [dvergr.model.provider :as p]
+            [dvergr.model.quirks :as quirks]
+            [jsonista.core :as json]
+            [taoensso.telemere :as tel])
+  (:import [java.io BufferedReader InputStreamReader]
+           [java.nio.charset StandardCharsets]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]
+           [java.security MessageDigest]
+           [java.util UUID]))
+
+(def ^:private output-schema
+  {:type "object"
+   :properties
+   {:content {:type "string"
+              :description "Text to show the user before or instead of tool calls."}
+    :tool_calls
+    {:type "array"
+     :items {:type "object"
+             :properties {:id {:type "string"}
+                          :name {:type "string"}
+                          ;; Codex strict output schemas reject an open-ended
+                          ;; nested object. Carry arbitrary dvergr arguments as
+                          ;; JSON on the wire and decode them at the boundary.
+                          :input {:type "string"
+                                  :description "A JSON-encoded object containing the tool arguments."}}
+             :required ["id" "name" "input"]
+             :additionalProperties false}}}
+   :required ["content" "tool_calls"]
+   :additionalProperties false})
+
+(def ^:private model-aliases
+  {"codex-subscription-sol" "gpt-5.6-sol"
+   "codex-subscription-terra" "gpt-5.6-terra"
+   "codex-subscription-luna" "gpt-5.6-luna"})
+
+(def ^:private passive-item-types
+  ;; Fail closed for every other current or future Codex item type. Dvergr only
+  ;; accepts model text/reasoning; command, file, MCP, collaboration, web, plan,
+  ;; and unknown items belong to Codex's harness and must never cross over.
+  #{"agent_message" "reasoning" "error"})
+
+(defn- role-name [role]
+  (if (keyword? role) (name role) (str role)))
+
+(defn- format-conversation [messages]
+  (->> messages
+       (remove #(= "system" (role-name (:role %))))
+       (map (fn [{:keys [role content] :as message}]
+              (case (role-name role)
+                "tool" (str "Tool result "
+                            (or (:tool_call_id message) (:tool-use-id message) "unknown")
+                            ":\n" content)
+                "tool-result" (str "Tool result "
+                                   (or (:message/tool-use-id message)
+                                       (:tool-use-id message)
+                                       "unknown")
+                                   ":\n" content)
+                (str (str/capitalize (role-name role)) ":\n" content))))
+       (str/join "\n\n")))
+
+(defn- extract-system [messages opts]
+  (or (:system opts)
+      (->> messages
+           (filter #(= "system" (role-name (:role %))))
+           (map :content)
+           (remove str/blank?)
+           (str/join "\n\n")
+           not-empty)))
+
+(defn- tools-instructions [tools]
+  (when (seq tools)
+    (str "\n\nAvailable dvergr tools:\n"
+         (json/write-value-as-string
+          (mapv (fn [{:keys [name description parameters]}]
+                  {:name name
+                   :description description
+                   :input_schema (or parameters {:type "object" :properties {}})})
+                tools))
+         "\n\nWhen a tool is needed, return it in tool_calls and stop. "
+         "Encode each tool call's input object as JSON in its input string. "
+         "Do not execute, simulate, or predict tool results. The host dvergr "
+         "runtime executes the calls and supplies their results on the next turn.")))
+
+(defn- build-prompt [messages opts]
+  (str "You are acting as the model inside the dvergr agent harness. "
+       "Dvergr owns the conversation, tools, sandbox, and workflow. "
+       "Do not use any Codex-native tools or inspect the local environment.\n\n"
+       (when-let [system (extract-system messages opts)]
+         (str "System instructions:\n" system "\n\n"))
+       "Conversation:\n"
+       (format-conversation messages)
+       (tools-instructions (:tools opts))))
+
+(defn- resolve-model [model]
+  ;; The generic model intentionally omits -m so the installed Codex version can
+  ;; choose its current subscription default. Named entries provide reproducible
+  ;; opt-in choices without colliding with the OpenAI API provider's model ids.
+  (get model-aliases model))
+
+(defn- resolve-effort [opts]
+  (let [effort (or (some-> (:effort opts) name)
+                   (when-let [budget (get-in opts [:thinking :budget-tokens])]
+                     (cond
+                       (<= budget 2000) "low"
+                       (<= budget 8000) "medium"
+                       (<= budget 20000) "high"
+                       :else "xhigh")))]
+    (when (and effort
+               (not (contains? #{"low" "medium" "high" "xhigh" "max" "ultra"}
+                               effort)))
+      (throw (ex-info "Unsupported Codex reasoning effort" {:effort effort})))
+    effort))
+
+(defn- build-command [schema-path workspace opts]
+  (let [model (resolve-model (:model opts))
+        effort (resolve-effort opts)]
+    (cond-> ["codex" "exec"
+             "--json"
+             "--ephemeral"
+             "--ignore-user-config"
+             "--ignore-rules"
+             "--skip-git-repo-check"
+             "--sandbox" "read-only"
+             "--disable" "shell_tool"
+             "--disable" "view_image"
+             "--disable" "multi_agent"
+             "--disable" "apps"
+             "--disable" "plugins"
+             "--disable" "hooks"
+             "-c" "web_search=\"disabled\""
+             "-c" "update_plan_enabled=false"
+             "-C" workspace
+             "--output-schema" schema-path]
+      model (into ["--model" model])
+      effort (into ["-c" (str "model_reasoning_effort=\"" effort "\"")])
+      true (conj "-"))))
+
+(defn- default-runner [command prompt]
+  (let [process (.start (doto (ProcessBuilder. ^java.util.List command)
+                          (.redirectErrorStream false)))
+        stderr-future (future (slurp (.getErrorStream process)))]
+    (try
+      (with-open [stdin (.getOutputStream process)]
+        (.write stdin (.getBytes ^String prompt StandardCharsets/UTF_8)))
+      (let [lines (with-open [reader (BufferedReader.
+                                      (InputStreamReader. (.getInputStream process)
+                                                          StandardCharsets/UTF_8))]
+                    (loop [acc []]
+                      (if-let [line (.readLine reader)]
+                        (recur (conj acc line))
+                        acc)))
+            exit-code (.waitFor process)]
+        {:exit-code exit-code
+         :lines lines
+         :stderr @stderr-future})
+      (finally
+        (when (.isAlive process)
+          (.destroyForcibly process))))))
+
+(defn- parse-json-line [line]
+  (when-not (str/blank? line)
+    (try
+      (json/read-value line json/keyword-keys-object-mapper)
+      (catch Exception _ nil))))
+
+(defn- accumulate-event [state event]
+  (let [event-type (:type event)
+        item (:item event)
+        item-type (:type item)]
+    (cond
+      (= event-type "thread.started")
+      (assoc state :thread-id (:thread_id event))
+
+      (and (= event-type "item.completed") (= item-type "agent_message"))
+      (update state :messages conj (:text item))
+
+      (and (= event-type "item.completed") (= item-type "error"))
+      (assoc state :error (:message item))
+
+      (and (#{"item.started" "item.updated" "item.completed"} event-type)
+           item-type
+           (not (passive-item-types item-type)))
+      (update state :native-effects conj item-type)
+
+      (= event-type "turn.completed")
+      (assoc state :usage (:usage event) :completed? true)
+
+      (= event-type "turn.failed")
+      (assoc state :error (get-in event [:error :message]))
+
+      (= event-type "error")
+      (assoc state :error (:message event))
+
+      :else state)))
+
+(defn- parse-structured-message [text]
+  (try
+    (json/read-value text json/keyword-keys-object-mapper)
+    (catch Exception e
+      (throw (ex-info "Codex did not return the required structured response"
+                      {:response text}
+                      e)))))
+
+(defn- parse-tool-input [input]
+  (let [value (if (string? input)
+                (try
+                  (json/read-value input json/keyword-keys-object-mapper)
+                  (catch Exception e
+                    (throw (ex-info "Codex returned invalid JSON tool input"
+                                    {:input input}
+                                    e))))
+                input)]
+    (if (map? value)
+      value
+      (throw (ex-info "Codex tool input must decode to an object"
+                      {:input input :decoded value})))))
+
+(defn- run-codex [config messages opts]
+  (let [schema-path (Files/createTempFile "dvergr-codex-schema-" ".json"
+                                          (make-array FileAttribute 0))
+        workspace (Files/createTempDirectory "dvergr-codex-workspace-"
+                                             (make-array FileAttribute 0))]
+    (try
+      (Files/writeString schema-path
+                         (json/write-value-as-string output-schema)
+                         StandardCharsets/UTF_8
+                         (make-array java.nio.file.OpenOption 0))
+      (let [runner (or (:runner config) default-runner)
+            command (build-command (str schema-path) (str workspace) opts)
+            {:keys [exit-code lines stderr]} (runner command (build-prompt messages opts))
+            state (reduce accumulate-event
+                          {:messages [] :native-effects []}
+                          (keep parse-json-line lines))]
+        (when (seq (:native-effects state))
+          (throw (ex-info "Codex attempted to use its native harness; refusing the result"
+                          {:native-effects (:native-effects state)})))
+        (when (or (not (zero? exit-code)) (:error state) (not (:completed? state)))
+          (throw (ex-info (or (:error state)
+                              (str "Codex CLI failed (exit " exit-code ")"))
+                          {:exit-code exit-code :stderr stderr :state state})))
+        (let [raw (last (:messages state))
+              parsed (parse-structured-message raw)
+              tool-calls (->> (:tool_calls parsed)
+                              (mapv (fn [{:keys [id name input]}]
+                                      {:id id :name name :input (parse-tool-input input)})))
+              usage (:usage state)
+              result {:content (or (:content parsed) "")
+                      :tool-calls (when (seq tool-calls) tool-calls)
+                      :usage {:input-tokens (or (:input_tokens usage) 0)
+                              :output-tokens (or (:output_tokens usage) 0)
+                              :cache-read-tokens (or (:cached_input_tokens usage) 0)
+                              :cache-write-tokens (or (:cache_write_input_tokens usage) 0)
+                              :reasoning-output-tokens (or (:reasoning_output_tokens usage) 0)}
+                      :stop-reason (if (seq tool-calls) :tool-use :end-turn)
+                      :model (or (resolve-model (:model opts)) "codex-default")
+                      :id (:thread-id state)}]
+          (when-let [on-text (:on-text opts)]
+            (when-not (str/blank? (:content result))
+              (on-text (:content result))))
+          result))
+      (finally
+        (Files/deleteIfExists schema-path)
+        (Files/deleteIfExists workspace)))))
+
+(defrecord CodexSubscriptionCliProvider [config]
+  p/LLMProvider
+  (provider-id [_] :codex-subscription-cli)
+  (api-type [_] :codex-cli)
+  (build-request [_ _ _]
+    (throw (ex-info "CodexSubscriptionProvider uses DirectChat" {})))
+  (create-accumulator [_ _]
+    (throw (ex-info "CodexSubscriptionProvider uses DirectChat" {})))
+  (accumulate-event [_ _ _ _ _]
+    (throw (ex-info "CodexSubscriptionProvider uses DirectChat" {})))
+  (extract-response [_ _]
+    (throw (ex-info "CodexSubscriptionProvider uses DirectChat" {})))
+
+  p/DirectChat
+  (direct-chat [_ messages opts]
+    (tel/log! {:id :codex-subscription-cli/chat-start
+               :data {:model (:model opts)
+                      :message-count (count messages)
+                      :tools (count (:tools opts))}}
+              "Codex subscription CLI chat")
+    (let [response (run-codex config messages opts)]
+      (tel/log! {:id :codex-subscription-cli/chat-complete
+                 :data {:model (:model response)
+                        :usage (:usage response)
+                        :stop-reason (:stop-reason response)
+                        :tool-calls (mapv :name (:tool-calls response))}}
+                "Codex subscription CLI chat complete")
+      response))
+
+  p/ToolFormatter
+  (format-tools [_ tools] tools)
+
+  p/MessageFormatter
+  (format-messages [_ messages _model]
+    ;; Codex receives a text transcript, but the durable dvergr history remains
+    ;; authoritative. Preserve both halves of every tool exchange so a fresh,
+    ;; ephemeral CLI process can reconstruct the next turn without owning any
+    ;; conversation state itself.
+    (mapv (fn [message]
+            (case (:message/role message)
+              :tool-result
+              {:role "tool-result"
+               :content (:message/content message)
+               :tool-use-id (:message/tool-use-id message)}
+
+              :assistant
+              (let [tool-calls (mapv (fn [tool-use]
+                                       {:id (:tool-use/id tool-use)
+                                        :name (quirks/clean-tool-name
+                                               (:tool-use/name tool-use))
+                                        :input (tool-schema/input-entity->args
+                                                (:tool-use/input tool-use))})
+                                     (:message/tool-uses message))]
+                {:role "assistant"
+                 :content (str (or (:message/content message) "")
+                               (when (seq tool-calls)
+                                 (str "\nDvergr tool calls:\n"
+                                      (json/write-value-as-string tool-calls))))})
+
+              {:role (name (:message/role message))
+               :content (:message/content message)}))
+          messages)))
+
+(defn create-cli
+  "Create the isolated `codex exec` compatibility provider. An optional
+   :runner is intended for deterministic tests."
+  [config]
+  (->CodexSubscriptionCliProvider config))
+
+(defn- default-login-probe []
+  (try
+    (let [process (.start (doto (ProcessBuilder. ^java.util.List
+                                 ["codex" "login" "status"])
+                            (.redirectErrorStream true)))
+          output (slurp (.getInputStream process))
+          exit-code (.waitFor process)]
+      (and (zero? exit-code) (str/includes? output "ChatGPT")))
+    (catch Exception _ false)))
+
+(defn create-cli-if-available
+  "Create the CLI fallback only when Codex reports a ChatGPT login."
+  [config]
+  (when ((or (:login-probe config) default-login-probe))
+    (create-cli config)))
+
+;; ============================================================================
+;; Native Responses transport
+;; ============================================================================
+
+(def ^:private native-default-model "gpt-5.6-sol")
+
+(defn- resolve-native-model [model]
+  (or (get model-aliases model)
+      (when (and model (str/starts-with? model "gpt-")) model)
+      native-default-model))
+
+(defn- sha256-hex [value]
+  (let [digest (.digest (MessageDigest/getInstance "SHA-256")
+                        (.getBytes (str value) StandardCharsets/UTF_8))]
+    (apply str (map #(format "%02x" (bit-and (int %) 0xff)) digest))))
+
+(defn- stable-id [prefix value]
+  (str prefix "_" (subs (sha256-hex value) 0 32)))
+
+(defn- response-message [role content]
+  {:type "message"
+   :role role
+   :content [{:type (if (= "assistant" role) "output_text" "input_text")
+              :text (or content "")}]})
+
+(defn- formatted-input [messages]
+  (mapv (fn [message]
+          (if (:type message)
+            message
+            (response-message (role-name (:role message)) (:content message))))
+        messages))
+
+(defn- native-tools [tools responses-lite?]
+  (let [functions (mapv (fn [{:keys [name description parameters]}]
+                          {:type "function"
+                           :name name
+                           :description (or description "")
+                           :strict false
+                           :parameters (or parameters
+                                           {:type "object" :properties {}})})
+                        tools)]
+    (if responses-lite?
+      (when (seq functions)
+        [{:type "namespace"
+          :name "functions"
+          :description ""
+          :tools functions}])
+      functions)))
+
+(defn- prompt-cache-key [instructions tools opts]
+  (or (:prompt-cache-key opts)
+      (str "dvergr-" (subs (sha256-hex [instructions tools]) 0 32))))
+
+(defn- session-id [cache-key]
+  (str (UUID/nameUUIDFromBytes (.getBytes ^String cache-key StandardCharsets/UTF_8))))
+
+(defn- native-prefix [instructions tools]
+  (cond-> []
+    (seq tools)
+    (conj {:id (stable-id "at" tools)
+           :type "additional_tools"
+           :role "developer"
+           :tools tools})
+
+    (not (str/blank? instructions))
+    (conj {:id (stable-id "msg" instructions)
+           :type "message"
+           :role "developer"
+           :content [{:type "input_text" :text instructions}]})))
+
+(defn- native-request [config credentials messages opts]
+  (let [model (resolve-native-model (:model opts))
+        responses-lite? (not= false (:responses-lite? config))
+        instructions (or (extract-system messages opts) "")
+        messages (remove #(= "system" (role-name (:role %))) messages)
+        tools (native-tools (:tools opts) responses-lite?)
+        cache-key (prompt-cache-key instructions tools opts)
+        sid (session-id cache-key)
+        effort (or (resolve-effort opts)
+                   (:default-effort config)
+                   (if (= model "gpt-5.6-sol") "low" "medium"))
+        input (formatted-input messages)
+        body-base {:model model
+                   :input (if responses-lite?
+                            (into (native-prefix instructions tools) input)
+                            input)
+                   :tool_choice "auto"
+                   :parallel_tool_calls (and (boolean (:parallel-tool-calls opts))
+                                             (not responses-lite?))
+                   :reasoning (cond-> {:effort effort}
+                                responses-lite? (assoc :context "all_turns"))
+                   :store false
+                   :stream true
+                   :include ["reasoning.encrypted_content"]
+                   :prompt_cache_key cache-key
+                   :text {:verbosity (or (:verbosity opts) "low")}}
+        body (if responses-lite?
+               body-base
+               (cond-> (assoc body-base :instructions instructions)
+                 (seq tools) (assoc :tools tools)))]
+    {:url (str (or (:base-url config)
+                   "https://chatgpt.com/backend-api/codex")
+               "/responses")
+     :headers (cond-> {"Content-Type" "application/json"
+                       "Accept" "text/event-stream"
+                       "originator" (or (:originator config) "dvergr")
+                       "session-id" sid
+                       "thread-id" sid
+                       "x-codex-routing-hint" (str "model=" model)}
+                responses-lite?
+                (assoc "x-openai-internal-codex-responses-lite" "true"))
+     :credentials credentials
+     :body body}))
+
+(defn- parse-arguments [arguments]
+  (try
+    (let [value (json/read-value (or arguments "{}")
+                                 json/keyword-keys-object-mapper)]
+      (if (map? value) value {:value value}))
+    (catch Exception e
+      (throw (ex-info "Codex returned invalid function arguments"
+                      {:arguments arguments}
+                      e)))))
+
+(defn- output-item-text [item]
+  (->> (:content item)
+       (filter #(= "output_text" (:type %)))
+       (map :text)
+       (apply str)))
+
+(defrecord CodexSubscriptionProvider [config credentials]
+  p/LLMProvider
+  (provider-id [_] :codex-subscription)
+  (api-type [_] :openai-responses)
+
+  (build-request [_ messages opts]
+    (native-request config credentials messages opts))
+
+  (create-accumulator [_ _]
+    {:content ""
+     :reasoning ""
+     :tool-calls []
+     :usage {:input-tokens 0 :output-tokens 0}
+     :stop-reason nil
+     :model nil
+     :id nil})
+
+  (accumulate-event [_ state event-type event-data _]
+    (case event-type
+      "response.output_text.delta"
+      (update state :content str (:delta event-data))
+
+      "response.reasoning_summary_text.delta"
+      (update state :reasoning str (:delta event-data))
+
+      "response.output_item.done"
+      (let [item (:item event-data)]
+        (case (:type item)
+          "function_call"
+          (update state :tool-calls conj
+                  {:id (:call_id item)
+                   :name (quirks/clean-tool-name (:name item))
+                   :input (parse-arguments (:arguments item))})
+
+          "message"
+          (if (str/blank? (:content state))
+            (assoc state :content (output-item-text item))
+            state)
+
+          state))
+
+      "response.completed"
+      (let [response (:response event-data)
+            usage (:usage response)]
+        (-> state
+            (assoc :id (:id response)
+                   :model (:model response)
+                   :stop-reason (if (seq (:tool-calls state))
+                                  :tool-use
+                                  :end-turn)
+                   :usage {:input-tokens (or (:input_tokens usage) 0)
+                           :output-tokens (or (:output_tokens usage) 0)
+                           :cache-read-tokens (or (get-in usage
+                                                          [:input_tokens_details
+                                                           :cached_tokens])
+                                                  0)
+                           :reasoning-output-tokens
+                           (or (get-in usage
+                                       [:output_tokens_details :reasoning_tokens])
+                               0)})))
+
+      "response.incomplete"
+      (assoc state :stop-reason :max-tokens)
+
+      "response.failed"
+      (throw (ex-info (or (get-in event-data [:response :error :message])
+                          "Codex Responses request failed")
+                      {:error (get-in event-data [:response :error])}))
+
+      state))
+
+  (extract-response [_ state]
+    {:content (:content state)
+     :reasoning (not-empty (:reasoning state))
+     :tool-calls (not-empty (:tool-calls state))
+     :usage (:usage state)
+     :stop-reason (or (:stop-reason state)
+                      (if (seq (:tool-calls state)) :tool-use :end-turn))
+     :model (:model state)
+     :id (:id state)})
+
+  p/ToolFormatter
+  (format-tools [_ tools]
+    (native-tools tools (not= false (:responses-lite? config))))
+
+  p/MessageFormatter
+  (format-messages [_ messages _]
+    (vec
+     (mapcat
+      (fn [message]
+        (case (:message/role message)
+          :tool-result
+          [{:type "function_call_output"
+            :call_id (:message/tool-use-id message)
+            :output (:message/content message)}]
+
+          :assistant
+          (let [text (:message/content message)
+                calls (mapv (fn [tool-use]
+                              {:type "function_call"
+                               :call_id (:tool-use/id tool-use)
+                               :name (quirks/clean-tool-name (:tool-use/name tool-use))
+                               :arguments (json/write-value-as-string
+                                           (tool-schema/input-entity->args
+                                            (:tool-use/input tool-use)))})
+                            (:message/tool-uses message))]
+            (cond-> []
+              (not (str/blank? text)) (conj (response-message "assistant" text))
+              (seq calls) (into calls)))
+
+          [{:role (name (:message/role message))
+            :content (:message/content message)}]))
+      messages))))
+
+(defn create
+  "Create the native subscription provider. :credentials may inject a gateway
+   Credentials implementation; production defaults to Codex's auth.json."
+  [config]
+  (->CodexSubscriptionProvider
+   config
+   (or (:credentials config) (codex-auth/create config))))
+
+(defn create-if-available
+  "Create the native provider for a usable file-backed ChatGPT login."
+  [config]
+  (when (or (:credentials config) (codex-auth/available? config))
+    (create config)))

--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -3,6 +3,7 @@
 
    Also used by OpenAI-compatible providers like Fireworks, Together, etc."
   (:require [dvergr.model.provider :as p]
+            [dvergr.model.gateway :as gateway]
             [dvergr.model.registry :as registry]
             [dvergr.model.quirks :as quirks]
             [dvergr.chat.tool-schema :as tool-schema]
@@ -58,9 +59,9 @@
   (build-request [_ messages opts]
     (let [tools (:tools opts)]
       {:url (str (or (:base-url config) "https://api.openai.com/v1") "/chat/completions")
-       :headers (merge {"Authorization" (str "Bearer " (:api-key config))
-                        "Content-Type" "application/json"}
+       :headers (merge {"Content-Type" "application/json"}
                        (:extra-headers config))
+       :credentials (:credentials config)
        :body (cond-> {:model (:model opts "gpt-4o")
                       :max_completion_tokens (:max-tokens opts 8192)
                       :stream true
@@ -284,9 +285,20 @@
   [config]
   (let [api-key (or (:api-key config)
                     (System/getenv "OPENAI_API_KEY"))]
-    (when-not api-key
+    (when-not (or api-key (:credentials config))
       (throw (ex-info "OpenAI API key required" {:env "OPENAI_API_KEY"})))
-    (->OpenAIProvider (assoc config :api-key api-key))))
+    (let [base-url (or (:base-url config)
+                       (System/getenv "OPENAI_BASE_URL")
+                       "https://api.openai.com/v1")
+          credentials (or (:credentials config)
+                          (gateway/static-credentials
+                           :openai-api-key
+                           {"Authorization" (str "Bearer " api-key)}
+                           #{(gateway/request-origin base-url)}))]
+      (->OpenAIProvider (-> config
+                            (dissoc :api-key)
+                            (assoc :base-url base-url
+                                   :credentials credentials))))))
 
 (defn create-if-available
   "Create OpenAI provider if API key is available, otherwise nil."
@@ -307,23 +319,27 @@
    - :extra-headers - Additional HTTP headers"
   [config]
   (let [api-key (or (:api-key config)
-                    (System/getenv "FIREWORKS_API_KEY")
-                    (System/getenv "OPENAI_API_KEY"))
+                    (System/getenv "FIREWORKS_API_KEY"))
         base-url (or (:base-url config)
-                     (System/getenv "OPENAI_BASE_URL")
+                     (System/getenv "FIREWORKS_BASE_URL")
                      "https://api.fireworks.ai/inference/v1")]
-    (when-not api-key
+    (when-not (or api-key (:credentials config))
       (throw (ex-info "Fireworks API key required"
-                      {:env ["FIREWORKS_API_KEY" "OPENAI_API_KEY"]})))
-    (->OpenAIProvider (assoc config
-                             :api-key api-key
-                             :base-url base-url
-                             :provider-id :fireworks))))
+                      {:env "FIREWORKS_API_KEY"})))
+    (let [credentials (or (:credentials config)
+                          (gateway/static-credentials
+                           :fireworks-api-key
+                           {"Authorization" (str "Bearer " api-key)}
+                           #{(gateway/request-origin base-url)}))]
+      (->OpenAIProvider (-> config
+                            (dissoc :api-key)
+                            (assoc :credentials credentials
+                                   :base-url base-url
+                                   :provider-id :fireworks))))))
 
 (defn create-fireworks-if-available
   "Create Fireworks provider if API key is available, otherwise nil."
   [config]
   (when (or (:api-key config)
-            (System/getenv "FIREWORKS_API_KEY")
-            (System/getenv "OPENAI_API_KEY"))
+            (System/getenv "FIREWORKS_API_KEY"))
     (create-fireworks config)))

--- a/src/dvergr/model/chat.clj
+++ b/src/dvergr/model/chat.clj
@@ -4,6 +4,7 @@
    This is the main entry point for sending chat requests to any provider.
    Uses the provider abstraction to handle provider-specific details."
   (:require [dvergr.model.provider :as p]
+            [dvergr.model.gateway :as gateway]
             [dvergr.model.providers :as providers]
             [dvergr.model.registry :as registry]
             [hato.client :as hc]
@@ -124,14 +125,15 @@
 
 (defn- make-request
   "Make HTTP request with error handling. Returns response or throws."
-  [url headers body]
-  (let [response (hc/request {:method :post
-                              :url url
-                              :headers headers
-                              :body (json/write-value-as-string body)
-                              :as :stream
-                              :http-client (get-http-client)
-                              :throw-exceptions false})]
+  [url headers body credentials]
+  (let [response (gateway/request! {:method :post
+                                    :url url
+                                    :headers headers
+                                    :credentials credentials
+                                    :body (json/write-value-as-string body)
+                                    :as :stream
+                                    :http-client (get-http-client)
+                                    :throw-exceptions false})]
     (if (>= (:status response) 400)
       (throw (wrap-api-error response))
       response)))
@@ -144,10 +146,10 @@
   "Internal implementation of streaming chat with a provider."
   [provider model-def messages opts]
   (let [;; Build request using provider
-        {:keys [url headers body]} (p/build-request provider messages opts)
+        {:keys [url headers body credentials]} (p/build-request provider messages opts)
 
         ;; Make HTTP request
-        response (make-request url headers body)
+        response (make-request url headers body credentials)
         reader (BufferedReader. (io/reader (:body response)))]
 
     {:events (sse-seq reader)
@@ -161,6 +163,7 @@
   (case (p/api-type provider)
     :anthropic-messages (:type event)
     :openai-chat "chunk"  ; OpenAI doesn't have explicit types
+    :openai-responses (:type event)
     "chunk"))
 
 (defn stream-chat
@@ -317,6 +320,11 @@
                        :openai-chat
                        (doseq [choice (:choices event)]
                          (when-let [text (get-in choice [:delta :content])]
+                           (on-text text)))
+
+                       :openai-responses
+                       (when (= "response.output_text.delta" (:type event))
+                         (when-let [text (:delta event)]
                            (on-text text)))
 
                        nil))

--- a/src/dvergr/model/gateway.clj
+++ b/src/dvergr/model/gateway.clj
@@ -1,0 +1,105 @@
+(ns dvergr.model.gateway
+  "Trusted provider egress and credential boundary.
+
+   Sandboxed code asks dvergr to invoke a model; it never receives credentials
+   or an arbitrary authenticated HTTP primitive. Providers describe a request
+   and attach a Credentials implementation. The gateway validates the target,
+   injects authentication at the last possible moment, and owns the one-shot
+   unauthorized recovery path used by rotating credentials."
+  (:require [hato.client :as hc])
+  (:import [java.io Closeable]
+           [java.net URI]))
+
+(defprotocol Credentials
+  (credential-kind [this]
+    "Non-secret identifier used for diagnostics.")
+  (allowed-origins [this]
+    "Exact lower-case URI origins this credential may authorize.")
+  (resolve-auth! [this request]
+    "Return {:headers {...} :version opaque-version} for request.")
+  (recover-auth! [this request prior-auth]
+    "Recover after a 401. Return truthy to retry the request exactly once."))
+
+(defn request-origin
+  "Return the normalized scheme://host[:port] origin for an absolute URL."
+  [url]
+  (let [uri (URI. url)
+        scheme (some-> (.getScheme uri) .toLowerCase)
+        host (some-> (.getHost uri) .toLowerCase)
+        port (.getPort uri)]
+    (when-not (and scheme host (contains? #{"http" "https"} scheme))
+      (throw (ex-info "Provider URL must be absolute HTTP(S)"
+                      {:url url})))
+    (str scheme "://" host (when (not= -1 port) (str ":" port)))))
+
+(deftype StaticCredentials [kind auth-headers origins]
+  Credentials
+  (credential-kind [_] kind)
+  (allowed-origins [_] origins)
+  (resolve-auth! [_ _]
+    {:headers auth-headers
+     :version :static})
+  (recover-auth! [_ _ _] false)
+
+  Object
+  (toString [_] (str "#<StaticCredentials " (name kind) ">")))
+
+(defn static-credentials
+  "Create non-refreshing credentials restricted to configured origins."
+  [kind auth-headers origins]
+  (when-not (seq origins)
+    (throw (ex-info "Credentials require at least one allowed origin"
+                    {:kind kind})))
+  (StaticCredentials. kind auth-headers (set (map #(.toLowerCase ^String %) origins))))
+
+(defn unauthenticated-credentials
+  "Create an origin-confined, intentionally unauthenticated capability for a
+   local or otherwise credential-free provider."
+  [origins]
+  (static-credentials :unauthenticated {} origins))
+
+(def ^:dynamic *request-fn*
+  "Injectable hato-compatible request function for deterministic tests."
+  hc/request)
+
+(defn- close-body! [response]
+  (when-let [body (:body response)]
+    (when (instance? Closeable body)
+      (.close ^Closeable body))))
+
+(defn- authorize
+  [{:keys [url headers credentials] :as request}]
+  (when-not (satisfies? Credentials credentials)
+    (throw (ex-info "Provider request has no trusted credentials"
+                    {:url url})))
+  (let [origin (request-origin url)
+        allowed (allowed-origins credentials)]
+    (when-not (contains? allowed origin)
+      (throw (ex-info "Credential is not permitted for provider origin"
+                      {:credential-kind (credential-kind credentials)
+                       :origin origin
+                       :allowed-origins allowed})))
+    (let [auth (resolve-auth! credentials request)]
+      {:request (-> request
+                    (dissoc :credentials)
+                    ;; Credential headers win over provider-supplied headers.
+                    (assoc :headers (merge headers (:headers auth))))
+       :auth auth})))
+
+(defn request!
+  "Execute a trusted provider request.
+
+   The input is a hato request map plus :credentials. A refreshable credential
+   may recover one 401; response bodies from the rejected attempt are closed
+   before retrying. Authentication headers are never returned in errors or
+   telemetry by this layer."
+  [request]
+  (let [{authorized :request auth :auth} (authorize request)
+        response (*request-fn* authorized)]
+    (if (and (= 401 (:status response))
+             (recover-auth! (:credentials request) request auth))
+      (do
+        (close-body! response)
+        (let [{retry :request} (authorize request)]
+          (*request-fn* retry)))
+      response)))

--- a/src/dvergr/model/providers.clj
+++ b/src/dvergr/model/providers.clj
@@ -6,6 +6,7 @@
             [dvergr.model.api.anthropic :as anthropic]
             [dvergr.model.api.openai :as openai]
             [dvergr.model.api.claude-code :as claude-code]
+            [dvergr.model.api.codex-subscription :as codex-subscription]
             [taoensso.telemere :as tel]))
 
 ;; ============================================================================
@@ -103,6 +104,18 @@
     (register! :claude-code provider)
     (tel/log! {:id :providers/registered :data {:provider :claude-code}} "Registered provider"))
 
+  ;; Native OpenAI Codex Responses transport via a file-backed ChatGPT login.
+  (when-let [provider (codex-subscription/create-if-available {})]
+    (register! :codex-subscription provider)
+    (tel/log! {:id :providers/registered :data {:provider :codex-subscription}}
+              "Registered provider"))
+
+  ;; Compatibility path for keyring-only logins or upstream wire changes.
+  (when-let [provider (codex-subscription/create-cli-if-available {})]
+    (register! :codex-subscription-cli provider)
+    (tel/log! {:id :providers/registered :data {:provider :codex-subscription-cli}}
+              "Registered provider"))
+
   ;; Load extra models from resources/models.edn
   (try
     (when-let [n (registry/load-models-resource!)]
@@ -116,9 +129,9 @@
   ;; failing with a confusing model/provider error.
   (when (empty? @providers)
     (tel/log! {:level :warn :id :providers/none-registered :data {}}
-              (str "No LLM providers registered — set an API key. The default "
-                   "config uses Fireworks: export FIREWORKS_API_KEY=… "
-                   "(also accepts OPENAI_API_KEY / ANTHROPIC_API_KEY).")))
+              (str "No LLM providers registered — set ANTHROPIC_API_KEY, "
+                   "OPENAI_API_KEY, or FIREWORKS_API_KEY, or sign in with "
+                   "the Claude Code or Codex CLI.")))
 
   (tel/log! {:id :providers/init-complete :data {:count (count @providers)}} "Providers ready"))
 
@@ -139,11 +152,14 @@
   {:anthropic   "claude-sonnet-4-6"
    :fireworks   "accounts/fireworks/models/minimax-m2p7"
    :openai      "gpt-4o"
-   :claude-code "claude-code-sonnet"})
+   :claude-code "claude-code-sonnet"
+   :codex-subscription "codex-subscription"
+   :codex-subscription-cli "codex-subscription-cli"})
 
 (def ^:private provider-preference
   "Order in which to pick a default provider when one isn't specified."
-  [:anthropic :fireworks :openai :claude-code])
+  [:anthropic :fireworks :openai :codex-subscription
+   :codex-subscription-cli :claude-code])
 
 (defn default-spec
   "`{:provider :model}` for the best AVAILABLE (registered) provider, by
@@ -182,6 +198,16 @@
   "Register a Claude Code CLI provider."
   [config]
   (register! :claude-code (claude-code/create config)))
+
+(defn register-codex-subscription!
+  "Register the native Codex Responses provider backed by a ChatGPT subscription."
+  [config]
+  (register! :codex-subscription (codex-subscription/create config)))
+
+(defn register-codex-subscription-cli!
+  "Register the isolated Codex CLI compatibility provider."
+  [config]
+  (register! :codex-subscription-cli (codex-subscription/create-cli config)))
 
 (defn register-openai-compatible!
   "Register a custom OpenAI-compatible provider.

--- a/src/dvergr/model/registry.clj
+++ b/src/dvergr/model/registry.clj
@@ -141,6 +141,64 @@
     :context 200000
     :max-output 32000
     :pricing {:input 0 :output 0}
+    :quirks {}}
+
+   ;; Native Codex Responses models (via an existing ChatGPT subscription). These ids are
+   ;; deliberately distinct from the OpenAI API models so both providers can be
+   ;; configured at once.
+   "codex-subscription"
+   {:id "codex-subscription"
+    :name "Codex GPT-5.6 Sol (subscription default)"
+    :provider :codex-subscription
+    :api-type :openai-responses
+    :capabilities #{:tools :system-prompt :thinking :streaming}
+    :context 272000
+    :max-output 128000
+    :pricing {:input 0 :output 0}
+    :quirks {}}
+
+   "codex-subscription-sol"
+   {:id "codex-subscription-sol"
+    :name "Codex GPT-5.6 Sol (subscription)"
+    :provider :codex-subscription
+    :api-type :openai-responses
+    :capabilities #{:tools :system-prompt :thinking :streaming}
+    :context 272000
+    :max-output 128000
+    :pricing {:input 0 :output 0}
+    :quirks {}}
+
+   "codex-subscription-terra"
+   {:id "codex-subscription-terra"
+    :name "Codex GPT-5.6 Terra (subscription)"
+    :provider :codex-subscription
+    :api-type :openai-responses
+    :capabilities #{:tools :system-prompt :thinking :streaming}
+    :context 272000
+    :max-output 128000
+    :pricing {:input 0 :output 0}
+    :quirks {}}
+
+   "codex-subscription-luna"
+   {:id "codex-subscription-luna"
+    :name "Codex GPT-5.6 Luna (subscription)"
+    :provider :codex-subscription
+    :api-type :openai-responses
+    :capabilities #{:tools :system-prompt :thinking :streaming}
+    :context 272000
+    :max-output 128000
+    :pricing {:input 0 :output 0}
+    :quirks {}}
+
+   "codex-subscription-cli"
+   {:id "codex-subscription-cli"
+    :name "Codex subscription (CLI fallback)"
+    :provider :codex-subscription-cli
+    :api-type :codex-cli
+    :capabilities #{:tools :system-prompt :thinking :streaming}
+    :context 272000
+    :max-output 128000
+    :pricing {:input 0 :output 0}
     :quirks {}}})
 
 ;; ============================================================================
@@ -412,7 +470,11 @@
                  "sonnet-4-5" "claude-sonnet-4-5"
                  "cc-sonnet" "claude-code-sonnet"
                  "cc-opus" "claude-code-opus"
-                 "cc-haiku" "claude-code-haiku"}))
+                 "cc-haiku" "claude-code-haiku"
+                 "codex" "codex-subscription"
+                 "codex-sol" "codex-subscription-sol"
+                 "codex-terra" "codex-subscription-terra"
+                 "codex-luna" "codex-subscription-luna"}))
 
 (defn register-alias!
   "Register an alias for a model ID."

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -328,7 +328,8 @@
     ;; llm-agent now, so a daemon agent is just a plain llm-agent.
     ;; When an agent pins NEITHER provider nor model, fall back to the env-aware
     ;; default (providers/default-spec) — best AVAILABLE registered provider by
-    ;; preference (anthropic→fireworks→openai→claude-code) + its default model — so
+    ;; preference (anthropic→fireworks→openai→codex-subscription→claude-code)
+    ;; + its default model — so
     ;; a fresh install works with WHICHEVER provider key is set, not only Fireworks.
     ;; The :fireworks/minimax literals remain only as a last resort when no provider
     ;; is registered at all (the agent then fails at call time; boot already warns).

--- a/test/dvergr/model/codex_auth_test.clj
+++ b/test/dvergr/model/codex_auth_test.clj
@@ -1,0 +1,71 @@
+(ns dvergr.model.codex-auth-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.model.api.codex-auth :as auth]
+            [dvergr.model.gateway :as gateway]
+            [jsonista.core :as json])
+  (:import [java.nio.charset StandardCharsets]
+           [java.time Instant]
+           [java.util Base64]))
+
+(defn- jwt [claims]
+  (let [encoder (.withoutPadding (Base64/getUrlEncoder))
+        encoded (fn [value]
+                  (.encodeToString encoder
+                                   (.getBytes (json/write-value-as-string value)
+                                              StandardCharsets/UTF_8)))]
+    (str (encoded {:alg "none"}) "." (encoded claims) ".signature")))
+
+(defn- auth-state [access expiry]
+  {:auth_mode "chatgpt"
+   :tokens {:id_token (jwt {"https://api.openai.com/auth"
+                            {:chatgpt_account_id "account-1"}})
+            :access_token (jwt {:exp (.getEpochSecond expiry)
+                                :token access})
+            :refresh_token "refresh-1"
+            :account_id "account-1"}
+   :last_refresh (str (Instant/now))})
+
+(deftest codex-file-credentials-resolve-without-exporting-storage
+  (let [state (atom (auth-state "current" (.plusSeconds (Instant/now) 3600)))
+        credentials (auth/create {:load-auth #(deref state)
+                                  :save-auth #(reset! state %)
+                                  :refresh-request (fn [_]
+                                                     (throw (ex-info "unexpected refresh" {})))})
+        resolved (gateway/resolve-auth! credentials
+                                        {:url "https://chatgpt.com/backend-api/codex/responses"})]
+    (is (re-find #"^Bearer " (get-in resolved [:headers "Authorization"])))
+    (is (= "account-1" (get-in resolved [:headers "ChatGPT-Account-ID"])))
+    (is (= :codex-subscription (gateway/credential-kind credentials)))
+    (is (= "#<CodexFileCredentials>" (str credentials)))
+    (is (not (re-find #"refresh-1" (str credentials))))))
+
+(deftest expiring-codex-credentials-refresh-and-persist-rotation
+  (let [state (atom (auth-state "old" (.minusSeconds (Instant/now) 10)))
+        request-seen (atom nil)
+        new-access (jwt {:exp (.getEpochSecond (.plusSeconds (Instant/now) 7200))
+                         :token "new"})
+        credentials (auth/create
+                     {:load-auth #(deref state)
+                      :save-auth #(reset! state %)
+                      :refresh-request
+                      (fn [request]
+                        (reset! request-seen request)
+                        {:status 200
+                         :body (json/write-value-as-string
+                                {:access_token new-access
+                                 :refresh_token "refresh-2"})})})
+        resolved (gateway/resolve-auth! credentials
+                                        {:url "https://chatgpt.com/backend-api/codex/responses"})]
+    (is (= "refresh_token" (:grant_type @request-seen)))
+    (is (= "refresh-1" (:refresh_token @request-seen)))
+    (is (= "refresh-2" (get-in @state [:tokens :refresh_token])))
+    (is (= new-access (get-in @state [:tokens :access_token])))
+    (is (= (str "Bearer " new-access)
+           (get-in resolved [:headers "Authorization"])))))
+
+(deftest native-availability-is-file-store-specific
+  (testing "valid injected file state is available"
+    (is (auth/available?
+         {:load-auth #(auth-state "current" (.plusSeconds (Instant/now) 3600))})))
+  (testing "missing state is not available"
+    (is (false? (auth/available? {:load-auth (constantly nil)})))))

--- a/test/dvergr/model/codex_subscription_test.clj
+++ b/test/dvergr/model/codex_subscription_test.clj
@@ -1,0 +1,215 @@
+(ns dvergr.model.codex-subscription-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.model.api.codex-subscription :as codex]
+            [dvergr.model.provider :as provider]
+            [dvergr.model.providers :as providers]
+            [jsonista.core :as json]))
+
+(defn- json-line [value]
+  (json/write-value-as-string value))
+
+(defn- successful-lines [response usage]
+  [(json-line {:type "thread.started" :thread_id "thread-test"})
+   (json-line {:type "turn.started"})
+   (json-line {:type "item.completed"
+               :item {:id "item-1"
+                      :type "agent_message"
+                      :text (json/write-value-as-string response)}})
+   (json-line {:type "turn.completed" :usage usage})])
+
+(deftest subscription-provider-translates-structured-tool-call
+  (let [captured (atom nil)
+        streamed (atom [])
+        runner (fn [command prompt]
+                 (reset! captured {:command command :prompt prompt})
+                 {:exit-code 0
+                  :stderr ""
+                  :lines (successful-lines
+                          {:content "I will inspect that."
+                           :tool_calls [{:id "call-1"
+                                         :name "lookup"
+                                         :input "{\"query\":\"fork semantics\"}"}]}
+                          {:input_tokens 40
+                           :cached_input_tokens 12
+                           :cache_write_input_tokens 3
+                           :output_tokens 9
+                           :reasoning_output_tokens 4})})
+        codex-provider (codex/create-cli {:runner runner})
+        response (provider/direct-chat
+                  codex-provider
+                  [{:role :system :content "Be precise"}
+                   {:role :user :content "Research this"}]
+                  {:model "codex-subscription-sol"
+                   :effort :high
+                   :tools [{:name "lookup"
+                            :description "Look something up"
+                            :parameters {:type "object"
+                                         :properties {:query {:type "string"}}}}]
+                   :on-text #(swap! streamed conj %)})]
+    (is (= "I will inspect that." (:content response)))
+    (is (= [{:id "call-1" :name "lookup" :input {:query "fork semantics"}}]
+           (:tool-calls response)))
+    (is (= :tool-use (:stop-reason response)))
+    (is (= {:input-tokens 40
+            :output-tokens 9
+            :cache-read-tokens 12
+            :cache-write-tokens 3
+            :reasoning-output-tokens 4}
+           (:usage response)))
+    (is (= ["I will inspect that."] @streamed))
+    (is (some #{"gpt-5.6-sol"} (get-in @captured [:command])))
+    (is (some #{"model_reasoning_effort=\"high\""} (get-in @captured [:command])))
+    (is (some #{"--ignore-user-config"} (get-in @captured [:command])))
+    (is (some #{"read-only"} (get-in @captured [:command])))
+    (is (some #{"web_search=\"disabled\""} (get-in @captured [:command])))
+    (is (some #{"multi_agent"} (get-in @captured [:command])))
+    (is (re-find #"Dvergr owns the conversation" (get-in @captured [:prompt])))
+    (is (re-find #"Be precise" (get-in @captured [:prompt])))
+    (is (re-find #"lookup" (get-in @captured [:prompt])))))
+
+(deftest generic-subscription-model-follows-cli-default
+  (let [command (atom nil)
+        codex-provider
+        (codex/create-cli
+         {:runner (fn [cmd _]
+                    (reset! command cmd)
+                    {:exit-code 0
+                     :stderr ""
+                     :lines (successful-lines
+                             {:content "ok" :tool_calls []}
+                             {:input_tokens 1 :output_tokens 1})})})]
+    (provider/direct-chat codex-provider
+                          [{:role :user :content "hello"}]
+                          {:model "codex-subscription"})
+    (is (not (some #{"--model"} @command)))))
+
+(deftest native-codex-effects-fail-closed
+  (let [codex-provider
+        (codex/create-cli
+         {:runner (fn [_ _]
+                    {:exit-code 0
+                     :stderr ""
+                     :lines [(json-line {:type "thread.started" :thread_id "t"})
+                             (json-line {:type "item.started"
+                                         :item {:id "native-1"
+                                                :type "command_execution"
+                                                :command "pwd"
+                                                :status "in_progress"}})
+                             (json-line {:type "turn.completed"
+                                         :usage {:input_tokens 1 :output_tokens 1}})]})})]
+    (try
+      (provider/direct-chat codex-provider
+                            [{:role :user :content "hello"}]
+                            {:model "codex-subscription"})
+      (is false "native effects must reject the response")
+      (catch clojure.lang.ExceptionInfo error
+        (is (= ["command_execution"] (:native-effects (ex-data error))))))))
+
+(deftest availability-requires-chatgpt-login
+  (testing "ChatGPT login registers"
+    (is (some? (codex/create-cli-if-available {:login-probe (constantly true)}))))
+  (testing "missing or API-key-only login does not register"
+    (is (nil? (codex/create-cli-if-available {:login-probe (constantly false)})))))
+
+(deftest cli-compatibility-provider-can-be-the-default
+  (let [original @providers/providers]
+    (try
+      (reset! providers/providers {:codex-subscription-cli ::available})
+      (with-redefs [providers/ensure-initialized! (constantly nil)]
+        (is (= {:provider :codex-subscription-cli
+                :model "codex-subscription-cli"}
+               (providers/default-spec))))
+      (finally
+        (reset! providers/providers original)))))
+
+(deftest durable-tool-history-is-replayed-to-ephemeral-codex
+  (let [codex-provider (codex/create {:credentials ::fake})
+        formatted (provider/format-messages
+                   codex-provider
+                   [{:message/role :assistant
+                     :message/content "I will look that up."
+                     :message/tool-uses
+                     [{:tool-use/id "call-1"
+                       :tool-use/name "lookup"
+                       :tool-use/input {:db/id 42 :lookup/query "fork semantics"}}]}
+                    {:message/role :tool-result
+                     :message/tool-use-id "call-1"
+                     :message/content "Copy-on-write forks share immutable history."}]
+                   "codex-subscription")]
+    (is (= "message" (get-in formatted [0 :type])))
+    (is (= "assistant" (get-in formatted [0 :role])))
+    (is (= "function_call" (get-in formatted [1 :type])))
+    (is (= "lookup" (get-in formatted [1 :name])))
+    (is (re-find #"fork semantics" (get-in formatted [1 :arguments])))
+    (is (= {:type "function_call_output"
+            :call_id "call-1"
+            :output "Copy-on-write forks share immutable history."}
+           (nth formatted 2)))))
+
+(deftest native-provider-builds-responses-lite-request
+  (let [credentials ::fake
+        codex-provider (codex/create {:credentials credentials})
+        request (provider/build-request
+                 codex-provider
+                 [{:role :system :content "Own the runtime semantics."}
+                  {:role :user :content "Create a nested room."}]
+                 {:model "codex-subscription-sol"
+                  :effort :high
+                  :tools [{:name "create_room"
+                           :description "Create a nested room"
+                           :parameters {:type "object"
+                                        :properties {:title {:type "string"}}
+                                        :required ["title"]}}]})
+        body (:body request)]
+    (is (= "https://chatgpt.com/backend-api/codex/responses" (:url request)))
+    (is (= credentials (:credentials request)))
+    (is (= "dvergr" (get-in request [:headers "originator"])))
+    (is (= "true" (get-in request [:headers
+                                   "x-openai-internal-codex-responses-lite"])))
+    (is (= "gpt-5.6-sol" (:model body)))
+    (is (nil? (:instructions body)))
+    (is (nil? (:tools body)))
+    (is (= "additional_tools" (get-in body [:input 0 :type])))
+    (is (= "functions" (get-in body [:input 0 :tools 0 :name])))
+    (is (= "create_room" (get-in body [:input 0 :tools 0 :tools 0 :name])))
+    (is (= "developer" (get-in body [:input 1 :role])))
+    (is (= "Own the runtime semantics."
+           (get-in body [:input 1 :content 0 :text])))
+    (is (= "Create a nested room."
+           (get-in body [:input 2 :content 0 :text])))
+    (is (= {:effort "high" :context "all_turns"} (:reasoning body)))))
+
+(deftest native-provider-accumulates-text-tools-and-usage
+  (let [codex-provider (codex/create {:credentials ::fake})
+        model-def {:id "codex-subscription-sol"}
+        events [{:type "response.output_text.delta" :delta "I will "}
+                {:type "response.output_text.delta" :delta "create it."}
+                {:type "response.output_item.done"
+                 :item {:type "function_call"
+                        :call_id "call-room"
+                        :name "create_room"
+                        :arguments "{\"title\":\"Child\"}"}}
+                {:type "response.completed"
+                 :response {:id "resp-1"
+                            :model "gpt-5.6-sol"
+                            :usage {:input_tokens 71
+                                    :output_tokens 12
+                                    :input_tokens_details {:cached_tokens 31}
+                                    :output_tokens_details {:reasoning_tokens 4}}}}]
+        final-state (reduce (fn [state event]
+                              (provider/accumulate-event codex-provider state
+                                                         (:type event) event model-def))
+                            (provider/create-accumulator codex-provider model-def)
+                            events)
+        response (provider/extract-response codex-provider final-state)]
+    (is (= "I will create it." (:content response)))
+    (is (= [{:id "call-room"
+             :name "create_room"
+             :input {:title "Child"}}]
+           (:tool-calls response)))
+    (is (= :tool-use (:stop-reason response)))
+    (is (= {:input-tokens 71
+            :output-tokens 12
+            :cache-read-tokens 31
+            :reasoning-output-tokens 4}
+           (:usage response)))))

--- a/test/dvergr/model/gateway_test.clj
+++ b/test/dvergr/model/gateway_test.clj
@@ -1,0 +1,111 @@
+(ns dvergr.model.gateway-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.model.api.anthropic :as anthropic]
+            [dvergr.model.api.openai :as openai]
+            [dvergr.model.gateway :as gateway]
+            [dvergr.model.provider :as provider])
+  (:import [java.io ByteArrayInputStream]))
+
+(deftype RotatingCredentials [token recovered?]
+  gateway/Credentials
+  (credential-kind [_] :rotating-test)
+  (allowed-origins [_] #{"https://provider.test"})
+  (resolve-auth! [_ _]
+    {:headers {"Authorization" (str "Bearer " @token)}
+     :version @token})
+  (recover-auth! [_ _ _]
+    (reset! recovered? true)
+    (reset! token "fresh")
+    true))
+
+(defn- empty-body []
+  (ByteArrayInputStream. (byte-array 0)))
+
+(deftest gateway-injects-static-credentials-at-the-egress-boundary
+  (let [seen (atom nil)
+        credentials (gateway/static-credentials
+                     :test-key
+                     {"Authorization" "Bearer secret"}
+                     #{"https://provider.test"})]
+    (binding [gateway/*request-fn*
+              (fn [request]
+                (reset! seen request)
+                {:status 200 :body (empty-body)})]
+      (gateway/request! {:method :post
+                         :url "https://provider.test/v1/responses"
+                         :headers {"Content-Type" "application/json"}
+                         :credentials credentials})
+      (is (= "Bearer secret" (get-in @seen [:headers "Authorization"])))
+      (is (nil? (:credentials @seen))))))
+
+(deftest gateway-rejects-credential-confusion
+  (let [called? (atom false)
+        credentials (gateway/static-credentials
+                     :test-key
+                     {"Authorization" "Bearer secret"}
+                     #{"https://provider.test"})]
+    (binding [gateway/*request-fn* (fn [_] (reset! called? true))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"not permitted"
+                            (gateway/request! {:method :post
+                                               :url "https://attacker.test/steal"
+                                               :credentials credentials})))
+      (is (false? @called?)))))
+
+(deftest gateway-recovers-one-unauthorized-response
+  (let [token (atom "stale")
+        recovered? (atom false)
+        attempts (atom [])
+        credentials (RotatingCredentials. token recovered?)]
+    (binding [gateway/*request-fn*
+              (fn [request]
+                (swap! attempts conj (get-in request [:headers "Authorization"]))
+                {:status (if (= 1 (count @attempts)) 401 200)
+                 :body (empty-body)})]
+      (is (= 200 (:status (gateway/request!
+                           {:method :post
+                            :url "https://provider.test/responses"
+                            :credentials credentials}))))
+      (is @recovered?)
+      (is (= ["Bearer stale" "Bearer fresh"] @attempts)))))
+
+(deftest api-providers-use-the-shared-credential-boundary
+  (testing "OpenAI build-request contains no bearer token"
+    (let [instance (openai/create {:api-key "openai-secret"})
+          request (provider/build-request instance [{:role "user" :content "hi"}]
+                                          {:model "gpt-test"})]
+      (is (nil? (get-in request [:headers "Authorization"])))
+      (is (satisfies? gateway/Credentials (:credentials request)))
+      (is (not (re-find #"openai-secret" (str (:credentials request)))))))
+  (testing "Anthropic build-request contains no API key"
+    (let [instance (anthropic/create {:api-key "anthropic-secret"})
+          request (provider/build-request instance [{:role "user" :content "hi"}]
+                                          {:model "claude-test"})]
+      (is (nil? (get-in request [:headers "x-api-key"])))
+      (is (satisfies? gateway/Credentials (:credentials request)))
+      (is (not (re-find #"anthropic-secret" (str (:credentials request)))))))
+  (testing "OpenAI and Fireworks credentials stay provider-scoped"
+    (let [openai-request (provider/build-request
+                          (openai/create {:api-key "openai-secret"
+                                          :base-url "https://openai.test/v1"})
+                          [{:role "user" :content "hi"}]
+                          {:model "gpt-test"})
+          fireworks-request (provider/build-request
+                             (openai/create-fireworks
+                              {:api-key "fireworks-secret"
+                               :base-url "https://fireworks.test/v1"})
+                             [{:role "user" :content "hi"}]
+                             {:model "fireworks-test"})]
+      (is (= "https://openai.test/v1/chat/completions"
+             (:url openai-request)))
+      (is (= "https://fireworks.test/v1/chat/completions"
+             (:url fireworks-request)))
+      (is (= #{"https://openai.test"}
+             (gateway/allowed-origins (:credentials openai-request))))
+      (is (= #{"https://fireworks.test"}
+             (gateway/allowed-origins (:credentials fireworks-request))))
+      (is (= :openai (provider/provider-id
+                      (openai/create {:api-key "openai-secret"}))))
+      (is (= :fireworks (provider/provider-id
+                         (openai/create-fireworks
+                          {:api-key "fireworks-secret"})))))))


### PR DESCRIPTION
## Summary

- add a trusted, in-process credential gateway that validates exact provider origins before injecting authentication
- migrate Anthropic, OpenAI, and Fireworks onto the gateway and keep OpenAI/Fireworks credentials and base URLs provider-scoped
- add native ChatGPT Codex subscription auth with token refresh and atomic file persistence
- add a native Responses Lite transport for Codex subscription models, including streaming, structured function calls, usage, and durable tool-call replay
- retain a locked-down, ephemeral `codex exec` compatibility provider for keyring-only logins and upstream wire changes
- document setup, REPL verification, agent pinning, fallback behavior, API providers, and credential-free local OpenAI-compatible providers

## Ownership boundary

Dvergr remains the agent harness in both modes. It owns messages, context, tool execution, effects, sandboxing, persistence, and fork semantics.

The native provider only uses Codex's ChatGPT authentication and Responses transport. The CLI compatibility provider gives an ephemeral Codex process a dvergr-owned transcript and accepts only text/reasoning plus the structured dvergr tool envelope; Codex-native command, file, MCP, collaboration, web, plugin, and hook effects fail closed.

Credentials are absent from provider request maps. The gateway binds each credential to exact origins and injects headers only at egress. Codex OAuth rotations are written atomically with owner-only file permissions where supported.

## User path

1. Run `codex login` and choose **Sign in with ChatGPT**.
2. In a dvergr REPL, run `providers/ensure-initialized!` and inspect `providers/list-providers`.
3. Use model alias `codex`, or pin `:codex-subscription` / `codex-subscription`.
4. If the login is keyring-only, select `:codex-subscription-cli` / `codex-subscription-cli`, or configure Codex's credential store as `file` and log in again.

See `doc/provider-setup.md` for the complete provider matrix and executable REPL examples.

## Compatibility caveat

The native route targets the private ChatGPT Codex endpoint used by the open-source Codex client, not the stable public OpenAI API. The CLI provider isolates that compatibility risk, but fallback remains explicit. Dvergr does not automatically replay a request after a stream or tool call may have begun, because doing so could duplicate effects.

## Verification

- `clojure -M:test` — 441 tests, 1,752 assertions, 0 failures
- focused provider suite — 15 tests, 74 assertions, 0 failures
- `clojure -M:format` — clean
- `git diff --check` — clean
- live REPL native text turn — passed
- live REPL native structured tool-call continuation — passed

## Relation to #48

This PR should land before draft #48. That PR can then rebase onto the shared credential gateway and retain its public OpenAI API model registry and Chat Completions work without competing credential plumbing.
