### PR TITLE
Persist tool authorization receipts

### DIFF
--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -302,24 +302,24 @@
                                                  resource-type resource-id grant-id]}
                                          (:authorization result)]
                                      (dh/transact conn
-                                                [(cond-> {:tool-call/id (java.util.UUID/randomUUID)
-                                                          :tool-call/name name
-                                                          :tool-call/input (pr-str input)
-                                                          :tool-call/result (pr-str (select-keys result [:type :content :error]))
-                                                          :tool-call/duration-ms duration-ms
-                                                          :tool-call/error? error?
-                                                          :tool-call/status (if error? :error :completed)
-                                                          :tool-call/authorization-decision decision
-                                                          :tool-call/authorization-source sources
-                                                          :tool-call/tool-use-id id
-                                                          :tool-call/started-at (java.util.Date.)}
-                                                   subject-type (assoc :tool-call/authorization-subject-type subject-type)
-                                                   subject-id (assoc :tool-call/authorization-subject-id (str subject-id))
-                                                   action (assoc :tool-call/authorization-action action)
-                                                   resource-type (assoc :tool-call/authorization-resource-type resource-type)
-                                                   resource-id (assoc :tool-call/authorization-resource-id (str resource-id))
-                                                   grant-id (assoc :tool-call/authorization-grant-id (str grant-id))
-                                                   run-id (assoc :tool-call/run-id run-id))]))
+                                                  [(cond-> {:tool-call/id (java.util.UUID/randomUUID)
+                                                            :tool-call/name name
+                                                            :tool-call/input (pr-str input)
+                                                            :tool-call/result (pr-str (select-keys result [:type :content :error]))
+                                                            :tool-call/duration-ms duration-ms
+                                                            :tool-call/error? error?
+                                                            :tool-call/status (if error? :error :completed)
+                                                            :tool-call/authorization-decision decision
+                                                            :tool-call/authorization-source sources
+                                                            :tool-call/tool-use-id id
+                                                            :tool-call/started-at (java.util.Date.)}
+                                                     subject-type (assoc :tool-call/authorization-subject-type subject-type)
+                                                     subject-id (assoc :tool-call/authorization-subject-id (str subject-id))
+                                                     action (assoc :tool-call/authorization-action action)
+                                                     resource-type (assoc :tool-call/authorization-resource-type resource-type)
+                                                     resource-id (assoc :tool-call/authorization-resource-id (str resource-id))
+                                                     grant-id (assoc :tool-call/authorization-grant-id (str grant-id))
+                                                     run-id (assoc :tool-call/run-id run-id))]))
                                    (catch Exception e
                                      (tel/log! {:level :warn :id :agent/tool-call-persist-error :error e}
                                                "Failed to persist tool-call analytics"))))

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -298,7 +298,10 @@
                                    error? (= :error (:type result))]
                                (when-let [conn (:db-conn chat-ctx)]
                                  (try
-                                   (dh/transact conn
+                                   (let [{:keys [decision sources subject-type subject-id action
+                                                 resource-type resource-id grant-id]}
+                                         (:authorization result)]
+                                     (dh/transact conn
                                                 [(cond-> {:tool-call/id (java.util.UUID/randomUUID)
                                                           :tool-call/name name
                                                           :tool-call/input (pr-str input)
@@ -306,10 +309,17 @@
                                                           :tool-call/duration-ms duration-ms
                                                           :tool-call/error? error?
                                                           :tool-call/status (if error? :error :completed)
-                                                          :tool-call/approval :auto-approved
+                                                          :tool-call/authorization-decision decision
+                                                          :tool-call/authorization-source sources
                                                           :tool-call/tool-use-id id
                                                           :tool-call/started-at (java.util.Date.)}
-                                                   run-id (assoc :tool-call/run-id run-id))])
+                                                   subject-type (assoc :tool-call/authorization-subject-type subject-type)
+                                                   subject-id (assoc :tool-call/authorization-subject-id (str subject-id))
+                                                   action (assoc :tool-call/authorization-action action)
+                                                   resource-type (assoc :tool-call/authorization-resource-type resource-type)
+                                                   resource-id (assoc :tool-call/authorization-resource-id (str resource-id))
+                                                   grant-id (assoc :tool-call/authorization-grant-id (str grant-id))
+                                                   run-id (assoc :tool-call/run-id run-id))]))
                                    (catch Exception e
                                      (tel/log! {:level :warn :id :agent/tool-call-persist-error :error e}
                                                "Failed to persist tool-call analytics"))))

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -359,10 +359,40 @@
     :db/cardinality :db.cardinality/one
     :db/doc "Execution lifecycle: :pending :running :completed :error :skipped"}
 
-   {:db/ident :tool-call/approval
+   {:db/ident :tool-call/authorization-decision
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one
-    :db/doc "Approval state: :auto-approved :pending-approval :approved :rejected :cached"}
+    :db/doc "Admission outcome, normally :authorized or :denied"}
+
+   {:db/ident :tool-call/authorization-source
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/many
+    :db/doc "Independent policy gates contributing to the decision"}
+
+   {:db/ident :tool-call/authorization-subject-type
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :tool-call/authorization-subject-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :tool-call/authorization-action
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :tool-call/authorization-resource-type
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :tool-call/authorization-resource-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :tool-call/authorization-grant-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "Optional stable EACL/capability/resource grant identifier"}
 
    {:db/ident :tool-call/tool-use-id
     :db/valueType :db.type/string
@@ -1169,7 +1199,9 @@
                           db message-id)]
     (when (seq tool-use-ids)
       (vec (for [tuid tool-use-ids]
-             (d/q '[:find (pull ?tc [:tool-call/name :tool-call/status :tool-call/approval
+             (d/q '[:find (pull ?tc [:tool-call/name :tool-call/status
+                                     :tool-call/authorization-decision
+                                     :tool-call/authorization-source
                                      :tool-call/duration-ms :tool-call/error?
                                      :tool-call/started-at]) .
                     :in $ ?tuid

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -263,16 +263,44 @@
         tool  (if local (get local tool-name) (get-tool tool-name))]
     (cond
       tool
-      (try
-        (-> (if-let [exec-fn (:execute tool)]
-              (exec-fn input ctx)
-              (when-let [handler-fn (:handler tool)]
-                (handler-fn input)))
-            (compaction/truncate-tool-result))
-        (catch Exception e
+      (let [default-decision {:decision :authorized
+                              :sources #{(if local :agent-tool-grant
+                                             :runtime-registry)}}
+            decision (if-let [authorize (:authorize tool)]
+                       (try
+                         (let [answer (authorize input ctx)]
+                           (if (contains? #{:authorized :denied :requires-decision}
+                                          (:decision answer))
+                             (update answer :sources
+                                     #(into (:sources default-decision) (or % #{})))
+                             {:decision :denied
+                              :sources #{:agent-tool-grant :authorization-error}
+                              :reason "Authorizer returned no valid decision"}))
+                         (catch Exception e
+                           {:decision :denied
+                            :sources #{:agent-tool-grant :authorization-error}
+                            :reason (.getMessage e)}))
+                       default-decision)]
+        (if (= :authorized (:decision decision))
+          (try
+            ;; The runtime, not the tool implementation, owns this field: an
+            ;; untrusted/custom tool cannot claim broader authority by putting
+            ;; a fabricated receipt in its result.
+            (assoc (-> (if-let [exec-fn (:execute tool)]
+                         (exec-fn input ctx)
+                         (when-let [handler-fn (:handler tool)]
+                           (handler-fn input)))
+                       (compaction/truncate-tool-result))
+                   :authorization decision)
+            (catch Exception e
+              {:type :error
+               :error (.getMessage e)
+               :exception (class e)
+               :authorization decision}))
           {:type :error
-           :error (.getMessage e)
-           :exception (class e)}))
+           :error (or (:reason decision)
+                      (str "Tool call not authorized: " tool-name))
+           :authorization decision}))
 
       local
       {:type :error

--- a/test/dvergr/tools_authorization_test.clj
+++ b/test/dvergr/tools_authorization_test.clj
@@ -1,0 +1,72 @@
+(ns dvergr.tools-authorization-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.tools :as tools]))
+
+(defn- tool [authorize called]
+  {:name "effect"
+   :authorize authorize
+   :execute (fn [_ _]
+              (swap! called inc)
+              {:type :success :content "done"
+               :authorization {:decision :authorized :sources #{:forged}}})})
+
+(deftest tool-authorization-is-an-execution-boundary
+  (let [called (atom 0)
+        receipt {:decision :authorized
+                 :sources #{:simmis-rebac}
+                 :subject-type :party :subject-id "agent"
+                 :action :write :resource-type :room :resource-id "room"}
+        result (tools/execute "effect" {} {:tools {"effect" (tool (constantly receipt) called)}})]
+    (is (= 1 @called))
+    (is (= (update receipt :sources conj :agent-tool-grant)
+           (:authorization result))
+        "the runtime replaces any receipt fabricated by the tool"))
+
+  (testing "denial does not invoke the effect"
+    (let [called (atom 0)
+          result (tools/execute
+                  "effect" {}
+                  {:tools {"effect" (tool (constantly {:decision :denied
+                                                        :sources #{:simmis-rebac}
+                                                        :reason "room access revoked"})
+                                          called)}})]
+      (is (zero? @called))
+      (is (= :error (:type result)))
+      (is (= :denied (get-in result [:authorization :decision])))))
+
+  (testing "an authorizer failure denies closed"
+    (let [called (atom 0)
+          result (tools/execute
+                  "effect" {}
+                  {:tools {"effect" (tool (fn [& _] (throw (ex-info "policy unavailable" {})))
+                                          called)}})]
+      (is (zero? @called))
+      (is (= #{:agent-tool-grant :authorization-error}
+             (get-in result [:authorization :sources]))))))
+
+(deftest missing-authorization-decision-denies-closed
+  (let [called (atom 0)
+        result (tools/execute "effect" {}
+                              {:tools {"effect" (tool (constantly nil) called)}})]
+    (is (zero? @called))
+    (is (= :denied (get-in result [:authorization :decision])))
+    (is (= #{:agent-tool-grant :authorization-error}
+           (get-in result [:authorization :sources])))))
+
+(deftest effect-failure-retains-the-admission-receipt
+  (let [result (tools/execute
+                "effect" {}
+                {:tools {"effect" {:name "effect"
+                                    :authorize (constantly {:decision :authorized
+                                                            :sources #{:simmis-rebac}})
+                                    :execute (fn [& _] (throw (ex-info "effect failed" {})))}}})]
+    (is (= :error (:type result)))
+    (is (= {:decision :authorized
+            :sources #{:agent-tool-grant :simmis-rebac}}
+           (:authorization result)))))
+
+(deftest allowlisted-tools-have-an-explicit-default-receipt
+  (let [called (atom 0)
+        result (tools/execute "effect" {} {:tools {"effect" (dissoc (tool nil called) :authorize)}})]
+    (is (= {:decision :authorized :sources #{:agent-tool-grant}}
+           (:authorization result)))))

--- a/test/dvergr/tools_authorization_test.clj
+++ b/test/dvergr/tools_authorization_test.clj
@@ -27,8 +27,8 @@
           result (tools/execute
                   "effect" {}
                   {:tools {"effect" (tool (constantly {:decision :denied
-                                                        :sources #{:simmis-rebac}
-                                                        :reason "room access revoked"})
+                                                       :sources #{:simmis-rebac}
+                                                       :reason "room access revoked"})
                                           called)}})]
       (is (zero? @called))
       (is (= :error (:type result)))
@@ -57,9 +57,9 @@
   (let [result (tools/execute
                 "effect" {}
                 {:tools {"effect" {:name "effect"
-                                    :authorize (constantly {:decision :authorized
-                                                            :sources #{:simmis-rebac}})
-                                    :execute (fn [& _] (throw (ex-info "effect failed" {})))}}})]
+                                   :authorize (constantly {:decision :authorized
+                                                           :sources #{:simmis-rebac}})
+                                   :execute (fn [& _] (throw (ex-info "effect failed" {})))}}})]
     (is (= :error (:type result)))
     (is (= {:decision :authorized
             :sources #{:agent-tool-grant :simmis-rebac}}


### PR DESCRIPTION
Summary:
- replace generic auto-approved tool metadata with structured authorization decisions
- add a fail-closed per-tool authorizer seam while preserving AgentDef tool-map admission
- persist subject, action, resource, source, and grant provenance for causal Run inspection

Authorization is compositional: embedders such as Simmis can add ReBAC decisions, while Kontor can later contribute resource grants. Routine admitted calls remain automatic; requires-decision is a distinct outcome.

Verification:
- full suite: 489 tests, 2004 assertions, 0 failures
- focused authorization suite: 4 tests, 13 assertions, 0 failures