### PR TITLE
feat(orchestration): add durable agent run lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ fork-and-merge proposal pattern, see
   REPL + CLI paths
 - **[Programming Model](doc/programming-model.md)** — bus, tagged
   routing, GenerationHandle, the distributive law λ
+- **[Runs](doc/runs.md)** — durable agent-turn identity, activity/output
+  correlation, lifecycle observation, and targeted cancellation
 - **[CLI Reference](doc/cli.md)** — `dvergr-cli` keys, persistence,
   provider config
 - **[Architecture](doc/architecture.md)** — the formal model: rooms,

--- a/doc/README.md
+++ b/doc/README.md
@@ -16,6 +16,7 @@ New to dvergr? Start with **[Getting Started](getting-started.md)**.
 - **[Rooms & Agents](rooms-and-agents.md)** — the core model: Rooms + Participants on a Bus, addressing (DM vs broadcast), forks
 - **[Programming Model](programming-model.md)** — the compositional kernel: tagged messages, capability routing, dynamic subscriptions, escalation
 - **[Recursive work orchestration](orchestration.md)** — Rooms, threads, tasks, executions, recursive Workrooms, and provider-neutral collaboration
+- **[Runs](runs.md)** — durable execution identity, lifecycle subscription, correlation, and targeted cancellation
 - **[Discourse Theory](discourse-theory.md)** — why "discourse": speech acts, theory of mind, and the Rational-Speech-Acts/FRP lineage (short, optional)
 - **[Architecture](architecture.md)** — the L0–L7 layer map, subsystem graph, inbound message flow, per-file table
 - **[State Model](state-model.md)** — the three-tier copy-on-write state + workspace model

--- a/doc/orchestration.md
+++ b/doc/orchestration.md
@@ -461,10 +461,14 @@ This is the immediate dependency for Simmis's room UI.
 
 ### Stage 2: lightweight execution correlation
 
-1. Allocate an execution ID for each agent turn.
-2. Correlate trigger, thread, tool activity, final response, failure, and cancel.
-3. Key live control by execution ID while preserving room-level convenience APIs.
-4. Do not introduce a universal workflow-run aggregate in this stage.
+Implemented for `:agent-turn` Runs; see [runs.md](runs.md):
+
+1. Allocate a Run ID before each agent turn and persist its precise trigger.
+2. Correlate tool activity and output messages by typed Run ID; derive Thread
+   membership through the trigger rather than duplicating it on the Run.
+3. Key live control by Run ID while preserving room-level convenience APIs.
+4. Expose an initial-snapshot lifecycle subscription and targeted cancellation.
+5. Do not introduce a universal workflow-run aggregate in this stage.
 
 ### Stage 3: durable delegated tasks
 

--- a/doc/runs.md
+++ b/doc/runs.md
@@ -1,0 +1,139 @@
+# Runs
+
+A **Run** is one causally bounded execution by an actor in a Room. It is the
+durable answer to: what started, what exact message caused it, who performed it,
+what output/activity belongs to it, and how it ended?
+
+The first implemented Run kind is `:agent-turn`. One such Run spans every model
+round, tool call, same-thread steer, and model switch needed to handle one
+trigger. A Run is not a Room, Thread, actor identity, model request, UI spinner,
+or private copy of the transcript.
+
+```text
+trigger message
+└── agent-turn Run
+    ├── model round
+    ├── tool activity
+    ├── model round
+    └── output message
+```
+
+## Durable shape
+
+```clojure
+{:run/id         #uuid "..."
+ :run/kind       :agent-turn
+ :run/room       :research
+ :run/actor      :researcher
+ :run/trigger    trigger-message-id
+ :run/parent     parent-run-id       ; optional explicit spawning/containment
+ :run/status     :running
+ :run/created-at instant
+ :run/started-at instant
+ :run/updated-at instant
+ :run/ended-at   instant}            ; terminal only
+```
+
+The trigger is the canonical causal and topical link. Its
+`:message/thread-root-id` determines the Run's Thread; Run rows do not duplicate
+thread identity. When an output message from one Run triggers another agent, its
+typed `:message/run-id` remains available through the trigger as a causal edge;
+it does not become `:run/parent`. Parent is reserved for explicit structural
+spawning/containment, which stays meaningful across fork/join and multi-input
+workflows.
+
+Output and `:_activity` messages carry `:message/run-id`. Activity messages also
+reply to the trigger and preserve its thread root. Clients can therefore query
+by Thread, by Run, or combine both without chronological heuristics.
+
+Admission is durability-first: a Run is neither executed nor published to live
+subscribers unless its initial row is stored. Likewise, `:run/finished` is
+published only after the terminal projection is durable. When a turn returns a
+visible reply, the Room persists that correlated output before the Run becomes
+`:completed`, so a finished event is a safe query frontier for clients.
+
+Durable statuses currently are:
+
+| Status | Meaning |
+|---|---|
+| `:running` | The execution was admitted and may have a live handle. |
+| `:waiting` | It stopped at a resumable product boundary, currently budget exhaustion. |
+| `:completed` | It ended successfully, with or without a visible reply. |
+| `:failed` | The turn failed or produced no usable output. |
+| `:cancelled` | The executor acknowledged cancellation. |
+
+`:cancelling` exists only in the live snapshot between request and
+acknowledgement. A durable `:running` row after process loss means unfinished,
+not proof that work is still live; reconciliation is a later feature.
+Targeted cancellation uses a private per-Run token. It does not cancel or poison
+the actor's reusable ChatContext, so a later Run by the same actor can proceed.
+
+`:waiting` currently means this execution stopped at a resumable product
+boundary; it is no longer live and therefore does not appear in `active-runs`.
+A later message starts a new Run rather than resuming a parked continuation.
+When durable continuations exist, we can refine this state without changing Run
+identity or correlation.
+
+## REPL use
+
+The most common operations are re-exported from `dvergr.core` and the REPL
+client:
+
+```clojure
+(require '[dvergr.core :as d])
+
+(d/active-runs)                 ; every live Run
+(d/active-runs :research)       ; one runtime Room id
+(d/runs room)                   ; recent durable Runs, newest first
+(d/runs room {:actor :researcher :status :failed :limit 20})
+(d/run room run-id)             ; one durable Run
+(d/cancel-run! run-id)          ; targeted cooperative cancellation
+```
+
+Lifecycle subscription emits one atomic initial frontier followed by changes:
+
+```clojure
+(d/watch-runs!
+ ::ui
+ (fn [{:keys [type run runs]}]
+   (case type
+     :runs/snapshot       (render-all! runs)
+     :run/started         (render! run)
+     :run/cancel-requested (render! run)
+     :run/finished        (render! run))))
+
+(d/unwatch-runs! ::ui)
+```
+
+Snapshots and events contain only serializable Run fields. The live ChatContext,
+per-Run cancellation token, Spindel context, provider stream, and SCI context
+remain process-local.
+
+The existing room-wide surface remains compatible:
+
+```clojure
+(dvergr.agent.turn/room-turn-running? :research)
+(dvergr.agent.turn/cancel-room-turn! :research)
+```
+
+It is now a projection over active Runs; room-wide cancel delegates to targeted
+cancellation for every Run in that Room.
+
+## UI projection
+
+Simmis and other clients can build active/recent Run cards directly:
+
+```text
+researcher · running · 2m 14s
+8 correlated activity messages
+[Cancel] [Details]
+```
+
+Use the live subscription for immediate status and the room store for durable
+history. Join `:message/run-id` to `:run/id` for raw activity/output, and join
+`:run/trigger` to `:message/id` for Thread membership. Do not infer ownership
+from timestamps or assume the final reply is the completion record.
+
+This slice intentionally does not yet define generic effect receipts, approvals,
+retry semantics, resource scopes, replay, or arbitrary SCI ProgramRefs. Those can
+extend the stable Run identity without replacing it.

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -1,0 +1,209 @@
+(ns dvergr.agent.run
+  "Minimal durable Run lifecycle for causally bounded room execution.
+
+   A Run is durable identity and correlation data. Live execution and
+   cancellation handles remain private in this namespace and are never returned
+   by snapshots, lifecycle events, or the Room store."
+  (:require [dvergr.chat.context :as chat-ctx]
+            [dvergr.room.store :as store]
+            [taoensso.telemere :as tel]))
+
+(def ^:private finish-statuses #{:waiting :completed :failed :cancelled})
+(defonce ^:private active (atom {}))
+(defonce ^:private subscribers (atom {}))
+(def ^:private lifecycle-lock (Object.))
+
+(defn- store-room-id [room]
+  (or (some-> room :meta deref :conversation-id)
+      (:id room)))
+
+(defn- public-entry [entry]
+  (:run entry))
+
+(defn- ordered-runs [entries]
+  (->> entries
+       (map public-entry)
+       (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
+                      #(str (:run/id %))))
+       vec))
+
+(defn active-runs
+  "Return serializable snapshots of live Runs, never their ChatContexts or
+   cancellation handles. With `room-id`, restrict to that runtime Room."
+  ([] (ordered-runs (vals @active)))
+  ([room-id]
+   (ordered-runs (filter #(= room-id (get-in % [:run :run/room]))
+                         (vals @active)))))
+
+(defn- notify! [event]
+  ;; Called while lifecycle-lock is held. Serializing snapshot registration and
+  ;; transitions makes the initial snapshot a real subscription frontier.
+  (doseq [[_ f] @subscribers]
+    (try
+      (f event)
+      (catch Throwable t
+        (tel/log! {:level :warn :id ::subscriber-failed
+                   :data {:error (.getMessage t)}}
+                  "Run lifecycle subscriber failed")))))
+
+(defn watch-runs!
+  "Subscribe `f` to Run lifecycle events. Registration first emits
+   `{:type :runs/snapshot :runs [...]}`, then ordered `:run/started`,
+   `:run/cancel-requested`, and `:run/finished` events. `key` is idempotent."
+  [key f]
+  (locking lifecycle-lock
+    (swap! subscribers assoc key f)
+    (try
+      (f {:type :runs/snapshot :runs (active-runs)})
+      (catch Throwable t
+        (tel/log! {:level :warn :id ::subscriber-failed
+                   :data {:error (.getMessage t)}}
+                  "Run lifecycle subscriber failed during initial snapshot"))))
+  key)
+
+(defn unwatch-runs! [key]
+  (locking lifecycle-lock
+    (swap! subscribers dissoc key))
+  nil)
+
+(defn start!
+  "Persist and publish one live Run before execution begins.
+
+   `trigger` is the precise triggering message (or its UUID). `:parent` is
+   optional explicit structural containment (the Run that spawned this Run),
+   never inferred from causal message succession. Returns the public Run map."
+  ([room actor trigger live-chat-ctx]
+   (start! room actor trigger live-chat-ctx {}))
+  ([room actor trigger live-chat-ctx {:keys [id kind parent now]
+                                      :or {kind :agent-turn}}]
+   (let [now        (or now (java.util.Date.))
+         trigger-id (if (map? trigger) (:id trigger) trigger)
+         run        (store/validate-run!
+                     (cond-> {:run/id         (or id (random-uuid))
+                              :run/kind       kind
+                              :run/room       (:id room)
+                              :run/actor      actor
+                              :run/trigger    trigger-id
+                              :run/status     :running
+                              :run/created-at now
+                              :run/started-at now
+                              :run/updated-at now}
+                       parent (assoc :run/parent parent)))
+         entry      {:run run
+                     :chat-ctx live-chat-ctx
+                     :cancelled? (atom false)
+                     :store (:store room)
+                     :store-room-id (store-room-id room)}]
+     (when-let [room-store (:store entry)]
+       (when-not (store/-store-run! room-store (:store-room-id entry) run)
+         (throw (ex-info "Run admission failed: start was not durable"
+                         {:type ::start-not-durable
+                          :run/id (:run/id run)
+                          :run/room (:id room)}))))
+     (locking lifecycle-lock
+       (swap! active assoc (:run/id run) entry)
+       (notify! {:type :run/started :run run}))
+     run)))
+
+(defn finish!
+  "End the live execution and persist its final/waiting projection. Idempotent
+   after the live entry has gone. `:waiting` has no ended-at; terminal states do."
+  ([run-id status] (finish! run-id status {}))
+  ([run-id status {:keys [reason error now]}]
+   (when-not (contains? finish-statuses status)
+     (throw (ex-info "Invalid run finish status"
+                     {:type ::invalid-finish-status :status status :run-id run-id})))
+   (locking lifecycle-lock
+     (when-let [entry (get @active run-id)]
+       (let [now (or now (java.util.Date.))
+             run (cond-> (assoc (:run entry)
+                                :run/status status
+                                :run/updated-at now)
+                   (contains? store/terminal-run-statuses status)
+                   (assoc :run/ended-at now)
+                   reason (assoc :run/reason reason)
+                   error (assoc :run/error (or (ex-message error) (str error))))]
+         (when-let [room-store (:store entry)]
+           (when-not (store/-store-run! room-store (:store-room-id entry) run)
+             ;; Keep the live entry: callers may retry and subscribers must not
+             ;; observe a terminal projection that the Room store does not own.
+             (throw (ex-info "Run finish was not durable"
+                             {:type ::finish-not-durable
+                              :run/id run-id
+                              :run/status status}))))
+         (swap! active dissoc run-id)
+         (notify! {:type :run/finished :run run})
+         run)))))
+
+(defn cancel-requested?
+  "True when targeted cancellation has been requested for this live Run. The
+   private token disappears with the live entry; durable cancellation is the
+   executor's later `:cancelled` acknowledgement."
+  [run-id]
+  (boolean (some-> (get @active run-id) :cancelled? deref)))
+
+(defn cancel-run!
+  "Request cooperative cancellation of exactly one live Run. Returns true when
+   found/signalled, false for an unknown or already-finished Run. Durable status
+   becomes `:cancelled` only when the executor acknowledges via `finish!`."
+  [run-id]
+  (let [entry
+        (locking lifecycle-lock
+          (when-let [entry (get @active run-id)]
+            (if (cancel-requested? run-id)
+              entry
+              (let [_ (reset! (:cancelled? entry) true)
+                    entry' (assoc-in entry [:run :run/status] :cancelling)]
+                (swap! active assoc run-id entry')
+                (notify! {:type :run/cancel-requested :run (public-entry entry')})
+                entry'))))]
+    (if entry
+      true
+      false)))
+
+(defn cancel-room-runs!
+  "Request cancellation of every live Run in `room-id`; return the count."
+  [room-id]
+  (let [ids (mapv :run/id (active-runs room-id))]
+    (doseq [run-id ids] (cancel-run! run-id))
+    (count ids)))
+
+(defn register-live!
+  "Compatibility registration for callers that only have the old
+   `[room-id actor ChatContext]` tuple. New execution paths should call `start!`
+   with the real Room and trigger message so the Run is durable and causal."
+  [room-id actor live-chat-ctx]
+  (:run/id (start! {:id room-id :store nil :meta (atom {})}
+                   actor (random-uuid) live-chat-ctx)))
+
+(defn unregister-live!
+  "Compatibility live unregister. The run-id arity is targeted; the two-arity
+   form removes every matching old-style room/actor registration."
+  ([run-id]
+   (when-let [entry (get @active run-id)]
+     (finish! run-id
+              (if (or (cancel-requested? run-id)
+                      (= :cancelled (chat-ctx/get-status (:chat-ctx entry))))
+                :cancelled
+                :completed))))
+  ([room-id actor]
+   (doseq [run-id (->> (vals @active)
+                       (filter #(and (= room-id (get-in % [:run :run/room]))
+                                     (= actor (get-in % [:run :run/actor]))))
+                       (map #(get-in % [:run :run/id]))
+                       vec)]
+     (unregister-live! run-id))))
+
+(defn run
+  "Load one durable Run from its Room store."
+  [room run-id]
+  (when-let [room-store (:store room)]
+    (store/-load-run room-store (store-room-id room) run-id)))
+
+(defn runs
+  "List recent durable Runs from a Room store. Options: :limit, :status, :actor."
+  ([room] (runs room {}))
+  ([room opts]
+   (if-let [room-store (:store room)]
+     (store/-list-runs room-store (store-room-id room) opts)
+     [])))

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -14,6 +14,7 @@
             [org.replikativ.spindel.engine.core :as rtc]
             [dvergr.discourse :as d]
             [dvergr.chat.context :as chat-ctx]
+            [dvergr.agent.run :as run]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.io :as ns-io]
             ;; loaded so add-process-ns! can (find-ns 'dvergr.agent.process)
@@ -81,23 +82,23 @@
 (def activity-id :_activity)
 
 ;; ----------------------------------------------------------------------------
-;; Room-turn registry — publishes the LIVE chat-ctx keyed by [room-id agent-id]
-;; for the duration of a turn. Esc-cancel looks it up and flips its status to
-;; :cancelled — the turn loop bails at the next boundary AND the :cancel?
-;; predicate aborts the in-flight SSE stream.
+;; Compatibility projection over the Run registry. New callers use
+;; dvergr.agent.run directly; TUI/web room-wide turn controls keep their existing
+;; API while gaining targeted Run cancellation underneath.
 ;; ----------------------------------------------------------------------------
-(defonce ^:private room-turns (atom {}))
+(defonce ^:private room-turn-watch-keys (atom {}))
 
 (defn register-room-turn! [room-id agent-id chat-ctx]
-  (swap! room-turns assoc-in [room-id agent-id] chat-ctx))
+  (run/register-live! room-id agent-id chat-ctx))
 
-(defn unregister-room-turn! [room-id agent-id]
-  (swap! room-turns update room-id dissoc agent-id))
+(defn unregister-room-turn!
+  ([run-id] (run/unregister-live! run-id))
+  ([room-id agent-id] (run/unregister-live! room-id agent-id)))
 
 (defn room-turn-running?
   "True if any agent currently has an in-flight turn in `room-id`."
   [room-id]
-  (boolean (seq (get @room-turns room-id))))
+  (boolean (seq (run/active-runs room-id))))
 
 (defn watch-room-turns!
   "Subscribe `f` — a fn of `[room-id running?]` — to be called whenever a room's
@@ -106,39 +107,77 @@
    silent (`[SKIP]`) turn — which posts no message — still clears the spinner.
    `key` identifies the watch (idempotent; remove via `unwatch-room-turns!`)."
   [key f]
-  (add-watch room-turns key
-             (fn [_ _ old new]
-               (doseq [rid (into (set (keys old)) (set (keys new)))]
-                 (let [was (boolean (seq (get old rid)))
-                       now (boolean (seq (get new rid)))]
-                   (when (not= was now)
-                     (try (f rid now) (catch Throwable _ nil))))))))
+  (let [run-key [::room-turn-watch key]
+        previous (atom nil)]
+    (swap! room-turn-watch-keys assoc key run-key)
+    (run/watch-runs!
+     run-key
+     (fn [_event]
+       (let [now (->> (run/active-runs)
+                      (group-by :run/room)
+                      (map (fn [[rid runs]] [rid (boolean (seq runs))]))
+                      (into {}))]
+         (if-let [old @previous]
+           (doseq [rid (into (set (keys old)) (set (keys now)))]
+             (let [was (boolean (get old rid))
+                   running? (boolean (get now rid))]
+               (when (not= was running?)
+                 (try (f rid running?) (catch Throwable _ nil)))))
+           nil)
+         (reset! previous now))))
+    key))
 
-(defn unwatch-room-turns! [key] (remove-watch room-turns key))
+(defn unwatch-room-turns! [key]
+  (when-let [run-key (get @room-turn-watch-keys key)]
+    (run/unwatch-runs! run-key)
+    (swap! room-turn-watch-keys dissoc key))
+  nil)
 
 (defn cancel-room-turn!
-  "Cancel every in-flight agent turn in `room-id` — sets each live turn's
-   chat-ctx status to :cancelled (cooperative bail + SSE abort). Returns the
-   number of turns signalled. The 2-arity `_daemon` arg is kept for the existing
-   `daemon/cancel-room-turn!` call signature (TUI passes the daemon)."
+  "Cancel every in-flight agent turn in `room-id` through its private Run token
+   (cooperative bail + SSE abort). Returns the number of turns signalled. The
+   2-arity `_daemon` arg is kept for the existing daemon/TUI call signature."
   ([room-id] (cancel-room-turn! nil room-id))
   ([_daemon room-id]
-   (let [ctxs (vals (get @room-turns room-id))]
-     (doseq [cctx ctxs]
-       (try (chat-ctx/cancel-chat! cctx) (catch Throwable _ nil)))
-     (count ctxs))))
+   (run/cancel-room-runs! room-id)))
+
+(def active-runs run/active-runs)
+(def watch-runs! run/watch-runs!)
+(def unwatch-runs! run/unwatch-runs!)
+(def cancel-run! run/cancel-run!)
+(def cancel-requested? run/cancel-requested?)
 
 (defn cancel?-fn
-  "Build the `:cancel?` predicate for `run-agent-turn!` — true once the chat-ctx's
-   status flips to :cancelled (Esc-cancel), so the in-flight SSE aborts mid-stream.
-   `run-agent-turn!` threads it through `model-chat/chat`."
-  [chat-ctx execution-ctx]
-  (fn [] (binding [rtc/*execution-context* execution-ctx]
-           (= :cancelled (chat-ctx/get-status chat-ctx)))))
+  "Build the `:cancel?` predicate for `run-agent-turn!`. Chat-wide shutdown and
+   an optional Run-local predicate both abort the in-flight SSE; targeted Run
+   cancellation never mutates the reusable ChatContext."
+  ([chat-ctx execution-ctx]
+   (cancel?-fn chat-ctx execution-ctx nil))
+  ([chat-ctx execution-ctx run-cancelled?]
+   (fn []
+     (or (boolean (and run-cancelled? (run-cancelled?)))
+         (binding [rtc/*execution-context* execution-ctx]
+           (= :cancelled (chat-ctx/get-status chat-ctx)))))))
 
 ;; ----------------------------------------------------------------------------
 ;; Tool-activity play-by-play
 ;; ----------------------------------------------------------------------------
+(defn tool-activity-count
+  "Number of assistant messages in `chat-ctx` that already contain tool uses.
+   A new Run initializes its watermark here so rehydrated historical activity is
+   never reposted or attributed to the new Run."
+  [chat-ctx]
+  (->> (chat-ctx/get-messages chat-ctx)
+       (filter #(= :assistant (or (:role %) (:message/role %))))
+       (filter #(seq (or (:message/tool-uses %) (:tool-uses %))))
+       count))
+
+(defn- activity-message [agent-id content run-id trigger metadata]
+  (let [metadata (cond-> metadata run-id (assoc :run-id run-id))]
+    (if trigger
+      (d/reply agent-id activity-id content trigger metadata)
+      (d/message agent-id activity-id content nil metadata))))
+
 (defn post-turn-activity!
   "Post an agent's tool-call activity into `room` so rich frontends render the
    play-by-play. Each tool-bearing assistant message (read from `chat-ctx`)
@@ -146,23 +185,26 @@
    structured `:tool-uses` (and `:reasoning` if present). `posted` is an atom of
    how many tool-bearing messages were already emitted, so repeated calls across
    the turn loop don't duplicate. Returns nil."
-  [room agent-id chat-ctx posted]
-  (let [tool-msgs (->> (chat-ctx/get-messages chat-ctx)
-                       (filter #(= :assistant (or (:role %) (:message/role %))))
-                       (filter #(seq (or (:message/tool-uses %) (:tool-uses %))))
-                       vec)]
-    (when (> (count tool-msgs) @posted)
-      (binding [rtc/*execution-context* (:ctx room)]
-        (doseq [m (subvec tool-msgs @posted)]
-          (let [uses    (vec (or (:message/tool-uses m) (:tool-uses m)))
-                names   (keep #(or (:tool-use/name %) (:name %)) uses)
-                summary (str "🔧 " (str/join ", " names))
-                reason  (or (:message/reasoning m) (:reasoning m))]
-            (d/post! room (d/message agent-id activity-id summary nil
-                                     (cond-> {:role :tool :tool-uses uses}
-                                       (seq reason) (assoc :reasoning reason)))))))
-      (reset! posted (count tool-msgs)))
-    nil))
+  ([room agent-id chat-ctx posted]
+   (post-turn-activity! room agent-id chat-ctx posted nil nil))
+  ([room agent-id chat-ctx posted run-id trigger]
+   (let [tool-msgs (->> (chat-ctx/get-messages chat-ctx)
+                        (filter #(= :assistant (or (:role %) (:message/role %))))
+                        (filter #(seq (or (:message/tool-uses %) (:tool-uses %))))
+                        vec)]
+     (when (> (count tool-msgs) @posted)
+       (binding [rtc/*execution-context* (:ctx room)]
+         (doseq [m (subvec tool-msgs @posted)]
+           (let [uses    (vec (or (:message/tool-uses m) (:tool-uses m)))
+                 names   (keep #(or (:tool-use/name %) (:name %)) uses)
+                 summary (str "🔧 " (str/join ", " names))
+                 reason  (or (:message/reasoning m) (:reasoning m))]
+             (d/post! room (activity-message
+                            agent-id summary run-id trigger
+                            (cond-> {:role :tool :tool-uses uses}
+                              (seq reason) (assoc :reasoning reason)))))))
+       (reset! posted (count tool-msgs)))
+     nil)))
 
 (defn post-budget-warning!
   "Surface budget exhaustion as a visible, NON-triggering activity row: the
@@ -175,15 +217,18 @@
    stopwatch a human never agreed to, and letting it lapse SPENT MORE MONEY on a
    wrap-up turn — after the ceiling had already been hit. No-op when `room` is
    nil. Returns nil."
-  [room agent-id used-dollars total-dollars]
-  (when room
-    (binding [rtc/*execution-context* (:ctx room)]
-      (d/post! room (d/message agent-id activity-id
-                               (format "⚠️ budget exhausted — $%.2f of $%.2f used. I have stopped and am spending nothing. Raise the room budget and message me to continue."
-                                       (double used-dollars) (double total-dollars))
-                               nil
-                               {:role :tool}))))
-  nil)
+  ([room agent-id used-dollars total-dollars]
+   (post-budget-warning! room agent-id used-dollars total-dollars nil nil))
+  ([room agent-id used-dollars total-dollars run-id trigger]
+   (when room
+     (binding [rtc/*execution-context* (:ctx room)]
+       (d/post! room
+                (activity-message
+                 agent-id
+                 (format "⚠️ budget exhausted — $%.2f of $%.2f used. I have stopped and am spending nothing. Raise the room budget and message me to continue."
+                         (double used-dollars) (double total-dollars))
+                 run-id trigger {:role :tool}))))
+   nil))
 
 (defn post-turn-error!
   "Surface a FAILED agent turn as a visible, NON-triggering activity row (→ room
@@ -192,11 +237,13 @@
    (which the room's other agents would answer, looping — the \"repeating\" bug).
    `err` is the throwable from the errored turn result. No-op when `room` is nil.
    Returns nil."
-  [room agent-id err]
-  (when room
-    (binding [rtc/*execution-context* (:ctx room)]
-      (let [detail (or (some-> err ex-message) (some-> err str) "LLM error")]
-        (d/post! room (d/message agent-id activity-id
-                                 (str "⚠️ turn failed — " detail) nil
-                                 {:role :tool})))))
-  nil)
+  ([room agent-id err]
+   (post-turn-error! room agent-id err nil nil))
+  ([room agent-id err run-id trigger]
+   (when room
+     (binding [rtc/*execution-context* (:ctx room)]
+       (let [detail (or (some-> err ex-message) (some-> err str) "LLM error")]
+         (d/post! room
+                  (activity-message agent-id (str "⚠️ turn failed — " detail)
+                                    run-id trigger {:role :tool})))))
+   nil))

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -129,7 +129,7 @@
    - :complete if agent is done (no tool calls)
    - :error if something failed"
   [chat-ctx {:keys [provider model tools tool-ctx on-text auto-compact? compaction-model turn-number cancel?
-                    system-suffix on-reply]
+                    system-suffix on-reply run-id]
              :or {auto-compact? true}}]
   (try
     ;; Check for automatic compaction before turn
@@ -299,16 +299,17 @@
                                (when-let [conn (:db-conn chat-ctx)]
                                  (try
                                    (dh/transact conn
-                                                [{:tool-call/id (java.util.UUID/randomUUID)
-                                                  :tool-call/name name
-                                                  :tool-call/input (pr-str input)
-                                                  :tool-call/result (pr-str (select-keys result [:type :content :error]))
-                                                  :tool-call/duration-ms duration-ms
-                                                  :tool-call/error? error?
-                                                  :tool-call/status (if error? :error :completed)
-                                                  :tool-call/approval :auto-approved
-                                                  :tool-call/tool-use-id id
-                                                  :tool-call/started-at (java.util.Date.)}])
+                                                [(cond-> {:tool-call/id (java.util.UUID/randomUUID)
+                                                          :tool-call/name name
+                                                          :tool-call/input (pr-str input)
+                                                          :tool-call/result (pr-str (select-keys result [:type :content :error]))
+                                                          :tool-call/duration-ms duration-ms
+                                                          :tool-call/error? error?
+                                                          :tool-call/status (if error? :error :completed)
+                                                          :tool-call/approval :auto-approved
+                                                          :tool-call/tool-use-id id
+                                                          :tool-call/started-at (java.util.Date.)}
+                                                   run-id (assoc :tool-call/run-id run-id))])
                                    (catch Exception e
                                      (tel/log! {:level :warn :id :agent/tool-call-persist-error :error e}
                                                "Failed to persist tool-call analytics"))))

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -161,6 +161,12 @@
     :db/doc "Stable root message id for the thread projection inside a room.
              Top-level messages self-root; replies preserve their ancestor root."}
 
+   {:db/ident :message/run-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Run that causally produced this output or activity message"}
+
    ;; Structured envelope metadata. These are ordinary datoms on the message:
    ;; clients can query/sync them independently and never need to parse an
    ;; opaque EDN string. Actor ids remain keyword values for the same reason as
@@ -364,6 +370,12 @@
     :db/index true
     :db/doc "Links to the tool-use/id in the assistant message (for joining)"}
 
+   {:db/ident :tool-call/run-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Run that performed this tool call"}
+
    {:db/ident :tool-call/result-message
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/one
@@ -470,6 +482,81 @@
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/many
     :db/doc "Tags for categorizing tasks"}])
+
+;; ============================================================================
+;; Run Schema
+;; ============================================================================
+
+(def run-schema
+  "Durable lifecycle for one causally bounded program execution in a room."
+  [{:db/ident :run/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :run/chat
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Room-store chat entity that owns the run"}
+
+   {:db/ident :run/kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :run/room
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Runtime Room identity; may name a fork of :run/chat"}
+
+   {:db/ident :run/actor
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :run/trigger
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Precise message that caused the run; its thread is canonical"}
+
+   {:db/ident :run/parent
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Explicit structural parent that spawned/contains this run"}
+
+   {:db/ident :run/status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :run/created-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :run/started-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :run/updated-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :run/ended-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :run/reason
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :run/error
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}])
 
 ;; ============================================================================
 ;; Full Schema
@@ -856,6 +943,7 @@
    `:task/*` follow in their own S3/S4 slices."
   (vec (concat chat-schema
                message-schema
+               run-schema
                tool-call-schema
                ledger-schema
                budget-schema

--- a/src/dvergr/clients/client.clj
+++ b/src/dvergr/clients/client.clj
@@ -32,6 +32,7 @@
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.discourse :as d]
             [dvergr.discourse.personas :as personas]
+            [dvergr.agent.run :as run]
             [dvergr.room.registry :as rreg]
             [dvergr.ops :as ops]
             [dvergr.orchestration.skills :as skills]
@@ -125,6 +126,21 @@
    id→Room step; every other fn takes the Room."
   [id-or-slug]
   (with-ctx (fn [_ _ _] (rreg/lookup (if (string? id-or-slug) (keyword id-or-slug) id-or-slug)))))
+
+(defn active-runs
+  "Live Run snapshots. With a Room handle, restrict to that Room."
+  ([] (run/active-runs))
+  ([room] (run/active-runs (:id room))))
+
+(defn runs
+  "Recent durable Runs for a Room, newest first."
+  ([room] (run/runs room))
+  ([room opts] (run/runs room opts)))
+
+(defn cancel-run!
+  "Cooperatively cancel one live Run by UUID."
+  [run-id]
+  (run/cancel-run! run-id))
 
 (defn spawn
   "Create a room with one agent joined; return the Room. The agent is room-safe by

--- a/src/dvergr/core.clj
+++ b/src/dvergr/core.clj
@@ -21,6 +21,7 @@
   (:require [dvergr.discourse]
             [dvergr.discourse.llm]
             [dvergr.discourse.generation]
+            [dvergr.agent.run]
             [dvergr.runtime.bus]
             [dvergr.participant.context]
             [dvergr.discourse.personas]))
@@ -67,6 +68,17 @@
 ;; ============================================================================
 
 (def llm-agent               @#'dvergr.discourse.llm/llm-agent)
+
+;; ============================================================================
+;; Durable Run lifecycle
+;; ============================================================================
+
+(def active-runs             @#'dvergr.agent.run/active-runs)
+(def watch-runs!             @#'dvergr.agent.run/watch-runs!)
+(def unwatch-runs!           @#'dvergr.agent.run/unwatch-runs!)
+(def cancel-run!             @#'dvergr.agent.run/cancel-run!)
+(def runs                    @#'dvergr.agent.run/runs)
+(def run                     @#'dvergr.agent.run/run)
 
 ;; ============================================================================
 ;; Personas (pre-built llm-agent factories)

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -352,19 +352,54 @@
 ;; Participant lifecycle in a room
 ;; ============================================================================
 
+(def ^:private reply-emitted-key ::reply-emitted)
+(def ^:private reply-emit-failed-key ::reply-emit-failed)
+
+(defn after-reply-emission
+  "Attach process-local lifecycle callbacks to a ReplySpec. `on-emitted` runs
+   only after the reply is durably posted to the Room; `on-failed` receives a
+   posting error. The callbacks are control data and never enter the Message."
+  [reply-spec on-emitted on-failed]
+  (cond-> reply-spec
+    on-emitted (assoc reply-emitted-key on-emitted)
+    on-failed (assoc reply-emit-failed-key on-failed)))
+
 (defn- emit-reply!
   "Route a reply-spec from `p` into `room`, preserving the triggering Message's
    immediate-parent and thread-root identities. Non-message events start a new
    thread if they produce conversational output."
   [room p reply-spec parent-message]
   (when reply-spec
-    (route-and-log!
-     room
-     (if parent-message
-       (reply (:id p) (:to reply-spec) (:content reply-spec)
-              parent-message (:metadata reply-spec))
-       (message (:id p) (:to reply-spec) (:content reply-spec)
-                nil (:metadata reply-spec))))))
+    (let [on-emitted (get reply-spec reply-emitted-key)
+          on-failed  (get reply-spec reply-emit-failed-key)
+          emitted
+          (try
+            (route-and-log!
+             room
+             (if parent-message
+               (reply (:id p) (:to reply-spec) (:content reply-spec)
+                      parent-message (:metadata reply-spec))
+               (message (:id p) (:to reply-spec) (:content reply-spec)
+                        nil (:metadata reply-spec))))
+            (catch Throwable t
+              (when on-failed
+                (try (on-failed t)
+                     (catch Throwable callback-error
+                       (tel/log! {:level :error :id ::reply-failure-callback-error
+                                  :data {:participant (:id p)
+                                         :error (.getMessage callback-error)}}
+                                 "reply failure callback failed"))))
+              (throw t)))]
+      (when on-emitted
+        (try (on-emitted emitted)
+             (catch Throwable t
+               ;; The reply is already durable. Do not misreport this as an
+               ;; emission failure; the lifecycle owner retained its retryable
+               ;; active projection when its terminal write failed.
+               (tel/log! {:level :error :id ::reply-emitted-callback-error
+                          :data {:participant (:id p) :error (.getMessage t)}}
+                         "reply emitted but its lifecycle callback failed"))))
+      emitted)))
 
 (defn- drain-into!
   "Spawn a spin that drains `(:aseq sub)` and posts each item into `mbx`.

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -47,6 +47,7 @@
             [dvergr.discourse.generation :as gen]
             [dvergr.chat.context :as cc]
             [dvergr.chat.agent :as ca]
+            [dvergr.agent.run :as run]
             [dvergr.agent.turn :as turn]
             [dvergr.agent.room-context :as room-context]
             [dvergr.agent.prompt :as prompt]
@@ -277,7 +278,7 @@
                    nil
 
                ;; --- default: user/agent content → run generation ---
-                   (let [posted   (atom 0)        ; 🔧 activity watermark (dedup)
+                   (let [posted   (atom (turn/tool-activity-count chat-ctx))
                          ;; The active arbiter temporarily owns content for other
                          ;; threads, then hands it back to the participant's FIFO
                          ;; inbox after this execution. The Room log is already the
@@ -323,6 +324,8 @@
                                       ;; RF5: the Room itself, so room-scoped tools
                                       ;; (schedule_*) write into THIS room's store.
                                           (assoc :room room)))
+                         run-ref           (when room (run/start! room id msg chat-ctx))
+                         run-id            (:run/id run-ref)
                          turn-opts {:provider         (:provider spec)
                                 ;; Per-room /model override (commands registry)
                                 ;; wins over the spec's model, matching the daemon.
@@ -332,7 +335,9 @@
                                     :tools            tools
                                     :tool-ctx         tool-ctx
                                 ;; SSE-abort predicate (Esc-cancel flips status).
-                                    :cancel?          (turn/cancel?-fn chat-ctx turn-ctx)
+                                    :cancel?          (turn/cancel?-fn
+                                                       chat-ctx turn-ctx
+                                                       #(run/cancel-requested? run-id))
                                 ;; TRANSIENT per-turn system note(s) — applied to
                                 ;; THIS call only, never persisted (run-agent-turn!
                                 ;; appends to the first system message): always the
@@ -352,6 +357,8 @@
                                 ;; system notes for unresolvable ones.
                                     :on-reply         on-reply}
                          errored           (atom nil)
+                         waiting?          (atom false)
+                         finish-after-reply? (atom false)
                      ;; #38: the last assistant message BEFORE this invocation
                      ;; runs (the store-seeded prior reply, or nil) — the exit
                      ;; path uses it to tell a genuinely NEW reply from stale
@@ -371,10 +378,8 @@
                              (cc/add-message! chat-ctx {:role :user :content (:content m)})))]
                  ;; The just-arrived user message (and any message that STEERS a
                  ;; running turn, below) folds in via fold-inbound! from the let.
-                     (fold-inbound! msg)
-                 ;; Publish the live chat-ctx so a frontend (TUI/web) can
-                 ;; Esc-cancel this turn (turn/cancel-room-turn! flips its status).
-                     (when room (turn/register-room-turn! (:id room) id chat-ctx))
+                     (try
+                       (fold-inbound! msg)
                  ;; ONE CONTROL PLANE (steerable turn). Every influence on a
                  ;; running turn arrives as a message on the participant's own
                  ;; inbox — INCLUDING the LLM call's completion, which a bridge
@@ -409,83 +414,84 @@
                  ;; running compact! whenever (should-compact?) AND no
                  ;; compaction is already in flight. The next turn picks up
                  ;; the compacted chat-ctx state once it lands.
-                     (loop [turn 0]
-                       (if @cancelled?
-                         nil
-                         (do
-                           (when race-compaction?
-                             (when (or (nil? @compaction-h)
-                                       (some-> ^java.util.concurrent.Future @compaction-h
-                                               .isDone))
-                               (when (compaction/should-compact? chat-ctx)
-                                 (reset! compaction-h
-                                         (future
-                                           (binding [ec/*execution-context* turn-ctx]
-                                             (try
-                                               (compaction/maybe-compact!
-                                                chat-ctx
-                                                :model (:model compaction))
-                                               (catch Throwable _ nil))))))))
-                           (let [h (gen/future-handle
-                                    turn-ctx
-                                    #(run-turn-fn chat-ctx
-                                                  (assoc turn-opts
-                                                         :turn-number turn
-                                                         :spec @spec-atom
-                                                         :tools tools)))
-                                 call-id (random-uuid)
-                                 mbx     (:inbox-mbx p)
+                       (loop [turn 0]
+                         (if (or @cancelled? (run/cancel-requested? run-id))
+                           nil
+                           (do
+                             (when race-compaction?
+                               (when (or (nil? @compaction-h)
+                                         (some-> ^java.util.concurrent.Future @compaction-h
+                                                 .isDone))
+                                 (when (compaction/should-compact? chat-ctx)
+                                   (reset! compaction-h
+                                           (future
+                                             (binding [ec/*execution-context* turn-ctx]
+                                               (try
+                                                 (compaction/maybe-compact!
+                                                  chat-ctx
+                                                  :model (:model compaction))
+                                                 (catch Throwable _ nil))))))))
+                             (let [h (gen/future-handle
+                                      turn-ctx
+                                      #(run-turn-fn chat-ctx
+                                                    (assoc turn-opts
+                                                           :turn-number turn
+                                                           :spec @spec-atom
+                                                           :tools tools
+                                                           :run-id run-id)))
+                                   call-id (random-uuid)
+                                   mbx     (:inbox-mbx p)
                                  ;; Bridge the call's completion into the SAME
                                  ;; inbox steering messages arrive on. (:done h)
                                  ;; is a Deferred — multi-reader — so the settle
                                  ;; awaits below can read it too.
-                                 _ (when mbx
-                                     (binding [ec/*execution-context* turn-ctx]
-                                       (ssync/spawn!
-                                        (sp/spin
-                                         (let [r (sp/await (:done h))]
-                                           (mbx {:type ::llm-done
-                                                 :call-id call-id
-                                                 :result r}))))))
-                                 decision
-                                 (if mbx
+                                   _ (when mbx
+                                       (binding [ec/*execution-context* turn-ctx]
+                                         (ssync/spawn!
+                                          (sp/spin
+                                           (let [r (sp/await (:done h))]
+                                             (mbx {:type ::llm-done
+                                                   :call-id call-id
+                                                   :result r}))))))
+                                   decision
+                                   (if mbx
                                    ;; Arbiter: single consumer of the inbox for
                                    ;; the duration of this call. Awaits the
                                    ;; Mailbox DIRECTLY (its 2-arity carries the
                                    ;; cancel-token — never via anext/aseq).
-                                   (loop []
-                                     (let [m (if-let [deferred (d/take-deferred-inbox! p)]
-                                               deferred
-                                               (sp/await mbx))]
-                                       (cond
-                                         (and (= ::llm-done (:type m))
-                                              (= call-id (:call-id m)))
-                                         {:tag :llm-done :result (:result m)}
+                                     (loop []
+                                       (let [m (if-let [deferred (d/take-deferred-inbox! p)]
+                                                 deferred
+                                                 (sp/await mbx))]
+                                         (cond
+                                           (and (= ::llm-done (:type m))
+                                                (= call-id (:call-id m)))
+                                           {:tag :llm-done :result (:result m)}
 
                                          ;; a cancelled earlier call settling late
-                                         (= ::llm-done (:type m))
-                                         (recur)
+                                           (= ::llm-done (:type m))
+                                           (recur)
 
-                                         :else
-                                         (case (:type m)
-                                           :directive/raise-budget
-                                           (do (apply-raise-budget! chat-ctx m) (recur))
+                                           :else
+                                           (case (:type m)
+                                             :directive/raise-budget
+                                             (do (apply-raise-budget! chat-ctx m) (recur))
 
-                                           :directive/system-message
-                                           (do (apply-system-message! chat-ctx m) (recur))
+                                             :directive/system-message
+                                             (do (apply-system-message! chat-ctx m) (recur))
 
-                                           :probe/memory
-                                           (do (when room
-                                                 (d/post! room (assoc (probe-memory-reply chat-ctx m)
-                                                                      :from id)))
-                                               (recur))
+                                             :probe/memory
+                                             (do (when room
+                                                   (d/post! room (assoc (probe-memory-reply chat-ctx m)
+                                                                        :from id)))
+                                                 (recur))
 
-                                           :directive/cancel
-                                           {:tag :cancel}
+                                             :directive/cancel
+                                             {:tag :cancel}
 
-                                           :directive/switch-model
-                                           (do (swap! spec-atom merge (:payload m))
-                                               {:tag :switch})
+                                             :directive/switch-model
+                                             (do (swap! spec-atom merge (:payload m))
+                                                 {:tag :switch})
 
                                            ;; Default: classify conversational
                                            ;; content at the thread-aware attention
@@ -493,41 +499,42 @@
                                            ;; can deliver the same id more than once;
                                            ;; ignore the duplicate while this inner
                                            ;; arbiter owns the participant inbox.
-                                           (let [mid (:id m)]
-                                             (if (and mid
-                                                      (contains? @seen-inflight-ids mid))
-                                               (recur)
-                                               (do
-                                                 (when mid
-                                                   (swap! seen-inflight-ids conj mid))
-                                                 (let [attention
-                                                       (attention-policy
-                                                        {:active-message msg
-                                                         :incoming-message m
-                                                         :participant p
-                                                         :room room})]
-                                                   (case attention
-                                                     :steer {:tag :steer :msg m}
-                                                     :observe (recur)
-                                                     :queue (do
-                                                              (swap! queued-other-threads conj m)
-                                                              (recur))
-                                                     (do
-                                                       (tel/log!
-                                                        {:level :warn
-                                                         :id ::invalid-attention-decision
-                                                         :data {:agent id
-                                                                :decision attention}}
-                                                        "Invalid attention decision; queued conservatively")
-                                                       (swap! queued-other-threads conj m)
-                                                       (recur)))))))))))
+                                             (let [mid (:id m)]
+                                               (if (and mid
+                                                        (contains? @seen-inflight-ids mid))
+                                                 (recur)
+                                                 (do
+                                                   (when mid
+                                                     (swap! seen-inflight-ids conj mid))
+                                                   (let [attention
+                                                         (attention-policy
+                                                          {:active-message msg
+                                                           :incoming-message m
+                                                           :participant p
+                                                           :room room})]
+                                                     (case attention
+                                                       :steer {:tag :steer :msg m}
+                                                       :observe (recur)
+                                                       :queue (do
+                                                                (swap! queued-other-threads conj m)
+                                                                (recur))
+                                                       (do
+                                                         (tel/log!
+                                                          {:level :warn
+                                                           :id ::invalid-attention-decision
+                                                           :data {:agent id
+                                                                  :decision attention}}
+                                                          "Invalid attention decision; queued conservatively")
+                                                         (swap! queued-other-threads conj m)
+                                                         (recur)))))))))))
                                    ;; No inbox (room-less participant that was
                                    ;; never joined): plain await, no steering.
-                                   {:tag :llm-done :result (sp/await (:done h))})]
+                                     {:tag :llm-done :result (sp/await (:done h))})]
                          ;; Mirror this turn's tool calls into the room as 🔧
                          ;; play-by-play rows (same as daemon agents).
-                             (when room (turn/post-turn-activity! room id chat-ctx posted))
-                             (if (not= :llm-done (:tag decision))
+                               (when room
+                                 (turn/post-turn-activity! room id chat-ctx posted run-id msg))
+                               (if (not= :llm-done (:tag decision))
                                ;; Preempted: cancel the in-flight call through
                                ;; the SAME path as Esc (status :cancelled → the
                                ;; SSE :cancel? poll → CancellationException
@@ -537,24 +544,24 @@
                                ;; result). Then AWAIT THE SETTLE — never a hard
                                ;; future-cancel — so history is coherent before
                                ;; the next step.
-                               (do
-                                 (cc/set-status! chat-ctx :cancelled)
-                                 (sp/await (:done h))
-                                 (cc/set-status! chat-ctx :active)
-                                 (case (:tag decision)
-                                   :cancel (do (reset! cancelled? true) nil)
-                                   :switch (recur turn)
-                                   :steer  (do (fold-inbound! (:msg decision))
-                                               (recur (inc turn)))))
-                               (let [result (:result decision)]
-                                 (cond
-                                   @cancelled? nil
+                                 (do
+                                   (cc/set-status! chat-ctx :cancelled)
+                                   (sp/await (:done h))
+                                   (cc/set-status! chat-ctx :active)
+                                   (case (:tag decision)
+                                     :cancel (do (reset! cancelled? true) nil)
+                                     :switch (recur turn)
+                                     :steer  (do (fold-inbound! (:msg decision))
+                                                 (recur (inc turn)))))
+                                 (let [result (:result decision)]
+                                   (cond
+                                     (or @cancelled? (run/cancel-requested? run-id)) nil
 
-                                   (gen/error-result? result)
-                                   (do (reset! errored (:dvergr.discourse.generation/error result)) nil)
+                                     (gen/error-result? result)
+                                     (do (reset! errored (:dvergr.discourse.generation/error result)) nil)
 
                                ;; LLM finished cleanly (no more tool calls).
-                                   (not= result :continue) nil
+                                     (not= result :continue) nil
 
                                ;; Budget exhausted → the turn ENDS here.
                                ;;
@@ -571,68 +578,105 @@
                                ;; The durable room log IS the continuation — which is
                                ;; the only kind spindel can actually have (it has no
                                ;; durable conts, and a park would be lost on restart).
-                                   (cc/budget-exceeded? chat-ctx)
-                                   (do
-                                     (when room
-                                       (let [b (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-                                                 @(:budget-signal chat-ctx))
-                                             used  (/ (:used b) (double acct/MICRODOLLARS-PER-DOLLAR))
-                                             total (/ (:total b) (double acct/MICRODOLLARS-PER-DOLLAR))]
-                                         (turn/post-budget-warning! room id used total)))
-                                     (proc/budget-exhausted! id chat-ctx)
-                                     nil)
+                                     (cc/budget-exceeded? chat-ctx)
+                                     (do
+                                       (when room
+                                         (let [b (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+                                                   @(:budget-signal chat-ctx))
+                                               used  (/ (:used b) (double acct/MICRODOLLARS-PER-DOLLAR))
+                                               total (/ (:total b) (double acct/MICRODOLLARS-PER-DOLLAR))]
+                                           (turn/post-budget-warning! room id used total run-id msg)))
+                                       (reset! waiting? true)
+                                       (proc/budget-exhausted! id chat-ctx)
+                                       nil)
 
                                ;; Normal :continue, budget OK → next turn.
-                                   :else (recur (inc turn)))))))))
+                                     :else (recur (inc turn)))))))))
 
-                     (when room (turn/unregister-room-turn! (:id room) id))
                      ;; The outer participant loop can now start queued work. Put
                      ;; consumed messages in the participant-owned priority FIFO,
                      ;; not at the live mailbox tail: a newer arrival during this
                      ;; hand-back window must not overtake older topics.
-                     (doseq [queued @queued-other-threads]
-                       (d/defer-inbox! p queued))
+                       (doseq [queued @queued-other-threads]
+                         (d/defer-inbox! p queued))
                      ;; A FAILED turn produced no new reply — surface it as a NON-triggering
                      ;; :_activity row and DON'T fall through to re-post the STALE last reply
                      ;; (which the room's other agents answer, looping — the "repeating" bug).
-                     (when @errored (turn/post-turn-error! room id @errored))
+                       (when @errored (turn/post-turn-error! room id @errored run-id msg))
                      ;; #38: the SILENT-failure shape — the turn ended with no
                      ;; error tag AND no new assistant message (e.g. provider
                      ;; resolution failed before any generation). The last
                      ;; assistant message is then the store-SEEDED prior reply;
                      ;; posting it is the repeating bug. Surface it instead.
                      ;; A deliberate cancel stays quiet.
-                     (when (and (not @errored) (not @cancelled?)
-                                (= pre-turn-last-asst (last-assistant-message chat-ctx)))
-                       (turn/post-turn-error!
-                        room id
-                        "turn ended without producing a reply — likely a provider/model resolution failure"))
-                     (when-let [last-asst (when-not @errored
-                                            (let [la (last-assistant-message chat-ctx)]
-                                              (when (not= la pre-turn-last-asst) la)))]
-                       (when-let [reply (assistant-text last-asst)]
+                       (when (and (not @errored) (not @cancelled?)
+                                  (not (run/cancel-requested? run-id))
+                                  (not= :cancelled (cc/get-status chat-ctx))
+                                  (= pre-turn-last-asst (last-assistant-message chat-ctx)))
+                         (let [error "turn ended without producing a reply — likely a provider/model resolution failure"]
+                           (reset! errored error)
+                           (turn/post-turn-error! room id error run-id msg)))
+                       (when-let [last-asst (when-not @errored
+                                              (let [la (last-assistant-message chat-ctx)]
+                                                (when (not= la pre-turn-last-asst) la)))]
+                         (when-let [reply (assistant-text last-asst)]
                      ;; Last line of defence: a model that fumbled code into the
                      ;; prose channel TWICE (agent.clj nudged it once) must still
                      ;; not have that fragment posted as its reply — the room
                      ;; would show code as an answer and other agents would reply
                      ;; TO it. Surface it as a non-triggering activity row instead.
-                         (if (quirks/code-fragment? reply)
-                           (do (tel/log! {:level :warn :id ::reply-was-code-fragment
-                                          :data {:agent id}}
-                                         "Suppressed a code fragment posing as a reply")
-                               (when room
-                                 (turn/post-turn-error!
-                                  room id
-                                  (str "emitted code instead of a reply — the tool call "
-                                       "never reached the tool channel, so nothing ran")))
-                               nil)
+                           (if (quirks/code-fragment? reply)
+                             (do (tel/log! {:level :warn :id ::reply-was-code-fragment
+                                            :data {:agent id}}
+                                           "Suppressed a code fragment posing as a reply")
+                                 (when room
+                                   (let [error (str "emitted code instead of a reply — the tool call "
+                                                    "never reached the tool channel, so nothing ran")]
+                                     (reset! errored error)
+                                     (turn/post-turn-error! room id error run-id msg)))
+                                 nil)
                      ;; Carry this turn's interleaved-thinking trace into the room
                      ;; record (metadata → store → seeding) so reasoning models
                      ;; (MiniMax M2 / Kimi / DeepSeek) keep their <think> context
                      ;; across a rehydrate/restart, not just within a live session.
-                           (let [reasoning (or (:message/reasoning last-asst) (:reasoning last-asst))]
-                             (cond-> {:to (:from msg) :content reply}
-                               (seq reasoning) (assoc :metadata {:reasoning reasoning})))))))))))
+                             (let [reasoning (or (:message/reasoning last-asst) (:reasoning last-asst))
+                                   reply-spec
+                                   (cond-> {:to (:from msg) :content reply
+                                            :metadata {:run-id run-id}}
+                                     (seq reasoning) (assoc-in [:metadata :reasoning] reasoning))]
+                               (if-not run-id
+                                 reply-spec
+                                 (do
+                                   ;; The outer participant owns Room emission.
+                                   ;; Completion is acknowledged only after its
+                                   ;; durability-first post succeeds.
+                                   (reset! finish-after-reply? true)
+                                   (d/after-reply-emission
+                                    reply-spec
+                                    (fn [_emitted]
+                                      (run/finish! run-id :completed))
+                                    (fn [error]
+                                      (run/finish! run-id :failed
+                                                   {:reason :reply-emission-failed
+                                                    :error error})))))))))
+                       (catch Throwable t
+                         (reset! errored t)
+                         (throw t))
+                       (finally
+                         (when (and run-id (not @finish-after-reply?))
+                           (let [cancelled-run? (or @cancelled?
+                                                    (run/cancel-requested? run-id)
+                                                    (= :cancelled (cc/get-status chat-ctx)))
+                                 status (cond
+                                          cancelled-run? :cancelled
+                                          @errored :failed
+                                          @waiting? :waiting
+                                          :else :completed)]
+                             (run/finish! run-id status
+                                          (cond-> {}
+                                            cancelled-run? (assoc :reason :cancel-requested)
+                                            @waiting? (assoc :reason :budget-exhausted)
+                                            @errored (assoc :reason :error :error @errored))))))))))))
 
             :factory
             (fn [new-ctx]

--- a/src/dvergr/orchestration/daemon.clj
+++ b/src/dvergr/orchestration/daemon.clj
@@ -98,6 +98,10 @@
 (def ^:private activity-id     turn/activity-id)
 (def room-turn-running?        turn/room-turn-running?)
 (def cancel-room-turn!         turn/cancel-room-turn!)
+(def active-runs               turn/active-runs)
+(def watch-runs!               turn/watch-runs!)
+(def unwatch-runs!             turn/unwatch-runs!)
+(def cancel-run!               turn/cancel-run!)
 
 ;; ============================================================================
 ;; Safety

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -68,11 +68,80 @@
     "Return messages in chronological order. :limit caps result size
      (default impl-specific); :since is an instant — only messages
      after that ts are returned; :thread-root-id restricts the result to one
-     topical projection before the limit is applied."))
+     topical projection before the limit is applied.")
+
+  (-store-run! [this room-id run]
+    "Create or update a durable Run projection owned by `room-id`. Run identity,
+     kind, room, actor, trigger, parent, and start timestamps are immutable by
+     contract; lifecycle updates change status and terminal fields.")
+
+  (-load-run [this room-id run-id]
+    "Return one durable Run by UUID when it belongs to `room-id`, else nil.")
+
+  (-list-runs [this room-id {:keys [limit status actor]}]
+    "Return recent Runs, newest first. Optional :status and :actor filters are
+     applied before :limit."))
 
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
+
+(def durable-run-statuses
+  "Lifecycle states stored in a Room. `:cancelling` is deliberately live-only:
+   durable cancellation is acknowledged by the terminal `:cancelled` state."
+  #{:running :waiting :completed :failed :cancelled})
+
+(def terminal-run-statuses #{:completed :failed :cancelled})
+
+(def immutable-run-keys
+  [:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+   :run/created-at :run/started-at])
+
+(defn validate-run!
+  "Validate the minimal durable Run contract and return `run`."
+  [run]
+  (doseq [k [:run/id :run/trigger]]
+    (when-not (uuid? (get run k))
+      (throw (ex-info (str k " must be a UUID")
+                      {:type :room-store/invalid-run :key k :run run}))))
+  (when-not (keyword? (:run/room run))
+    (throw (ex-info ":run/room must be a keyword"
+                    {:type :room-store/invalid-run :key :run/room :run run})))
+  (when-not (keyword? (:run/actor run))
+    (throw (ex-info ":run/actor must be a keyword"
+                    {:type :room-store/invalid-run :key :run/actor :run run})))
+  (when-not (keyword? (:run/kind run))
+    (throw (ex-info ":run/kind must be a keyword"
+                    {:type :room-store/invalid-run :key :run/kind :run run})))
+  (when-not (contains? durable-run-statuses (:run/status run))
+    (throw (ex-info "Invalid durable run status"
+                    {:type :room-store/invalid-run-status
+                     :status (:run/status run) :run run})))
+  (when (and (:run/parent run) (not (uuid? (:run/parent run))))
+    (throw (ex-info ":run/parent must be a UUID"
+                    {:type :room-store/invalid-run :key :run/parent :run run})))
+  (doseq [k [:run/created-at :run/started-at :run/updated-at]
+          :when (not (instance? java.util.Date (get run k)))]
+    (throw (ex-info (str k " must be an instant")
+                    {:type :room-store/invalid-run :key k :run run})))
+  (when (and (contains? terminal-run-statuses (:run/status run))
+             (not (instance? java.util.Date (:run/ended-at run))))
+    (throw (ex-info "A terminal run requires :run/ended-at"
+                    {:type :room-store/invalid-run :key :run/ended-at :run run})))
+  run)
+
+(defn validate-run-update!
+  "Reject an update that changes the causal identity of an existing Run."
+  [existing run]
+  (when (and existing
+             (not= (select-keys existing immutable-run-keys)
+                   (select-keys run immutable-run-keys)))
+    (throw (ex-info "Durable run identity fields are immutable"
+                    {:type :room-store/immutable-run-update
+                     :run-id (:run/id run)
+                     :existing (select-keys existing immutable-run-keys)
+                     :update (select-keys run immutable-run-keys)})))
+  run)
 
 (def durable-message-metadata-keys
   "The top-level metadata keys that every PRoomStore implementation accepts.
@@ -82,7 +151,7 @@
     :audience :mentions :attachment :provenance
     :tool-uses :reasoning :kind :from :source :schedule-id
     :notification/type :notification/agent :notification/task
-    :notification/elapsed})
+    :notification/elapsed :run-id})
 
 (def ^:private attachment-metadata-keys #{:blob-id :node-id :mime :name :size})
 (def ^:private provenance-metadata-keys #{:mode :source})
@@ -119,6 +188,10 @@
                         {:type :room-store/invalid-message-metadata
                          :provenance provenance})))
       (reject-unknown-metadata! :provenance provenance-metadata-keys provenance)))
+  (when (and (:run-id metadata) (not (uuid? (:run-id metadata))))
+    (throw (ex-info "Message :run-id metadata must be a UUID"
+                    {:type :room-store/invalid-message-metadata
+                     :run-id (:run-id metadata)})))
   metadata)
 
 (defn normalize-message-thread

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -98,6 +98,7 @@
       (keyword? (:to msg)) (assoc :message/to (:to msg))
       (uuid? (:in-reply-to msg)) (assoc :message/in-reply-to (:in-reply-to msg))
       (uuid? (:thread-root-id msg)) (assoc :message/thread-root-id (:thread-root-id msg))
+      (uuid? (:run-id metadata)) (assoc :message/run-id (:run-id metadata))
       (:source-username metadata) (assoc :message/source-username (:source-username metadata))
       (:source-user-id  metadata) (assoc :message/source-user-id  (long (:source-user-id metadata)))
       (seq (:audience metadata)) (assoc :message/audience (set (:audience metadata)))
@@ -141,7 +142,7 @@
     :message/created-at :message/source-user
     :message/source-username :message/source-user-id
     :message/from :message/to :message/in-reply-to
-    :message/thread-root-id
+    :message/thread-root-id :message/run-id
     :message/reasoning
     :message/audience :message/mention-handles
     :message/metadata-kind :message/context-from
@@ -161,6 +162,27 @@
     {:message/tool-uses
      [:tool-use/id :tool-use/name
       {:tool-use/input [*]}]}])
+
+(def ^:private run-pull-pattern
+  '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+    :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
+    :run/reason :run/error])
+
+(defn- run->entity [chat-id run]
+  (cond-> {:run/id         (:run/id run)
+           :run/chat       [:chat/id chat-id]
+           :run/kind       (:run/kind run)
+           :run/room       (:run/room run)
+           :run/actor      (:run/actor run)
+           :run/trigger    (:run/trigger run)
+           :run/status     (:run/status run)
+           :run/created-at (:run/created-at run)
+           :run/started-at (:run/started-at run)
+           :run/updated-at (:run/updated-at run)}
+    (:run/parent run)   (assoc :run/parent (:run/parent run))
+    (:run/ended-at run) (assoc :run/ended-at (:run/ended-at run))
+    (:run/reason run)   (assoc :run/reason (:run/reason run))
+    (:run/error run)    (assoc :run/error (str (:run/error run)))))
 
 ;; =============================================================================
 ;; Store impl
@@ -197,8 +219,16 @@
                               :where [?c :chat/id ?cid]
                               [?m :message/chat ?c]
                               [?m :message/id ?mid]]
+                            @conn chat-id)
+              run-ids (dh/q '[:find [?rid ...]
+                              :in $ ?cid
+                              :where
+                              [?c :chat/id ?cid]
+                              [?r :run/chat ?c]
+                              [?r :run/id ?rid]]
                             @conn chat-id)]
           (dh/transact conn (-> (mapv (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids)
+                                (into (map (fn [rid] [:db/retractEntity [:run/id rid]]) run-ids))
                                 (conj [:db/retractEntity [:chat/id chat-id]])))))))
 
   (-list-rooms [_]
@@ -373,8 +403,54 @@
                     ;; Surface the interleaved-thinking trace so seeding can feed
                     ;; it back to reasoning models (MiniMax M2 / Kimi / DeepSeek).
                        (seq (:message/reasoning m))
-                       (assoc :reasoning (:message/reasoning m))))))
-                (vec (take-last (or limit 100) filtered))))))))
+                       (assoc :reasoning (:message/reasoning m))
+                       (:message/run-id m)
+                       (assoc-in [:metadata :run-id] (:message/run-id m))))))
+                (vec (take-last (or limit 100) filtered)))))))
+
+  (-store-run! [this room-id run]
+    (let [slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        (let [run (->> run
+                       store/validate-run!
+                       (store/validate-run-update!
+                        (store/-load-run this room-id (:run/id run))))]
+          (when (persist/persist-tx!
+                 conn
+                 [(run->entity (:chat/id ent) run)
+                  {:db/id [:chat/id (:chat/id ent)]
+                   :chat/updated-at (java.util.Date.)}]
+                 {:op :store-run :room-id room-id :run-id (:run/id run)})
+            run)))))
+
+  (-load-run [_ room-id run-id]
+    (let [slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        (dh/q '[:find (pull ?r pattern) .
+                :in $ ?chat-id ?run-id pattern
+                :where
+                [?c :chat/id ?chat-id]
+                [?r :run/chat ?c]
+                [?r :run/id ?run-id]]
+              @conn (:chat/id ent) run-id run-pull-pattern))))
+
+  (-list-runs [_ room-id {:keys [limit status actor]}]
+    (let [slug (store/room-id->slug room-id)]
+      (if-let [ent (room-by-slug conn slug)]
+        (->> (dh/q '[:find [(pull ?r pattern) ...]
+                     :in $ ?chat-id pattern
+                     :where
+                     [?c :chat/id ?chat-id]
+                     [?r :run/chat ?c]]
+                   @conn (:chat/id ent) run-pull-pattern)
+             (filter #(if status (= status (:run/status %)) true))
+             (filter #(if actor (= actor (:run/actor %)) true))
+             (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
+                            #(str (:run/id %)))
+                      #(compare %2 %1))
+             (take (or limit 100))
+             vec)
+        []))))
 
 (defn make
   "Create a DatahikeStore. `conn` must be an existing Datahike

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -7,7 +7,8 @@
 (defrecord MemoryStore [state]
   ;; state atom shape:
   ;;   {:rooms     {room-id metadata}
-  ;;    :messages  {room-id [msg ...] (chronological)}}
+  ;;    :messages  {room-id [msg ...] (chronological)}
+  ;;    :runs      {room-id {run-id run}}}
   store/PRoomStore
 
   (-store-room! [_ room-id metadata]
@@ -23,7 +24,8 @@
     (swap! state (fn [s]
                    (-> s
                        (update :rooms    dissoc room-id)
-                       (update :messages dissoc room-id)))))
+                       (update :messages dissoc room-id)
+                       (update :runs     dissoc room-id)))))
 
   (-list-rooms [_]
     (->> (vals (:rooms @state))
@@ -59,9 +61,30 @@
                      thread-root-id
                      (filter #(= thread-root-id (:thread-root-id %))))
           n (or limit (count filtered))]
-      (vec (take-last n filtered)))))
+      (vec (take-last n filtered))))
+
+  (-store-run! [_ room-id run]
+    (let [run (->> run
+                   store/validate-run!
+                   (store/validate-run-update!
+                    (get-in @state [:runs room-id (:run/id run)])))]
+      (swap! state assoc-in [:runs room-id (:run/id run)] run)
+      run))
+
+  (-load-run [_ room-id run-id]
+    (get-in @state [:runs room-id run-id]))
+
+  (-list-runs [_ room-id {:keys [limit status actor]}]
+    (->> (vals (get-in @state [:runs room-id] {}))
+         (filter #(if status (= status (:run/status %)) true))
+         (filter #(if actor (= actor (:run/actor %)) true))
+         (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
+                        #(str (:run/id %)))
+                  #(compare %2 %1))
+         (take (or limit 100))
+         vec)))
 
 (defn make
   "Create a fresh in-memory store."
   []
-  (->MemoryStore (atom {:rooms {} :messages {}})))
+  (->MemoryStore (atom {:rooms {} :messages {} :runs {}})))

--- a/test/dvergr/agent/run_test.clj
+++ b/test/dvergr/agent/run_test.clj
@@ -1,0 +1,167 @@
+(ns dvergr.agent.run-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.run :as run]
+            [dvergr.chat.context :as chat-ctx]
+            [dvergr.discourse :as d]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]))
+
+(defn- run-room [id]
+  (let [st (memory/make)]
+    [(d/make-room {:id id :store st}) st]))
+
+(defn- live-ctx []
+  (chat-ctx/create-chat-context {:budget-dollars 0.01 :with-sci? false}))
+
+(defn- controlled-run-store [delegate receipts?]
+  (reify store/PRoomStore
+    (-store-room! [_ room-id metadata]
+      (store/-store-room! delegate room-id metadata))
+    (-load-room [_ id-or-slug]
+      (store/-load-room delegate id-or-slug))
+    (-delete-room! [_ room-id]
+      (store/-delete-room! delegate room-id))
+    (-list-rooms [_]
+      (store/-list-rooms delegate))
+    (-store-message! [_ room-id message]
+      (store/-store-message! delegate room-id message))
+    (-message-thread-root [_ room-id message-id]
+      (store/-message-thread-root delegate room-id message-id))
+    (-list-messages [_ room-id opts]
+      (store/-list-messages delegate room-id opts))
+    (-store-run! [_ room-id run]
+      (when @receipts?
+        (store/-store-run! delegate room-id run)))
+    (-load-run [_ room-id run-id]
+      (store/-load-run delegate room-id run-id))
+    (-list-runs [_ room-id opts]
+      (store/-list-runs delegate room-id opts))))
+
+(deftest lifecycle-is-durable-observable-and-handle-free
+  (let [[room st] (run-room :run-lifecycle)
+        trigger (d/message :alice :researcher "investigate")
+        cctx (live-ctx)
+        events (atom [])
+        watch-key (random-uuid)]
+    (try
+      (run/watch-runs! watch-key #(swap! events conj %))
+      (let [started (run/start! room :researcher trigger cctx
+                                {:id (random-uuid)
+                                 :now (java.util.Date. 1000)})
+            run-id (:run/id started)]
+        (is (= :runs/snapshot (:type (first @events))))
+        (is (= :run/started (:type (second @events))))
+        (is (= [started] (run/active-runs :run-lifecycle)))
+        (is (not-any? #(contains? started %)
+                      [:chat-ctx :sci-ctx :spindel-ctx :cancel!]))
+        (is (= started (store/-load-run st :run-lifecycle run-id)))
+        (let [finished (run/finish! run-id :completed
+                                    {:now (java.util.Date. 2000)})]
+          (is (= :completed (:run/status finished)))
+          (is (= (java.util.Date. 2000) (:run/ended-at finished)))
+          (is (empty? (run/active-runs :run-lifecycle)))
+          (is (= finished (store/-load-run st :run-lifecycle run-id)))
+          (is (= :run/finished (:type (last @events))))))
+      (finally
+        (run/unwatch-runs! watch-key)
+        (d/close-room! room)))))
+
+(deftest targeted-cancel-does-not-touch-a-peer-run
+  (let [[room _st] (run-room :targeted-cancel)
+        a-ctx (live-ctx)
+        b-ctx (live-ctx)
+        a (run/start! room :a (d/message :alice :a "a") a-ctx)
+        b (run/start! room :b (d/message :alice :b "b") b-ctx)]
+    (try
+      (is (true? (run/cancel-run! (:run/id a))))
+      (is (= :active (chat-ctx/get-status a-ctx))
+          "targeted cancellation does not poison the reusable ChatContext")
+      (is (= :active (chat-ctx/get-status b-ctx)))
+      (is (= :cancelling (:run/status
+                          (first (filter #(= (:run/id a) (:run/id %))
+                                         (run/active-runs :targeted-cancel))))))
+      (is (false? (run/cancel-run! (random-uuid))))
+      (finally
+        (run/finish! (:run/id a) :cancelled)
+        (run/finish! (:run/id b) :completed)
+        (d/close-room! room)))))
+
+(deftest room-wide-cancel-and-old-turn-api-remain-compatible
+  (testing "room cancellation signals every run but no other room"
+    (let [a (live-ctx)
+          b (live-ctx)
+          other (live-ctx)
+          a-id (run/register-live! :same-room :a a)
+          b-id (run/register-live! :same-room :b b)
+          other-id (run/register-live! :other-room :c other)]
+      (try
+        (is (= 2 (run/cancel-room-runs! :same-room)))
+        (is (run/cancel-requested? a-id))
+        (is (run/cancel-requested? b-id))
+        (is (= :active (chat-ctx/get-status a)))
+        (is (= :active (chat-ctx/get-status b)))
+        (is (= :active (chat-ctx/get-status other)))
+        (finally
+          (run/unregister-live! a-id)
+          (run/unregister-live! b-id)
+          (run/unregister-live! other-id))))))
+
+(deftest precise-unregister-does-not-remove-a-newer-run
+  (let [old-id (run/register-live! :aba :agent (live-ctx))
+        new-id (run/register-live! :aba :agent (live-ctx))]
+    (try
+      (run/unregister-live! old-id)
+      (is (= [new-id] (mapv :run/id (run/active-runs :aba))))
+      (finally
+        (run/unregister-live! new-id)))))
+
+(deftest parent-is-explicit-structure-not-message-causality
+  (let [[room _st] (run-room :explicit-parent)
+        causal-run-id (random-uuid)
+        structural-parent-id (random-uuid)
+        trigger (assoc (d/message :upstream :agent "handoff")
+                       :metadata {:run-id causal-run-id})
+        causal-only (run/start! room :agent trigger (live-ctx))
+        explicit (run/start! room :agent trigger (live-ctx)
+                             {:parent structural-parent-id})]
+    (try
+      (is (nil? (:run/parent causal-only))
+          "the triggering message carries causality without becoming containment")
+      (is (= structural-parent-id (:run/parent explicit)))
+      (finally
+        (run/finish! (:run/id causal-only) :completed)
+        (run/finish! (:run/id explicit) :completed)
+        (d/close-room! room)))))
+
+(deftest lifecycle-publication-requires-durable-receipts
+  (let [base (memory/make)
+        receipts? (atom false)
+        st (controlled-run-store base receipts?)
+        room (d/make-room {:id :durable-admission :store st})
+        ctx (live-ctx)
+        trigger (d/message :alice :agent "work")
+        events (atom [])
+        watch-key (random-uuid)]
+    (try
+      (run/watch-runs! watch-key #(swap! events conj %))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (run/start! room :agent trigger ctx)))
+      (is (empty? (run/active-runs :durable-admission)))
+      (is (= [:runs/snapshot] (mapv :type @events))
+          "a non-durable start is never published")
+      (reset! receipts? true)
+      (let [started (run/start! room :agent trigger ctx)
+            run-id (:run/id started)]
+        (reset! receipts? false)
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (run/finish! run-id :completed)))
+        (is (= :running (:run/status (store/-load-run st :durable-admission run-id))))
+        (is (= [run-id] (mapv :run/id (run/active-runs :durable-admission)))
+            "a failed terminal write retains a retryable live projection")
+        (is (not-any? #(= :run/finished (:type %)) @events))
+        (reset! receipts? true)
+        (run/finish! run-id :completed)
+        (is (= :run/finished (:type (last @events)))))
+      (finally
+        (run/unwatch-runs! watch-key)
+        (d/close-room! room)))))

--- a/test/dvergr/discourse/llm_test.clj
+++ b/test/dvergr/discourse/llm_test.clj
@@ -6,7 +6,10 @@
             [org.replikativ.spindel.engine.core :as ec]
             [dvergr.discourse :as d]
             [dvergr.discourse.llm :as llm]
-            [dvergr.chat.context :as cc]))
+            [dvergr.chat.context :as cc]
+            [dvergr.agent.run :as run]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]))
 
 ;; ============================================================================
 ;; Mock turn-fn — scripts the LLM responses
@@ -44,6 +47,39 @@
         (sp/spin (deliver p (sp/await (spin-fn room))))))
      (deref p wait-ms ::timeout))))
 
+(defn- await-condition [pred wait-ms]
+  (let [deadline (+ (System/currentTimeMillis) wait-ms)]
+    (loop []
+      (cond
+        (pred) true
+        (>= (System/currentTimeMillis) deadline) false
+        :else (do (Thread/sleep 5) (recur))))))
+
+(defn- fail-output-store [delegate actor]
+  (reify store/PRoomStore
+    (-store-room! [_ room-id metadata]
+      (store/-store-room! delegate room-id metadata))
+    (-load-room [_ id-or-slug]
+      (store/-load-room delegate id-or-slug))
+    (-delete-room! [_ room-id]
+      (store/-delete-room! delegate room-id))
+    (-list-rooms [_]
+      (store/-list-rooms delegate))
+    (-store-message! [_ room-id message]
+      (if (= actor (:from message))
+        (throw (ex-info "scripted output persistence failure" {:message message}))
+        (store/-store-message! delegate room-id message)))
+    (-message-thread-root [_ room-id message-id]
+      (store/-message-thread-root delegate room-id message-id))
+    (-list-messages [_ room-id opts]
+      (store/-list-messages delegate room-id opts))
+    (-store-run! [_ room-id run]
+      (store/-store-run! delegate room-id run))
+    (-load-run [_ room-id run-id]
+      (store/-load-run delegate room-id run-id))
+    (-list-runs [_ room-id opts]
+      (store/-list-runs delegate room-id opts))))
+
 ;; ============================================================================
 ;; Tests
 ;; ============================================================================
@@ -63,6 +99,148 @@
         (is (= "Hello, I'm ready to help." (:content reply)))
         (is (= :researcher (:from reply)))
         (is (empty? @script) "script fully consumed")))))
+
+(deftest agent-turn-persists-and-correlates-one-run
+  (testing "one inbound trigger owns all model rounds, activity, and final output"
+    (let [st (memory/make)
+          r (d/make-room {:id :run-correlated :store st})
+          calls (atom 0)
+          turn-fn (fn [chat-ctx _opts]
+                    (if (= 1 (swap! calls inc))
+                      (do
+                        (cc/add-message! chat-ctx
+                                         {:role :assistant
+                                          :content "checking"
+                                          :tool-uses [{:tool-use/id "t1"
+                                                       :tool-use/name "search"
+                                                       :tool-use/input {:q "x"}}]})
+                        :continue)
+                      (do
+                        (cc/add-message! chat-ctx {:role :assistant :content "done"})
+                        :complete)))]
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :researcher
+                                  :spec {:provider :mock :model "mock"}
+                                  :run-turn-fn turn-fn})))
+      (try
+        (let [reply (await-spin r #(d/ask % :researcher {:content "go"}))
+              second-reply (await-spin r #(d/ask % :researcher {:content "again"}))
+              runs (run/runs r)
+              stored (d/messages r {:limit 20})
+              activities (filterv #(= :_activity (:to %)) stored)
+              activity (first activities)
+              run-row (first (filter #(= (:in-reply-to reply) (:run/trigger %)) runs))
+              run-id (:run/id run-row)]
+          (is (= 3 @calls))
+          (is (= 2 (count runs)))
+          (is (= :completed (:run/status run-row)))
+          (is (= (:in-reply-to reply) (:run/trigger run-row)))
+          (is (= run-id (get-in reply [:metadata :run-id])))
+          (is (not= run-id (get-in second-reply [:metadata :run-id])))
+          (is (= run-id (get-in activity [:metadata :run-id])))
+          (is (= 1 (count activities))
+              "a new run does not replay historical tool activity")
+          (is (= (:thread-root-id reply) (:thread-root-id activity))
+              "tool activity projects into the trigger's dedicated thread")
+          (is (empty? (run/active-runs :run-correlated))))
+        (finally
+          (d/close-room! r))))))
+
+(deftest targeted-cancel-does-not-cancel-the-next-run
+  (testing "a Run-local cancellation token expires with that Run"
+    (let [st (memory/make)
+          r (d/make-room {:id :run-cancel-reuse :store st})
+          first-started (promise)
+          calls (atom 0)
+          turn-fn
+          (fn [chat-ctx {:keys [cancel?]}]
+            (if (= 1 (swap! calls inc))
+              (do
+                (deliver first-started true)
+                (loop []
+                  (when-not (cancel?)
+                    (Thread/sleep 5)
+                    (recur)))
+                :complete)
+              (do
+                (cc/add-message! chat-ctx {:role :assistant :content "second completed"})
+                :complete)))]
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :run-turn-fn turn-fn})))
+      (try
+        (d/post! r (d/message :alice :worker "cancel this run"))
+        (is (= true (deref first-started 2000 ::timeout)))
+        (let [run-id (:run/id (first (run/active-runs :run-cancel-reuse)))]
+          (is (uuid? run-id))
+          (is (run/cancel-run! run-id))
+          (is (await-condition
+               #(= :cancelled (:run/status (run/run r run-id)))
+               3000)))
+        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 3000)]
+          (is (= "second completed" (:content reply)))
+          (is (= :completed
+                 (:run/status (run/run r (get-in reply [:metadata :run-id])))))
+          (is (= #{:cancelled :completed}
+                 (set (map :run/status (run/runs r)))))
+          (is (empty? (run/active-runs :run-cancel-reuse))))
+        (finally
+          (d/close-room! r))))))
+
+(deftest run-finish-is-observed-after-durable-output
+  (testing "a finished event is a safe frontier for querying correlated output"
+    (let [st (memory/make)
+          r (d/make-room {:id :run-output-frontier :store st})
+          observed (promise)
+          watch-key (random-uuid)
+          turn-fn (fn [chat-ctx _opts]
+                    (cc/add-message! chat-ctx {:role :assistant :content "durable output"})
+                    :complete)]
+      (try
+        (run/watch-runs!
+         watch-key
+         (fn [{:keys [type run]}]
+           (when (and (= :run/finished type)
+                      (= :run-output-frontier (:run/room run)))
+             (deliver observed
+                      (boolean
+                       (some #(and (= (:run/id run) (get-in % [:metadata :run-id]))
+                                   (= :worker (:from %)))
+                             (d/messages r {:limit 20})))))))
+        (binding [ec/*execution-context* (:ctx r)]
+          (d/join r (llm/llm-agent {:id :worker
+                                    :spec {:provider :mock :model "mock"}
+                                    :run-turn-fn turn-fn})))
+        (let [reply (await-spin r #(d/ask % :worker {:content "go"}) 3000)]
+          (is (= "durable output" (:content reply)))
+          (is (= true (deref observed 2000 ::timeout))))
+        (finally
+          (run/unwatch-runs! watch-key)
+          (d/close-room! r))))))
+
+(deftest reply-emission-failure-fails-the-run
+  (testing "completion is not recorded when the correlated output cannot persist"
+    (let [base (memory/make)
+          st (fail-output-store base :worker)
+          r (d/make-room {:id :run-output-failure :store st})
+          turn-fn (fn [chat-ctx _opts]
+                    (cc/add-message! chat-ctx {:role :assistant :content "lost output"})
+                    :complete)]
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :run-turn-fn turn-fn})))
+      (try
+        (d/post! r (d/message :alice :worker "go"))
+        (is (await-condition #(= :failed (:run/status (first (run/runs r)))) 3000))
+        (let [failed (first (run/runs r))]
+          (is (= :reply-emission-failed (:run/reason failed)))
+          (is (empty? (filter #(= (:run/id failed) (get-in % [:metadata :run-id]))
+                              (d/messages r {:limit 20}))))
+          (is (empty? (run/active-runs :run-output-failure))))
+        (finally
+          (d/close-room! r))))))
 
 (deftest multi-turn-loop-continues-until-complete
   (testing "Agent loops :continue → :continue → :complete; reply is the last"

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -57,3 +57,37 @@
                (set (map :id (store/-list-messages
                               st room-id {:thread-root-id parent-id}))))
             "thread query excludes another top-level topic before limiting")))))
+
+(defn assert-run-lifecycle!
+  "Exercise durable Run creation, update, lookup, filtering, and identity safety."
+  [st room-id]
+  (testing "run lifecycle round-trips"
+    (store/-store-room! st room-id {:slug (name room-id) :title "Runs"})
+    (let [run-id (random-uuid)
+          trigger-id (random-uuid)
+          parent-id (random-uuid)
+          started (java.util.Date. 1787860800000)
+          ended (java.util.Date. 1787860801000)
+          running {:run/id run-id
+                   :run/kind :agent-turn
+                   :run/room room-id
+                   :run/actor :agent/researcher
+                   :run/trigger trigger-id
+                   :run/parent parent-id
+                   :run/status :running
+                   :run/created-at started
+                   :run/started-at started
+                   :run/updated-at started}
+          completed (assoc running
+                           :run/status :completed
+                           :run/updated-at ended
+                           :run/ended-at ended)]
+      (is (= running (store/-store-run! st room-id running)))
+      (is (= running (store/-load-run st room-id run-id)))
+      (is (= completed (store/-store-run! st room-id completed)))
+      (is (= [completed] (store/-list-runs st room-id {:actor :agent/researcher})))
+      (is (empty? (store/-list-runs st room-id {:status :failed})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"immutable"
+           (store/-store-run! st room-id (assoc completed :run/trigger (random-uuid))))))))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -23,6 +23,10 @@
   (let [[_conn st] (mem-store)]
     (contract/assert-message-envelope! st :envelope-datahike)))
 
+(deftest run-lifecycle-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-run-lifecycle! st :runs-datahike)))
+
 (deftest thread-filter-bounds-the-datahike-pull
   (testing "the indexed root predicate runs before message bodies are pulled"
     (let [[_conn st] (mem-store)

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -7,6 +7,9 @@
 (deftest message-envelope-contract
   (contract/assert-message-envelope! (memory/make) :envelope-memory))
 
+(deftest run-lifecycle-contract
+  (contract/assert-run-lifecycle! (memory/make) :runs-memory))
+
 (deftest rejects-unmodelled-durable-metadata
   (let [st (memory/make)]
     (store/-store-room! st :strict-memory {:slug "strict-memory"})

--- a/test/dvergr/tui/app_test.clj
+++ b/test/dvergr/tui/app_test.clj
@@ -176,15 +176,16 @@
 (def ^:private unregister-room-turn! turn/unregister-room-turn!)
 
 (deftest daemon-room-turn-registry-cancels
-  (testing "the room-turn registry exposes a live chat-ctx that cancel flips
-            to :cancelled (the handle the TUI Esc uses)"
+  (testing "the room-turn registry targets the live Run without poisoning the
+            reusable chat context"
     (let [c (cctx/create-chat-context {:budget-dollars 0.01 :with-sci? false})]
       (try
         (is (not (daemon/room-turn-running? :r1)))
-        (register-room-turn! :r1 :bot c)
-        (is (daemon/room-turn-running? :r1))
-        (is (= 1 (daemon/cancel-room-turn! nil :r1)) "one turn signalled")
-        (is (= :cancelled (cctx/get-status c)) "chat-ctx status flipped")
+        (let [run-id (register-room-turn! :r1 :bot c)]
+          (is (daemon/room-turn-running? :r1))
+          (is (= 1 (daemon/cancel-room-turn! nil :r1)) "one turn signalled")
+          (is (turn/cancel-requested? run-id))
+          (is (= :active (cctx/get-status c)) "chat context remains reusable"))
         (finally
           (unregister-room-turn! :r1 :bot)
           (is (not (daemon/room-turn-running? :r1)) "unregister clears it")
@@ -204,9 +205,9 @@
                  :on-key (fn [sm ev] (dashboard-on-key {:execution-ctx c} sm ev (atom nil)))
                  :size   {:width 80 :height 30}})]
       (try
-        (register-room-turn! :dm-esc :bot turn)
-        ((:send-key hh) {:key "escape"})
-        (is (= :cancelled (cctx/get-status turn)) "Esc cancelled the turn")
+        (let [run-id (register-room-turn! :dm-esc :bot turn)]
+          ((:send-key hh) {:key "escape"})
+          (is (turn/cancel-requested? run-id) "Esc cancelled the Run"))
         (is (= :room ((:get hh) :view-mode)) "stayed in the room while cancelling")
         (unregister-room-turn! :dm-esc :bot)
         ((:send-key hh) {:key "escape"})


### PR DESCRIPTION
## Summary

- persist a stable Run before each agent turn with kind, room, actor, exact trigger, parent, lifecycle status, and timestamps
- expose active snapshots and lifecycle events, targeted run cancellation, and compatible room-wide cancellation
- correlate model/tool activity and output messages with the Run while keeping live ChatContext handles process-local
- derive Thread membership from the canonical trigger message and document the public REPL/client contract

This is the minimal lifecycle slice required by the Simmis run UI. Generic effects, approvals, retries, resource scopes, and arbitrary SCI programs remain follow-ups built on the same Run identity.

## Verification

- `clojure -J-Xmx512m -M:format`
- `clojure -J-Xmx1g -M:test` — 457 tests, 1850 assertions, 0 failures
- `clojure -J-Xmx1g -T:build harness`
- persistent local nREPL exercise with a scripted provider-free agent turn, durable query, lifecycle watcher, and output correlation