### PR TITLE
feat(agent): add native reactive agent programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,21 @@ The standalone, runnable scenarios these import live in [`examples/`](examples/)
 ;; OpenAI via a Codex/ChatGPT subscription (no API key needed).
 ;; Run `codex login` once, then select :codex-subscription / "codex-subscription".
 
+;; Use that subscription from a bounded, Dvergr-native AgentDef program.
+(require '[dvergr.agent.roster :as roster]
+         '[dvergr.agent.program :as program])
+(def team
+  (roster/make-agent
+   (roster/make-roster)
+   {:id :researcher
+    :prompt "Investigate carefully and report evidence."
+    :tools #{:clojure_eval}
+    :model-policy {:provider :codex-subscription
+                   :model "codex-subscription-sol"}
+    :program {:kind :llm :budget-dollars 0.25}}))
+;; Inside a Room execution context:
+;; @(program/hire! room team :researcher {:task "test this hypothesis"})
+
 ;; Any OpenAI-compatible provider
 (providers/register-openai-compatible!
   :groq

--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -1,0 +1,119 @@
+(ns dvergr.agent.program-bench
+  "Opt-in, subscription-backed REPL probes for the agent programming surface.
+
+   These are deliberately not CI tests: responses, latency, and provider access
+   are nondeterministic and consume subscription resources. The corresponding
+   provider-free language and lifecycle contracts live in ordinary tests. Run
+   this namespace interactively to compare model comprehension using one fixed
+   task and the exact production prompt/tool path."
+  (:require [clojure.edn :as edn]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.engine.core :as ec])
+  (:import [java.io PushbackReader StringReader]))
+
+(def task-v1
+  (str "Use clojure_eval to solve this task. Construct an immutable roster "
+       "containing an :analyst with a scripted reply of evidence and a "
+       ":reviewer with an echo program. Hire both: ask the analyst to "
+       "investigate and give the reviewer the map {:claim 42}. Compose their "
+       "result Spins with Spindel await inside spin. Your final answer must be "
+       "exactly this EDN value: {:analyst \"evidence\" :reviewer {:claim 42}}. "
+       "Do not merely describe the code; execute it."))
+
+(def expected-v1 {:analyst "evidence" :reviewer {:claim 42}})
+
+(defn- parse-edn [value]
+  (when (string? value)
+    (with-open [reader (PushbackReader. (StringReader. value))]
+      (try
+        (let [eof (Object.)
+              parsed (edn/read {:eof eof} reader)
+              trailing (edn/read {:eof eof} reader)]
+          (when (and (not (identical? eof parsed))
+                     (identical? eof trailing))
+            parsed))
+        (catch Throwable _ nil)))))
+
+(defn run-v1!
+  "Run programming benchmark v1 through `provider`/`model`.
+
+   Intended REPL usage:
+
+     (run-v1! :codex-subscription \"codex-subscription-sol\")
+     (run-v1! :claude-code \"claude-code-sonnet\")
+
+   The returned report includes generated SCI calls so a failure distinguishes
+   language/API confusion from model or transport failure."
+  [provider model]
+  (let [room-id (keyword (str "programming-bench-" (random-uuid)))
+        room (d/make-room {:id room-id :store (memory/make)})
+        team (roster/make-agent
+              (roster/make-roster {:id :benchmark})
+              {:id :orchestrator
+               :prompt (str "Exercise Dvergr through clojure_eval. Complete the "
+                            "requested computation before answering.")
+               :tools #{:clojure_eval}
+               :model-policy {:provider provider :model model}
+               :program {:kind :llm
+                         :max-model-steps 8
+                         :budget-dollars 1.0
+                         :auto-compact? false}})
+        started (System/nanoTime)]
+    (try
+      (let [handle (binding [ec/*execution-context* (:ctx room)]
+                     (program/hire! room team :orchestrator {:task task-v1}))
+            initial-result (binding [ec/*execution-context* (:ctx room)]
+                             (deref handle 120000 ::timeout))
+            timed-out? (= ::timeout initial-result)
+            _ (when timed-out?
+                (binding [ec/*execution-context* (:ctx room)]
+                  (program/cancel! handle)))
+            result (if timed-out?
+                     (binding [ec/*execution-context* (:ctx room)]
+                       (deref handle 10000
+                              {:run/id (program/run-id handle)
+                               :run/status :failed
+                               :run/error "Cancellation did not quiesce within 10s"}))
+                     initial-result)
+            durable (program/observe room handle)
+            all-runs (run/runs room {:limit 20})
+            messages (d/messages room {:limit 100})
+            activity (filter #(= :_activity (:to %)) messages)
+            parsed (parse-edn (:run/value result))
+            root-run-id (program/run-id handle)
+            child-runs (remove #(= root-run-id (:run/id %)) all-runs)]
+        {:benchmark :programming/v1
+         :provider provider
+         :model model
+         :task task-v1
+         :expected expected-v1
+         :passed? (and (= :completed (:run/status result))
+                       (= expected-v1 parsed)
+                       (= 2 (count child-runs))
+                       (= #{:analyst :reviewer} (set (map :run/actor child-runs)))
+                       (every? #(= root-run-id (:run/parent %)) child-runs)
+                       (every? #(= :completed (:run/status %)) child-runs))
+         :timed-out? timed-out?
+         :elapsed-ms (long (/ (- (System/nanoTime) started) 1000000))
+         ;; Each activity row is a tool-bearing provider exchange. A successful
+         ;; exact answer requires one final, non-tool provider exchange as well.
+         :model-steps (cond-> (count activity)
+                        (= :completed (:run/status result)) inc)
+         :result result
+         :parsed-value parsed
+         :durable-status (:run/status durable)
+         :runs (mapv #(select-keys % [:run/id :run/parent :run/actor
+                                     :run/status :run/error])
+                     all-runs)
+         :tool-calls
+         (mapv (fn [message]
+                 (mapv #(select-keys % [:tool-use/name :tool-use/input])
+                       (get-in message [:metadata :tool-uses])))
+               activity)
+         :active-after (count (run/active-runs room-id))})
+      (finally
+        (d/close-room! room)))))

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -1,9 +1,8 @@
 # Agent programs in the room REPL
 
-Status: first provider-free slice implemented. The data model and Run boundary
-are intentional; the built-in interpreter currently supports only deterministic
-`:echo` and `:scripted` programs while the native LLM/tool interpreter is being
-lifted onto the same contract.
+Status: deterministic and native LLM/tool interpreters implemented. The data
+model and Run boundary are intentional; simulation, replay, resource splitting,
+and durable continuation are later interpreters over the same contract.
 
 Dvergr agents can construct specialized workers and compose their executions
 from the SCI REPL. The initial surface separates four concepts:
@@ -17,6 +16,32 @@ from the SCI REPL. The initial surface separates four concepts:
 
 An actor is durable identity; an AgentDef describes behavior; a Run is one
 performance. They must not collapse into one mutable "agent object."
+
+## Reactive process semantics
+
+The primitive is a reactive process, not a chat turn. A model API exchange is a
+discrete integration step inside one interpreter; a Run may instead be a single
+calculation, a queued dialogue, a continuously updated monitor, a fork/join
+workflow, or a probabilistic search. Room messages are the durable event source,
+thread views select conversational context, and the Run is the causal/resource
+lifetime that owns effects.
+
+The current surface deliberately reuses Spindel's algebra:
+
+| Composition | Conversational interpretation |
+|---|---|
+| `await` / join | depend on one or several completed computations |
+| parallel Spins | gather independent evidence concurrently |
+| `race` | take the first satisfactory branch and cancel losers |
+| signals / reactive atoms | accumulate beliefs, memory, or workflow state with fork semantics |
+| context fork | explore a copy-on-write alternative or particle |
+| cancellation | withdraw attention and terminate owned effects |
+
+Queueing, merging observations, switch-to-latest steering, approval gates, and
+long-lived output/effect streams should be derived attention combinators over
+the same substrate. They must not be encoded as special cases of a global turn
+loop. `:llm` is the first convenient process interpreter, not the definition of
+an agent.
 
 ## Construct and compose
 
@@ -45,26 +70,128 @@ Inside a room-bound agent sandbox:
 
 `roster`, `make-agent`, and `revise-agent` have no bang because they are pure:
 each returns a new value and leaves its input unchanged. `hire!` has a bang
-because it immediately posts the precise trigger, admits a durable
-`:agent-task` Run, and starts its Spin in the current Room. Admission is
-synchronous and durability-first: once `hire!` returns, `observe` and `cancel!`
-can address the Run without a startup race.
+because it admits a durable `:agent-task` Run, posts the precise trigger, and
+starts its Spin in the current Room. Admission is synchronous and
+durability-first: once `hire!` returns, `observe` and `cancel!` can address the
+Run without a startup race. If trigger persistence or spawning fails, the
+already-admitted Run is durably failed.
 
-Use `await` on `(agent/result-spin handle)` inside `spin`. The opaque handle does
-not pretend to implement Spindel's graph protocol; exposing the native Spin
-preserves structured cancellation and dependency tracking in the owning fork.
-Dereference is available at a REPL or test boundary, but workflow
-code should stay compositional. A top-level blocking `await` shim is not
-required.
+Use `await` on `(agent/result-spin handle)` inside `spin`. This is a passive
+observer: several branches may await one Run, and cancelling one observation
+does not cancel the shared work. Use `(agent/owned-result-spin handle)` for a
+race arm whose loss should cancel the hired Run. The opaque handle does not
+pretend to implement Spindel's graph protocol; the explicit distinction keeps
+ownership and dependency tracking visible in the owning fork. Dereference is
+available at a REPL or test boundary, but workflow code should stay
+compositional. A top-level blocking `await` shim is not required.
 
 The handle supports:
 
 ```clojure
 (agent/run-id handle)        ; durable UUID
-(agent/result-spin handle)   ; fresh native observer Spin for await/race/parallel
+(agent/result-spin handle)   ; passive observer Spin; safe to share
+(agent/owned-result-spin handle) ; owning race arm; losing cancels the Run
 (agent/observe handle)       ; durable Run projection
 (agent/cancel! handle)       ; targeted cooperative cancellation
 ```
+
+## Native model and tool programs
+
+An `:llm` program lifts Dvergr's existing single-exchange model/tool core directly behind
+the same Run boundary:
+
+```clojure
+(let [team (agent/make-agent
+            (agent/roster {:id :research})
+            {:id :analyst
+             :prompt "Investigate the task and report evidence with caveats."
+             :tools #{:clojure_eval :knowledge_search}
+             :model-policy {:provider :codex-subscription
+                            :model "codex-subscription-sol"}
+             :program {:kind :llm
+                       :max-model-steps 32
+                       :budget-dollars 0.50}})
+      work (agent/hire! team :analyst {:task "Test the strongest contrary case"})]
+  @(spin (await (agent/result-spin work))))
+```
+
+Every hire receives a fresh ChatContext in the Room's Spindel execution context.
+Parallel hires therefore have independent dialogue and budget state while seeing
+the same fork-local Geschichte/Datahike substrate. The AgentDef tool set is both
+the schema shown to the model and the authoritative execution allowlist. An
+omitted tool set means no tools.
+
+An LLM Run records a deterministic `:run/chat-id`. With a Datahike-backed Room,
+that ID addresses the persistent model/tool trace; an ephemeral Room owns and
+closes the per-Run chat database when the worker has physically terminated.
+Automatic reconstruction of an interrupted live exchange is not implemented yet:
+the durable trace supports inspection and a later explicit retry/resume policy,
+not resurrection of native streams after process loss.
+
+Blocking provider I/O runs off Spindel's drain thread. Dvergr owns prompt and
+context assembly, compaction, tool dispatch, SCI isolation, cancellation,
+activity messages, and Run settlement; providers—including Codex and Claude
+subscription transports—only supply model responses.
+
+`:max-model-steps` bounds automatic model/effect integration (default 32,
+maximum 256). A step is one provider exchange, not a conversational turn and
+not Dvergr's scheduling clock. Reactive attention may queue, merge, observe,
+fork, or switch work around these discrete transport boundaries.
+`:budget-dollars` is a per-execution spending ceiling (default $1), not a Kontor
+resource allocation. When it is exceeded after a tool-bearing model step, the Run
+settles as `:waiting` with reason `:budget-exhausted`; no process remains active.
+A true resumable continuation and affine resource settlement are separate later
+contracts.
+
+An LLM-created sandbox can still build and revise arbitrary immutable rosters,
+but its `hire!` authority currently accepts only provider-free `:echo` and
+`:scripted` children. This prevents a child from minting new provider spend,
+tools, or recursive LLM work before Kontor can split a resource vector from the
+parent Run. A top-level Room REPL has no such program-kind ceiling.
+
+## Evaluation ladder
+
+The API and the instructions that teach it are evaluated together at three
+levels:
+
+1. Deterministic law/contract tests exercise fork ownership, parallel join,
+   race cancellation, admission, drain, authority, and durability without a
+   provider.
+2. Stub-model interpreter tests exercise prompt/context assembly, exact tool
+   schemas, model-step continuation, activity correlation, budgets, and cleanup.
+3. Opt-in model benchmarks give the same room-REPL tasks to Codex, Claude Code,
+   API models, and local models. They record whether generated SCI compiles,
+   whether the causal result/effects are correct, leaked Runs/resources, model
+   steps, wall time, task version, and model. Token/cost receipts and a stable
+   hash of the assembled system prompt remain benchmark-reporting follow-ups.
+
+The initial model-facing task set should include pure roster specialization,
+parallel research/review and reduction, race-with-loser-cancellation, explicit
+structural child Runs, delegation-ceiling recognition, and creation of a nested
+durable Room. Later attention combinators add queue/observe/steer/switch tests.
+Passing only one model is not sufficient evidence that the programming surface
+is clear.
+
+The first opt-in comprehension probe is `dvergr.agent.program-bench/run-v1!`
+on the `:dev` classpath. It runs through the production prompt, provider, tool,
+SCI, Spindel, and Run paths while retaining every generated `clojure_eval` call
+in its report:
+
+```clojure
+(require '[dvergr.agent.program-bench :as bench])
+(bench/run-v1! :codex-subscription "codex-subscription-sol")
+(bench/run-v1! :claude-code "claude-code-sonnet")
+```
+
+It is an explicit REPL benchmark rather than a CI test because it is
+nondeterministic, needs local subscription authentication, and consumes model
+resources. Its language and lifecycle contracts are duplicated as
+provider-free deterministic tests. In the 2026-08-28 probe, Codex Sol and Claude
+Code Sonnet each discovered the API, created and joined two child Runs, and
+returned the expected value with two `clojure_eval` calls. Earlier attempts
+exposed two real harness defects: the native interpreter omitted the shared
+sandbox prelude, and Claude Code's own native tools shadowed Dvergr's supplied
+tool protocol.
 
 An explicit `:parent-run` on `hire!` records structural spawning. Causal
 succession remains derivable through the new Run's trigger message and that
@@ -121,14 +248,14 @@ Using it from a child or sibling fork fails explicitly: observe the durable Run
 facts there, or start a branch-local Run. A future cross-context result bridge
 must copy values deliberately rather than sharing continuations across forks.
 
-## Current boundary and next interpreter
+## Current boundary and next interpreters
 
 The deterministic interpreter proves the bounded programming contract without an LLM:
 parallel composition, targeted cancellation, exact trigger/output correlation,
 and room-scoped execution all run through the same SCI surface an agent uses.
 
-The next interpreter should lift Dvergr's existing agent-turn core rather than
-wrap another harness. It must preserve:
+The native `:llm` interpreter now lifts Dvergr's existing single-exchange core rather
+than wrapping another harness. It preserves:
 
 - Dvergr-owned ChatContext assembly and compaction;
 - the room-bound SCI sandbox and forked Geschichte/Datahike workspace;
@@ -136,10 +263,10 @@ wrap another harness. It must preserve:
 - native API, Codex subscription, Claude Code subscription, and local providers;
 - Run-correlated activity/output and resource accounting;
 - blocking provider I/O off the Spindel drain thread;
-- pure scope attenuation before execution.
+- delegation attenuation before child execution.
 
-`:roster/scope` is currently portable policy data, not an enforced resource
-grant. Until a Kontor-backed split/settlement interpreter lands, the
-provider-free program kinds are deliberately the only accepted kinds. This keeps
-the public boundary honest: declaring a budget or authority in data must not
-pretend to enforce it.
+`:roster/scope` is still portable policy data, not an enforced resource grant.
+The native interpreter enforces its concrete tool allowlist, model-step bound, and
+ChatContext spending ceiling, but does not pretend those are an affine resource
+split. A Kontor-backed admission/settlement interpreter should make declared
+resource vectors executable before scopes can delegate assets to child Runs.

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -1,19 +1,31 @@
 (ns dvergr.agent.program
   "Run-backed execution of portable AgentDefs.
 
-   This is deliberately a thin first interpreter. Roster construction is pure;
-   `hire!` is the effect boundary that posts the precise task trigger, admits a
-   durable Run, and starts a Spindel Spin. Live results are cached by Spindel,
-   while Room messages and Run lifecycle remain the durable source of truth."
+   Roster construction is pure; `hire!` is the effect boundary that admits a
+   durable Run, posts its precise task trigger, and starts a Spindel Spin.
+   Workflow results live in the fork-aware execution graph, while Room messages
+   and Run lifecycle remain the durable source of truth."
   (:require [dvergr.agent.roster :as roster]
+            [dvergr.agent.prompt :as prompt]
+            [dvergr.agent.room-context :as room-context]
             [dvergr.agent.run :as run]
+            [dvergr.agent.turn :as turn]
+            [dvergr.chat.agent :as chat-agent]
+            [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as d]
+            [dvergr.model.providers :as providers]
+            [dvergr.system.rooms :as system-rooms]
+            [dvergr.tools :as tools]
             [hasch.core :as hasch]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.atom :as ratom]
             [org.replikativ.spindel.spin.combinators :as comb]
             [org.replikativ.spindel.spin.core :as spin-core]
-            [org.replikativ.spindel.spin.sync :as sync]))
+            [org.replikativ.spindel.spin.sync :as sync])
+  (:import [java.nio.charset StandardCharsets]
+           [java.util UUID]
+           [java.util.concurrent Callable CountDownLatch FutureTask]))
 
 (def run-sink
   "Reserved non-subscribed Room address for private Run inputs and outputs.
@@ -21,7 +33,183 @@
    to a Participant is a separate, explicit speech act."
   :_runs)
 
-(def interpreter-version 1)
+(def interpreter-version 2)
+
+(def ^:private default-max-model-steps 32)
+
+(defn- program-result
+  ([status value] {::status status ::value value})
+  ([status value reason] {::status status ::value value ::reason reason}))
+
+(defn- run-chat-id [run-id]
+  (UUID/nameUUIDFromBytes
+   (.getBytes (str "dvergr-agent-run|" run-id) StandardCharsets/UTF_8)))
+
+(declare start-worker!)
+
+(defn- make-supervisor [execution-ctx]
+  {:execution-ctx execution-ctx
+   :state (atom {:cancelled? false
+                 :sealed? false
+                 :workers {}
+                 :cleanup nil
+                 :cleanup-phase :pending
+                 :cleanup-error nil
+                 :quiesced? false})
+   :quiesced (sync/deferred)
+   :quiesced-latch (CountDownLatch. 1)})
+
+(defn- advance-supervisor!
+  "Advance cleanup/quiescence after an atomic supervisor transition. Cleanup
+   starts only after every normal worker has acknowledged termination."
+  [supervisor]
+  (let [action
+        (locking supervisor
+          (let [{:keys [sealed? workers cleanup cleanup-phase quiesced?] :as state}
+                @(:state supervisor)
+                normal-live? (some #(= :normal (:kind %)) (vals workers))]
+            (cond
+              (and sealed? (not normal-live?) (= :pending cleanup-phase) cleanup)
+              (do (swap! (:state supervisor) assoc :cleanup-phase :running)
+                  [:cleanup cleanup])
+
+              (and sealed? (not normal-live?) (= :pending cleanup-phase))
+              (do (swap! (:state supervisor) assoc :cleanup-phase :done)
+                  :advance)
+
+              (and sealed? (= :done cleanup-phase) (empty? workers) (not quiesced?))
+              (let [state' (assoc state :quiesced? true)]
+                (reset! (:state supervisor) state')
+                [:quiesced state'])
+
+              :else nil)))]
+    (cond
+      (= :advance action)
+      (advance-supervisor! supervisor)
+
+      (= :cleanup (first action))
+      (start-worker! supervisor (second action) :cleanup)
+
+      (= :quiesced (first action))
+      (try
+        ;; Deferred publication is context access. The stable latch is released
+        ;; only afterwards, so Room drain can treat it as a true quiescence ack.
+        (binding [ec/*execution-context* (:execution-ctx supervisor)]
+          ((:quiesced supervisor) (second action)))
+        (finally
+          (.countDown ^CountDownLatch (:quiesced-latch supervisor)))))
+    nil))
+
+(defn- worker-finished! [supervisor worker-id kind result]
+  (locking supervisor
+    (swap! (:state supervisor)
+           (fn [state]
+             (cond-> (update state :workers dissoc worker-id)
+               (= :cleanup kind)
+               (assoc :cleanup-phase :done
+                      :cleanup-error (when (and (map? result)
+                                                (contains? result ::worker-error))
+                                       (::worker-error result)))))))
+  (advance-supervisor! supervisor))
+
+(defn- start-worker!
+  "Register and start blocking/native work under the process-local supervisor.
+   Cancellation is sticky: registration and the cancellation check share the
+   supervisor lock, closing the cancel-before-start and between-step races."
+  ([supervisor f] (start-worker! supervisor f :normal))
+  ([supervisor f kind]
+   (let [done       (sync/deferred)
+         worker-id  (random-uuid)
+         phase      (atom :new)
+         result     (atom nil)
+         callable   (reify Callable
+                      (call [_]
+                        (when (compare-and-set! phase :new :running)
+                          (binding [ec/*execution-context* (:execution-ctx supervisor)]
+                            (try
+                              (reset! result (f))
+                              (catch Throwable t
+                                (reset! result {::worker-error t}))
+                              (finally
+                                (reset! phase :terminated)
+                               ;; Publish the per-worker result before removing
+                               ;; its live lease from the stable supervisor.
+                                (try
+                                  (done @result)
+                                  (finally
+                                    (worker-finished! supervisor worker-id kind
+                                                      @result)))))))))
+         task       (proxy [FutureTask] [callable]
+                      (done []
+                       ;; Cancellation before the executor begins means the
+                       ;; Callable's finally cannot acknowledge termination.
+                       ;; Win that one state transition here. If it was already
+                       ;; running, its finally is the only acknowledgement.
+                        (when (and (.isCancelled this)
+                                   (compare-and-set! phase :new :terminated))
+                          (let [value (or @result ::worker-cancelled)]
+                            (binding [ec/*execution-context* (:execution-ctx supervisor)]
+                              (try
+                                (done value)
+                                (finally
+                                  (worker-finished! supervisor worker-id kind
+                                                    value))))))))
+         worker     {:id worker-id :task task :done done :kind kind}
+         cancel-now?
+         (locking supervisor
+           (let [{:keys [sealed? cancelled?]} @(:state supervisor)]
+             (when (and sealed? (= :normal kind))
+               (throw (ex-info "Cannot start work after supervisor seal"
+                               {:type ::supervisor-sealed})))
+             (swap! (:state supervisor) assoc-in [:workers worker-id] worker)
+             (and cancelled? (= :normal kind))))]
+     (if cancel-now?
+      ;; Do not even enqueue work when cancellation preceded registration.
+       (.cancel task false)
+       (try
+         (.execute clojure.lang.Agent/soloExecutor task)
+         (catch Throwable t
+          ;; Make executor rejection flow through the same acknowledgement path.
+           (reset! result {::worker-error t})
+           (.cancel task false))))
+     worker)))
+
+(defn- cancel-supervisor! [supervisor]
+  (let [tasks
+        (locking supervisor
+          (swap! (:state supervisor) assoc :cancelled? true)
+          (->> (get @(:state supervisor) :workers)
+               vals
+               (filter #(= :normal (:kind %)))
+               (map :task)
+               vec))]
+    (doseq [^FutureTask task tasks]
+      (.cancel task true)))
+  nil)
+
+(defn- register-cleanup! [supervisor cleanup]
+  (locking supervisor
+    (when-not (= :pending (:cleanup-phase @(:state supervisor)))
+      (throw (ex-info "Cleanup registered after supervisor cleanup began"
+                      {:type ::late-cleanup-registration})))
+    (swap! (:state supervisor) assoc :cleanup cleanup))
+  nil)
+
+(defn- seal-supervisor! [supervisor]
+  (locking supervisor
+    (swap! (:state supervisor) assoc :sealed? true))
+  (advance-supervisor! supervisor)
+  (:quiesced supervisor))
+
+(defn- worker-result-spin [worker]
+  (sp/spin (sp/await (:done worker))))
+
+(defn- worker-error? [value]
+  (and (map? value) (contains? value ::worker-error)))
+
+(defn- await-supervisor! [supervisor]
+  (.await ^CountDownLatch (:quiesced-latch supervisor))
+  nil)
 
 (deftype RunHandle [id room-id owner-fork-id execution completion]
   clojure.lang.ILookup
@@ -80,19 +268,28 @@
   (:run/id handle))
 
 (defn result-spin
-  "A native Spindel observer Spin for `handle`'s completion. Await this inside
+  "A passive Spindel observer Spin for `handle`'s completion. Await this inside
    workflow Spins. Each call returns a fresh graph node over a fork-aware
-   Deferred, so combinators never invoke the already-running execution again.
-  The observer owns that execution during its initial pre-await window."
+   Deferred; cancelling one observer never cancels the shared execution or a
+   peer observer. Use `owned-result-spin` when structured cancellation should
+   propagate from a race arm to the hired Run."
+  [^RunHandle handle]
+  (ensure-owner-context! handle)
+  (let [completion (.-completion handle)]
+    (sp/spin (sp/await completion))))
+
+(defn owned-result-spin
+  "An owning Spindel observer for a RunHandle. If a combinator cancels this
+   observer (for example, as the losing arm of `race`), cancellation propagates
+   to the hired Run. Prefer passive `result-spin` for ordinary or shared reads."
   [^RunHandle handle]
   (ensure-owner-context! handle)
   (let [execution (.-execution handle)
-        completion (.-completion handle)
         id (:run/id handle)
         room-id (:run/room handle)
         observer (sp/spin
                   (try
-                    (sp/await completion)
+                    (sp/await (.-completion handle))
                     (catch Throwable t
                       (when (= spin-core/spin-cancelled (:type (ex-data t)))
                         (run/cancel-room-run! room-id id))
@@ -118,8 +315,8 @@
          (sp/await (comb/sleep slice))
          (recur (- remaining slice)))))))
 
-(defn- execute-program
-  "Interpret the provider-free program vocabulary. Returns Spin[value]."
+(defn- execute-deterministic-program
+  "Interpret the deterministic program vocabulary. Returns Spin[ProgramResult]."
   [run-id agent task]
   (let [{:keys [kind delay-ms reply result] :as program} (:agent/program agent)]
     (sp/spin
@@ -127,11 +324,13 @@
      (when (run/cancel-requested? run-id)
        (cancelled! run-id))
      (case kind
-       :scripted (cond
-                   (contains? program :result) result
-                   (contains? program :reply) reply
-                   :else nil)
-       :echo task
+       :scripted (program-result
+                  :completed
+                  (cond
+                    (contains? program :result) result
+                    (contains? program :reply) reply
+                    :else nil))
+       :echo (program-result :completed task)
        (throw (ex-info "No interpreter for AgentDef program kind"
                        {:type ::unknown-program-kind
                         :kind kind
@@ -140,16 +339,208 @@
 (defn- result-content [value]
   (if (string? value) value (pr-str value)))
 
+(defn- last-assistant-content [chat-ctx]
+  (some->> (chat-context/get-messages chat-ctx)
+           reverse
+           (some (fn [message]
+                   (when (= :assistant
+                            (or (:message/role message) (:role message)))
+                     (or (:message/content message) (:content message)))))))
+
+(defn- resolve-model-spec [agent]
+  (providers/ensure-initialized!)
+  (or (:agent/model-policy agent)
+      (providers/default-spec)
+      (throw (ex-info "No LLM provider is available for AgentDef"
+                      {:type ::no-provider
+                       :agent/id (:agent/id agent)}))))
+
+(defn- new-llm-context [room run-id agent budget-dollars chat-id]
+  (let [system-id (room-context/room-system-id room)
+        borrowed-db (some-> room :store :conn)
+        chat-ctx (turn/new-working-ctx
+                  {:execution-ctx (:ctx room)
+                   :chat-id chat-id
+                   :title (str "agent-task " (name (:agent/id agent)))
+                   :budget-dollars budget-dollars
+                   :db-conn borrowed-db
+                   :kb-conn (when system-id (system-rooms/room-kb-conn system-id))
+                   :room-id system-id
+                   :room-runtime-id (:id room)
+                   ;; Until Kontor can split a resource vector, a paid child may
+                   ;; only delegate provider-free work. Pure roster construction
+                   ;; remains available inside SCI.
+                   :agent-program-ceiling {:program-kinds #{:echo :scripted}
+                                           :provider-effects? false
+                                           :parent-run run-id}})]
+    {:chat-ctx chat-ctx
+     :owned-db? (nil? borrowed-db)}))
+
+(defn- llm-tool-context [room chat-ctx agent]
+  (let [system-id (room-context/room-system-id room)
+        tool-map (tools/normalize-tools (or (:agent/tools agent) #{}))]
+    {:tool-map tool-map
+     :tool-ctx
+     (-> (tools/make-context
+          {:db-conn (:db-conn chat-ctx)
+           :chat-ctx chat-ctx
+           :sci-ctx (:sci-ctx chat-ctx)
+           :tools tool-map
+           :isolation :sci
+           :execution-ctx (:ctx room)})
+         (assoc :workspace-roots
+                (when system-id (system-rooms/room-load-roots system-id)))
+         (assoc :kb-conn
+                (when system-id (system-rooms/room-kb-conn system-id)))
+         (assoc :room room))}))
+
+(defn- execute-llm-program
+  "Run a bounded Dvergr-native model/tool loop. Each blocking model round-trip
+   runs under a supervised worker; this Spin retains orchestration, activity
+   correlation, cleanup, and cancellation in the Room's execution graph."
+  [room run-id chat-id agent task trigger supervisor]
+  (let [{:keys [max-model-steps budget-dollars auto-compact? compaction-model]
+         :or {max-model-steps default-max-model-steps
+              budget-dollars 1.0
+              auto-compact? true}} (:agent/program agent)]
+    (sp/spin
+     ;; Context/schema/SCI construction and credential discovery may block.
+     ;; Build the whole runtime bundle under the same supervised worker as
+     ;; provider calls, before exposing it to the orchestration Spin.
+     (let [init-worker
+           (start-worker!
+            supervisor
+            (fn []
+              (let [{:keys [chat-ctx owned-db?]}
+                    (new-llm-context room run-id agent budget-dollars chat-id)
+                    _ (when owned-db?
+                        (register-cleanup!
+                         supervisor #(chat-context/close-chat! chat-ctx)))
+                    {:keys [tool-map tool-ctx]}
+                    (llm-tool-context room chat-ctx agent)
+                    model-spec (resolve-model-spec agent)
+                    instructions
+                    (prompt/assemble-system-prompt
+                     (str "You are a model inside the Dvergr harness. Dvergr owns "
+                          "tools and the sandbox. Call only tools explicitly supplied "
+                          "in this request; when none are supplied, answer directly. "
+                          "Never request shell, grep, file, web, or other native "
+                          "Codex tools unless Dvergr explicitly supplied that exact tool."
+                          (when-let [agent-prompt (:agent/prompt agent)]
+                            (str "\n\n" agent-prompt)))
+                     {:tools tool-map :isolation :sci :profile :workflow})]
+                (chat-context/add-message!
+                 chat-ctx {:role :system :content instructions})
+                (chat-context/add-message!
+                 chat-ctx {:role :user :content (result-content task)})
+                {:chat-ctx chat-ctx
+                 :tool-map tool-map
+                 :tool-ctx tool-ctx
+                 :model-spec model-spec})))
+           initialized (sp/await (worker-result-spin init-worker))]
+       (when (or (= ::worker-cancelled initialized)
+                 (run/cancel-requested? run-id))
+         (cancelled! run-id))
+       (when (worker-error? initialized)
+         (throw (ex-info "LLM runtime initialization failed"
+                         {:type ::runtime-initialization-failed
+                          :agent/id (:agent/id agent)}
+                         (::worker-error initialized))))
+       (let [{:keys [chat-ctx tool-map tool-ctx model-spec]} initialized
+             posted (ratom/create-atom 0)]
+         (loop [model-step 0]
+           (when (run/cancel-requested? run-id)
+             (cancelled! run-id))
+           (let [call
+                 (start-worker!
+                  supervisor
+                  (fn []
+                    (chat-agent/run-agent-turn!
+                     chat-ctx
+                     {:provider (:provider model-spec)
+                      :model (:model model-spec)
+                        ;; The SAME normalized map defines both the model schema
+                        ;; and execute-side authority. Empty means no tools.
+                      :tools tool-map
+                      :tool-ctx tool-ctx
+                      :cancel? (turn/cancel?-fn
+                                chat-ctx (:ctx room)
+                                (fn [] (run/cancel-requested? run-id)))
+                      :auto-compact? auto-compact?
+                      :compaction-model compaction-model
+                      ;; The existing single-exchange core still calls this
+                      ;; trace field `turn-number`; semantically it is a model
+                      ;; integration step, not a conversational turn.
+                      :turn-number model-step
+                      :run-id run-id})))
+                 outcome (sp/await (worker-result-spin call))]
+             (turn/post-turn-activity! room (:agent/id agent) chat-ctx posted
+                                       run-id trigger)
+             (cond
+               (or (= ::worker-cancelled outcome)
+                   (run/cancel-requested? run-id))
+               (cancelled! run-id)
+
+               (worker-error? outcome)
+               (throw (ex-info "LLM model step failed"
+                               {:type ::llm-model-step-failed
+                                :agent/id (:agent/id agent)
+                                :model-step model-step}
+                               (::worker-error outcome)))
+
+               (= :cancelled outcome)
+               (cancelled! run-id)
+
+               (= :error outcome)
+               (throw (ex-info "LLM model step failed"
+                               {:type ::llm-model-step-failed
+                                :agent/id (:agent/id agent)
+                                :model-step model-step}))
+
+               (= :complete outcome)
+               (if-let [value (last-assistant-content chat-ctx)]
+                 (program-result :completed value)
+                 (throw (ex-info "LLM program completed without an assistant result"
+                                 {:type ::missing-llm-result
+                                  :agent/id (:agent/id agent)})))
+
+               (not= :continue outcome)
+               (throw (ex-info "Unknown LLM model-step outcome"
+                               {:type ::unknown-model-step-outcome
+                                :outcome outcome
+                                :model-step model-step}))
+
+               (chat-context/budget-exceeded? chat-ctx)
+               (program-result :waiting nil :budget-exhausted)
+
+               (>= (inc model-step) max-model-steps)
+               (throw (ex-info "LLM program exceeded its model-step bound"
+                               {:type ::model-step-limit-exceeded
+                                :agent/id (:agent/id agent)
+                                :max-model-steps max-model-steps}))
+
+               :else
+               (recur (inc model-step))))))))))
+
+(defn- execute-program
+  [room run-id chat-id agent task trigger supervisor]
+  (case (get-in agent [:agent/program :kind])
+    :llm (execute-llm-program room run-id chat-id agent task trigger supervisor)
+    (execute-deterministic-program run-id agent task)))
+
 (def ^:private hire-option-keys #{:task :from :parent-run})
 
 (defn- validate-program!
-  [{:keys [kind delay-ms] :as program} agent-ref]
+  [{:keys [kind delay-ms max-model-steps budget-dollars auto-compact? compaction-model]
+    :as program} agent-ref agent]
   (let [allowed (case kind
                   :scripted #{:kind :delay-ms :reply :result}
                   :echo #{:kind :delay-ms}
+                  :llm #{:kind :max-model-steps :budget-dollars
+                         :auto-compact? :compaction-model}
                   nil)]
     (when-not allowed
-      (throw (ex-info "hire! currently requires a provider-free program"
+      (throw (ex-info "hire! does not have an interpreter for this program"
                       {:type ::unsupported-program
                        :agent-ref agent-ref
                        :kind kind})))
@@ -164,6 +555,34 @@
                (not (and (integer? delay-ms) (<= 0 delay-ms 600000))))
       (throw (ex-info "Program :delay-ms must be an integer from 0 to 600000"
                       {:type ::invalid-delay :delay-ms delay-ms})))
+    (when (and (= :llm kind)
+               (not (and (integer? (or max-model-steps default-max-model-steps))
+                         (<= 1 (or max-model-steps default-max-model-steps) 256))))
+      (throw (ex-info "LLM program :max-model-steps must be an integer from 1 to 256"
+                      {:type ::invalid-max-model-steps
+                       :max-model-steps max-model-steps})))
+    (when (and (= :llm kind)
+               (not (and (number? (or budget-dollars 1.0))
+                         (pos? (double (or budget-dollars 1.0))))))
+      (throw (ex-info "LLM program :budget-dollars must be positive"
+                      {:type ::invalid-budget :budget-dollars budget-dollars})))
+    (when (and (= :llm kind) (some? auto-compact?) (not (boolean? auto-compact?)))
+      (throw (ex-info "LLM program :auto-compact? must be boolean"
+                      {:type ::invalid-auto-compact :auto-compact? auto-compact?})))
+    (when (and (= :llm kind) compaction-model (not (string? compaction-model)))
+      (throw (ex-info "LLM program :compaction-model must be a string"
+                      {:type ::invalid-compaction-model :compaction-model compaction-model})))
+    (when (= :llm kind)
+      (let [policy (:agent/model-policy agent)]
+        (when (and policy
+                   (not (and (= #{:provider :model} (set (keys policy)))
+                             (keyword? (:provider policy))
+                             (string? (:model policy))
+                             (seq (:model policy)))))
+          (throw (ex-info "LLM AgentDef :model-policy must be {:provider keyword :model string}"
+                          {:type ::invalid-model-policy
+                           :agent-ref agent-ref
+                           :model-policy policy})))))
     program))
 
 (defn- validate-hire!
@@ -188,51 +607,137 @@
   (let [agent (or (roster/agent roster agent-ref)
                   (throw (ex-info "Unknown AgentRef"
                                   {:type ::unknown-agent :agent-ref agent-ref})))]
-    (validate-program! (:agent/program agent) agent-ref)
+    (validate-program! (:agent/program agent) agent-ref agent)
     agent))
 
 (defn- cancelled-error? [t run-id]
-  (or (= ::cancelled (:type (ex-data t)))
-      (= spin-core/spin-cancelled (:type (ex-data t)))
+  (or (loop [error t]
+        (when error
+          (or (= ::cancelled (:type (ex-data error)))
+              (= spin-core/spin-cancelled (:type (ex-data error)))
+              ;; Some Spindel graph boundaries preserve the cancellation
+              ;; message while wrapping its ex-data. Follow the cause chain so
+              ;; a structured race cannot be misclassified as program failure.
+              (= "Spin cancelled" (ex-message error))
+              (recur (ex-cause error)))))
       (run/cancel-requested? run-id)))
 
-(defn- execution-spin
-  [room agent task trigger id completion]
+(defn- publish-result-and-release-spin
+  "Retry terminal persistence without losing the computed result. The Run keeps
+   its live execution lease and its completion remains unresolved until the
+   durable projection succeeds. This makes a transient store outage visible as
+   a still-active Run and gives it a real recovery path instead of silently
+   leaving a durable `:running` projection behind."
+  [id completion result finish-opts]
   (sp/spin
-   (let [result
+   (loop []
+     (let [retained (try
+                      (run/retain-finished! id (:run/status result) finish-opts)
+                      (catch Throwable t t))]
+       (cond
+         (instance? Throwable retained)
+         (do
+           ;; Store calls are normally immediate. Only the backoff is async, so
+           ;; an unavailable durable store never parks Spindel's drain thread.
+           (sp/await (comb/sleep 25))
+           (recur))
+
+         retained
          (try
-           (let [value (sp/await (execute-program id agent task))]
+           (completion result)
+           (finally
+             (run/release-finished! id)))
+
+         ;; Another exactly-once settlement path already retained/released it.
+         :else nil)))
+   result))
+
+(defn- settle-after-supervisor!
+  "Settle a graph-cancelled execution only after the stable supervisor reports
+   every native worker and owned cleanup quiescent."
+  [room id supervisor completion result]
+  (future
+    (await-supervisor! supervisor)
+    (let [cleanup-error (:cleanup-error @(:state supervisor))
+          result (if cleanup-error
+                   {:run/id id :run/status :failed
+                    :run/error (ex-message cleanup-error)}
+                   result)
+          finish-opts (if (= :cancelled (:run/status result))
+                        {:reason :structured-cancellation}
+                        {:reason (if cleanup-error :cleanup-error :execution-error)
+                         :error (or cleanup-error (:run/error result))})]
+      (binding [ec/*execution-context* (:ctx room)]
+        @(publish-result-and-release-spin id completion result finish-opts)))))
+
+(defn- execution-spin
+  [room agent task trigger id chat-id completion supervisor]
+  (sp/spin
+   (let [outcome
+         (try
+           (let [{status ::status value ::value reason ::reason}
+                 (sp/await (execute-program room id chat-id agent task trigger supervisor))
+                 ;; Seal admits no further provider work, runs owned cleanup
+                 ;; after all workers terminate, and publishes one stable
+                 ;; quiescence acknowledgement.
+                 _ (sp/await (seal-supervisor! supervisor))
+                 cleanup-error (:cleanup-error @(:state supervisor))]
+             (when cleanup-error
+               (throw (ex-info "Agent program cleanup failed"
+                               {:type ::cleanup-failed}
+                               cleanup-error)))
              (when (run/cancel-requested? id)
                (cancelled! id))
-             (let [output (d/reply (:agent/id agent) run-sink
-                                   (result-content value) trigger
-                                   {:role :assistant :run-id id})]
-               ;; Room posting is durability-first. Completion is acknowledged
-               ;; only after the correlated private output exists.
-               (d/post! room output)
-               (run/finish! id :completed)
-               {:run/id id
-                :run/status :completed
-                :run/value value
-                :run/output output}))
+             (case status
+               :completed
+               (let [output (d/reply (:agent/id agent) run-sink
+                                     (result-content value) trigger
+                                     {:role :assistant :run-id id})]
+                 ;; Room posting is durability-first. Completion is acknowledged
+                 ;; only after the correlated private output exists.
+                 (d/post! room output)
+                 {:result {:run/id id
+                           :run/status :completed
+                           :run/value value
+                           :run/output output}
+                  :finish-opts {}})
+
+               :waiting
+               {:result {:run/id id :run/status :waiting :run/reason reason}
+                :finish-opts {:reason reason}}
+
+               (throw (ex-info "Interpreter returned an unknown program status"
+                               {:type ::unknown-program-status
+                                :status status
+                                :agent/id (:agent/id agent)}))))
            (catch Throwable t
-             (if (cancelled-error? t id)
-               (do
-                 (run/finish! id :cancelled {:reason :cancel-requested})
-                 {:run/id id :run/status :cancelled})
-               (do
-                 (run/finish! id :failed {:reason :program-error :error t})
-                 {:run/id id
-                  :run/status :failed
-                  :run/error (ex-message t)}))))]
+             ;; Ordinary exceptions still own their Spin and can quiesce here.
+             ;; A graph-level cancellation that bypasses this body is handled by
+             ;; the spawn on-error callback below.
+             (sp/await (seal-supervisor! supervisor))
+             (let [cleanup-error (:cleanup-error @(:state supervisor))
+                   error (or cleanup-error t)]
+               (if (and (nil? cleanup-error) (cancelled-error? t id))
+                 {:result {:run/id id :run/status :cancelled}
+                  :finish-opts {:reason :cancel-requested}}
+                 {:result {:run/id id
+                           :run/status :failed
+                           :run/error (ex-message error)}
+                  :finish-opts {:reason (if cleanup-error
+                                          :cleanup-error
+                                          :program-error)
+                                :error error}}))))
+         result (:result outcome)]
      ;; Completion is a Spindel Deferred allocated in this Room's execution
      ;; context, not a JVM promise or host atom. Its value therefore follows
-     ;; Spindel's copy-on-write state semantics.
-     (completion result)
-     result)))
+     ;; Spindel's copy-on-write state semantics. The durable terminal projection
+     ;; retains its live lease until this publication has completed.
+     (sp/await
+      (publish-result-and-release-spin id completion result
+                                       (:finish-opts outcome))))))
 
 (defn hire!
-  "Start one provider-free AgentDef execution and return an opaque RunHandle.
+  "Start one AgentDef execution and return an opaque RunHandle.
 
    `agent-ref` is a keyword id or versioned ref resolved against immutable
    `roster`. Options:
@@ -240,8 +745,9 @@
    - `:task`       portable task value (required)
    - `:from`       triggering actor, default `:repl`
    - `:parent-run` explicit structural parent Run UUID
-   The built-in first-pass program kinds are `:scripted` and `:echo`. Real LLM,
-   tool, simulation, and replay interpreters will implement the same boundary."
+   Built-in program kinds are deterministic `:scripted` / `:echo` and the
+   bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
+   interpreters implement the same boundary."
   [room roster agent-ref {:keys [task from parent-run]
                           :or {from :repl}
                           :as raw-opts}]
@@ -249,6 +755,8 @@
         agent     (validate-hire! roster agent-ref opts)
         actor     (:agent/id agent)
         id        (random-uuid)
+        chat-id   (run-chat-id id)
+        supervisor (make-supervisor (:ctx room))
         ;; Private Run facts are still Room messages, but never addressed to an
         ;; installed Participant: direct interpretation and participant routing
         ;; must not execute the same task twice.
@@ -257,6 +765,8 @@
                             :run/program-kind (get-in agent [:agent/program :kind])
                             :run/interpreter-version interpreter-version
                             :run/agent-def-hash (hasch/uuid agent)}
+                     (= :llm (get-in agent [:agent/program :kind]))
+                     (assoc :run/chat-id chat-id)
                      (:roster/id roster) (assoc :run/roster (:roster/id roster)))]
     ;; Reserve durable Run ownership before any trigger effect. Teardown either
     ;; fences us out here or includes this Run in its fixed drain set; it can
@@ -264,6 +774,8 @@
     (run/start! room actor trigger nil
                 (cond-> {:id id :kind :agent-task :provenance provenance}
                   parent-run (assoc :parent parent-run)))
+    (run/register-cancel-hook! id ::native-worker
+                               #(cancel-supervisor! supervisor))
     (try
       ;; The precise trigger must exist before execution begins. A failed post
       ;; terminalizes the already-admitted Run instead of leaving a :running
@@ -274,7 +786,8 @@
         (throw t)))
     (try
       (let [completion (sync/deferred)
-            execution (execution-spin room agent task trigger id completion)
+            execution (execution-spin room agent task trigger id chat-id
+                                      completion supervisor)
             owner-fork-id (:fork-id (ec/current-execution-context))
             handle    (RunHandle. id (:id room) owner-fork-id execution completion)]
         (sp/spawn!
@@ -288,12 +801,11 @@
                            {:run/id id :run/status :cancelled}
                            {:run/id id :run/status :failed
                             :run/error (ex-message t)})]
-              (try
-                (if (= :cancelled (:run/status result))
-                  (run/finish! id :cancelled {:reason :structured-cancellation})
-                  (run/finish! id :failed {:reason :execution-error :error t}))
-                (catch Throwable _ nil))
-              (completion result)))})
+              (when (= :cancelled (:run/status result))
+                (run/cancel-room-run! (:id room) id))
+              (cancel-supervisor! supervisor)
+              (seal-supervisor! supervisor)
+              (settle-after-supervisor! room id supervisor completion result)))})
         handle)
       (catch Throwable t
         (run/finish! id :failed {:reason :spawn-failed :error t})

--- a/src/dvergr/agent/prompt.clj
+++ b/src/dvergr/agent/prompt.clj
@@ -41,6 +41,29 @@
        "workaround cost you). Silent grinding hides exactly the information "
        "your operators need to improve your tools."))
 
+(def workflow-tool-use-guideline
+  "Operational guideline for bounded, private workflow/model-step execution.
+   Unlike the participant guideline, this does not claim unlimited authority:
+   a workflow inherits explicit tools, budgets, and delegation limits from its
+   parent Run."
+  (str "## Acting\n\n"
+       "You act ONLY by calling tools — describing an action does not perform "
+       "it. This model step ENDS when you reply with text and no tool call, so:\n"
+       "- To do or continue ANY work, call the tool in THIS message. Never end "
+       "a message by announcing what you'll do next ('Now let me…', 'Next "
+       "I'll…') — either call the tool now, or give your final answer if the "
+       "task is fully done.\n"
+       "- For multi-step tasks, call the tools for each step in sequence; don't "
+       "stop after one step to describe the rest.\n"
+       "- You already have the results of tools you called earlier in this "
+       "execution — reuse them; do not re-fetch the same thing.\n\n"
+       "## Bounded authority\n\n"
+       "This workflow is intentionally bounded by the tools, model-step limit, "
+       "budget, and delegation authority supplied by its parent Run. Work within "
+       "those bounds. If a bound prevents completion, preserve the useful partial "
+       "result and report the precise missing capability or exhausted resource; "
+       "do not claim authority or resources you were not given."))
+
 (defn now-note
   "A per-turn system note stating TODAY'S DATE, so the model anchors 'today',
    'this week', 'recent', deadlines and current-event questions to reality
@@ -116,6 +139,10 @@
      + sandbox pointer    ── when `clojure_eval` is among the tools
 
    `tools` may be a tool map (name→def, string keys) OR a set/vector of names.
+   `:profile :workflow` selects a private, bounded execution prompt: it omits
+   shared-room discourse/`[SKIP]` and states that tools, model steps, budget,
+   and delegation authority come from the parent Run. The default participant
+   profile retains the established prompt bytes.
    `isolation` is optional (`:native` / `:sci`); omit it to leave the proven
    daemon prompt byte-identical. `:room-dir` (optional) is a room's sandbox-repo
    path — when given, skills the room itself defines are injected too.
@@ -124,10 +151,11 @@
    so an embedder can gate skill eligibility on its own env source. The dynamic
    planning-mode guideline is appended elsewhere (per turn). sandbox pointer
    via requiring-resolve to avoid a cycle."
-  [base-prompt {:keys [tools isolation room-dir env-lookup]}]
+  [base-prompt {:keys [tools isolation room-dir env-lookup profile]}]
   (let [names   (mapv tool-name-str (if (map? tools) (keys tools) (or tools [])))
         nameset (set names)
         eval?   (contains? nameset "clojure_eval")
+        workflow? (= :workflow profile)
         ;; When not pinned, resolve the current room's sandbox-repo best-effort
         ;; (nil at the daemon root / no room ctx → global skills only), so an
         ;; agent assembled within a room sees that room's own skills.
@@ -135,13 +163,17 @@
                      (try ((requiring-resolve 'dvergr.sandbox.workspace/workspace-root))
                           (catch Throwable _ nil)))]
     (cond-> (skills/inject-skills
-             (str discourse-preamble "\n\n---\n\n" base-prompt)
+             (if workflow?
+               base-prompt
+               (str discourse-preamble "\n\n---\n\n" base-prompt))
              names room-dir (or env-lookup #(System/getenv (name %))))
       isolation     (str "\n\n## Runtime\n\nIsolation: " (name isolation)
                          (if (= :native (keyword isolation))
                            " — full Clojure eval at the system root (trusted)."
                            " — sandboxed Clojure eval (safe default)."))
-      (seq nameset) (str "\n\n" tool-use-guideline)
+      (seq nameset) (str "\n\n" (if workflow?
+                                  workflow-tool-use-guideline
+                                  tool-use-guideline))
       eval?         (str "\n\n" @(requiring-resolve 'dvergr.sandbox/sandbox-prompt-pointer))
       ;; The workspace's own AGENTS.md (stdlib map + intake catalog +
       ;; copy-a-source pattern) — the AGENTS.md/CLAUDE.md convention. Without

--- a/src/dvergr/agent/room_context.clj
+++ b/src/dvergr/agent/room_context.clj
@@ -43,7 +43,7 @@
 ;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set :sub Subscription}
 (defonce ^:private room-agent-ctxs (atom {}))
 
-(defn- provisioned-uuid
+(defn room-system-id
   "The system-db room UUID for `room`, or — for a FORK — its nearest provisioned
    ancestor's. A fork isn't a system-db room; it shares its parent's yggdrasil
    systems (branched under the fork ctx), so the parent's UUID is what the system
@@ -180,7 +180,7 @@
                 ;; in-memory keyword `room-id`. Threads to the sandbox so `dvergr.room`
                 ;; + the guarded `d/connect`/`list-databases` resolve THIS room's
                 ;; fork-aware databases.
-                room-uuid (provisioned-uuid room)
+                room-uuid (room-system-id room)
                 cctx (turn/new-working-ctx
                       {:execution-ctx  (:ctx room)
                        :chat-id        (stable-chat-id room-id agent-id)
@@ -198,6 +198,11 @@
                         ;; system-db for knowledge; this is how the room KB gets in.
                        :kb-conn        (some-> room-uuid srooms/room-kb-conn)
                        :room-id        room-uuid
+                       ;; Room registry identity is distinct from the system-db
+                       ;; UUID above. SCI's agent-programming surface needs the
+                       ;; former so a hired agent can recursively hire into this
+                       ;; exact live Room, including an ephemeral fork.
+                       :room-runtime-id room-id
                         ;; Per-agent network egress scope: an actor's optional
                         ;; `:config {:allowed-domains #{"https://…"}}` restricts the
                         ;; sandbox `http` primitive (nil/empty ⇒ open).

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -17,7 +17,7 @@
 (def provenance-keys
   "Run fields an interpreter may add without changing core causal identity."
   #{:run/roster :run/agent-version :run/program-kind
-    :run/interpreter-version :run/agent-def-hash})
+    :run/interpreter-version :run/agent-def-hash :run/chat-id})
 
 (defn- store-room-id [room]
   (or (some-> room :meta deref :conversation-id)
@@ -134,6 +134,10 @@
                      ;; and its token are never copied or restored as workflow
                      ;; state.
                      :cancelled? (atom false)
+                     ;; Process-local callbacks let an interpreter abort native
+                     ;; workers as soon as cancellation is requested. They are
+                     ;; control capabilities, never durable Run state.
+                     :cancel-hooks {}
                      :store (:store room)
                      :store-room-id (store-room-id room)}]
      (locking lifecycle-lock
@@ -188,6 +192,56 @@
          (notify! {:type :run/finished :run run})
          run)))))
 
+(defn retain-finished!
+  "Durably write a final/waiting Run projection while retaining its live
+   execution lease. Interpreters use this before publishing fork-local result
+   state; `release-finished!` then removes the lease and emits `:run/finished`.
+
+   This two-phase boundary prevents Room teardown from closing the execution
+   context between durable terminal persistence and Deferred publication."
+  ([run-id status] (retain-finished! run-id status {}))
+  ([run-id status {:keys [reason error now]}]
+   (when-not (contains? finish-statuses status)
+     (throw (ex-info "Invalid run finish status"
+                     {:type ::invalid-finish-status :status status :run-id run-id})))
+   (locking lifecycle-lock
+     (when-let [entry (get @active run-id)]
+       ;; Exactly one settlement path owns result publication. A graph callback
+       ;; racing the normal Spin sees this retained terminal state and yields.
+       (when-not (contains? finish-statuses (get-in entry [:run :run/status]))
+         (let [now (or now (java.util.Date.))
+               run (cond-> (assoc (:run entry)
+                                  :run/status status
+                                  :run/updated-at now)
+                     (contains? store/terminal-run-statuses status)
+                     (assoc :run/ended-at now)
+                     reason (assoc :run/reason reason)
+                     error (assoc :run/error (or (ex-message error) (str error))))]
+           (when-let [room-store (:store entry)]
+             (when-not (store/-store-run! room-store (:store-room-id entry) run)
+               (throw (ex-info "Run finish was not durable"
+                               {:type ::finish-not-durable
+                                :run/id run-id
+                                :run/status status}))))
+           (swap! active assoc-in [run-id :run] run)
+           run))))))
+
+(defn release-finished!
+  "Release a Run whose terminal projection was written by `retain-finished!`.
+   Emits the lifecycle finish event only as the execution lease disappears."
+  [run-id]
+  (locking lifecycle-lock
+    (when-let [entry (get @active run-id)]
+      (let [run (:run entry)]
+        (when-not (contains? finish-statuses (:run/status run))
+          (throw (ex-info "Cannot release a non-finished Run"
+                          {:type ::run-not-finished
+                           :run/id run-id
+                           :run/status (:run/status run)})))
+        (swap! active dissoc run-id)
+        (notify! {:type :run/finished :run run})
+        run))))
+
 (defn cancel-requested?
   "True when targeted cancellation has been requested for this live Run. The
   private token disappears with the live entry; durable cancellation is the
@@ -202,14 +256,53 @@
           (when-let [entry (get @active run-id)]
             (when (or (nil? expected-room)
                       (= expected-room (get-in entry [:run :run/room])))
-              (if @(:cancelled? entry)
+              (if (or @(:cancelled? entry)
+                      ;; A two-phase finisher retains its execution lease only
+                      ;; to publish fork-local state. Teardown must wait for that
+                      ;; lease, not turn the already-durable outcome back into
+                      ;; `:cancelling` or interrupt its publication.
+                      (contains? finish-statuses
+                                 (get-in entry [:run :run/status])))
                 entry
                 (let [_ (reset! (:cancelled? entry) true)
                       entry' (assoc-in entry [:run :run/status] :cancelling)]
                   (swap! active assoc run-id entry')
                   (notify! {:type :run/cancel-requested :run (public-entry entry')})
                   entry')))))]
+    ;; Never invoke interpreter code under lifecycle-lock: a hook may settle the
+    ;; Run, which takes the same lock. Repeated requests re-invoke idempotent
+    ;; hooks so a worker registered concurrently with the first request is not
+    ;; missed.
+    (doseq [hook (if (contains? finish-statuses
+                                (get-in entry [:run :run/status]))
+                   []
+                   (vals (:cancel-hooks entry)))]
+      (try
+        (hook)
+        (catch Throwable t
+          (tel/log! {:level :warn :id ::cancel-hook-failed
+                     :data {:run-id run-id :error (.getMessage t)}}
+                    "Run cancellation hook failed"))))
     (boolean entry)))
+
+(defn register-cancel-hook!
+  "Register process-local `f` for targeted cancellation of a live Run. If a
+   cancellation request already won the race, invoke `f` immediately. Returns
+   true when the Run is still live, false after settlement."
+  [run-id key f]
+  (let [cancelled?
+        (locking lifecycle-lock
+          (when-let [entry (get @active run-id)]
+            (swap! active assoc-in [run-id :cancel-hooks key] f)
+            @(:cancelled? entry)))]
+    (when cancelled? (f))
+    (some? cancelled?)))
+
+(defn unregister-cancel-hook! [run-id key]
+  (locking lifecycle-lock
+    (when (get @active run-id)
+      (swap! active update-in [run-id :cancel-hooks] dissoc key)))
+  nil)
 
 (defn cancel-run!
   "Request cooperative cancellation of exactly one live Run. Returns true when

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -41,8 +41,8 @@
    transient/standalone ctx). `durable?` (when supplied) overrides the chat-ctx's
    datahike-write behaviour (room folds pass false: the room store is the durable
    writer). Returns the ChatContext."
-  [{:keys [execution-ctx chat-id title budget-dollars db-conn kb-conn room-id durable?
-           allowed-domains]}]
+  [{:keys [execution-ctx chat-id title budget-dollars db-conn kb-conn room-id
+           room-runtime-id agent-program-ceiling durable? allowed-domains]}]
   (binding [rtc/*execution-context* execution-ctx]
     (let [cctx (cond-> (chat-ctx/create-chat-context
                         (cond-> {:budget-dollars (or budget-dollars 1.0)
@@ -61,6 +61,8 @@
       (when-let [sci (:sci-ctx cctx)]
         (sandbox/setup-agent-namespaces! sci execution-ctx
                                          :room-conn db-conn :kb-conn kb-conn :room-id room-id
+                                         :room-runtime-id room-runtime-id
+                                         :agent-program-ceiling agent-program-ceiling
                                          ;; per-agent network egress scoping (nil/empty = open)
                                          :allowed-http-domains allowed-domains)
         ;; Two namespaces bound to THIS chat-ctx (not just the spindel ctx), so

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -586,6 +586,12 @@
     :db/index true
     :db/doc "Content address of the exact portable AgentDef value"}
 
+   {:db/ident :run/chat-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Durable ChatContext trace identity owned by this Run"}
+
    {:db/ident :run/status
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one

--- a/src/dvergr/model/api/claude_code.clj
+++ b/src/dvergr/model/api/claude_code.clj
@@ -14,7 +14,8 @@
             [jsonista.core :as json]
             [clojure.string :as str]
             [taoensso.telemere :as tel])
-  (:import [java.io BufferedReader InputStreamReader]))
+  (:import [java.io BufferedReader Closeable InputStreamReader]
+           [java.util.concurrent CancellationException TimeUnit]))
 
 ;; ============================================================================
 ;; Message Formatting
@@ -197,20 +198,51 @@
              "--no-session-persistence"
              ;; Isolate the subprocess from the host's Claude Code environment,
              ;; or its leaked native tools shadow dvergr's text <tool_use>
-             ;; protocol and tool calls fail non-deterministically (dvergr #11):
+             ;; protocol and tool calls fail non-deterministically (dvergr #11).
+             ;; `--safe-mode` drops user/project customizations while retaining
+             ;; subscription auth; current Claude Code versions honor an empty
+             ;; `--tools` list as the authoritative way to disable built-ins.
+             "--safe-mode"
+             "--disable-slash-commands"
+             "--tools" ""
+             ;; Defense in depth for older CLI versions where an empty tools
+             ;; list was ineffective:
              ;;  - MCP: --strict-mcp-config + an empty config drops the user's
              ;;    global MCP servers ("{}" alone is rejected — needs mcpServers).
-             ;;  - Built-ins: --tools "" is a no-op in print mode, so DENY the
-             ;;    built-in tools explicitly to force the model onto <tool_use>.
              "--strict-mcp-config"
              "--mcp-config" "{\"mcpServers\":{}}"
-             "--disallowedTools" "Bash Read Edit Write Glob Grep Task WebFetch WebSearch"]
+             "--disallowedTools"
+             "Bash Read Edit Write Glob Grep Task WebFetch WebSearch ToolSearch Skill Workflow ListAgents ReportFindings ScheduleWakeup"]
       system (into ["--system-prompt" system])
       effort (into ["--effort" effort]))))
 
 ;; ============================================================================
 ;; Streaming Event Processing
 ;; ============================================================================
+
+(def ^:private cancel-poll-ms 10)
+(def ^:private process-exit-grace-ms 100)
+
+(defn- start-process [cmd]
+  (.start (doto (ProcessBuilder. ^java.util.List cmd)
+            (.redirectErrorStream false))))
+
+(defn- close-quietly! [resource]
+  (when (instance? Closeable resource)
+    (try
+      (.close ^Closeable resource)
+      (catch Exception _))))
+
+(defn- terminate-process!
+  "Terminate process, escalating promptly when a graceful destroy is ignored."
+  [^Process process]
+  (when process
+    (locking process
+      (when (.isAlive process)
+        (.destroy process)
+        (when-not (.waitFor process process-exit-grace-ms TimeUnit/MILLISECONDS)
+          (.destroyForcibly process)
+          (.waitFor process process-exit-grace-ms TimeUnit/MILLISECONDS))))))
 
 (defn- parse-json-line [line]
   (when (and (string? line) (not (str/blank? line)))
@@ -255,51 +287,108 @@
                            (assoc opts :system effective-system)
                            opts)
         cmd (build-command opts-with-system)
-        pb (ProcessBuilder. ^java.util.List cmd)
-        _ (.redirectErrorStream pb false)
-        process (.start pb)
+        process (start-process cmd)
         stdin (.getOutputStream process)
-        _ (.write stdin (.getBytes prompt "UTF-8"))
-        _ (.close stdin)
         stdout-reader (BufferedReader. (InputStreamReader. (.getInputStream process) "UTF-8"))
-        on-text (:on-text opts)
-        result-event (loop [line (.readLine stdout-reader)
-                            result nil]
-                       (if (nil? line)
-                         result
-                         (let [event (parse-json-line line)]
-                           (when event
-                             (when on-text
-                               (when-let [text (extract-text-delta event)]
-                                 (on-text text))))
-                           (recur (.readLine stdout-reader)
-                                  (if (and event (= "result" (:type event)))
-                                    event
-                                    result)))))
         stderr-reader (BufferedReader. (InputStreamReader. (.getErrorStream process) "UTF-8"))
-        stderr (slurp stderr-reader)
-        exit-code (.waitFor process)]
-    (.close stdout-reader)
-    (.close stderr-reader)
-    (if (and result-event (or (zero? exit-code) result-event))
-      (let [model-usage (:modelUsage result-event)
-            model-key (first (keys model-usage))
-            raw-content (or (:result result-event) "")
-            ;; Parse tool calls from response text
-            {:keys [text tool-calls]} (if (seq tools)
-                                        (parse-tool-calls raw-content)
-                                        {:text raw-content :tool-calls nil})]
-        {:content text
-         :tool-calls tool-calls
-         :usage (parse-result-usage result-event)
-         :stop-reason (if (seq tool-calls) :tool-use :end-turn)
-         :model (when model-key (name model-key))
-         :id (:session_id result-event)
-         :cost-usd (:total_cost_usd result-event)})
-      (throw (ex-info (str "claude CLI failed (exit " exit-code ")")
-                      {:exit-code exit-code
-                       :stderr stderr
-                       :result result-event})))))
+        on-text (:on-text opts)
+        ;; Claude can fill the OS stderr pipe before producing stdout. Drain it
+        ;; from process start so neither stream can block the other.
+        stderr-future (future (slurp stderr-reader))
+        cancelled? (atom false)
+        monitor-done? (atom false)
+        cancel? (:cancel? opts)
+        cancel-monitor
+        (when cancel?
+          (future
+            (try
+              (loop []
+                (when (and (not @monitor-done?) (.isAlive process))
+                  (if (cancel?)
+                    (do
+                      (reset! cancelled? true)
+                      (terminate-process! process))
+                    (do
+                      (Thread/sleep cancel-poll-ms)
+                      (recur)))))
+              (catch InterruptedException _)
+              (catch Exception e
+                (tel/log! {:level :warn :id :claude-code/cancel-monitor-error
+                           :data {:error (.getMessage e)}}
+                          "Claude Code cancellation monitor failed")))))]
+    (try
+      ;; Check once synchronously so an already-cancelled request cannot feed
+      ;; the subprocess before the monitor's first poll.
+      (when (and cancel? (cancel?))
+        (reset! cancelled? true)
+        (terminate-process! process)
+        (throw (CancellationException. "LLM call cancelled")))
+      (try
+        (.write stdin (.getBytes prompt "UTF-8"))
+        (.close stdin)
+        (catch java.io.IOException e
+          ;; A CLI that rejects its invocation may close stdin immediately.
+          ;; Preserve its exit code and stderr instead of masking them with a
+          ;; broken-pipe exception. An alive process still indicates a real I/O
+          ;; failure (or a cancellation race handled by the outer catch).
+          (when (.isAlive process)
+            (throw e))))
+      (let [result-event (loop [line (.readLine stdout-reader)
+                                result nil]
+                           (if (nil? line)
+                             result
+                             (let [event (parse-json-line line)]
+                               (when event
+                                 (when on-text
+                                   (when-let [text (extract-text-delta event)]
+                                     (on-text text))))
+                               (recur (.readLine stdout-reader)
+                                      (if (and event (= "result" (:type event)))
+                                        event
+                                        result)))))
+            exit-code (.waitFor process)
+            stderr @stderr-future]
+        (when @cancelled?
+          (throw (CancellationException. "LLM call cancelled")))
+        (if (and result-event (or (zero? exit-code) result-event))
+          (let [model-usage (:modelUsage result-event)
+                model-key (first (keys model-usage))
+                raw-content (or (:result result-event) "")
+                ;; Parse tool calls from response text
+                {:keys [text tool-calls]} (if (seq tools)
+                                            (parse-tool-calls raw-content)
+                                            {:text raw-content :tool-calls nil})]
+            {:content text
+             :tool-calls tool-calls
+             :usage (parse-result-usage result-event)
+             :stop-reason (if (seq tool-calls) :tool-use :end-turn)
+             :model (when model-key (name model-key))
+             :id (:session_id result-event)
+             :cost-usd (:total_cost_usd result-event)})
+          (throw (ex-info (str "claude CLI failed (exit " exit-code ")")
+                          {:exit-code exit-code
+                           :stderr stderr
+                           :result result-event}))))
+      (catch Throwable t
+        ;; The monitor can destroy the process between any two stream
+        ;; operations. Cancellation remains the public outcome regardless of
+        ;; which blocked I/O operation observes process death first.
+        (if (and @cancelled? (not (instance? CancellationException t)))
+          (throw (doto (CancellationException. "LLM call cancelled")
+                   (.initCause t)))
+          (throw t)))
+      (finally
+        (reset! monitor-done? true)
+        ;; Closing all streams plus process termination releases reader futures
+        ;; on success, cancellation, callback failure, and malformed output.
+        (close-quietly! stdin)
+        (close-quietly! stdout-reader)
+        (close-quietly! stderr-reader)
+        (terminate-process! process)
+        (when cancel-monitor
+          (future-cancel cancel-monitor))
+        (when-not (realized? stderr-future)
+          (future-cancel stderr-future))))))
 
 ;; ============================================================================
 ;; Provider Record

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -98,13 +98,13 @@
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error
     :run/roster :run/agent-version :run/program-kind
-    :run/interpreter-version :run/agent-def-hash})
+    :run/interpreter-version :run/agent-def-hash :run/chat-id})
 
 (def immutable-run-keys
   [:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
    :run/created-at :run/started-at
    :run/roster :run/agent-version :run/program-kind
-   :run/interpreter-version :run/agent-def-hash])
+   :run/interpreter-version :run/agent-def-hash :run/chat-id])
 
 (defn validate-run!
   "Validate the minimal durable Run contract and return `run`."
@@ -148,6 +148,9 @@
   (when (and (:run/agent-def-hash run) (not (uuid? (:run/agent-def-hash run))))
     (throw (ex-info ":run/agent-def-hash must be a UUID"
                     {:type :room-store/invalid-run :key :run/agent-def-hash :run run})))
+  (when (and (:run/chat-id run) (not (uuid? (:run/chat-id run))))
+    (throw (ex-info ":run/chat-id must be a UUID"
+                    {:type :room-store/invalid-run :key :run/chat-id :run run})))
   (doseq [k [:run/created-at :run/started-at :run/updated-at]
           :when (not (instance? java.util.Date (get run k)))]
     (throw (ex-info (str k " must be an instant")

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -166,7 +166,7 @@
 (def ^:private run-pull-pattern
   '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
     :run/roster :run/agent-version :run/program-kind :run/interpreter-version
-    :run/agent-def-hash
+    :run/agent-def-hash :run/chat-id
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error])
 
@@ -188,6 +188,7 @@
     (:run/interpreter-version run)
     (assoc :run/interpreter-version (:run/interpreter-version run))
     (:run/agent-def-hash run) (assoc :run/agent-def-hash (:run/agent-def-hash run))
+    (:run/chat-id run) (assoc :run/chat-id (:run/chat-id run))
     (:run/ended-at run) (assoc :run/ended-at (:run/ended-at run))
     (:run/reason run)   (assoc :run/reason (:run/reason run))
     (:run/error run)    (assoc :run/error (str (:run/error run)))))

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -666,7 +666,7 @@
    "dvergr.tasks"    ["the shared task ledger — list/accept/complete work items"
                       "(dvergr.tasks/list)   (dvergr.tasks/complete! id)"]
    "dvergr.agent"    ["program specialized agents as immutable rosters; hire! starts a durable Run with an explicit result Spin"
-                      "(let [team (dvergr.agent/make-agent (dvergr.agent/roster) {:id :analyst :program {:kind :echo}})] (dvergr.agent/hire! team :analyst {:task :inspect}))"]
+                      "(let [team (-> (dvergr.agent/roster) (dvergr.agent/make-agent {:id :a :program {:kind :scripted :reply \"evidence\"}}) (dvergr.agent/make-agent {:id :b :program {:kind :echo}})) a (dvergr.agent/hire! team :a {:task :inspect}) b (dvergr.agent/hire! team :b {:task {:claim 42}})] @(spin [(-> (await (dvergr.agent/result-spin a)) :run/value) (-> (await (dvergr.agent/result-spin b)) :run/value)]))"]
    "dvergr.agents"   ["directory of agents (read-only): who exists / is online"
                       "(dvergr.agents/list)   (dvergr.agents/online? :var)"]
    "dvergr.actors"   ["durable participant identities — register/retire agents or humans and assign skills"
@@ -802,6 +802,15 @@
        "with a task string) only when each run needs your judgment. To publish a STATIC SITE for "
        "this room, write `app/index.html` (+ assets under `app/`) in your "
        "workspace — served at `/apps/<room-slug>/`.\n\n"
+       "**Reactive agent programs.** `dvergr.agent` provides immutable rosters "
+       "and Run-backed execution. Use the exact Spindel namespaces: "
+       "`(require '[dvergr.agent :as agent] "
+       "'[org.replikativ.spindel.spin.cps :refer [spin]] "
+       "'[org.replikativ.spindel.effects.await :refer [await]])`. "
+       "`agent/roster`, `agent/make-agent`, and `agent/revise-agent` return new "
+       "values; only `agent/hire!` starts an effect. Compose `(agent/result-spin "
+       "handle)` with `await`, parallel Spins, or `race`; inspect exact signatures "
+       "with `(sandbox/doc 'dvergr.agent)`.\n\n"
        "**Your databases.** Your room owns its data — NOT a shared global DB. "
        "`dvergr.room/*kb*` is your knowledge base, `dvergr.room/*room*` your room's "
        "own datahike (messages/state); query them with ordinary datahike, e.g. "
@@ -921,7 +930,8 @@
 
    Returns the audit-log atom — a vector of IO events ({:op :t :data}) accumulated
    during the agent's execution.  Attach to the agent result for post-hoc analysis."
-  [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id]
+  [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id
+                                 room-runtime-id agent-program-ceiling]
                           :or   {proc-allow #{}}}]
   (let [audit-log  (make-audit-log)
         workspace  (binding [rtc/*execution-context* spindel-ctx]
@@ -954,7 +964,8 @@
         ;; room's DB surface (*room*/*kb*/databases/db + queries). The KB is reached
         ;; via `dvergr.room/*kb*` + `kb-find`/`kb-search` + `d` — no separate `entity`
         ;; namespace (dropped as redundant; a global entity CRM can return later).
-        (ns-room/add-room-ns! sci-ctx room-conn kb-conn room-id spindel-ctx)
+        (ns-room/add-room-ns! sci-ctx room-conn kb-conn room-id spindel-ctx
+                              agent-program-ceiling)
         ;; dvergr.mail/*inbox* — the room's attached mailbox conn (fork-aware),
         ;; nil when no mailbox attached. Read helpers are seed source (dvergr/mail/).
         (ns-mail/add-mail-ns! sci-ctx)
@@ -965,7 +976,8 @@
     ;; Pure AgentDef/Roster construction plus the explicit, Run-backed `hire!`
     ;; effect. No roster is kept in a host atom: callers thread the immutable
     ;; value, and live execution state belongs to the Room's Spindel context.
-    (ns-agent/add-programming-ns! sci-ctx room-id spindel-ctx)
+    (ns-agent/add-programming-ns! sci-ctx (or room-runtime-id room-id) spindel-ctx
+                                  agent-program-ceiling)
     (ns-data/add-spindel-extras-ns! sci-ctx spindel-ctx)
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)
@@ -974,7 +986,7 @@
     ;; (proc folded into the muschel-backed babashka.process — add-bash-ns! in turn.clj)
     (ns-io/add-git-ns!  sci-ctx :base-path cwd :workspace workspace
                         :audit-log audit-log)
-    (ns-kb/add-llm-ns!  sci-ctx)
+    (ns-kb/add-llm-ns!  sci-ctx agent-program-ceiling)
     ;; Boundary secret injection (doc/boundary-secret-injection.md): build the
     ;; host-side secret registry from config `:secrets` (resolved against the host
     ;; env), and share it between `env` (returns placeholders) and `http`

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -19,7 +19,9 @@
    Spindel computation can branch with a different team without coordinating a
    mutable registry. `hire!` is the explicit effect boundary: it resolves this
    sandbox's Room, starts a durable Run in the Room's execution context, and
-   returns an opaque RunHandle whose native observer Spin is explicit.
+   returns an opaque RunHandle whose native observer Spin is explicit. When
+   the authority map supplies `:parent-run`, `hire!` uses it as the structural
+   parent unless the caller explicitly supplies one.
 
    Usage:
      (require '[dvergr.agent :as agent]
@@ -33,7 +35,7 @@
        @(spin (-> (await (agent/result-spin
                           (agent/hire! team :analyst {:task :inspect})))
                   :run/value)))"
-  [sci-ctx room-id spindel-ctx]
+  [sci-ctx room-id spindel-ctx agent-program-ceiling]
   (let [make-roster*   (requiring-resolve 'dvergr.agent.roster/make-roster)
         make-agent*    (requiring-resolve 'dvergr.agent.roster/make-agent)
         revise-agent*  (requiring-resolve 'dvergr.agent.roster/revise-agent)
@@ -46,6 +48,7 @@
         cancel*        (requiring-resolve 'dvergr.agent.program/cancel!)
         run-id*        (requiring-resolve 'dvergr.agent.program/run-id)
         result-spin*   (requiring-resolve 'dvergr.agent.program/result-spin)
+        owned-result-spin* (requiring-resolve 'dvergr.agent.program/owned-result-spin)
         room-lookup*   (requiring-resolve 'dvergr.room.registry/lookup)
         current-room   (fn []
                          (when room-id
@@ -58,9 +61,25 @@
                                      {:type ::no-current-room
                                       :room-id room-id}))))
         hire-fn        (fn [roster agent-ref opts]
-                         (let [room (room!)]
+                         (let [room (room!)
+                               definition (lookup-agent* roster agent-ref)
+                               kind (get-in definition [:agent/program :kind])
+                               allowed-kinds (:program-kinds agent-program-ceiling)]
+                           (when (and allowed-kinds
+                                      (not (contains? allowed-kinds kind)))
+                             (throw (ex-info
+                                     "Child program exceeds this sandbox's delegation ceiling"
+                                     {:type ::program-ceiling-exceeded
+                                      :agent-ref agent-ref
+                                      :program-kind kind
+                                      :allowed-program-kinds allowed-kinds})))
                            (binding [ec/*execution-context* (:ctx room)]
-                             (hire* room roster agent-ref opts))))
+                             (hire* room roster agent-ref
+                                    (if (and (:parent-run agent-program-ceiling)
+                                             (not (contains? opts :parent-run)))
+                                      (assoc opts :parent-run
+                                             (:parent-run agent-program-ceiling))
+                                      opts)))))
         observe-fn     (fn [handle-or-id]
                          (let [room (room!)]
                            (binding [ec/*execution-context* (:ctx room)]
@@ -86,19 +105,21 @@
         'observe      observe-fn
         'cancel!      cancel-fn
         'run-id       run-id*
-        'result-spin  result-spin*}
+        'result-spin  result-spin*
+        'owned-result-spin owned-result-spin*}
        '{roster       [([] [opts]) "Create an immutable Roster value. Options may include portable :id, :defaults, :scope, and :metadata data."]
-         make-agent   [([roster spec]) "Return a NEW Roster containing the portable AgentDef `spec`; no agent is started and the input roster is unchanged."]
+         make-agent   [([roster spec]) "Return a NEW Roster containing `spec`; use {:id :a :program {:kind :echo}}, {:kind :scripted :reply value}, or {:kind :llm} plus :model-policy and :tools. Pure: input unchanged."]
          revise-agent [([roster id patch]) "Return a NEW Roster with AgentDef `id` revised and its version incremented."]
          lookup       [([roster id-or-ref]) "Resolve an AgentDef by keyword id or versioned AgentRef. A stale versioned ref is an error."]
          ref          [([agent-def]) "Return the stable {:agent/id :agent/version} reference for an AgentDef."]
          list         [([roster]) "All AgentDefs in a Roster, deterministically ordered by id."]
          select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
-         hire!        [([roster agent-ref opts]) "Durably admit and start one AgentDef execution in the current Room. Returns an opaque RunHandle; opts requires :task and may include :from and :parent-run."]
+         hire!        [([roster agent-ref opts]) "Durably start one AgentDef in the current Room: (hire! team :a {:task value}). Returns a RunHandle; opts may also include :from and structural :parent-run."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
          cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]
          run-id       [([handle]) "Return the durable Run UUID represented by a RunHandle."]
-         result-spin  [([handle]) "Return a fresh native Spindel observer Spin for a RunHandle. Use (await (result-spin handle)) inside a workflow Spin."]}))))
+         result-spin  [([handle]) "Return a passive Spindel observer Spin for a RunHandle. Multiple observers may await it; cancelling an observer does not cancel the Run."]
+         owned-result-spin [([handle]) "Return an ownership-coupled result Spin. Cancelling this observer also cancels the underlying Run; use only when the observer owns that child execution."]}))))
 
 (defn add-agents-ns!
   "Expose the agent registry as 'agents namespace in SCI.

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -17,11 +17,18 @@
      (llm/summarize transcript {:max-tokens 300})
      (llm/call \"Extract product names:\" content)
 
-   Returns {:text :usage :model} or {:error}.
-   No SCI-level budget tracking — account at the tool level."
-  [sci-ctx]
+   Returns {:text :usage :model} or {:error}. Top-level sandboxes retain the
+   historical unbounded surface. A nested authority with
+   `:provider-effects? false` removes this provider-spend bypass."
+  [sci-ctx & [agent-program-ceiling]]
   (require 'dvergr.tools.llm-call)
-  (let [call-fn      @(ns-resolve 'dvergr.tools.llm-call 'cheap-llm-call)
+  (let [raw-call-fn  @(ns-resolve 'dvergr.tools.llm-call 'cheap-llm-call)
+        call-fn      (fn [& args]
+                       (when (false? (:provider-effects? agent-program-ceiling))
+                         (throw (ex-info
+                                 "LLM provider effects exceed this sandbox's delegation ceiling"
+                                 {:type ::provider-effects-disallowed})))
+                       (apply raw-call-fn args))
         summarize-fn (fn [content & [opts]]
                        (call-fn "Summarize the key points concisely:"
                                 content (or opts {})))]
@@ -29,7 +36,7 @@
                         (doc/with-docs
                           {'call      call-fn
                            'summarize summarize-fn}
-                          '{call      [([system-prompt content] [system-prompt content opts]) "One-shot call to a CHEAP model — for mechanical language work (extract, classify, rewrite) inside a larger job, not for reasoning you should do yourself. `opts` takes :max-tokens. Not budget-tracked at this level."]
+                          '{call      [([system-prompt content] [system-prompt content opts]) "One-shot call to a CHEAP model — for mechanical language work (extract, classify, rewrite) inside a larger job, not for reasoning you should do yourself. `opts` takes :max-tokens. Available only when this sandbox has provider-effect authority."]
                             summarize [([content] [content opts]) "Summarize text with the cheap model. `opts` takes :max-tokens, e.g. (llm/summarize page {:max-tokens 300})."]}))))
 
 ;; (RF5: the calendar folded into the per-room scheduler — see `scheduler/*` +
@@ -41,7 +48,7 @@
    `review`/`classify`/`forks`/`participants`/`root` — for the `dvergr.room` SCI
    namespace (mounted, merged with the DB surface, by `dvergr.sandbox.ns.room`).
    Persistent rooms + forks are behind one surface — same for agents, TUI, web."
-  [spindel-ctx]
+  [spindel-ctx & [agent-program-ceiling]]
   (require 'dvergr.discourse)
   (require 'dvergr.rooms)
   (require 'dvergr.room.registry)
@@ -199,9 +206,17 @@
      ;; tracked as a `:dvergr/subagent` lifecycle log; `pending-subagents` lists
      ;; the still-running ones.
        'hire         (fn [ref opts]
-                       (when-let [room (resolve-room ref)]
-                         (binding [rtc/*execution-context* (:ctx room)]
-                           (subagent-hire* room opts))))
+                       (let [allowed-kinds (:program-kinds agent-program-ceiling)]
+                         (when (and allowed-kinds
+                                    (not (contains? allowed-kinds :llm)))
+                           (throw (ex-info
+                                   "Legacy sub-agent hire exceeds this sandbox's delegation ceiling"
+                                   {:type ::program-ceiling-exceeded
+                                    :program-kind :llm
+                                    :allowed-program-kinds allowed-kinds})))
+                         (when-let [room (resolve-room ref)]
+                           (binding [rtc/*execution-context* (:ctx room)]
+                             (subagent-hire* room opts)))))
        'pending-subagents (fn [ref]
                             (when-let [room (resolve-room ref)]
                               (binding [rtc/*execution-context* (:ctx room)]
@@ -227,5 +242,3 @@
         root         [([]) "The root room of the tree."]
         hire         [([ref opts]) "Delegate a goal to an EPHEMERAL sub-agent in a forked subroom (`:ctx` substrate + shared CRDTs), then merge or discard it. `opts` takes :goal and :spec. Returns a SPIN — (await (dvergr.room/hire …)) to run it in the foreground, or hold the spin and await it later to run it in the background. Tracked durably as a :dvergr/subagent lifecycle log."]
         pending-subagents [([ref]) "Sub-agents hired from this room that are still running."]})))
-
-

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -31,8 +31,10 @@
    and the common-query helpers. Also mounted under the legacy alias `room` for
    back-compat with existing agent profiles. `room-conn` = the room's messages
    store; `kb-conn` = its knowledge base. Any of `room-conn`/`kb-conn`/`room-id`
-   may be nil (room-less ctx) — the helpers degrade gracefully."
-  [sci-ctx room-conn kb-conn room-id ctx]
+   may be nil (room-less ctx) — the helpers degrade gracefully.
+   `agent-program-ceiling` is the ambient child-program authority; it also
+   constrains the legacy `dvergr.room/hire` path."
+  [sci-ctx room-conn kb-conn room-id ctx & [agent-program-ceiling]]
   (let [;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
         ;; its own KB plus whatever is granted to it, and the two are written
         ;; through different bindings of the same katzen schema — dvergr's
@@ -125,7 +127,7 @@
                                     ws)))))
         kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
                                 (srooms/room-kb-conn room-id slug))))
-        room-map (merge (ns-kb/room-ops-map ctx)        ; create!/fork!/merge!/post!/messages/…
+        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling) ; create!/fork!/merge!/post!/messages/…
                         ;; Docs live HERE rather than only in these trailing
                         ;; comments: the comments never reached the sandbox, so
                         ;; `(clojure.repl/doc dvergr.room/kb-search)` answered

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -3,8 +3,14 @@
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
+            [dvergr.agent.turn :as turn]
+            [dvergr.chat.agent :as chat-agent]
+            [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as d]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.providers :as providers]
             [dvergr.room.registry :as registry]
+            [dvergr.room.store :as room-store]
             [dvergr.room.store.memory :as memory]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.effects.await :refer [await]]
@@ -23,6 +29,32 @@
 
 (defn- test-room [id]
   (d/make-room {:id id :store (memory/make)}))
+
+(defn- fail-terminal-store [delegate fail-terminal?]
+  (reify room-store/PRoomStore
+    (-store-room! [_ room-id metadata]
+      (room-store/-store-room! delegate room-id metadata))
+    (-load-room [_ id-or-slug]
+      (room-store/-load-room delegate id-or-slug))
+    (-delete-room! [_ room-id]
+      (room-store/-delete-room! delegate room-id))
+    (-list-rooms [_]
+      (room-store/-list-rooms delegate))
+    (-store-message! [_ room-id message]
+      (room-store/-store-message! delegate room-id message))
+    (-message-thread-root [_ room-id message-id]
+      (room-store/-message-thread-root delegate room-id message-id))
+    (-list-messages [_ room-id opts]
+      (room-store/-list-messages delegate room-id opts))
+    (-store-run! [_ room-id run]
+      (when-not (and @fail-terminal?
+                     (contains? room-store/terminal-run-statuses
+                                (:run/status run)))
+        (room-store/-store-run! delegate room-id run)))
+    (-load-run [_ room-id run-id]
+      (room-store/-load-run delegate room-id run-id))
+    (-list-runs [_ room-id opts]
+      (room-store/-list-runs delegate room-id opts))))
 
 (defn- wait-until [pred timeout-ms]
   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
@@ -75,6 +107,334 @@
                        (-> (await (program/result-spin b)) :run/value)])]
           (is (= ["evidence" {:review "claim"}] @joined))))
       (finally
+        (d/close-room! room)))))
+
+(deftest llm-program-lifts-the-native-turn-loop
+  (let [room (test-room :program-llm)
+        team (roster/make-agent
+              (roster/make-roster {:id :native-team})
+              {:id :researcher
+               :prompt "Investigate carefully."
+               :tools #{:clojure_eval}
+               :model-policy {:provider :codex-subscription
+                              :model "codex-subscription-sol"}
+               :program {:kind :llm :max-model-steps 4 :auto-compact? false}})
+        calls (atom [])]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [chat-ctx opts]
+                      (swap! calls conj {:chat-id (:chat-id chat-ctx)
+                                         :opts opts
+                                         :system (->> (chat-context/get-messages chat-ctx)
+                                                      (filter #(= :system
+                                                                  (:message/role %)))
+                                                      first
+                                                      :message/content)
+                                         :thread (.getName (Thread/currentThread))})
+                      (if (= 1 (count @calls))
+                        (do
+                          (chat-context/add-message!
+                           chat-ctx
+                           {:role :assistant
+                            :content ""
+                            :tool-uses [{:tool-use/id "call-1"
+                                         :tool-use/name "clojure_eval"
+                                         :tool-use/input {:code "(+ 1 1)"}}]})
+                          (chat-context/add-message!
+                           chat-ctx
+                           {:role :tool-result
+                            :tool-use-id "call-1"
+                            :content "2"})
+                          :continue)
+                        (do
+                          (chat-context/add-message!
+                           chat-ctx {:role :assistant :content "The result is 2."})
+                          :complete)))]
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire! room team :researcher
+                                      {:task "calculate"}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)
+              durable (program/observe room handle)
+              messages (d/messages room {:limit 20})
+              activity (first (filter #(= :_activity (:to %)) messages))]
+          (is (= :completed (:run/status result)))
+          (is (= "The result is 2." (:run/value result)))
+          (is (= :completed (:run/status durable)))
+          (is (uuid? (:run/chat-id durable)))
+          (is (= 2 (count @calls)))
+          (is (= [0 1] (mapv #(get-in % [:opts :turn-number]) @calls)))
+          (is (re-find #"Your sandbox" (:system (first @calls))))
+          (is (not (re-find #"shared room" (:system (first @calls))))
+              "private Run programs use the workflow prompt profile")
+          (is (every? #(= :codex-subscription
+                          (get-in % [:opts :provider])) @calls))
+          (is (every? #(= (program/run-id handle)
+                          (get-in % [:opts :run-id])) @calls))
+          (is (= (get-in activity [:metadata :run-id])
+                 (program/run-id handle)))
+          (is (= ["clojure_eval"]
+                 (mapv :tool-use/name
+                       (get-in activity [:metadata :tool-uses]))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest parallel-llm-hires-have-independent-chat-contexts
+  (let [room (test-room :program-llm-isolation)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :particle
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 1}})
+        seen (atom [])]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [chat-ctx _]
+                      (let [task (->> (chat-context/get-messages chat-ctx)
+                                      (filter #(= :user (:message/role %)))
+                                      last :message/content)]
+                        (swap! seen conj [(:chat-id chat-ctx) task])
+                        (chat-context/add-message!
+                         chat-ctx {:role :assistant :content task})
+                        :complete))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [a (program/hire! room team :particle {:task :a})
+                b (program/hire! room team :particle {:task :b})]
+            (is (= #{":a" ":b"}
+                   (set (map :run/value [@a @b]))))
+            (is (= 2 (count (set (map first @seen))))
+                "each particle gets a fresh ChatContext"))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest llm-program-settles-at-budget-boundary
+  (let [room (test-room :program-llm-budget)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :bounded
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :budget-dollars 0.01}})]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn! (fn [_ _] :continue)
+                    chat-context/budget-exceeded? (constantly true)]
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire! room team :bounded {:task "bounded"}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)]
+          (is (= {:run/id (program/run-id handle)
+                  :run/status :waiting
+                  :run/reason :budget-exhausted}
+                 result))
+          (is (= :waiting (:run/status (program/observe room handle))))
+          (is (empty? (filter #(= (program/run-id handle)
+                                  (get-in % [:metadata :run-id]))
+                              (d/messages room {:limit 10}))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest llm-program-cancellation-aborts-the-live-turn
+  (let [room (test-room :program-llm-cancel)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm}})
+        started (promise)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [_ {:keys [cancel?]}]
+                      (deliver started true)
+                      (loop []
+                        (if (cancel?)
+                          :cancelled
+                          (do (Thread/sleep 5) (recur)))))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle (program/hire! room team :worker {:task "stop"})]
+            (is (= true (deref started 10000 ::timeout)))
+            (is (true? (program/cancel! handle)))
+            (is (= :cancelled (:run/status (deref handle 2000 ::timeout))))
+            (is (= :cancelled (:run/status (program/observe room handle)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest llm-program-uses-one-normalized-tool-contract
+  (let [room (test-room :program-llm-tools)
+        team (-> (roster/make-roster)
+                 (roster/make-agent
+                  {:id :with-tool
+                   :tools #{:clojure_eval}
+                   :model-policy {:provider :test :model "stub"}
+                   :program {:kind :llm :max-model-steps 1 :auto-compact? false}})
+                 (roster/make-agent
+                  {:id :without-tools
+                   :model-policy {:provider :test :model "stub"}
+                   :program {:kind :llm :max-model-steps 1 :auto-compact? false}}))
+        advertised (atom [])]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/messages->api-format (fn [messages _ _] messages)
+                    model-chat/chat
+                    (fn [_ {:keys [tools]}]
+                      (swap! advertised conj tools)
+                      {:content "done"
+                       :tool-calls nil
+                       :usage {:input-tokens 0 :output-tokens 0}
+                       :stop-reason :end-turn})]
+        (binding [ec/*execution-context* (:ctx room)]
+          (is (= "done" (:run/value
+                         @(program/hire! room team :with-tool {:task "one"}))))
+          (is (= "done" (:run/value
+                         @(program/hire! room team :without-tools {:task "two"})))))
+        (is (= ["clojure_eval"] (mapv :name (first @advertised))))
+        (is (empty? (second @advertised))
+            "omitting AgentDef tools advertises none rather than the global registry"))
+      (finally
+        (d/close-room! room)))))
+
+(deftest llm-runtime-initialization-does-not-block-the-room-executor
+  (let [room (test-room :program-llm-init-worker)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 1}})
+        entered (promise)
+        release (promise)
+        original-new-working-ctx turn/new-working-ctx]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    turn/new-working-ctx
+                    (fn [opts]
+                      (deliver entered true)
+                      @release
+                      (original-new-working-ctx opts))
+                    chat-agent/run-agent-turn!
+                    (fn [chat-ctx _]
+                      (chat-context/add-message!
+                       chat-ctx {:role :assistant :content "ready"})
+                      :complete)]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle (program/hire! room team :worker {:task "initialize"})]
+            (is (= true (deref entered 10000 ::timeout)))
+            (let [unrelated (future
+                              (binding [ec/*execution-context* (:ctx room)]
+                                @(sp/spin :responsive)))]
+              (is (= :responsive (deref unrelated 1000 ::timeout))
+                  "an unrelated Spin drains while context/schema/SCI setup blocks"))
+            (deliver release true)
+            (is (= "ready" (:run/value (deref handle 10000 ::timeout)))))))
+      (finally
+        (deliver release true)
+        (d/close-room! room)))))
+
+(deftest cancellation-before-worker-registration-is-sticky
+  (let [room (test-room :program-llm-cancel-before-init)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 1}})
+        entered-post (promise)
+        release-post (promise)
+        init-calls (atom 0)
+        original-post d/post!]
+    (try
+      (with-redefs [d/post! (fn [target message]
+                              (deliver entered-post true)
+                              @release-post
+                              (original-post target message))
+                    turn/new-working-ctx
+                    (fn [_]
+                      (swap! init-calls inc)
+                      (throw (ex-info "cancelled init must not run" {})))]
+        (let [hiring (future
+                       (binding [ec/*execution-context* (:ctx room)]
+                         (program/hire! room team :worker {:task "stop"})))
+              _ (is (= true (deref entered-post 1000 ::timeout)))
+              run-id (:run/id (first (run/active-runs (:id room))))
+              closing (future (d/close-room! room))]
+          (is (wait-until #(run/cancel-requested? run-id) 1000))
+          (deliver release-post true)
+          (let [handle (deref hiring 2000 ::timeout)]
+            (is (not= ::timeout handle))
+            (is (nil? (deref closing 3000 ::timeout)))
+            (is (zero? @init-calls))
+            (is (= :cancelled (:run/status (program/observe room handle)))))))
+      (finally
+        (deliver release-post true)
+        (d/close-room! room)))))
+
+(deftest cancellation-between-model-steps-does-not-start-another-step
+  (let [room (test-room :program-llm-cancel-between-steps)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 4}})
+        between (promise)
+        release (promise)
+        calls (atom 0)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn! (fn [_ _]
+                                                 (swap! calls inc)
+                                                 :continue)
+                    turn/post-turn-activity! (fn [& _]
+                                               (deliver between true)
+                                               @release)]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle (program/hire! room team :worker {:task "observe"})]
+            (is (= true (deref between 10000 ::timeout)))
+            (is (true? (program/cancel! handle)))
+            (deliver release true)
+            (is (= :cancelled (:run/status (deref handle 3000 ::timeout))))
+            (is (= 1 @calls)))))
+      (finally
+        (deliver release true)
+        (d/close-room! room)))))
+
+(deftest room-close-waits-for-native-worker-termination
+  (let [room (test-room :program-llm-drain)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm}})
+        started (promise)
+        release (promise)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [_ _]
+                      (deliver started true)
+                      ;; Deliberately ignore Future.cancel's interrupt. The Run
+                      ;; must remain live until native work really terminates.
+                      (loop []
+                        (if (realized? release)
+                          :cancelled
+                          (do
+                            (try
+                              (Thread/sleep 10)
+                              (catch InterruptedException _ nil))
+                            (recur)))))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle (program/hire! room team :worker {:task "drain"})]
+            (is (= true (deref started 10000 ::timeout)))
+            (let [closing (future (d/close-room! room))]
+              (is (wait-until #(run/cancel-requested? (program/run-id handle)) 1000))
+              (Thread/sleep 50)
+              (is (false? (realized? closing))
+                  "Room substrate stays open while the interrupted worker is live")
+              (is (some #(= (program/run-id handle) (:run/id %))
+                        (run/active-runs (:id room))))
+              (deliver release true)
+              (is (nil? (deref closing 3000 ::timeout)))
+              (is (= :cancelled
+                     (:run/status (program/observe room handle))))))))
+      (finally
+        (deliver release true)
         (d/close-room! room)))))
 
 (deftest cancellation-is-targeted-and-acknowledged
@@ -198,12 +558,53 @@
         (dotimes [_ 10]
           (let [handle (program/hire! room team :slow {:task "race"})
                 winner (sp/spin :winner)]
-            (is (= :winner @(comb/race winner (program/result-spin handle))))
+            (is (= :winner @(comb/race winner (program/owned-result-spin handle))))
             (is (wait-until #(= :cancelled
                                 (:run/status (program/observe room handle)))
                             1000))))
         (is (empty? (run/active-runs (:id room)))))
       (finally
+        (d/close-room! room)))))
+
+(deftest passive-result-observers-do-not-own-the-shared-run
+  (let [room (test-room :program-passive-observers)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 75 :reply "shared"}})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle (program/hire! room team :slow {:task "observe"})
+              losing-observer (program/result-spin handle)
+              surviving-observer (program/result-spin handle)]
+          (is (= :winner @(comb/race (sp/spin :winner) losing-observer)))
+          (is (= "shared" (:run/value @surviving-observer)))
+          (is (= :completed (:run/status (program/observe room handle))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest terminal-persistence-retries-without-losing-the-result
+  (let [delegate (memory/make)
+        unavailable? (atom true)
+        room (d/make-room {:id :program-terminal-retry
+                           :store (fail-terminal-store delegate unavailable?)})
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker :program {:kind :scripted :reply "durable"}})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle (program/hire! room team :worker {:task "persist"})]
+          (is (= ::timeout (deref handle 100 ::timeout))
+              "completion remains unresolved while its terminal receipt fails")
+          (is (= :running (:run/status (program/observe room handle))))
+          (is (= 1 (count (run/active-runs (:id room))))
+              "the live lease makes the recovery boundary observable")
+          (reset! unavailable? false)
+          (is (= "durable" (:run/value (deref handle 2000 ::timeout))))
+          (is (= :completed (:run/status (program/observe room handle))))
+          (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (reset! unavailable? false)
         (d/close-room! room)))))
 
 (deftest direct-program-input-does-not-wake-a-same-id-participant

--- a/test/dvergr/agent/prompt_test.clj
+++ b/test/dvergr/agent/prompt_test.clj
@@ -1,0 +1,38 @@
+(ns dvergr.agent.prompt-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.prompt :as prompt]))
+
+(deftest participant-profile-preserves-the-established-prompt
+  (let [base "You are the room analyst."
+        opts {:tools #{:shell}
+              :env-lookup (constantly nil)}]
+    (is (= (str prompt/discourse-preamble "\n\n---\n\n" base)
+           (prompt/assemble-system-prompt
+            base {:tools []
+                  :room-dir "/tmp/dvergr-prompt-test-no-workspace"
+                  :env-lookup (constantly nil)}))
+        "the tool-free default keeps its exact historical assembly")
+    (is (= (prompt/assemble-system-prompt base opts)
+           (prompt/assemble-system-prompt base (assoc opts :profile :participant)))
+        "making the default profile explicit does not change prompt bytes")
+    (let [assembled (prompt/assemble-system-prompt base opts)]
+      (is (str/includes? assembled prompt/discourse-preamble))
+      (is (str/includes? assembled "[SKIP]"))
+      (is (str/includes? assembled "You are never capped")))))
+
+(deftest workflow-profile-is-private-and-bounded
+  (let [assembled (prompt/assemble-system-prompt
+                   "Solve the delegated task."
+                   {:profile :workflow
+                    :tools #{:shell}
+                    :env-lookup (constantly nil)})]
+    (testing "private model-step execution is not taught room-participant discourse"
+      (is (not (str/includes? assembled prompt/discourse-preamble)))
+      (is (not (str/includes? assembled "[SKIP]")))
+      (is (str/starts-with? assembled "Solve the delegated task.")))
+    (testing "workflow authority is explicitly bounded"
+      (is (str/includes? assembled "## Bounded authority"))
+      (is (str/includes? assembled "parent Run"))
+      (is (str/includes? assembled "model-step limit"))
+      (is (not (str/includes? assembled "You are never capped"))))))

--- a/test/dvergr/agent/run_test.clj
+++ b/test/dvergr/agent/run_test.clj
@@ -191,3 +191,25 @@
       (finally
         (run/unwatch-runs! watch-key)
         (d/close-room! room)))))
+
+(deftest retained-finish-keeps-the-drain-lease-until-publication
+  (let [[room st] (run-room :retained-finish)
+        started (run/start! room :agent (d/message :alice :agent "work") nil)
+        run-id (:run/id started)
+        cancelled (atom 0)]
+    (try
+      (run/register-cancel-hook! run-id :probe #(swap! cancelled inc))
+      (let [finished (run/retain-finished! run-id :completed)]
+        (is (= :completed (:run/status finished)))
+        (is (= :completed (:run/status (store/-load-run st :retained-finish run-id))))
+        (is (= [run-id] (mapv :run/id (run/active-runs :retained-finish)))
+            "durable completion still owns its execution lease")
+        (is (true? (run/cancel-run! run-id)))
+        (is (zero? @cancelled)
+            "teardown waits for publication instead of cancelling a finisher")
+        (is (= :completed (:run/status (first (run/active-runs :retained-finish)))))
+        (is (= finished (run/release-finished! run-id)))
+        (is (empty? (run/active-runs :retained-finish))))
+      (finally
+        (run/finish! run-id :failed)
+        (d/close-room! room)))))

--- a/test/dvergr/model/api/claude_code_test.clj
+++ b/test/dvergr/model/api/claude_code_test.clj
@@ -1,0 +1,115 @@
+(ns dvergr.model.api.claude-code-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [dvergr.model.api.claude-code :as claude-code])
+  (:import [java.util.concurrent CancellationException]))
+
+(def ^:private result-json
+  (str "{\"type\":\"result\",\"result\":\"transport ok\","
+       "\"session_id\":\"session-1\",\"total_cost_usd\":0.01,"
+       "\"usage\":{\"input_tokens\":3,\"output_tokens\":2},"
+       "\"modelUsage\":{\"claude-test\":{}}}"))
+
+(defn- run-with-command [command opts]
+  (with-redefs-fn
+    {#'claude-code/build-command (constantly command)}
+    #(@#'claude-code/run-claude-streaming
+      [{:role :user :content "test prompt"}]
+      opts)))
+
+(deftest cli-transport-does-not-leak-claude-codes-native-harness
+  (let [command (#'claude-code/build-command
+                 {:model "claude-code-sonnet"
+                  :system "Dvergr owns the tool protocol."})
+        option-value (fn [option]
+                       (second (drop-while #(not= option %) command)))]
+    (testing "subscription auth remains usable but customizations and tools do not"
+      (is (some #{"--safe-mode"} command))
+      (is (some #{"--disable-slash-commands"} command))
+      (is (= "" (option-value "--tools")))
+      (is (= "{\"mcpServers\":{}}" (option-value "--mcp-config"))))
+    (testing "older CLI versions receive an explicit native-tool denylist"
+      (let [denied (set (str/split (option-value "--disallowedTools") #" "))]
+        (is (every? denied
+                    ["Bash" "Read" "Edit" "Write" "Glob" "Grep" "Task"
+                     "WebFetch" "WebSearch" "ToolSearch" "Skill" "Workflow"
+                     "ListAgents" "ReportFindings" "ScheduleWakeup"]))))))
+
+(deftest cli-transport-drains-stderr-concurrently
+  (testing "stderr larger than a pipe buffer cannot block the result on stdout"
+    (let [command ["sh" "-c"
+                   (str "cat >/dev/null\n"
+                        "head -c 1048576 /dev/zero >&2\n"
+                        "printf '%s\\n' '" result-json "'")]
+          result (deref (future (run-with-command command {})) 5000 ::timeout)]
+      (is (not= ::timeout result))
+      (is (= "transport ok" (:content result)))
+      (is (= {:input-tokens 3
+              :output-tokens 2
+              :cache-read-tokens 0
+              :cache-creation-tokens 0
+              :raw-input-tokens 3}
+             (:usage result))))))
+
+(deftest cli-transport-cancellation-destroys-subprocess
+  (testing ":cancel? terminates an in-flight subscription CLI call"
+    (let [cancelled? (atom false)
+          started (promise)
+          start-process @#'claude-code/start-process
+          {:keys [process outcome]}
+          (with-redefs-fn
+            {#'claude-code/build-command (constantly ["sh" "-c" "cat >/dev/null; exec sleep 30"])
+             #'claude-code/start-process (fn [cmd]
+                                           (let [process (start-process cmd)]
+                                             (deliver started process)
+                                             process))}
+            (fn []
+              (let [call (future
+                           (try
+                             {:value (@#'claude-code/run-claude-streaming
+                                      [{:role :user :content "test prompt"}]
+                                      {:cancel? #(deref cancelled?)})}
+                             (catch Throwable t
+                               {:throwable t})))
+                    process (deref started 1000 ::not-started)]
+                (reset! cancelled? true)
+                {:process process
+                 :outcome (deref call 5000 ::timeout)})))]
+      (is (not= ::not-started process))
+      (let [{:keys [throwable]} outcome]
+        (is (not= ::timeout outcome))
+        (is (instance? CancellationException throwable))
+        (is (false? (.isAlive ^Process process)))))))
+
+(deftest cli-transport-cleans-up-after-stream-callback-failure
+  (testing "all failure paths terminate the subprocess and release its streams"
+    (let [stream-json (str "{\"type\":\"stream_event\","
+                           "\"event\":{\"type\":\"content_block_delta\","
+                           "\"delta\":{\"text\":\"partial\"}}}")
+          command ["sh" "-c"
+                   (str "cat >/dev/null\n"
+                        "printf '%s\\n' '" stream-json "'\n"
+                        "exec sleep 30")]
+          process-ref (atom nil)
+          start-process @#'claude-code/start-process
+          outcome
+          (with-redefs-fn
+            {#'claude-code/build-command (constantly command)
+             #'claude-code/start-process (fn [cmd]
+                                           (let [process (start-process cmd)]
+                                             (reset! process-ref process)
+                                             process))}
+            (fn []
+              (try
+                {:value (@#'claude-code/run-claude-streaming
+                         [{:role :user :content "test prompt"}]
+                         {:on-text (fn [_]
+                                     (throw (ex-info "callback failed" {})))})}
+                (catch Throwable t
+                  {:throwable t}))))
+          process @process-ref
+          {:keys [throwable]} outcome]
+      (is (not= ::not-started process))
+      (is (not= ::timeout outcome))
+      (is (= "callback failed" (ex-message throwable)))
+      (is (false? (.isAlive ^Process process))))))

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -69,6 +69,7 @@
           started (java.util.Date. 1787860800000)
           ended (java.util.Date. 1787860801000)
           definition-hash (random-uuid)
+          chat-id (random-uuid)
           running {:run/id run-id
                    :run/kind :agent-turn
                    :run/room room-id
@@ -80,6 +81,7 @@
                    :run/program-kind :llm
                    :run/interpreter-version 2
                    :run/agent-def-hash definition-hash
+                   :run/chat-id chat-id
                    :run/status :running
                    :run/created-at started
                    :run/started-at started
@@ -96,4 +98,8 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"immutable"
-           (store/-store-run! st room-id (assoc completed :run/trigger (random-uuid))))))))
+           (store/-store-run! st room-id (assoc completed :run/trigger (random-uuid)))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #":run/chat-id must be a UUID"
+           (store/-store-run! st room-id (assoc completed :run/chat-id :not-a-uuid)))))))

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -6,6 +6,8 @@
             [dvergr.room.store.memory :as memory]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.agent :as agent-ns]
+            [dvergr.sandbox.ns.kb :as kb-ns]
+            [dvergr.sandbox.ns.room :as room-ns]
             [org.replikativ.spindel.engine.context :as context]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -17,7 +19,12 @@
       ;; Keep this acceptance test focused on the new surface. Production calls
       ;; the same injector from setup-agent-namespaces!; doc-coverage exercises
       ;; that full wiring and catches any omission there.
-      (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room))
+      (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room) nil)
+      (testing "progressive help contains an executable composition example"
+        (let [guide (sandbox/ns-doc-md sci-ctx 'dvergr.agent)]
+          (is (re-find #":scripted :reply" guide))
+          (is (re-find #"result-spin" guide))
+          (is (re-find #"await" guide))))
       (let [result
             (binding [ec/*execution-context* (:ctx room)]
               (sandbox/eval-code
@@ -59,7 +66,7 @@
   (let [ctx     (context/create-execution-context)
         sci-ctx (sandbox/fork-for-session ctx)]
     (try
-      (agent-ns/add-programming-ns! sci-ctx nil ctx)
+      (agent-ns/add-programming-ns! sci-ctx nil ctx nil)
       (let [pure (sandbox/eval-code
                   sci-ctx
                   (str "(require '[dvergr.agent :as agent]) "
@@ -77,5 +84,103 @@
         (is (= 1 (:value pure)))
         (is (false? (:success effect)))
         (is (re-find #"room-scoped" (get-in effect [:error :message]))))
+      (finally
+        (context/stop-context! ctx)))))
+
+(deftest delegation-ceiling-allows-pure-children-but-rejects-paid-children
+  (let [room    (d/make-room {:id :sci-agent-delegation-ceiling
+                              :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room)
+       {:program-kinds #{:echo :scripted}})
+      (let [prefix (str
+                    "(require '[dvergr.agent :as agent] "
+                    "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                    "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                    "(def team (-> (agent/roster) "
+                    "              (agent/make-agent {:id :pure :program {:kind :echo}}) "
+                    "              (agent/make-agent {:id :paid :program {:kind :llm} "
+                    "                                 :model-policy {:provider :test :model \"stub\"}}))) ")
+            pure (binding [ec/*execution-context* (:ctx room)]
+                   (sandbox/eval-code
+                    sci-ctx
+                    (str prefix
+                         "@(spin (-> (await (agent/result-spin "
+                         "                    (agent/hire! team :pure {:task :ok}))) "
+                         "            :run/value))")))
+            paid (binding [ec/*execution-context* (:ctx room)]
+                   (sandbox/eval-code
+                    sci-ctx
+                    (str prefix
+                         "(agent/hire! team :paid {:task :forbidden})")))]
+        (is (= :ok (:value pure)))
+        (is (false? (:success paid)))
+        (is (re-find #"delegation ceiling" (get-in paid [:error :message])))
+        (is (empty? (run/active-runs (:id room)))
+            "rejected authority never admits a Run"))
+      (finally
+        (d/close-room! room)))))
+
+(deftest ambient-parent-run-is-the-default-structural-parent
+  (let [room      (d/make-room {:id :sci-agent-ambient-parent
+                                :store (memory/make)})
+        sci-ctx   (sandbox/fork-for-session (:ctx room))
+        parent-id (random-uuid)]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room)
+       {:program-kinds #{:echo :scripted}
+        :parent-run parent-id})
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                "(let [team (agent/make-agent (agent/roster) "
+                "                             {:id :child :program {:kind :echo}}) "
+                "      child (agent/hire! team :child {:task :work})] "
+                "  @(spin (await (agent/result-spin child))) "
+                "  (:run/parent (agent/observe child)))")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (= parent-id (:value result))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest legacy-room-hire-cannot-bypass-agent-program-ceiling
+  (let [room    (d/make-room {:id :sci-legacy-hire-ceiling
+                              :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      (room-ns/add-room-ns!
+       sci-ctx nil nil (:id room) (:ctx room)
+       {:program-kinds #{:echo :scripted}})
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               "(require '[dvergr.room :as room]) (room/hire :sci-legacy-hire-ceiling {:goal :forbidden})"))]
+        (is (false? (:success result)))
+        (is (re-find #"delegation ceiling" (get-in result [:error :message])))
+        (is (empty? (run/active-runs (:id room)))
+            "the legacy path is rejected before it reaches a model provider"))
+      (finally
+        (d/close-room! room)))))
+
+(deftest nested-sci-cannot-bypass-authority-through-cheap-llm-calls
+  (let [ctx     (context/create-execution-context)
+        sci-ctx (sandbox/fork-for-session ctx)]
+    (try
+      (kb-ns/add-llm-ns! sci-ctx {:provider-effects? false})
+      (doseq [form ["(require '[llm]) (llm/call \"classify\" \"input\")"
+                    "(require '[llm]) (llm/summarize \"input\")"]]
+        (let [result (sandbox/eval-code sci-ctx form)]
+          (is (false? (:success result)))
+          (is (re-find #"provider effects.*delegation ceiling"
+                       (get-in result [:error :message])))))
       (finally
         (context/stop-context! ctx)))))


### PR DESCRIPTION
## Summary

- add Run-backed native `:llm` AgentDef interpretation over Dvergr ChatContext, tools, SCI, subscription providers, and sandbox semantics
- make passive versus owning result observation explicit for FRP joins and races; supervise native work through stable cancellation, cleanup, quiescence, and durable settlement retries
- teach immutable roster/hire composition inside SCI with ambient structural parent Runs and attenuated recursive provider authority
- isolate and cancel Claude Code CLI subprocesses correctly, and persist deterministic Run chat correlation
- add a versioned opt-in REPL benchmark that the Codex and Claude subscriptions both pass through the production prompt/tool path

## Programming model

A Run is a bounded causal/resource lifetime, not a conversational turn. `:llm` is one interpreter whose provider exchanges are model steps. Workflows compose with Spindel await, parallel Spins, passive observation, explicit owning race arms, cancellation, and fork-aware state.

## Validation

- `clojure -M:format`
- `clojure -M:test` — 512 tests, 2114 assertions, 0 failures
- `clojure -T:build harness`
- live REPL benchmark: Codex Sol and Claude Code Sonnet both passed in 3 model steps / 2 `clojure_eval` calls, created exactly two completed structurally-linked child Runs, and left zero active Runs

Based on squash `15635f5` (tool authorization receipts).