### PR TITLE
feat(agent): add functional roster programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ fork-and-merge proposal pattern, see
   routing, GenerationHandle, the distributive law λ
 - **[Runs](doc/runs.md)** — durable agent-turn identity, activity/output
   correlation, lifecycle observation, and targeted cancellation
+- **[Agent programs](doc/agent-programs.md)** — immutable specialized-agent
+  rosters, Run-backed hiring, Spindel composition, and fork-safe state placement
 - **[CLI Reference](doc/cli.md)** — `dvergr-cli` keys, persistence,
   provider config
 - **[Architecture](doc/architecture.md)** — the formal model: rooms,

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,6 +17,7 @@ New to dvergr? Start with **[Getting Started](getting-started.md)**.
 - **[Programming Model](programming-model.md)** — the compositional kernel: tagged messages, capability routing, dynamic subscriptions, escalation
 - **[Recursive work orchestration](orchestration.md)** — Rooms, threads, tasks, executions, recursive Workrooms, and provider-neutral collaboration
 - **[Runs](runs.md)** — durable execution identity, lifecycle subscription, correlation, and targeted cancellation
+- **[Agent programs](agent-programs.md)** — immutable specialized-agent rosters, Run-backed hiring, Spindel composition, and fork-safe state placement
 - **[Discourse Theory](discourse-theory.md)** — why "discourse": speech acts, theory of mind, and the Rational-Speech-Acts/FRP lineage (short, optional)
 - **[Architecture](architecture.md)** — the L0–L7 layer map, subsystem graph, inbound message flow, per-file table
 - **[State Model](state-model.md)** — the three-tier copy-on-write state + workspace model

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -1,0 +1,145 @@
+# Agent programs in the room REPL
+
+Status: first provider-free slice implemented. The data model and Run boundary
+are intentional; the built-in interpreter currently supports only deterministic
+`:echo` and `:scripted` programs while the native LLM/tool interpreter is being
+lifted onto the same contract.
+
+Dvergr agents can construct specialized workers and compose their executions
+from the SCI REPL. The initial surface separates four concepts:
+
+| Concept | Meaning |
+|---|---|
+| `AgentDef` | Immutable, versioned executable data: role, prompt, skills, tools, model policy, and program reference. |
+| `Roster` | Immutable collection of AgentDefs plus portable defaults and scope data. |
+| `Run` | Durable identity and lifecycle of one bounded execution in a Room. |
+| `RunHandle` | Opaque process-local identity/control capability for a live Run; it exposes a native result Spin explicitly. |
+
+An actor is durable identity; an AgentDef describes behavior; a Run is one
+performance. They must not collapse into one mutable "agent object."
+
+## Construct and compose
+
+Inside a room-bound agent sandbox:
+
+```clojure
+(require '[dvergr.agent :as agent]
+         '[org.replikativ.spindel.spin.cps :refer [spin]]
+         '[org.replikativ.spindel.effects.await :refer [await]])
+
+(let [team (-> (agent/roster {:id :investigation})
+               (agent/make-agent
+                {:id :analyst
+                 :skills #{:research}
+                 :program {:kind :scripted :reply "evidence"}})
+               (agent/make-agent
+                {:id :reviewer
+                 :skills #{:review}
+                 :program {:kind :echo}}))
+      analyst (agent/hire! team :analyst {:task "inspect the claim"})
+      reviewer (agent/hire! team :reviewer {:task {:claim 42}})]
+  @(spin
+     {:evidence (-> (await (agent/result-spin analyst)) :run/value)
+      :review   (-> (await (agent/result-spin reviewer)) :run/value)}))
+```
+
+`roster`, `make-agent`, and `revise-agent` have no bang because they are pure:
+each returns a new value and leaves its input unchanged. `hire!` has a bang
+because it immediately posts the precise trigger, admits a durable
+`:agent-task` Run, and starts its Spin in the current Room. Admission is
+synchronous and durability-first: once `hire!` returns, `observe` and `cancel!`
+can address the Run without a startup race.
+
+Use `await` on `(agent/result-spin handle)` inside `spin`. The opaque handle does
+not pretend to implement Spindel's graph protocol; exposing the native Spin
+preserves structured cancellation and dependency tracking in the owning fork.
+Dereference is available at a REPL or test boundary, but workflow
+code should stay compositional. A top-level blocking `await` shim is not
+required.
+
+The handle supports:
+
+```clojure
+(agent/run-id handle)        ; durable UUID
+(agent/result-spin handle)   ; fresh native observer Spin for await/race/parallel
+(agent/observe handle)       ; durable Run projection
+(agent/cancel! handle)       ; targeted cooperative cancellation
+```
+
+An explicit `:parent-run` on `hire!` records structural spawning. Causal
+succession remains derivable through the new Run's trigger message and that
+message's `:run-id`; it is not mislabelled as parenthood.
+
+## Selection and specialization
+
+AgentDefs are ordinary data, so roles and policies can be generated, selected,
+revised, stored, reviewed, and passed into reusable workflow functions:
+
+```clojure
+(agent/select team {:skill :research})
+(agent/select team {:skills #{:legal :research}})
+
+(let [v1  (agent/lookup team :analyst)
+      ref (agent/ref v1)
+      v2  (agent/revise-agent team :analyst
+                              {:prompt "Challenge the strongest contrary case"})]
+  ;; A stale reference fails instead of silently running revised behavior.
+  (agent/lookup v2 ref))
+```
+
+Portable data is enforced at construction. Functions, JVM atoms, provider
+clients, connections, streams, and other live handles cannot be embedded in an
+AgentDef or Roster.
+
+## State and fork semantics
+
+A Roster is a value, not a hidden registry. Thread it through functions or carry
+it as a Spin result. Forked computations can therefore use different derived
+rosters without synchronization or leakage.
+
+If a workflow needs changing state, allocate it through Spindel's fork-aware
+state vocabulary (signals or reactive atoms) in the relevant execution context.
+Do not place semantic workflow state in a JVM atom, dynamic singleton, or
+process-global registry. SCI Var forkability is a separate runtime project; do
+not rely on a top-level `def` as the portable state boundary until that work is
+complete.
+
+A RunHandle is intentionally not durable state and should not be stored inside
+an AgentDef. Its awaitable result/cache belongs to the Spindel execution graph;
+provider streams and cancellation capabilities remain process-local. The
+completion value and admission fence are allocated in the Room's Spindel
+context, so those runtime values follow copy-on-write fork semantics. The live
+Run registry is likewise an explicitly process-local control plane, not
+workflow state: moving only one token into a forkable cell would not make native
+handles serializable or restorable. Durable meaning belongs to the Room's
+messages, Run projection, artifacts, and later
+effect receipts. Rehydrate those facts and construct fresh live handles rather
+than serializing a native handle.
+
+A live handle is confined to the Spindel execution-context fork that created it.
+Using it from a child or sibling fork fails explicitly: observe the durable Run
+facts there, or start a branch-local Run. A future cross-context result bridge
+must copy values deliberately rather than sharing continuations across forks.
+
+## Current boundary and next interpreter
+
+The deterministic interpreter proves the bounded programming contract without an LLM:
+parallel composition, targeted cancellation, exact trigger/output correlation,
+and room-scoped execution all run through the same SCI surface an agent uses.
+
+The next interpreter should lift Dvergr's existing agent-turn core rather than
+wrap another harness. It must preserve:
+
+- Dvergr-owned ChatContext assembly and compaction;
+- the room-bound SCI sandbox and forked Geschichte/Datahike workspace;
+- authoritative tool allowlists and approval boundaries;
+- native API, Codex subscription, Claude Code subscription, and local providers;
+- Run-correlated activity/output and resource accounting;
+- blocking provider I/O off the Spindel drain thread;
+- pure scope attenuation before execution.
+
+`:roster/scope` is currently portable policy data, not an enforced resource
+grant. Until a Kontor-backed split/settlement interpreter lands, the
+provider-free program kinds are deliberately the only accepted kinds. This keeps
+the public boundary honest: declaring a budget or authority in data must not
+pretend to enforce it.

--- a/doc/orchestration.md
+++ b/doc/orchestration.md
@@ -47,15 +47,17 @@ Use the following concepts distinctly:
 | **Thread** | Lightweight topical conversation rooted at a message. It shares the room substrate. |
 | **Task** | Durable intention or delegated responsibility to produce an outcome. |
 | **Workroom** | Scoped child room for complex collaborative work, optionally with a forked substrate. |
-| **Agent execution** | One bounded invocation/attempt by one agent in response to a trigger. |
-| **Workflow run** | One invocation of an explicit reusable workflow. |
-| **Simulation run** | One bounded inference or what-if experiment. |
+| **Run** | Durable identity and shared lifecycle for one causally bounded execution in a Room. |
+| **Agent execution** | A Run performed by one agent in response to a trigger (`:agent-turn` or task-scoped `:agent-task`). |
+| **Workflow run** | A `:workflow` Run: one invocation of an explicit reusable workflow. |
+| **Simulation run** | A `:simulation` Run: one bounded inference or what-if experiment. |
 | **Activity** | An observation about execution: tool action, edit, test, approval, error, or progress. |
 | **Process** | A live execution mechanism and control handle. It is transient unless separately persisted. |
 
 A thread answers “what are we discussing?” A task answers “what outcome is owed?”
-An execution answers “what did this agent do this time?” A run is reserved for an
-explicit program or simulation whose invocation has its own lifecycle.
+An execution answers “what computation happened this time?” Run kinds preserve
+the distinction between agent turns, reusable workflows, and simulations while
+sharing identity, lifecycle, correlation, and control machinery.
 
 ## The semantic graph
 
@@ -478,6 +480,11 @@ Implemented for `:agent-turn` Runs; see [runs.md](runs.md):
 3. Implement provider-neutral `delegate!`, `message!`, `follow-up!`, `interrupt!`,
    `await!`, and `snapshot` behavior using Spindel coordination primitives.
 4. Add permission narrowing and concurrency limits.
+
+The provider-free functional-programming precursor is implemented now: immutable
+AgentDefs/Rosters compose in room SCI, and `hire!` starts a Run-backed Spindel
+computation. See [agent-programs.md](agent-programs.md). Its `:roster/scope` is
+data only until this stage supplies enforceable attenuation/accounting.
 
 ### Stage 4: recursive workrooms
 

--- a/doc/programming-model.md
+++ b/doc/programming-model.md
@@ -39,6 +39,19 @@ policy) without touching the agent loop.
 Nothing in the model is special-cased to LLMs; humans, scripts, monitors, and
 future agent types all live as participants.
 
+## Agent programs in the REPL
+
+The room SCI surface also exposes `dvergr.agent`: immutable, versioned
+AgentDefs and Rosters are ordinary workflow data, while `hire!` is the explicit
+effect that starts a durable Run and returns an opaque handle whose result is an
+explicit native Spindel Spin. This is the first executable layer for agents
+constructing specialized teams and parallel workflows for themselves without a
+hidden mutable roster.
+
+See [Agent programs in the room REPL](agent-programs.md) for the API, a
+provider-free runnable example, and the state/fork contract. The native LLM/tool
+interpreter is deliberately a follow-up on the same boundary.
+
 ## The Room + Bus
 
 A `Room` is a substrate where participants exchange messages. Under the

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -1,0 +1,322 @@
+(ns dvergr.agent.program
+  "Run-backed execution of portable AgentDefs.
+
+   This is deliberately a thin first interpreter. Roster construction is pure;
+   `hire!` is the effect boundary that posts the precise task trigger, admits a
+   durable Run, and starts a Spindel Spin. Live results are cached by Spindel,
+   while Room messages and Run lifecycle remain the durable source of truth."
+  (:require [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [hasch.core :as hasch]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.sync :as sync]))
+
+(def run-sink
+  "Reserved non-subscribed Room address for private Run inputs and outputs.
+   Internal coordination is returned through the Run's result Spin; publishing
+   to a Participant is a separate, explicit speech act."
+  :_runs)
+
+(def interpreter-version 1)
+
+(deftype RunHandle [id room-id owner-fork-id execution completion]
+  clojure.lang.ILookup
+  (valAt [_ k]
+    (case k
+      :run/id id
+      :run/room room-id
+      nil))
+  (valAt [_ k not-found]
+    (case k
+      :run/id id
+      :run/room room-id
+      not-found))
+
+  ;; Blocking is intentionally available only at a REPL/test boundary.
+  clojure.lang.IDeref
+  (deref [_]
+    (let [current-fork-id (:fork-id (ec/current-execution-context))]
+      (when-not (= owner-fork-id current-fork-id)
+        (throw (ex-info "RunHandle belongs to another Spindel context"
+                        {:type ::foreign-execution-context
+                         :run/id id
+                         :owner-fork-id owner-fork-id
+                         :current-fork-id current-fork-id})))
+      @execution))
+  clojure.lang.IBlockingDeref
+  (deref [_ timeout-ms timeout-value]
+    (let [current-fork-id (:fork-id (ec/current-execution-context))]
+      (when-not (= owner-fork-id current-fork-id)
+        (throw (ex-info "RunHandle belongs to another Spindel context"
+                        {:type ::foreign-execution-context
+                         :run/id id
+                         :owner-fork-id owner-fork-id
+                         :current-fork-id current-fork-id})))
+      (deref execution timeout-ms timeout-value)))
+
+  Object
+  (toString [_]
+    (str "#<RunHandle " id " room=" room-id ">")))
+
+(defmethod print-method RunHandle [^RunHandle handle ^java.io.Writer writer]
+  (.write writer (.toString handle)))
+
+(defn- ensure-owner-context! [^RunHandle handle]
+  (let [owner-fork-id (.-owner-fork-id handle)
+        current-fork-id (:fork-id (ec/current-execution-context))]
+    (when-not (= owner-fork-id current-fork-id)
+      (throw (ex-info "RunHandle belongs to another Spindel context"
+                      {:type ::foreign-execution-context
+                       :run/id (:run/id handle)
+                       :owner-fork-id owner-fork-id
+                       :current-fork-id current-fork-id})))
+    handle))
+
+(defn run-id "The durable Run UUID represented by `handle`." [handle]
+  (:run/id handle))
+
+(defn result-spin
+  "A native Spindel observer Spin for `handle`'s completion. Await this inside
+   workflow Spins. Each call returns a fresh graph node over a fork-aware
+   Deferred, so combinators never invoke the already-running execution again.
+  The observer owns that execution during its initial pre-await window."
+  [^RunHandle handle]
+  (ensure-owner-context! handle)
+  (let [execution (.-execution handle)
+        completion (.-completion handle)
+        id (:run/id handle)
+        room-id (:run/room handle)
+        observer (sp/spin
+                  (try
+                    (sp/await completion)
+                    (catch Throwable t
+                      (when (= spin-core/spin-cancelled (:type (ex-data t)))
+                        (run/cancel-room-run! room-id id))
+                      (throw t))))]
+    ;; A race can choose another arm before its executor has started this
+    ;; observer, so no await-cont exists yet. Record the same fork-local
+    ;; ownership edge Spindel's fan-out combinators use for that initial window.
+    (spin-core/set-owned-spins! (spin-core/spin-id observer) [execution])
+    observer))
+
+(defn- cancelled! [run-id]
+  (throw (ex-info "Run cancelled" {:type ::cancelled :run/id run-id})))
+
+(defn- cooperative-delay
+  "Delay inside Spindel while polling the Run-local cancellation token."
+  [run-id delay-ms]
+  (sp/spin
+   (loop [remaining (long (or delay-ms 0))]
+     (when (run/cancel-requested? run-id)
+       (cancelled! run-id))
+     (when (pos? remaining)
+       (let [slice (min remaining 25)]
+         (sp/await (comb/sleep slice))
+         (recur (- remaining slice)))))))
+
+(defn- execute-program
+  "Interpret the provider-free program vocabulary. Returns Spin[value]."
+  [run-id agent task]
+  (let [{:keys [kind delay-ms reply result] :as program} (:agent/program agent)]
+    (sp/spin
+     (sp/await (cooperative-delay run-id delay-ms))
+     (when (run/cancel-requested? run-id)
+       (cancelled! run-id))
+     (case kind
+       :scripted (cond
+                   (contains? program :result) result
+                   (contains? program :reply) reply
+                   :else nil)
+       :echo task
+       (throw (ex-info "No interpreter for AgentDef program kind"
+                       {:type ::unknown-program-kind
+                        :kind kind
+                        :agent/id (:agent/id agent)}))))))
+
+(defn- result-content [value]
+  (if (string? value) value (pr-str value)))
+
+(def ^:private hire-option-keys #{:task :from :parent-run})
+
+(defn- validate-program!
+  [{:keys [kind delay-ms] :as program} agent-ref]
+  (let [allowed (case kind
+                  :scripted #{:kind :delay-ms :reply :result}
+                  :echo #{:kind :delay-ms}
+                  nil)]
+    (when-not allowed
+      (throw (ex-info "hire! currently requires a provider-free program"
+                      {:type ::unsupported-program
+                       :agent-ref agent-ref
+                       :kind kind})))
+    (when-let [unknown (seq (remove allowed (keys program)))]
+      (throw (ex-info "Unknown keys for AgentDef program kind"
+                      {:type ::unknown-program-options
+                       :agent-ref agent-ref
+                       :kind kind
+                       :unknown (set unknown)
+                       :allowed allowed})))
+    (when (and delay-ms
+               (not (and (integer? delay-ms) (<= 0 delay-ms 600000))))
+      (throw (ex-info "Program :delay-ms must be an integer from 0 to 600000"
+                      {:type ::invalid-delay :delay-ms delay-ms})))
+    program))
+
+(defn- validate-hire!
+  [roster agent-ref {:keys [task from parent-run] :as opts}]
+  (when-let [unknown (seq (remove hire-option-keys (keys opts)))]
+    (throw (ex-info "Unknown hire! options"
+                    {:type ::unknown-hire-options
+                     :unknown (set unknown)
+                     :allowed hire-option-keys})))
+  (when-not (contains? opts :task)
+    (throw (ex-info "hire! requires :task"
+                    {:type ::missing-task :agent-ref agent-ref})))
+  (when-not (keyword? from)
+    (throw (ex-info "hire! :from must be a keyword"
+                    {:type ::invalid-hirer :from from})))
+  (when (and parent-run (not (uuid? parent-run)))
+    (throw (ex-info "hire! :parent-run must be a UUID"
+                    {:type ::invalid-parent-run :parent-run parent-run})))
+  (when-not (roster/data-value? task)
+    (throw (ex-info "Task must be portable data"
+                    {:type ::non-portable-task :task task})))
+  (let [agent (or (roster/agent roster agent-ref)
+                  (throw (ex-info "Unknown AgentRef"
+                                  {:type ::unknown-agent :agent-ref agent-ref})))]
+    (validate-program! (:agent/program agent) agent-ref)
+    agent))
+
+(defn- cancelled-error? [t run-id]
+  (or (= ::cancelled (:type (ex-data t)))
+      (= spin-core/spin-cancelled (:type (ex-data t)))
+      (run/cancel-requested? run-id)))
+
+(defn- execution-spin
+  [room agent task trigger id completion]
+  (sp/spin
+   (let [result
+         (try
+           (let [value (sp/await (execute-program id agent task))]
+             (when (run/cancel-requested? id)
+               (cancelled! id))
+             (let [output (d/reply (:agent/id agent) run-sink
+                                   (result-content value) trigger
+                                   {:role :assistant :run-id id})]
+               ;; Room posting is durability-first. Completion is acknowledged
+               ;; only after the correlated private output exists.
+               (d/post! room output)
+               (run/finish! id :completed)
+               {:run/id id
+                :run/status :completed
+                :run/value value
+                :run/output output}))
+           (catch Throwable t
+             (if (cancelled-error? t id)
+               (do
+                 (run/finish! id :cancelled {:reason :cancel-requested})
+                 {:run/id id :run/status :cancelled})
+               (do
+                 (run/finish! id :failed {:reason :program-error :error t})
+                 {:run/id id
+                  :run/status :failed
+                  :run/error (ex-message t)}))))]
+     ;; Completion is a Spindel Deferred allocated in this Room's execution
+     ;; context, not a JVM promise or host atom. Its value therefore follows
+     ;; Spindel's copy-on-write state semantics.
+     (completion result)
+     result)))
+
+(defn hire!
+  "Start one provider-free AgentDef execution and return an opaque RunHandle.
+
+   `agent-ref` is a keyword id or versioned ref resolved against immutable
+   `roster`. Options:
+
+   - `:task`       portable task value (required)
+   - `:from`       triggering actor, default `:repl`
+   - `:parent-run` explicit structural parent Run UUID
+   The built-in first-pass program kinds are `:scripted` and `:echo`. Real LLM,
+   tool, simulation, and replay interpreters will implement the same boundary."
+  [room roster agent-ref {:keys [task from parent-run]
+                          :or {from :repl}
+                          :as raw-opts}]
+  (let [opts      (assoc raw-opts :from from)
+        agent     (validate-hire! roster agent-ref opts)
+        actor     (:agent/id agent)
+        id        (random-uuid)
+        ;; Private Run facts are still Room messages, but never addressed to an
+        ;; installed Participant: direct interpretation and participant routing
+        ;; must not execute the same task twice.
+        trigger   (d/message from run-sink (result-content task) nil {:role :user})
+        provenance (cond-> {:run/agent-version (:agent/version agent)
+                            :run/program-kind (get-in agent [:agent/program :kind])
+                            :run/interpreter-version interpreter-version
+                            :run/agent-def-hash (hasch/uuid agent)}
+                     (:roster/id roster) (assoc :run/roster (:roster/id roster)))]
+    ;; Reserve durable Run ownership before any trigger effect. Teardown either
+    ;; fences us out here or includes this Run in its fixed drain set; it can
+    ;; never miss an orphan trigger between posting and admission.
+    (run/start! room actor trigger nil
+                (cond-> {:id id :kind :agent-task :provenance provenance}
+                  parent-run (assoc :parent parent-run)))
+    (try
+      ;; The precise trigger must exist before execution begins. A failed post
+      ;; terminalizes the already-admitted Run instead of leaving a :running
+      ;; record or an unowned message behind.
+      (d/post! room trigger)
+      (catch Throwable t
+        (run/finish! id :failed {:reason :trigger-emission-failed :error t})
+        (throw t)))
+    (try
+      (let [completion (sync/deferred)
+            execution (execution-spin room agent task trigger id completion)
+            owner-fork-id (:fork-id (ec/current-execution-context))
+            handle    (RunHandle. id (:id room) owner-fork-id execution completion)]
+        (sp/spawn!
+         execution
+         {:on-error
+          (fn [t]
+            ;; Graph-level cancellation (parent/race) can abort before the Spin
+            ;; body catches. Settle the durable lifecycle from the callback;
+            ;; finish! is idempotent if the body already did so.
+            (let [result (if (cancelled-error? t id)
+                           {:run/id id :run/status :cancelled}
+                           {:run/id id :run/status :failed
+                            :run/error (ex-message t)})]
+              (try
+                (if (= :cancelled (:run/status result))
+                  (run/finish! id :cancelled {:reason :structured-cancellation})
+                  (run/finish! id :failed {:reason :execution-error :error t}))
+                (catch Throwable _ nil))
+              (completion result)))})
+        handle)
+      (catch Throwable t
+        (run/finish! id :failed {:reason :spawn-failed :error t})
+        (throw t)))))
+
+(defn observe
+  "Read the durable Run projection for `handle` or UUID."
+  [room handle-or-id]
+  (run/run room (if (uuid? handle-or-id) handle-or-id (run-id handle-or-id))))
+
+(defn cancel!
+  "Request room-scoped cancellation. A handle carries its Room capability;
+   cancelling an arbitrary UUID requires the explicit Room arity."
+  ([handle]
+   (when (uuid? handle)
+     (throw (ex-info "Cancelling a Run UUID requires an explicit Room"
+                     {:type ::room-required :run/id handle})))
+   (ensure-owner-context! handle)
+   (run/cancel-room-run! (:run/room handle) (run-id handle)))
+  ([room handle-or-id]
+   (when-not (uuid? handle-or-id)
+     (ensure-owner-context! handle-or-id))
+   (run/cancel-room-run! (:id room)
+                         (if (uuid? handle-or-id)
+                           handle-or-id
+                           (run-id handle-or-id)))))

--- a/src/dvergr/agent/roster.clj
+++ b/src/dvergr/agent/roster.clj
@@ -1,0 +1,266 @@
+(ns dvergr.agent.roster
+  "Pure, immutable construction of agent rosters and versioned AgentDefs.
+
+   A Roster is workflow data, not a registry handle. `make-agent` returns a new
+   value and never starts a Participant, opens a provider, or mutates a Room.
+   Effectful installation and execution consume these values at a later boundary."
+  (:refer-clojure :exclude [agent])
+  (:require [clojure.set :as set]))
+
+(defn data-value?
+  "Whether `x` is portable AgentDef data. Runtime handles, functions, atoms,
+   connections, and provider clients deliberately fail this predicate."
+  [x]
+  (cond
+    (or (nil? x)
+        (boolean? x)
+        (string? x)
+        (number? x)
+        (keyword? x)
+        (symbol? x)
+        (uuid? x)) true
+    (map? x) (every? (fn [[k v]] (and (data-value? k) (data-value? v))) x)
+    (vector? x) (every? data-value? x)
+    (set? x) (every? data-value? x)
+    (list? x) (every? data-value? x)
+    :else false))
+
+(defn- portable! [label value]
+  (when-not (data-value? value)
+    (throw (ex-info (str label " must contain only portable data")
+                    {:type ::non-portable-data :label label :value value})))
+  value)
+
+(def ^:private friendly-keys
+  {:id :agent/id
+   :version :agent/version
+   :status :agent/status
+   :skills :agent/skills
+   :name :agent/name
+   :prompt :agent/prompt
+   :program :agent/program
+   :tools :agent/tools
+   :model-policy :agent/model-policy
+   :metadata :agent/metadata})
+
+(def ^:private canonical-keys (set (vals friendly-keys)))
+(def ^:private agent-spec-keys (into (set (keys friendly-keys)) canonical-keys))
+
+(defn- known-agent-keys! [label m]
+  (when-let [unknown (seq (remove agent-spec-keys (keys (or m {}))))]
+    (throw (ex-info (str label " contains unknown AgentDef keys")
+                    {:type ::unknown-agent-keys
+                     :label label
+                     :unknown (set unknown)
+                     :allowed agent-spec-keys}))))
+
+(defn- keyword-set!
+  [label value]
+  (when-not (and (coll? value)
+                 (not (map? value))
+                 (every? keyword? value))
+    (throw (ex-info (str label " must be a collection of keywords")
+                    {:type ::invalid-keyword-set :label label :value value})))
+  (set value))
+
+(defn- canonicalize
+  "Normalize friendly AgentDef keys before merging. Canonical keys win within
+   one map; the caller's map then wins over defaults regardless of which key
+   spelling either side used."
+  [m]
+  (let [friendly (reduce-kv (fn [out k v]
+                              (if-let [canonical (get friendly-keys k)]
+                                (assoc out canonical v)
+                                out))
+                            {} (or m {}))
+        canonical (reduce-kv (fn [out k v]
+                               (if (contains? friendly-keys k)
+                                 out
+                                 (assoc out k v)))
+                             {} (or m {}))]
+    (merge friendly canonical)))
+
+(defn- normalize-agent
+  [defaults spec]
+  (known-agent-keys! "Roster defaults" defaults)
+  (known-agent-keys! "AgentDef" spec)
+  (let [spec    (merge (canonicalize defaults) (canonicalize spec))
+        id      (:agent/id spec)
+        version (or (:agent/version spec) 1)
+        program (:agent/program spec)
+        agent   (cond-> {:agent/id id
+                         :agent/version version
+                         :agent/status (or (:agent/status spec) :available)
+                         :agent/skills (keyword-set! "AgentDef :skills"
+                                                     (or (:agent/skills spec) #{}))}
+                  (:agent/name spec)
+                  (assoc :agent/name (:agent/name spec))
+
+                  (:agent/prompt spec)
+                  (assoc :agent/prompt (:agent/prompt spec))
+
+                  program (assoc :agent/program program)
+
+                  (:agent/tools spec)
+                  (assoc :agent/tools (keyword-set! "AgentDef :tools"
+                                                    (:agent/tools spec)))
+
+                  (:agent/model-policy spec)
+                  (assoc :agent/model-policy (:agent/model-policy spec))
+
+                  (:agent/metadata spec)
+                  (assoc :agent/metadata (:agent/metadata spec)))]
+    (when-not (keyword? id)
+      (throw (ex-info "AgentDef requires a keyword :id"
+                      {:type ::invalid-agent-id :id id :spec spec})))
+    (when-not (and (integer? version) (pos? version))
+      (throw (ex-info "AgentDef version must be a positive integer"
+                      {:type ::invalid-agent-version :version version :agent/id id})))
+    (when-not (keyword? (:agent/status agent))
+      (throw (ex-info "AgentDef :status must be a keyword"
+                      {:type ::invalid-agent-status
+                       :status (:agent/status agent)
+                       :agent/id id})))
+    (doseq [[k v] [[:agent/name (:agent/name agent)]
+                   [:agent/prompt (:agent/prompt agent)]]
+            :when (and (some? v) (not (string? v)))]
+      (throw (ex-info (str k " must be a string")
+                      {:type ::invalid-agent-field :key k :value v :agent/id id})))
+    (when (and program (not (map? program)))
+      (throw (ex-info "AgentDef :program must be a data map"
+                      {:type ::invalid-program :agent/id id :program program})))
+    (portable! "AgentDef" agent)))
+
+(defn make-roster
+  "Create an immutable Roster.
+
+   Options are portable data:
+   - `:id`       optional logical identity
+   - `:defaults` shallow defaults applied by `make-agent`
+   - `:scope`    resource/authority grant interpreted at execution time
+   - `:metadata` caller-owned descriptive data"
+  ([] (make-roster {}))
+  ([{:keys [id defaults scope metadata]
+     :or {defaults {} scope {}}
+     :as opts}]
+   (when-let [unknown (seq (remove #{:id :defaults :scope :metadata}
+                                   (keys opts)))]
+     (throw (ex-info "Unknown Roster options"
+                     {:type ::unknown-roster-options
+                      :unknown (set unknown)
+                      :allowed #{:id :defaults :scope :metadata}})))
+   (when (and id (not (keyword? id)))
+     (throw (ex-info "Roster :id must be a keyword"
+                     {:type ::invalid-roster-id :id id})))
+   (when-not (map? defaults)
+     (throw (ex-info "Roster :defaults must be a map"
+                     {:type ::invalid-roster-defaults :defaults defaults})))
+   (when-not (map? scope)
+     (throw (ex-info "Roster :scope must be a map"
+                     {:type ::invalid-roster-scope :scope scope})))
+   (when (and metadata (not (map? metadata)))
+     (throw (ex-info "Roster :metadata must be a map"
+                     {:type ::invalid-roster-metadata :metadata metadata})))
+   (portable! "Roster options" {:id id :defaults defaults :scope scope :metadata metadata})
+   (cond-> {:roster/agents {}
+            :roster/defaults defaults
+            :roster/scope scope}
+     id (assoc :roster/id id)
+     metadata (assoc :roster/metadata metadata))))
+
+(defn agent-ref
+  "Return the stable reference for an AgentDef value."
+  [agent]
+  (select-keys agent [:agent/id :agent/version]))
+
+(defn agents
+  "Every AgentDef in `roster`, deterministically ordered by id."
+  [roster]
+  (->> (:roster/agents roster)
+       vals
+       (sort-by (comp str :agent/id))
+       vec))
+
+(defn agent
+  "Resolve an AgentDef by keyword id or `agent-ref`. A versioned stale ref is an
+   error rather than silently selecting a revised program."
+  [roster id-or-ref]
+  (let [id       (if (map? id-or-ref) (:agent/id id-or-ref) id-or-ref)
+        expected (when (map? id-or-ref) (:agent/version id-or-ref))
+        found    (get-in roster [:roster/agents id])]
+    (when (and found expected (not= expected (:agent/version found)))
+      (throw (ex-info "AgentRef points to a different AgentDef version"
+                      {:type ::stale-agent-ref
+                       :agent/id id
+                       :expected-version expected
+                       :actual-version (:agent/version found)})))
+    found))
+
+(defn make-agent
+  "Return a new Roster containing `spec` as a portable AgentDef.
+
+   Adding an identical definition is idempotent. Reusing an id with different
+   data is rejected; use `revise-agent` so old Run references retain meaning."
+  [roster spec]
+  (let [definition (normalize-agent (:roster/defaults roster) spec)
+        id         (:agent/id definition)
+        prior      (agent roster id)]
+    (cond
+      (nil? prior) (assoc-in roster [:roster/agents id] definition)
+      (= prior definition) roster
+      :else (throw (ex-info "Agent id already names a different definition"
+                            {:type ::agent-conflict
+                             :agent/id id
+                             :existing prior
+                             :proposed definition})))))
+
+(defn revise-agent
+  "Return a new Roster with `id` revised by `patch` and its version incremented."
+  [roster id patch]
+  (when-let [forbidden (seq (filter #(contains? patch %)
+                                    [:id :agent/id :version :agent/version]))]
+    (throw (ex-info "revise-agent cannot change AgentDef identity or version"
+                    {:type ::immutable-agent-identity
+                     :agent/id id
+                     :forbidden (set forbidden)})))
+  (let [prior (or (agent roster id)
+                  (throw (ex-info "Cannot revise an unknown agent"
+                                  {:type ::unknown-agent :agent/id id})))
+        friendly-prior
+        {:id (:agent/id prior)
+         :version (inc (:agent/version prior))
+         :status (:agent/status prior)
+         :skills (:agent/skills prior)
+         :name (:agent/name prior)
+         :prompt (:agent/prompt prior)
+         :program (:agent/program prior)
+         :tools (:agent/tools prior)
+         :model-policy (:agent/model-policy prior)
+         :metadata (:agent/metadata prior)}
+        revised (normalize-agent friendly-prior patch)]
+    (when-not (and (= id (:agent/id revised))
+                   (= (inc (:agent/version prior)) (:agent/version revised)))
+      (throw (ex-info "Revised AgentDef violated roster identity invariants"
+                      {:type ::agent-invariant-violation
+                       :agent/id id
+                       :prior prior
+                       :revised revised})))
+    (assoc-in roster [:roster/agents id] revised)))
+
+(defn select-agents
+  "Select AgentDefs deterministically.
+
+   Selector keys:
+   - `:id`, `:status`
+   - `:skill` requires one skill
+   - `:skills` requires all skills
+   - `:where` portable map of exact AgentDef key/value matches"
+  [roster {:keys [id status skill skills where]
+           :or {skills #{} where {}}}]
+  (let [required (cond-> (set skills) skill (conj skill))]
+    (->> (agents roster)
+         (filter #(if id (= id (:agent/id %)) true))
+         (filter #(if status (= status (:agent/status %)) true))
+         (filter #(set/subset? required (:agent/skills %)))
+         (filter #(every? (fn [[k v]] (= v (get % k))) where))
+         vec)))

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -2,16 +2,22 @@
   "Minimal durable Run lifecycle for causally bounded room execution.
 
    A Run is durable identity and correlation data. Live execution and
-   cancellation handles remain private in this namespace and are never returned
+  cancellation handles remain private in this namespace and are never returned
    by snapshots, lifecycle events, or the Room store."
   (:require [dvergr.chat.context :as chat-ctx]
             [dvergr.room.store :as store]
+            [org.replikativ.spindel.engine.core :as ec]
             [taoensso.telemere :as tel]))
 
 (def ^:private finish-statuses #{:waiting :completed :failed :cancelled})
 (defonce ^:private active (atom {}))
 (defonce ^:private subscribers (atom {}))
 (def ^:private lifecycle-lock (Object.))
+
+(def provenance-keys
+  "Run fields an interpreter may add without changing core causal identity."
+  #{:run/roster :run/agent-version :run/program-kind
+    :run/interpreter-version :run/agent-def-hash})
 
 (defn- store-room-id [room]
   (or (some-> room :meta deref :conversation-id)
@@ -66,6 +72,31 @@
     (swap! subscribers dissoc key))
   nil)
 
+(defn- admission-path [room-id]
+  [:dvergr/run-admissions room-id])
+
+(defn open-room-admission!
+  "Open Run admission for a newly constructed Room in its Spindel context."
+  [room-id execution-ctx]
+  (locking lifecycle-lock
+    (binding [ec/*execution-context* execution-ctx]
+      (ec/swap-state! (admission-path room-id) (constantly :open))))
+  nil)
+
+(defn close-room-admission!
+  "Atomically close fork-local Run admission for `room` and return the fixed set
+   admitted before the fence. Teardown drains exactly this set."
+  [room]
+  (let [room-id (:id room)]
+    (locking lifecycle-lock
+      (binding [ec/*execution-context* (:ctx room)]
+        (ec/swap-state! (admission-path room-id) (constantly :closed)))
+      (->> (vals @active)
+           (keep (fn [entry]
+                   (when (= room-id (get-in entry [:run :run/room]))
+                     (get-in entry [:run :run/id]))))
+           set))))
+
 (defn start!
   "Persist and publish one live Run before execution begins.
 
@@ -74,33 +105,55 @@
    never inferred from causal message succession. Returns the public Run map."
   ([room actor trigger live-chat-ctx]
    (start! room actor trigger live-chat-ctx {}))
-  ([room actor trigger live-chat-ctx {:keys [id kind parent now]
+  ([room actor trigger live-chat-ctx {:keys [id kind parent now provenance]
                                       :or {kind :agent-turn}}]
+   (when-let [unknown (seq (remove provenance-keys (keys provenance)))]
+     (throw (ex-info "Run provenance may not override causal identity"
+                     {:type ::invalid-provenance
+                      :unknown (set unknown)
+                      :allowed provenance-keys})))
    (let [now        (or now (java.util.Date.))
          trigger-id (if (map? trigger) (:id trigger) trigger)
          run        (store/validate-run!
-                     (cond-> {:run/id         (or id (random-uuid))
-                              :run/kind       kind
-                              :run/room       (:id room)
-                              :run/actor      actor
-                              :run/trigger    trigger-id
-                              :run/status     :running
-                              :run/created-at now
-                              :run/started-at now
-                              :run/updated-at now}
-                       parent (assoc :run/parent parent)))
+                     (merge
+                      (cond-> {:run/id         (or id (random-uuid))
+                               :run/kind       kind
+                               :run/room       (:id room)
+                               :run/actor      actor
+                               :run/trigger    trigger-id
+                               :run/status     :running
+                               :run/created-at now
+                               :run/started-at now
+                               :run/updated-at now}
+                        parent (assoc :run/parent parent))
+                      provenance))
          entry      {:run run
                      :chat-ctx live-chat-ctx
+                     ;; Explicitly process-local control state. Durable meaning
+                     ;; is the Room-store Run projection; this live owner map
+                     ;; and its token are never copied or restored as workflow
+                     ;; state.
                      :cancelled? (atom false)
                      :store (:store room)
                      :store-room-id (store-room-id room)}]
-     (when-let [room-store (:store entry)]
-       (when-not (store/-store-run! room-store (:store-room-id entry) run)
-         (throw (ex-info "Run admission failed: start was not durable"
-                         {:type ::start-not-durable
-                          :run/id (:run/id run)
-                          :run/room (:id room)}))))
      (locking lifecycle-lock
+       (when (and (:ctx room)
+                  (= :closed
+                     (binding [ec/*execution-context* (:ctx room)]
+                       (ec/get-state (admission-path (:id room))))))
+         (throw (ex-info "Run admission is closed for Room teardown"
+                         {:type ::room-admission-closed
+                          :run/id (:run/id run)
+                          :run/room (:id room)})))
+       ;; Persistence is inside the same admission critical section as the
+       ;; fence check: teardown can see either no Run or the fully admitted Run,
+       ;; never a durable-but-unowned half-admission.
+       (when-let [room-store (:store entry)]
+         (when-not (store/-store-run! room-store (:store-room-id entry) run)
+           (throw (ex-info "Run admission failed: start was not durable"
+                           {:type ::start-not-durable
+                            :run/id (:run/id run)
+                            :run/room (:id room)}))))
        (swap! active assoc (:run/id run) entry)
        (notify! {:type :run/started :run run}))
      run)))
@@ -137,35 +190,46 @@
 
 (defn cancel-requested?
   "True when targeted cancellation has been requested for this live Run. The
-   private token disappears with the live entry; durable cancellation is the
-   executor's later `:cancelled` acknowledgement."
+  private token disappears with the live entry; durable cancellation is the
+  executor's later `:cancelled` acknowledgement."
   [run-id]
   (boolean (some-> (get @active run-id) :cancelled? deref)))
+
+(defn- request-cancel!
+  [run-id expected-room]
+  (let [entry
+        (locking lifecycle-lock
+          (when-let [entry (get @active run-id)]
+            (when (or (nil? expected-room)
+                      (= expected-room (get-in entry [:run :run/room])))
+              (if @(:cancelled? entry)
+                entry
+                (let [_ (reset! (:cancelled? entry) true)
+                      entry' (assoc-in entry [:run :run/status] :cancelling)]
+                  (swap! active assoc run-id entry')
+                  (notify! {:type :run/cancel-requested :run (public-entry entry')})
+                  entry')))))]
+    (boolean entry)))
 
 (defn cancel-run!
   "Request cooperative cancellation of exactly one live Run. Returns true when
    found/signalled, false for an unknown or already-finished Run. Durable status
-   becomes `:cancelled` only when the executor acknowledges via `finish!`."
+  becomes `:cancelled` only when the executor acknowledges via `finish!`."
   [run-id]
-  (let [entry
-        (locking lifecycle-lock
-          (when-let [entry (get @active run-id)]
-            (if (cancel-requested? run-id)
-              entry
-              (let [_ (reset! (:cancelled? entry) true)
-                    entry' (assoc-in entry [:run :run/status] :cancelling)]
-                (swap! active assoc run-id entry')
-                (notify! {:type :run/cancel-requested :run (public-entry entry')})
-                entry'))))]
-    (if entry
-      true
-      false)))
+  (request-cancel! run-id nil))
+
+(defn cancel-room-run!
+  "Request cancellation only when `run-id` is live in `room-id`. This is the
+   capability-scoped boundary for room SCI; UUID knowledge alone grants no
+   cross-Room control. Trusted host/admin code may use `cancel-run!`."
+  [room-id run-id]
+  (request-cancel! run-id room-id))
 
 (defn cancel-room-runs!
   "Request cancellation of every live Run in `room-id`; return the count."
   [room-id]
   (let [ids (mapv :run/id (active-runs room-id))]
-    (doseq [run-id ids] (cancel-run! run-id))
+    (doseq [run-id ids] (cancel-room-run! room-id run-id))
     (count ids)))
 
 (defn register-live!

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -528,6 +528,34 @@
     :db/index true
     :db/doc "Explicit structural parent that spawned/contains this run"}
 
+   {:db/ident :run/roster
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Logical immutable Roster identity, when supplied"}
+
+   {:db/ident :run/agent-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/doc "Exact AgentDef version resolved for this execution"}
+
+   {:db/ident :run/program-kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Interpreter kind selected from the AgentDef program"}
+
+   {:db/ident :run/interpreter-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/doc "Version of Dvergr's interpreter contract"}
+
+   {:db/ident :run/agent-def-hash
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Content address of the exact portable AgentDef value"}
+
    {:db/ident :run/status
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -24,7 +24,8 @@
    spin; select an inference kernel via `kernel-infer` from
    `org.replikativ.spindel.inference.inference`. No discourse-specific
    inference primitive is needed."
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]
@@ -36,6 +37,7 @@
             [dvergr.runtime.bus :as bus]
             [dvergr.substrate.geschichte :as geschichte]
             [dvergr.runtime.peer-bus :as peer-bus]
+            [dvergr.agent.run :as agent-run]
             [dvergr.room.store :as rstore]
             [dvergr.room.store.datahike :as store-dh]
             [dvergr.room.registry :as rreg]
@@ -280,6 +282,7 @@
                                    (when durable-append!
                                      {:durable-append! durable-append!}))
         room  (->Room id slug title parent-id (atom {}) b ctx 0 store (atom (or meta {})))]
+    (agent-run/open-room-admission! id ctx)
     ;; Persist metadata on creation so the store has it for re-hydration.
     (when store
       (rstore/-store-room! store id (cond-> {:id id :slug slug :title title}
@@ -746,6 +749,37 @@
   [room]
   (or (some-> room :ctx :parent-ctx) (:ctx room)))
 
+(defn- drain-room-runs!
+  "Request cancellation of every live Run owned by `room` and wait up to five
+   seconds for their executors to acknowledge a terminal state. The lifecycle
+   watch is installed before cancellation so the final transition cannot race
+   the wait. This covers LLM turns and directly interpreted agent programs."
+  [room]
+  (let [room-id (:id room)
+        admitted (agent-run/close-room-admission! room)
+        stopped (promise)
+        watch-key (Object.)]
+    (try
+      (agent-run/watch-runs!
+       watch-key
+       (fn [_]
+         (let [live-ids (into #{} (map :run/id) (agent-run/active-runs room-id))]
+           (when (empty? (set/intersection admitted live-ids))
+             (deliver stopped true)))))
+      (doseq [run-id admitted]
+        (agent-run/cancel-room-run! room-id run-id))
+      (when (seq admitted)
+        (deref stopped 5000 ::timeout))
+      (let [live-ids (into #{} (map :run/id) (agent-run/active-runs room-id))
+            remaining (set/intersection admitted live-ids)]
+        (when (seq remaining)
+          (throw (ex-info "Room teardown timed out waiting for live Runs"
+                          {:type ::run-drain-timeout
+                           :room-id room-id
+                           :run-ids remaining}))))
+      (finally
+        (agent-run/unwatch-runs! watch-key)))))
+
 (defn close-room!
   "Tear down a room: leave every participant, unregister the Room, and close
    its execution context. Any in-flight drain completes before this returns.
@@ -759,6 +793,7 @@
    No-op on already-closed rooms."
   [room]
   (when room
+    (drain-room-runs! room)
     (leave-all! room)
     (binding [ec/*execution-context* (room-home-ctx room)]
       (rreg/unregister! (:id room)))
@@ -959,6 +994,7 @@
                             (atom (assoc @(:meta room)
                                          :forked-from (:id room)
                                          :conversation-id conv-id)))]
+     (agent-run/open-room-admission! new-id child-ctx)
      ;; (Fork-local persistence rides the bus's durable-append! hook now —
      ;; wired at child-bus construction above.)
      ;; Register the fork in the PARENT ctx — where the daemon UI reads the
@@ -1030,32 +1066,6 @@
   [fork]
   (room-home-ctx fork))
 
-(defn- drain-fork-turns!
-  "Cancel any in-flight agent turn in `fork` and wait (bounded, ~5s) for it to
-   stop, so merge/discard doesn't yank the fork's worktree + branched conns out
-   from under a running turn (security audit P4). Best-effort."
-  [fork]
-  (let [fid      (:id fork)
-        cancel!  (requiring-resolve 'dvergr.agent.turn/cancel-room-turn!)
-        running? (requiring-resolve 'dvergr.agent.turn/room-turn-running?)
-        watch!   (requiring-resolve 'dvergr.agent.turn/watch-room-turns!)
-        unwatch! (requiring-resolve 'dvergr.agent.turn/unwatch-room-turns!)
-        stopped  (promise)
-        wkey     (Object.)]
-    (try (cancel! fid) (catch Throwable _))
-    ;; Block on the turn registry's own lifecycle watch (fires on the
-    ;; empty↔non-empty transition) instead of poll-sleeping — one bounded
-    ;; wait, delivered the moment the turn actually unregisters. Register
-    ;; the watch BEFORE the running? check so the transition can't slip
-    ;; between check and wait.
-    (try
-      (watch! wkey (fn [rid turn-running?]
-                     (when (and (= rid fid) (not turn-running?))
-                       (deliver stopped true))))
-      (when (try (running? fid) (catch Throwable _ false))
-        (deref stopped 5000 ::timeout))
-      (finally (try (unwatch! wkey) (catch Throwable _))))))
-
 (defn discard
   "Discard a fork: deregister its participants, drop it from the
    registry, and if the fork's ctx was forked (`:isolation :ctx`),
@@ -1070,9 +1080,9 @@
   ;; Idempotence: once unregistered, the fork is a zombie — re-discarding would
   ;; double-delete the yggdrasil branch (which errors). Guard on registry.
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
+    (drain-room-runs! fork)                    ; stop work before removing its substrate
     (leave-all! fork)
     (when (ctx-was-forked? fork)
-      (drain-fork-turns! fork)                 ; P4: stop in-flight turns first
       ;; P2: read the fork's deferred data-DB grants (fork-local ctx-state) and
       ;; delete the stores it created — they were never granted, so on discard they
       ;; must not linger. :on-discard fires inside discard-from-parent!.
@@ -1104,6 +1114,7 @@
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
   ([parent fork {:keys [merge-opts]}]
+   (drain-room-runs! fork)                     ; stop work before merging its substrate
    ;; (1) SUBSTRATE merge — branched yggdrasil systems (CRDTs, datahike, git) fold
    ;; back whenever the ctx was forked (`:isolation :ctx`), INDEPENDENT of any
    ;; conversation store. These are orthogonal: a room can carry shared CRDTs with
@@ -1114,7 +1125,6 @@
    ;; accept via :on-merge (store forks only). (doc/unified-fork-conversation.md)
    (when (ctx-was-forked? fork)
      (try
-       (drain-fork-turns! fork)                ; P4: stop in-flight turns before merge
        (let [pending (when (:store fork)
                        (binding [ec/*execution-context* (:ctx fork)]
                          (ec/get-state [:dvergr/pending-grants])))]

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -93,13 +93,27 @@
 
 (def terminal-run-statuses #{:completed :failed :cancelled})
 
+(def durable-run-keys
+  #{:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+    :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
+    :run/reason :run/error
+    :run/roster :run/agent-version :run/program-kind
+    :run/interpreter-version :run/agent-def-hash})
+
 (def immutable-run-keys
   [:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
-   :run/created-at :run/started-at])
+   :run/created-at :run/started-at
+   :run/roster :run/agent-version :run/program-kind
+   :run/interpreter-version :run/agent-def-hash])
 
 (defn validate-run!
   "Validate the minimal durable Run contract and return `run`."
   [run]
+  (when-let [unknown (seq (remove durable-run-keys (keys run)))]
+    (throw (ex-info "Unknown durable Run keys"
+                    {:type :room-store/unknown-run-keys
+                     :unknown (set unknown)
+                     :allowed durable-run-keys})))
   (doseq [k [:run/id :run/trigger]]
     (when-not (uuid? (get run k))
       (throw (ex-info (str k " must be a UUID")
@@ -120,6 +134,20 @@
   (when (and (:run/parent run) (not (uuid? (:run/parent run))))
     (throw (ex-info ":run/parent must be a UUID"
                     {:type :room-store/invalid-run :key :run/parent :run run})))
+  (when (and (:run/roster run) (not (keyword? (:run/roster run))))
+    (throw (ex-info ":run/roster must be a keyword"
+                    {:type :room-store/invalid-run :key :run/roster :run run})))
+  (doseq [k [:run/agent-version :run/interpreter-version]
+          :let [v (get run k)]
+          :when (and (some? v) (not (and (integer? v) (pos? v))))]
+    (throw (ex-info (str k " must be a positive integer")
+                    {:type :room-store/invalid-run :key k :run run})))
+  (when (and (:run/program-kind run) (not (keyword? (:run/program-kind run))))
+    (throw (ex-info ":run/program-kind must be a keyword"
+                    {:type :room-store/invalid-run :key :run/program-kind :run run})))
+  (when (and (:run/agent-def-hash run) (not (uuid? (:run/agent-def-hash run))))
+    (throw (ex-info ":run/agent-def-hash must be a UUID"
+                    {:type :room-store/invalid-run :key :run/agent-def-hash :run run})))
   (doseq [k [:run/created-at :run/started-at :run/updated-at]
           :when (not (instance? java.util.Date (get run k)))]
     (throw (ex-info (str k " must be an instant")

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -165,6 +165,8 @@
 
 (def ^:private run-pull-pattern
   '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+    :run/roster :run/agent-version :run/program-kind :run/interpreter-version
+    :run/agent-def-hash
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error])
 
@@ -180,6 +182,12 @@
            :run/started-at (:run/started-at run)
            :run/updated-at (:run/updated-at run)}
     (:run/parent run)   (assoc :run/parent (:run/parent run))
+    (:run/roster run) (assoc :run/roster (:run/roster run))
+    (:run/agent-version run) (assoc :run/agent-version (:run/agent-version run))
+    (:run/program-kind run) (assoc :run/program-kind (:run/program-kind run))
+    (:run/interpreter-version run)
+    (assoc :run/interpreter-version (:run/interpreter-version run))
+    (:run/agent-def-hash run) (assoc :run/agent-def-hash (:run/agent-def-hash run))
     (:run/ended-at run) (assoc :run/ended-at (:run/ended-at run))
     (:run/reason run)   (assoc :run/reason (:run/reason run))
     (:run/error run)    (assoc :run/error (str (:run/error run)))))

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -665,10 +665,12 @@
                        "(dvergr.scheduler/create {:agent-id :var :schedule {:every :hour :n 4} :code \"(require 'my.ns)(my.ns/run!)\" :description \"…\"})  (dvergr.scheduler/list)  (dvergr.scheduler/cancel id)"]
    "dvergr.tasks"    ["the shared task ledger — list/accept/complete work items"
                       "(dvergr.tasks/list)   (dvergr.tasks/complete! id)"]
+   "dvergr.agent"    ["program specialized agents as immutable rosters; hire! starts a durable Run with an explicit result Spin"
+                      "(let [team (dvergr.agent/make-agent (dvergr.agent/roster) {:id :analyst :program {:kind :echo}})] (dvergr.agent/hire! team :analyst {:task :inspect}))"]
    "dvergr.agents"   ["directory of agents (read-only): who exists / is online"
                       "(dvergr.agents/list)   (dvergr.agents/online? :var)"]
-   "dvergr.actors"   ["mutate the roster — spawn sub-agents / humans, assign skills"
-                      "(dvergr.actors/spawn-agent! {:prompt \"…\" :budget 0.10})"]
+   "dvergr.actors"   ["durable participant identities — register/retire agents or humans and assign skills"
+                      "(dvergr.actors/spawn-agent! {:id :scribe :name \"Scribe\" :profile-ref \"scribe.md\" :skills #{:writing} :config {}})"]
    "dvergr.skills"   ["reusable skills you can find + dispatch"
                       "(dvergr.skills/find \"draft a brief\")"]
    "clojure.test"    ["how you test IN here — the real clojure.test, run inside clojure_eval; failures print expected/actual to your stdout. This is the ONLY runner available to you, by design: kaocha/lein/clj are not reachable (handing control to a second runtime would let it read+write outside the sandbox), so requiring kaocha fails and the shell has no `clj`. To exercise code that lives in a FILE, load it — (load-string (slurp \"src/foo.clj\")) — then deftest against it here."
@@ -677,7 +679,7 @@
 (def ^:private guide-order
   ["babashka.fs" "babashka.http-client" "babashka.process" "cheshire.core" "clojure.data.xml"
    "datahike.api" "dvergr.room" "dvergr.mail" "dvergr.intake" "dvergr.codec" "git" "env" "llm"
-   "dvergr.scheduler" "dvergr.tasks" "dvergr.agents" "dvergr.actors" "dvergr.skills"
+   "dvergr.scheduler" "dvergr.tasks" "dvergr.agent" "dvergr.agents" "dvergr.actors" "dvergr.skills"
    "clojure.test"])
 
 (defn ns-overview-data
@@ -960,6 +962,10 @@
         (ns-agent/add-skills-ns! sci-ctx sys-conn)
         (ns-agent/add-tasks-ns! sci-ctx sys-conn)))
     (ns-agent/add-agents-ns! sci-ctx)
+    ;; Pure AgentDef/Roster construction plus the explicit, Run-backed `hire!`
+    ;; effect. No roster is kept in a host atom: callers thread the immutable
+    ;; value, and live execution state belongs to the Room's Spindel context.
+    (ns-agent/add-programming-ns! sci-ctx room-id spindel-ctx)
     (ns-data/add-spindel-extras-ns! sci-ctx spindel-ctx)
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -8,7 +8,97 @@
    `(find-doc …)` answer nothing for them inside the sandbox. See
    `dvergr.sandbox.ns.doc`."
   (:require [sci.core :as sci]
-            [dvergr.sandbox.ns.doc :as doc]))
+            [dvergr.sandbox.ns.doc :as doc]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(defn add-programming-ns!
+  "Expose immutable AgentDefs and Run-backed hiring as `dvergr.agent` in SCI.
+
+   The namespace deliberately has no hidden current roster. `roster`,
+   `make-agent`, and `revise-agent` return ordinary immutable values, so a
+   Spindel computation can branch with a different team without coordinating a
+   mutable registry. `hire!` is the explicit effect boundary: it resolves this
+   sandbox's Room, starts a durable Run in the Room's execution context, and
+   returns an opaque RunHandle whose native observer Spin is explicit.
+
+   Usage:
+     (require '[dvergr.agent :as agent]
+              '[org.replikativ.spindel.spin.cps :refer [spin]]
+              '[org.replikativ.spindel.effects.await :refer [await]])
+     (let [team (-> (agent/roster)
+                    (agent/make-agent
+                     {:id :analyst
+                      :skills #{:research}
+                      :program {:kind :echo}}))]
+       @(spin (-> (await (agent/result-spin
+                          (agent/hire! team :analyst {:task :inspect})))
+                  :run/value)))"
+  [sci-ctx room-id spindel-ctx]
+  (let [make-roster*   (requiring-resolve 'dvergr.agent.roster/make-roster)
+        make-agent*    (requiring-resolve 'dvergr.agent.roster/make-agent)
+        revise-agent*  (requiring-resolve 'dvergr.agent.roster/revise-agent)
+        lookup-agent*  (requiring-resolve 'dvergr.agent.roster/agent)
+        agent-ref*     (requiring-resolve 'dvergr.agent.roster/agent-ref)
+        agents*        (requiring-resolve 'dvergr.agent.roster/agents)
+        select-agents* (requiring-resolve 'dvergr.agent.roster/select-agents)
+        hire*          (requiring-resolve 'dvergr.agent.program/hire!)
+        observe*       (requiring-resolve 'dvergr.agent.program/observe)
+        cancel*        (requiring-resolve 'dvergr.agent.program/cancel!)
+        run-id*        (requiring-resolve 'dvergr.agent.program/run-id)
+        result-spin*   (requiring-resolve 'dvergr.agent.program/result-spin)
+        room-lookup*   (requiring-resolve 'dvergr.room.registry/lookup)
+        current-room   (fn []
+                         (when room-id
+                           (binding [ec/*execution-context* spindel-ctx]
+                             (room-lookup* room-id))))
+        room!          (fn []
+                         (or (current-room)
+                             (throw (ex-info
+                                     "No current Room — agent execution is room-scoped"
+                                     {:type ::no-current-room
+                                      :room-id room-id}))))
+        hire-fn        (fn [roster agent-ref opts]
+                         (let [room (room!)]
+                           (binding [ec/*execution-context* (:ctx room)]
+                             (hire* room roster agent-ref opts))))
+        observe-fn     (fn [handle-or-id]
+                         (let [room (room!)]
+                           (binding [ec/*execution-context* (:ctx room)]
+                             (observe* room handle-or-id))))
+        cancel-fn      (fn [handle-or-id]
+                         ;; Run cancellation tokens are process-local. Binding
+                         ;; the Room ctx keeps this boundary consistent with
+                         ;; hire/observe and ready for a Spindel-local registry.
+                         (let [room (room!)]
+                           (binding [ec/*execution-context* (:ctx room)]
+                             (cancel* room handle-or-id))))]
+    (sci/add-namespace!
+     sci-ctx 'dvergr.agent
+     (doc/with-docs
+       {'roster       make-roster*
+        'make-agent   make-agent*
+        'revise-agent revise-agent*
+        'lookup       lookup-agent*
+        'ref          agent-ref*
+        'list         agents*
+        'select       select-agents*
+        'hire!        hire-fn
+        'observe      observe-fn
+        'cancel!      cancel-fn
+        'run-id       run-id*
+        'result-spin  result-spin*}
+       '{roster       [([] [opts]) "Create an immutable Roster value. Options may include portable :id, :defaults, :scope, and :metadata data."]
+         make-agent   [([roster spec]) "Return a NEW Roster containing the portable AgentDef `spec`; no agent is started and the input roster is unchanged."]
+         revise-agent [([roster id patch]) "Return a NEW Roster with AgentDef `id` revised and its version incremented."]
+         lookup       [([roster id-or-ref]) "Resolve an AgentDef by keyword id or versioned AgentRef. A stale versioned ref is an error."]
+         ref          [([agent-def]) "Return the stable {:agent/id :agent/version} reference for an AgentDef."]
+         list         [([roster]) "All AgentDefs in a Roster, deterministically ordered by id."]
+         select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
+         hire!        [([roster agent-ref opts]) "Durably admit and start one AgentDef execution in the current Room. Returns an opaque RunHandle; opts requires :task and may include :from and :parent-run."]
+         observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
+         cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]
+         run-id       [([handle]) "Return the durable Run UUID represented by a RunHandle."]
+         result-spin  [([handle]) "Return a fresh native Spindel observer Spin for a RunHandle. Use (await (result-spin handle)) inside a workflow Spin."]}))))
 
 (defn add-agents-ns!
   "Expose the agent registry as 'agents namespace in SCI.
@@ -345,4 +435,3 @@
                                      '([])
                                      "Active schedules in this room, as maps carrying :id :kind :next-fire …"
                                      (fn [] (sched-list (room!))))})))
-

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -1,0 +1,308 @@
+(ns dvergr.agent.program-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.combinators :as comb]))
+
+(defn- test-roster []
+  (-> (roster/make-roster {:id :test-team})
+      (roster/make-agent {:id :analyst
+                          :skills #{:research}
+                          :program {:kind :scripted :reply "evidence"}})
+      (roster/make-agent {:id :reviewer
+                          :skills #{:review}
+                          :program {:kind :echo}})))
+
+(defn- test-room [id]
+  (d/make-room {:id id :store (memory/make)}))
+
+(defn- wait-until [pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (pred) true
+        (>= (System/currentTimeMillis) deadline) false
+        :else (do (Thread/sleep 5) (recur))))))
+
+(deftest hire-is-run-backed-and-output-correlated
+  (let [room (test-room :program-hire)
+        team (test-roster)]
+    (try
+      (let [handle (binding [ec/*execution-context* (:ctx room)]
+                     (program/hire! room team :analyst {:task "investigate"}))
+            result (binding [ec/*execution-context* (:ctx room)] @handle)
+            durable (program/observe room handle)
+            messages (d/messages room {:limit 10})
+            trigger (first (filter #(= (:run/trigger durable) (:id %)) messages))
+            output (first (filter #(= (:run/id durable)
+                                      (get-in % [:metadata :run-id]))
+                                  messages))]
+        (is (= :completed (:run/status result)))
+        (is (= "evidence" (:run/value result)))
+        (is (= :agent-task (:run/kind durable)))
+        (is (= :analyst (:run/actor durable)))
+        (is (= :test-team (:run/roster durable)))
+        (is (= 1 (:run/agent-version durable)))
+        (is (= :scripted (:run/program-kind durable)))
+        (is (= program/interpreter-version (:run/interpreter-version durable)))
+        (is (uuid? (:run/agent-def-hash durable)))
+        (is (= "investigate" (:content trigger)))
+        (is (= program/run-sink (:to trigger)))
+        (is (= "evidence" (:content output)))
+        (is (= program/run-sink (:to output)))
+        (is (= (:id trigger) (:in-reply-to output)))
+        (is (empty? (run/active-runs :program-hire))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest run-handles-compose-through-spindel-await
+  (let [room (test-room :program-compose)
+        team (test-roster)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [a (program/hire! room team :analyst {:task "research"})
+              b (program/hire! room team :reviewer {:task {:review "claim"}})
+              joined (sp/spin
+                      [(-> (await (program/result-spin a)) :run/value)
+                       (-> (await (program/result-spin b)) :run/value)])]
+          (is (= ["evidence" {:review "claim"}] @joined))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-is-targeted-and-acknowledged
+  (let [room (test-room :program-cancel)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 500 :reply "too late"}})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle (program/hire! room team :slow {:task "stop"})]
+          (is (some? (program/observe room handle))
+              "hire! returns only after durable admission")
+          (is (program/cancel! handle))
+          (is (= :cancelled (:run/status @handle)))
+          (is (= :cancelled (:run/status (program/observe room handle))))
+          (is (empty? (filter #(= (program/run-id handle)
+                                  (get-in % [:metadata :run-id]))
+                              (d/messages room {:limit 10}))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest structural-parent-is-explicit
+  (let [room (test-room :program-parent)
+        team (test-roster)
+        parent-id (random-uuid)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle (program/hire! room team :analyst
+                                    {:task "child" :parent-run parent-id})]
+          @handle
+          (is (= parent-id (:run/parent (program/observe room handle))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest hire-validates-the-effect-envelope-before-starting
+  (let [room (test-room :program-validation)
+        team (test-roster)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (program/hire! room team :missing {:task "work"})))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (program/hire! room team :analyst {})))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (program/hire! room team :analyst
+                                    {:task "work" :metadata {:callback identity}})))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (program/hire!
+                      room
+                      (roster/make-agent
+                       (roster/make-roster)
+                       {:id :typo :program {:kind :scripted :repy "missed"}})
+                      :typo {:task "work"})))
+        (is (empty? (run/active-runs (:id room))))
+        (is (empty? (d/messages room {:limit 10}))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest closed-admission-rejects-hire-before-posting
+  (let [room (test-room :program-admission-closed)
+        team (test-roster)
+        posts (atom 0)]
+    (try
+      (run/close-room-admission! room)
+      (with-redefs [d/post! (fn [& _] (swap! posts inc))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"admission is closed"
+               (program/hire! room team :analyst {:task "too late"})))))
+      (is (zero? @posts))
+      (is (empty? (run/active-runs (:id room))))
+      (is (empty? (d/messages room {:limit 10})))
+      (finally
+        (d/close-room! room)))))
+
+(deftest teardown-cannot-miss-a-hire-between-admission-and-trigger-post
+  (let [room (test-room :program-admission-race)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 500 :reply "too late"}})
+        entered-post (promise)
+        release-post (promise)
+        original-post d/post!]
+    (try
+      (with-redefs [d/post! (fn [target message]
+                              (deliver entered-post true)
+                              @release-post
+                              (original-post target message))]
+        (let [hire-future
+              (future
+                (binding [ec/*execution-context* (:ctx room)]
+                  (program/hire! room team :slow {:task "racing close"})))
+              _ (is (= true (deref entered-post 1000 ::timeout)))
+              admitted-id (:run/id (first (run/active-runs (:id room))))
+              close-future (future (d/close-room! room))]
+          (is (wait-until #(run/cancel-requested? admitted-id) 1000)
+              "close fenced admission and found the reserved Run")
+          (is (false? (realized? close-future))
+              "teardown waits rather than removing the substrate")
+          (deliver release-post true)
+          (let [handle (deref hire-future 2000 ::timeout)]
+            (is (not= ::timeout handle))
+            (is (nil? (deref close-future 2000 ::timeout)))
+            (is (= :cancelled (:run/status (program/observe room handle))))
+            (is (empty? (run/active-runs (:id room)))))))
+      (finally
+        (deliver release-post true)
+        (d/close-room! room)))))
+
+(deftest structured-race-cancels-the-losing-run-spin
+  (let [room (test-room :program-race)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 500 :reply "too late"}})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (dotimes [_ 10]
+          (let [handle (program/hire! room team :slow {:task "race"})
+                winner (sp/spin :winner)]
+            (is (= :winner @(comb/race winner (program/result-spin handle))))
+            (is (wait-until #(= :cancelled
+                                (:run/status (program/observe room handle)))
+                            1000))))
+        (is (empty? (run/active-runs (:id room)))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest direct-program-input-does-not-wake-a-same-id-participant
+  (let [room (test-room :program-routing)
+        team (test-roster)
+        deliveries (atom 0)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (d/join room
+                (d/participant
+                 {:id :analyst
+                  :on-message (fn [_ _]
+                                (sp/spin (swap! deliveries inc) nil))}))
+        @(program/hire! room team :analyst {:task "direct"})
+        (Thread/sleep 25)
+        (is (zero? @deliveries)))
+      (finally
+        (d/close-room! room)))))
+
+(deftest room-scoped-cancellation-rejects-another-rooms-run-id
+  (let [a (test-room :program-room-a)
+        b (test-room :program-room-b)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 500 :reply "done"}})]
+    (try
+      (let [handle (binding [ec/*execution-context* (:ctx b)]
+                     (program/hire! b team :slow {:task "private"}))]
+        (is (false? (program/cancel! a (program/run-id handle))))
+        (is (true? (program/cancel! b (program/run-id handle))))
+        (binding [ec/*execution-context* (:ctx b)] @handle)
+        (is (= :cancelled (:run/status (program/observe b handle)))))
+      (finally
+        (d/close-room! a)
+        (d/close-room! b)))))
+
+(deftest live-handles-reject-cross-fork-observation
+  (let [room (test-room :program-context-owner)
+        team (test-roster)
+        fork-ctx (context/fork-context (:ctx room))]
+    (try
+      (let [handle (binding [ec/*execution-context* (:ctx room)]
+                     (program/hire! room team :analyst {:task "owned"}))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"another Spindel context"
+             (binding [ec/*execution-context* fork-ctx]
+               (program/result-spin handle))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"another Spindel context"
+             (binding [ec/*execution-context* fork-ctx]
+               (program/cancel! handle))))
+        (binding [ec/*execution-context* (:ctx room)]
+          (is (= :completed (:run/status @handle)))))
+      (finally
+        (context/close-context! fork-ctx)
+        (d/close-room! room)))))
+
+(deftest discarding-an-isolated-fork-settles-hired-runs-first
+  (let [parent (test-room :program-fork-parent)
+        fork (d/fork-room parent {:isolation :ctx})
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 500 :reply "too late"}})
+        events (atom [])
+        watch-key (Object.)]
+    (run/watch-runs! watch-key #(swap! events conj %))
+    (try
+      (let [handle (binding [ec/*execution-context* (:ctx fork)]
+                     (program/hire! fork team :slow {:task "discard"}))
+            id (program/run-id handle)]
+        (d/discard fork)
+        (is (empty? (run/active-runs (:id fork))))
+        (is (= :cancelled
+               (some (fn [{:keys [type run]}]
+                       (when (and (= :run/finished type)
+                                  (= id (:run/id run)))
+                         (:run/status run)))
+                     @events)))
+        (is (empty? (filter #(= id (get-in % [:metadata :run-id]))
+                            (d/messages fork {:limit 10}))))
+        (is (binding [ec/*execution-context* (:ctx parent)]
+              (nil? (registry/lookup (:id fork))))))
+      (finally
+        (run/unwatch-runs! watch-key)
+        (d/close-room! parent)))))
+
+(deftest closing-a-room-settles-its-program-runs-before-closing-spindel
+  (let [room (test-room :program-close)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 500 :reply "too late"}})
+        handle (binding [ec/*execution-context* (:ctx room)]
+                 (program/hire! room team :slow {:task "close"}))]
+    (d/close-room! room)
+    (is (empty? (run/active-runs (:id room))))
+    (is (= :cancelled (:run/status (program/observe room handle))))
+    (is (nil? (d/close-room! room)) "close remains idempotent")))

--- a/test/dvergr/agent/roster_test.clj
+++ b/test/dvergr/agent/roster_test.clj
@@ -1,0 +1,92 @@
+(ns dvergr.agent.roster-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.roster :as roster]))
+
+(def analyst-spec
+  {:id :analyst
+   :skills #{:research :analysis}
+   :prompt "Investigate carefully"
+   :program {:kind :scripted :reply "evidence"}})
+
+(deftest roster-construction-is-pure-portable-data
+  (let [empty-roster (roster/make-roster {:id :team
+                                          :scope {:tokens 1000}
+                                          :defaults {:tools #{:room/query}}})
+        populated (roster/make-agent empty-roster analyst-spec)
+        analyst (roster/agent populated :analyst)]
+    (is (empty? (roster/agents empty-roster)) "the input value is unchanged")
+    (is (= :analyst (:agent/id analyst)))
+    (is (= 1 (:agent/version analyst)))
+    (is (= #{:room/query} (:agent/tools analyst)))
+    (is (roster/data-value? populated))
+    (is (= populated (roster/make-agent populated analyst-spec))
+        "adding the same definition is idempotent")))
+
+(deftest runtime-state-is-rejected
+  (is (thrown? clojure.lang.ExceptionInfo
+               (roster/make-agent (roster/make-roster)
+                                  (assoc analyst-spec :metadata {:callback identity}))))
+  (is (thrown? clojure.lang.ExceptionInfo
+               (roster/make-roster {:scope {:counter (atom 0)}})))
+  (is (thrown? clojure.lang.ExceptionInfo
+               (roster/make-roster {:metadata {:mutable-date (java.util.Date.)}}))))
+
+(deftest conflicting-definitions-require-explicit-revision
+  (let [r1 (roster/make-agent (roster/make-roster) analyst-spec)
+        ref (roster/agent-ref (roster/agent r1 :analyst))
+        r2 (roster/revise-agent r1 :analyst {:prompt "Challenge assumptions"})]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (roster/make-agent r1 (assoc analyst-spec :prompt "different"))))
+    (is (= 2 (:agent/version (roster/agent r2 :analyst))))
+    (is (= "Challenge assumptions" (:agent/prompt (roster/agent r2 :analyst))))
+    (is (thrown? clojure.lang.ExceptionInfo (roster/agent r2 ref))
+        "a Run cannot silently resolve an old ref to revised behavior")))
+
+(deftest deterministic-selection-composes-over-roster-data
+  (let [r (-> (roster/make-roster)
+              (roster/make-agent analyst-spec)
+              (roster/make-agent {:id :lawyer
+                                  :skills #{:research :legal}
+                                  :program {:kind :scripted :reply "opinion"}})
+              (roster/make-agent {:id :reviewer
+                                  :skills #{:review}
+                                  :status :paused
+                                  :program {:kind :scripted :reply "review"}}))]
+    (is (= [:analyst :lawyer]
+           (mapv :agent/id (roster/select-agents r {:skill :research}))))
+    (is (= [:lawyer]
+           (mapv :agent/id (roster/select-agents r {:skills #{:research :legal}}))))
+    (is (= [:reviewer]
+           (mapv :agent/id (roster/select-agents r {:status :paused}))))))
+
+(deftest caller-keys-override-defaults-across-key-spellings
+  (let [r (-> (roster/make-roster
+               {:defaults {:agent/tools #{:read}
+                           :agent/prompt "default"}})
+              (roster/make-agent {:id :writer
+                                  :tools #{:write}
+                                  :prompt "specific"}))
+        a (roster/agent r :writer)]
+    (is (= #{:write} (:agent/tools a)))
+    (is (= "specific" (:agent/prompt a)))))
+
+(deftest revisions-preserve-map-key-identity-and-increment-exactly-once
+  (let [r (roster/make-agent (roster/make-roster) analyst-spec)]
+    (doseq [patch [{:id :other} {:agent/id :other}
+                   {:version 99} {:agent/version 99}]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (roster/revise-agent r :analyst patch))))
+    (let [revised (roster/revise-agent r :analyst {:prompt "new"})]
+      (is (= :analyst (:agent/id (get-in revised [:roster/agents :analyst]))))
+      (is (= 2 (:agent/version (get-in revised [:roster/agents :analyst])))))))
+
+(deftest malformed-and-unknown-agent-fields-fail-loudly
+  (let [r (roster/make-roster)]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (roster/make-roster {:scpoe {:tokens 10}})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (roster/make-agent r (assoc analyst-spec :porgram {}))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (roster/make-agent r (assoc analyst-spec :skills "research"))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (roster/make-agent r (assoc analyst-spec :status "ready"))))))

--- a/test/dvergr/agent/run_test.clj
+++ b/test/dvergr/agent/run_test.clj
@@ -133,6 +133,32 @@
         (run/finish! (:run/id explicit) :completed)
         (d/close-room! room)))))
 
+(deftest provenance-cannot-override-core-run-identity
+  (let [[room _st] (run-room :provenance-boundary)
+        trigger (d/message :alice :agent "work")]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"may not override causal identity"
+           (run/start! room :agent trigger (live-ctx)
+                       {:provenance {:run/room :other-room}})))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest closing-admission-is-a-run-start-fence
+  (let [[room _st] (run-room :admission-fence)
+        trigger (d/message :alice :agent "too late")]
+    (try
+      (is (empty? (run/close-room-admission! room)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"admission is closed"
+           (run/start! room :agent trigger (live-ctx))))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
 (deftest lifecycle-publication-requires-durable-receipts
   (let [base (memory/make)
         receipts? (atom false)

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -68,12 +68,18 @@
           parent-id (random-uuid)
           started (java.util.Date. 1787860800000)
           ended (java.util.Date. 1787860801000)
+          definition-hash (random-uuid)
           running {:run/id run-id
                    :run/kind :agent-turn
                    :run/room room-id
                    :run/actor :agent/researcher
                    :run/trigger trigger-id
                    :run/parent parent-id
+                   :run/roster :research-team
+                   :run/agent-version 3
+                   :run/program-kind :llm
+                   :run/interpreter-version 2
+                   :run/agent-def-hash definition-hash
                    :run/status :running
                    :run/created-at started
                    :run/started-at started

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -1,0 +1,81 @@
+(ns dvergr.sandbox.agent-programming-test
+  "Provider-free acceptance tests for the functional agent surface in room SCI."
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.store.memory :as memory]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.sandbox.ns.agent :as agent-ns]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(deftest immutable-rosters-launch-composable-room-runs-from-sci
+  (let [room    (d/make-room {:id :sci-agent-programming
+                              :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      ;; Keep this acceptance test focused on the new surface. Production calls
+      ;; the same injector from setup-agent-namespaces!; doc-coverage exercises
+      ;; that full wiring and catches any omission there.
+      (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room))
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                "(let [empty-team (agent/roster {:id :investigation}) "
+                "      team (-> empty-team "
+                "               (agent/make-agent "
+                "                {:id :analyst :skills #{:research} "
+                "                 :program {:kind :scripted :reply \"evidence\"}}) "
+                "               (agent/make-agent "
+                "                {:id :reviewer :skills #{:review} "
+                "                 :program {:kind :echo}})) "
+                "      analyst (agent/hire! team :analyst {:task \"inspect\"}) "
+                "      reviewer (agent/hire! team :reviewer {:task {:claim 42}}) "
+                "      values @(spin [(-> (await (agent/result-spin analyst)) :run/value) "
+                "                     (-> (await (agent/result-spin reviewer)) :run/value)])] "
+                "  {:empty-count (count (agent/list empty-team)) "
+                "   :team-count (count (agent/list team)) "
+                "   :values values "
+                "   :analyst-run (agent/run-id analyst) "
+                "   :analyst-status (:run/status (agent/observe analyst))})")))]
+        (testing "roster construction remains a value transformation"
+          (is (:success result) (pr-str (:error result)))
+          (is (= 0 (get-in result [:value :empty-count])))
+          (is (= 2 (get-in result [:value :team-count]))))
+        (testing "RunHandles compose through Spindel await in SCI"
+          (is (= ["evidence" {:claim 42}] (get-in result [:value :values])))
+          (is (uuid? (get-in result [:value :analyst-run])))
+          (is (= :completed (get-in result [:value :analyst-status])))
+          (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest roomless-sci-can-build-rosters-but-cannot-launch-effects
+  (let [ctx     (context/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ctx)]
+    (try
+      (agent-ns/add-programming-ns! sci-ctx nil ctx)
+      (let [pure (sandbox/eval-code
+                  sci-ctx
+                  (str "(require '[dvergr.agent :as agent]) "
+                       "(-> (agent/roster) "
+                       "    (agent/make-agent {:id :worker "
+                       "                       :program {:kind :echo}}) "
+                       "    agent/list count)"))
+            effect (sandbox/eval-code
+                    sci-ctx
+                    (str "(require '[dvergr.agent :as agent]) "
+                         "(agent/hire! (agent/make-agent "
+                         "               (agent/roster) "
+                         "               {:id :worker :program {:kind :echo}}) "
+                         "             :worker {:task :work})"))]
+        (is (= 1 (:value pure)))
+        (is (false? (:success effect)))
+        (is (re-find #"room-scoped" (get-in effect [:error :message]))))
+      (finally
+        (context/stop-context! ctx)))))

--- a/test/dvergr/sandbox/doc_coverage_test.clj
+++ b/test/dvergr/sandbox/doc_coverage_test.clj
@@ -26,7 +26,7 @@
 (def ^:private agent-facing-namespaces
   "dvergr's own vocabulary — the namespaces an agent is pointed at that we
    inject ourselves (so metadata is our job, not `sci/copy-var`'s)."
-  '#{dvergr.room dvergr.agents dvergr.actors dvergr.skills dvergr.tasks
+  '#{dvergr.room dvergr.agent dvergr.agents dvergr.actors dvergr.skills dvergr.tasks
      dvergr.scheduler dvergr.codec dvergr.mail git env llm sandbox})
 
 (defn- undocumented-fns


### PR DESCRIPTION
## Summary

- add pure immutable AgentDef and Roster values to the room SCI REPL
- add Run-backed provider-free hiring with Spindel Deferred completion, structured cancellation, exact provenance, and room-scoped control
- harden Room close, merge, and discard with a fork-local admission fence and fail-closed Run drain
- document the REPL programming model and fork/state boundaries

## Verification

- clojure -M:format
- clojure -J-Xmx2g -M:test (486 tests, 1994 assertions)
- clojure -T:build harness
- live room-bound SCI REPL experiment covering immutable revision, hire, await, and durable provenance
- independent blocker-only review: no remaining blockers