### PR TITLE
feat(agent): add verified reactive race environments

### DIFF
--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -1,11 +1,11 @@
 (ns dvergr.agent.program-bench
-  "Opt-in, subscription-backed REPL probes for the agent programming surface.
+  "Opt-in, model-backed REPL environments for the agent programming surface.
 
    These are deliberately not CI tests: responses, latency, and provider access
-   are nondeterministic and consume subscription resources. The corresponding
-   provider-free language and lifecycle contracts live in ordinary tests. Run
-   this namespace interactively to compare model comprehension using one fixed
-   task and the exact production prompt/tool path."
+   are nondeterministic and consume subscription resources. Each environment has
+   a provider-independent verifier over durable Room/Run facts, so the reported
+   reward never depends on trusting the model's prose. The corresponding
+   language and lifecycle contracts live in ordinary deterministic tests."
   (:require [clojure.edn :as edn]
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
@@ -26,6 +26,17 @@
 
 (def expected-v1 {:analyst "evidence" :reviewer {:claim 42}})
 
+(def race-task-v1
+  (str "Use clojure_eval to solve this task. Construct an immutable roster with "
+       "a :fast scripted agent that waits 10 milliseconds and replies :fast, "
+       "and a :slow scripted agent that waits 5000 milliseconds and replies "
+       ":slow. Hire both, then race their ownership-coupled result Spins with "
+       "spindel.comb/race so the losing Run is really cancelled. Await the race "
+       "compositionally in a spin. Your final answer must be exactly this EDN "
+       "value: :fast. Do not merely describe the code; execute it."))
+
+(def expected-race-v1 :fast)
+
 (defn- parse-edn [value]
   (when (string? value)
     (with-open [reader (PushbackReader. (StringReader. value))]
@@ -38,18 +49,65 @@
             parsed))
         (catch Throwable _ nil)))))
 
-(defn run-v1!
-  "Run programming benchmark v1 through `provider`/`model`.
+(defn- common-checks
+  [{:keys [result parsed-value durable-status active-after]} expected]
+  {:root-completed? (= :completed (:run/status result))
+   :durably-completed? (= :completed durable-status)
+   :exact-result? (= expected parsed-value)
+   :quiescent? (zero? active-after)})
 
-   Intended REPL usage:
+(defn- join-checks [{:keys [root-run-id child-runs] :as observation}]
+  (let [by-actor (group-by :run/actor child-runs)]
+    (merge
+     (common-checks observation expected-v1)
+     {:two-children? (= 2 (count child-runs))
+      :expected-actors? (= #{:analyst :reviewer} (set (keys by-actor)))
+      :structural-parentage? (every? #(= root-run-id (:run/parent %)) child-runs)
+      :children-completed? (every? #(= :completed (:run/status %)) child-runs)})))
 
-     (run-v1! :codex-subscription \"codex-subscription-sol\")
-     (run-v1! :claude-code \"claude-code-sonnet\")
+(defn- race-checks [{:keys [root-run-id child-runs] :as observation}]
+  (let [by-actor (into {} (map (juxt :run/actor identity)) child-runs)]
+    (merge
+     (common-checks observation expected-race-v1)
+     {:two-children? (= 2 (count child-runs))
+      :expected-actors? (= #{:fast :slow} (set (keys by-actor)))
+      :structural-parentage? (every? #(= root-run-id (:run/parent %)) child-runs)
+      :winner-completed? (= :completed (get-in by-actor [:fast :run/status]))
+      :loser-cancelled? (= :cancelled (get-in by-actor [:slow :run/status]))})))
 
-   The returned report includes generated SCI calls so a failure distinguishes
-   language/API confusion from model or transport failure."
-  [provider model]
-  (let [room-id (keyword (str "programming-bench-" (random-uuid)))
+(def ^:private environments
+  {:programming/join-v1
+   {:task task-v1
+    :expected expected-v1
+    :max-model-steps 8
+    :verify join-checks}
+
+   :programming/race-v1
+   {:task race-task-v1
+    :expected expected-race-v1
+    :max-model-steps 8
+    :verify race-checks}})
+
+(defn run-environment!
+  "Run a named programming environment through `provider`/`model`.
+
+   The returned `:checks` are computed by trusted host code from the exact
+   parsed result plus durable Run projections. `:reward` is currently a strict
+   binary reward: every check must pass. Generated SCI calls remain in the
+   report so failures can be attributed to language/API confusion, provider
+   behavior, or runtime semantics.
+
+     (run-environment! :programming/join-v1 :codex-subscription
+                       \"codex-subscription-sol\")
+     (run-environment! :programming/race-v1 :claude-code
+                       \"claude-code-sonnet\")"
+  [environment-id provider model]
+  (let [{:keys [task expected max-model-steps verify]}
+        (or (get environments environment-id)
+            (throw (ex-info "Unknown programming environment"
+                            {:environment-id environment-id
+                             :known (set (keys environments))})))
+        room-id (keyword (str "programming-bench-" (random-uuid)))
         room (d/make-room {:id room-id :store (memory/make)})
         team (roster/make-agent
               (roster/make-roster {:id :benchmark})
@@ -59,13 +117,13 @@
                :tools #{:clojure_eval}
                :model-policy {:provider provider :model model}
                :program {:kind :llm
-                         :max-model-steps 8
+                         :max-model-steps max-model-steps
                          :budget-dollars 1.0
                          :auto-compact? false}})
         started (System/nanoTime)]
     (try
       (let [handle (binding [ec/*execution-context* (:ctx room)]
-                     (program/hire! room team :orchestrator {:task task-v1}))
+                     (program/hire! room team :orchestrator {:task task}))
             initial-result (binding [ec/*execution-context* (:ctx room)]
                              (deref handle 120000 ::timeout))
             timed-out? (= ::timeout initial-result)
@@ -85,18 +143,23 @@
             activity (filter #(= :_activity (:to %)) messages)
             parsed (parse-edn (:run/value result))
             root-run-id (program/run-id handle)
-            child-runs (remove #(= root-run-id (:run/id %)) all-runs)]
-        {:benchmark :programming/v1
+            child-runs (remove #(= root-run-id (:run/id %)) all-runs)
+            observation {:result result
+                         :parsed-value parsed
+                         :durable-status (:run/status durable)
+                         :root-run-id root-run-id
+                         :child-runs child-runs
+                         :active-after (count (run/active-runs room-id))}
+            checks (verify observation)
+            passed? (every? true? (vals checks))]
+        {:environment environment-id
          :provider provider
          :model model
-         :task task-v1
-         :expected expected-v1
-         :passed? (and (= :completed (:run/status result))
-                       (= expected-v1 parsed)
-                       (= 2 (count child-runs))
-                       (= #{:analyst :reviewer} (set (map :run/actor child-runs)))
-                       (every? #(= root-run-id (:run/parent %)) child-runs)
-                       (every? #(= :completed (:run/status %)) child-runs))
+         :task task
+         :expected expected
+         :checks checks
+         :reward (if passed? 1.0 0.0)
+         :passed? passed?
          :timed-out? timed-out?
          :elapsed-ms (long (/ (- (System/nanoTime) started) 1000000))
          ;; Each activity row is a tool-bearing provider exchange. A successful
@@ -114,6 +177,16 @@
                  (mapv #(select-keys % [:tool-use/name :tool-use/input])
                        (get-in message [:metadata :tool-uses])))
                activity)
-         :active-after (count (run/active-runs room-id))})
+         :active-after (:active-after observation)})
       (finally
         (d/close-room! room)))))
+
+(defn run-v1!
+  "Compatibility entry point for the original parallel-join environment."
+  [provider model]
+  (run-environment! :programming/join-v1 provider model))
+
+(defn run-race-v1!
+  "Run the ownership-aware race and loser-cancellation environment."
+  [provider model]
+  (run-environment! :programming/race-v1 provider model))

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -159,11 +159,13 @@ levels:
    provider.
 2. Stub-model interpreter tests exercise prompt/context assembly, exact tool
    schemas, model-step continuation, activity correlation, budgets, and cleanup.
-3. Opt-in model benchmarks give the same room-REPL tasks to Codex, Claude Code,
-   API models, and local models. They record whether generated SCI compiles,
-   whether the causal result/effects are correct, leaked Runs/resources, model
-   steps, wall time, task version, and model. Token/cost receipts and a stable
-   hash of the assembled system prompt remain benchmark-reporting follow-ups.
+3. Opt-in model environments give the same room-REPL tasks to Codex, Claude
+   Code, API models, and local models. A trusted host verifier scores the exact
+   result plus durable Room/Run facts; model prose is never the reward source.
+   Reports retain individual checks, binary reward, generated SCI, leaked
+   Runs/resources, model steps, wall time, task version, and model. Token/cost
+   receipts and a stable hash of the assembled system prompt remain reporting
+   follow-ups.
 
 The initial model-facing task set should include pure roster specialization,
 parallel research/review and reduction, race-with-loser-cancellation, explicit
@@ -172,15 +174,19 @@ durable Room. Later attention combinators add queue/observe/steer/switch tests.
 Passing only one model is not sufficient evidence that the programming surface
 is clear.
 
-The first opt-in comprehension probe is `dvergr.agent.program-bench/run-v1!`
-on the `:dev` classpath. It runs through the production prompt, provider, tool,
-SCI, Spindel, and Run paths while retaining every generated `clojure_eval` call
-in its report:
+The first opt-in environments live in `dvergr.agent.program-bench` on the
+`:dev` classpath. They run through the production prompt, provider, tool, SCI,
+Spindel, and Run paths while retaining every generated `clojure_eval` call in
+their reports:
 
 ```clojure
 (require '[dvergr.agent.program-bench :as bench])
 (bench/run-v1! :codex-subscription "codex-subscription-sol")
-(bench/run-v1! :claude-code "claude-code-sonnet")
+(bench/run-race-v1! :claude-code "claude-code-sonnet")
+
+;; The generic entry point makes the task/version explicit.
+(bench/run-environment! :programming/race-v1
+                        :codex-subscription "codex-subscription-sol")
 ```
 
 It is an explicit REPL benchmark rather than a CI test because it is
@@ -191,7 +197,24 @@ Code Sonnet each discovered the API, created and joined two child Runs, and
 returned the expected value with two `clojure_eval` calls. Earlier attempts
 exposed two real harness defects: the native interpreter omitted the shared
 sandbox prelude, and Claude Code's own native tools shadowed Dvergr's supplied
-tool protocol.
+tool protocol. The first race probe exposed a missing `:delay-ms` contract in
+progressive help and a deeper cancellation bug: a cancelled nested graph could
+also cancel/reap its own durable settlement Spin. Settlement now runs as a
+detached process-local watcher after executor and native-supervisor quiescence,
+and the exact SCI program is covered provider-free.
+
+On 2026-08-28, after that correction, Codex Sol solved
+`:programming/race-v1` in three model exchanges and Claude Code in five. Every
+verifier check passed: exact `:fast` result, completed winner, durably cancelled
+loser, structural parentage, completed root, and zero active Runs.
+
+This is only the seed of a training environment, not yet a reinforcement
+learning system. The intended general contract is: initialize a forked Room and
+resource authority; run an AgentDef/workflow; verify durable effects and
+artifacts with trusted code; settle a reward/resource vector; retain the trace
+for replay, comparison, or learning. A durable environment definition should
+eventually reference versioned verifier code stored with the room repository,
+while Kontor receipts supply resource-aware objectives and constraints.
 
 An explicit `:parent-run` on `hire!` records structural spawning. Causal
 succession remains derivable through the new Run's trigger message and that

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -622,6 +622,13 @@
               (recur (ex-cause error)))))
       (run/cancel-requested? run-id)))
 
+(defn- graph-cancelled-error? [t]
+  (loop [error t]
+    (when error
+      (or (= spin-core/spin-cancelled (:type (ex-data error)))
+          (= "Spin cancelled" (ex-message error))
+          (recur (ex-cause error))))))
+
 (defn- publish-result-and-release-spin
   "Retry terminal persistence without losing the computed result. The Run keeps
    its live execution lease and its completion remains unresolved until the
@@ -652,23 +659,65 @@
          :else nil)))
    result))
 
-(defn- settle-after-supervisor!
-  "Settle a graph-cancelled execution only after the stable supervisor reports
-   every native worker and owned cleanup quiescent."
-  [room id supervisor completion result]
+(defn- publish-result-and-release!
+  "Blocking counterpart for the process-local settlement watcher.
+
+   This must not construct a Spin: it runs specifically after its owning graph
+   was cancelled, and re-entering the same execution context through another
+   graph node can inherit/reuse cancellation bookkeeping. The watcher already
+   runs off the drain thread, so a short blocking durability backoff is safe."
+  [id completion result finish-opts]
+  (loop []
+    (let [retained (try
+                     (run/retain-finished! id (:run/status result) finish-opts)
+                     (catch Throwable t t))]
+      (cond
+        (instance? Throwable retained)
+        (do
+          (Thread/sleep 25)
+          (recur))
+
+        retained
+        (try
+          (completion result)
+          (finally
+            (run/release-finished! id)))
+
+        :else nil)))
+  result)
+
+(defn- settle-external!
+  "Settle from a process-local watcher only after the orchestration Spin has a
+   cached terminal result and the stable supervisor reports every native worker
+   and owned cleanup quiescent."
+  [room id supervisor execution completion result]
   (future
-    (await-supervisor! supervisor)
-    (let [cleanup-error (:cleanup-error @(:state supervisor))
-          result (if cleanup-error
-                   {:run/id id :run/status :failed
-                    :run/error (ex-message cleanup-error)}
-                   result)
-          finish-opts (if (= :cancelled (:run/status result))
-                        {:reason :structured-cancellation}
-                        {:reason (if cleanup-error :cleanup-error :execution-error)
-                         :error (or cleanup-error (:run/error result))})]
-      (binding [ec/*execution-context* (:ctx room)]
-        @(publish-result-and-release-spin id completion result finish-opts)))))
+    ;; `future` conveys dynamic bindings. A cancellation hook normally launches
+    ;; this watcher from the losing observer Spin, so retaining its *spin-id*
+    ;; would make the supposedly external durability path a child of the very
+    ;; graph being reaped. Keep the Room memory context but detach graph identity.
+    (binding [ec/*execution-context* (:ctx room)
+              ec/*spin-id* nil]
+      ;; Keep the durable cancellation token/live lease until the executor has
+      ;; acknowledged termination. Direct cancellation relies on that token at
+      ;; its next cooperative checkpoint; releasing it merely because a pure
+      ;; program has no native workers would let the body continue to effects.
+      (let [execution-id (spin-core/spin-id execution)]
+        (loop []
+          (when-not (ec/spin-current-result execution-id)
+            (Thread/sleep 5)
+            (recur))))
+      (await-supervisor! supervisor)
+      (let [cleanup-error (:cleanup-error @(:state supervisor))
+            result (if cleanup-error
+                     {:run/id id :run/status :failed
+                      :run/error (ex-message cleanup-error)}
+                     result)
+            finish-opts (if (= :cancelled (:run/status result))
+                          {:reason :structured-cancellation}
+                          {:reason (if cleanup-error :cleanup-error :execution-error)
+                           :error (or cleanup-error (:run/error result))})]
+        (publish-result-and-release! id completion result finish-opts)))))
 
 (defn- execution-spin
   [room agent task trigger id chat-id completion supervisor]
@@ -711,22 +760,37 @@
                                 :status status
                                 :agent/id (:agent/id agent)}))))
            (catch Throwable t
-             ;; Ordinary exceptions still own their Spin and can quiesce here.
-             ;; A graph-level cancellation that bypasses this body is handled by
-             ;; the spawn on-error callback below.
-             (sp/await (seal-supervisor! supervisor))
-             (let [cleanup-error (:cleanup-error @(:state supervisor))
-                   error (or cleanup-error t)]
-               (if (and (nil? cleanup-error) (cancelled-error? t id))
-                 {:result {:run/id id :run/status :cancelled}
-                  :finish-opts {:reason :cancel-requested}}
-                 {:result {:run/id id
-                           :run/status :failed
-                           :run/error (ex-message error)}
-                  :finish-opts {:reason (if cleanup-error
-                                          :cleanup-error
-                                          :program-error)
-                                :error error}}))))
+             (let [cancelled? (cancelled-error? t id)
+                   graph-cancelled? (graph-cancelled-error? t)
+                   quiesced (seal-supervisor! supervisor)]
+               (if graph-cancelled?
+                 ;; Cancellation is sticky on a Spin. Awaiting `quiesced` from
+                 ;; this catch would immediately throw cancellation again,
+                 ;; before the body reaches its local reject callback. Under a
+                 ;; nested race that can strand the durable Run at
+                 ;; :cancelling even though the native worker already stopped.
+                 ;; Reject without another breakpoint; the spawn callback below
+                 ;; waits on the stable supervisor from outside the cancelled
+                 ;; graph, then settles the Run durability-first.
+                 (throw t)
+                 (do
+                   ;; Ordinary failures still own a live, non-cancelled Spin and
+                   ;; can await cleanup compositionally. A direct Run
+                   ;; cancellation is in this branch too: its execution graph is
+                   ;; still valid, so it returns an ordinary cancelled result.
+                   (sp/await quiesced)
+                   (let [cleanup-error (:cleanup-error @(:state supervisor))
+                         error (or cleanup-error t)]
+                     (if (and cancelled? (nil? cleanup-error))
+                       {:result {:run/id id :run/status :cancelled}
+                        :finish-opts {:reason :cancel-requested}}
+                       {:result {:run/id id
+                                 :run/status :failed
+                                 :run/error (ex-message error)}
+                        :finish-opts {:reason (if cleanup-error
+                                                :cleanup-error
+                                                :program-error)
+                                      :error error}})))))))
          result (:result outcome)]
      ;; Completion is a Spindel Deferred allocated in this Room's execution
      ;; context, not a JVM promise or host atom. Its value therefore follows
@@ -789,14 +853,38 @@
             execution (execution-spin room agent task trigger id chat-id
                                       completion supervisor)
             owner-fork-id (:fork-id (ec/current-execution-context))
-            handle    (RunHandle. id (:id room) owner-fork-id execution completion)]
+            handle    (RunHandle. id (:id room) owner-fork-id execution completion)
+            settlement-started? (atom false)
+            settle! (fn [result]
+                      (when (compare-and-set! settlement-started? false true)
+                        (settle-external! room id supervisor execution
+                                          completion result)))
+            cancel! (fn []
+                      (cancel-supervisor! supervisor)
+                      ;; Cancellation closes admission to further native work.
+                      ;; Cleanup may still be registered by an already-running
+                      ;; initialization worker while the phase is :pending; the
+                      ;; supervisor starts it after that worker terminates.
+                      (seal-supervisor! supervisor)
+                      ;; Run cancellation is an execution boundary in its own
+                      ;; right, not merely a hint to the current graph. Start a
+                      ;; process-local settlement watcher now. A nested parent
+                      ;; may reap the spawned Spin's callback continuation while
+                      ;; cancelling its race arm; the execution result plus the
+                      ;; stable supervisor are the physical-quiescence fence.
+                      (settle! {:run/id id :run/status :cancelled}))]
+        ;; Replace the early sticky worker hook with the complete cancellation
+        ;; boundary. register-cancel-hook! immediately invokes it if cancellation
+        ;; won between durable admission and construction of this execution.
+        (run/register-cancel-hook! id ::native-worker cancel!)
         (sp/spawn!
          execution
          {:on-error
           (fn [t]
-            ;; Graph-level cancellation (parent/race) can abort before the Spin
-            ;; body catches. Settle the durable lifecycle from the callback;
-            ;; finish! is idempotent if the body already did so.
+            ;; Graph-level cancellation is settled outside the cancelled Spin:
+            ;; this callback may safely block on stable supervisor quiescence,
+            ;; while the cancelled body may not cross another await breakpoint.
+            ;; finish! is idempotent if another terminal path already won.
             (let [result (if (cancelled-error? t id)
                            {:run/id id :run/status :cancelled}
                            {:run/id id :run/status :failed
@@ -805,7 +893,7 @@
                 (run/cancel-room-run! (:id room) id))
               (cancel-supervisor! supervisor)
               (seal-supervisor! supervisor)
-              (settle-after-supervisor! room id supervisor completion result)))})
+              (settle! result)))})
         handle)
       (catch Throwable t
         (run/finish! id :failed {:reason :spawn-failed :error t})

--- a/src/dvergr/agent/roster.clj
+++ b/src/dvergr/agent/roster.clj
@@ -199,6 +199,14 @@
 (defn make-agent
   "Return a new Roster containing `spec` as a portable AgentDef.
 
+   Exact deterministic program shapes are:
+     {:kind :echo :delay-ms milliseconds}
+     {:kind :scripted :delay-ms milliseconds :reply value}
+
+   An LLM program uses {:kind :llm :max-model-steps n :budget-dollars n}
+   together with AgentDef :model-policy and :tools. `:delay-ms` is optional;
+   unknown program keys are rejected before a Run is admitted.
+
    Adding an identical definition is idempotent. Reusing an id with different
    data is rejected; use `revise-agent` so old Run references retain meaning."
   [roster spec]

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -665,8 +665,8 @@
                        "(dvergr.scheduler/create {:agent-id :var :schedule {:every :hour :n 4} :code \"(require 'my.ns)(my.ns/run!)\" :description \"…\"})  (dvergr.scheduler/list)  (dvergr.scheduler/cancel id)"]
    "dvergr.tasks"    ["the shared task ledger — list/accept/complete work items"
                       "(dvergr.tasks/list)   (dvergr.tasks/complete! id)"]
-   "dvergr.agent"    ["program specialized agents as immutable rosters; hire! starts a durable Run with an explicit result Spin"
-                      "(let [team (-> (dvergr.agent/roster) (dvergr.agent/make-agent {:id :a :program {:kind :scripted :reply \"evidence\"}}) (dvergr.agent/make-agent {:id :b :program {:kind :echo}})) a (dvergr.agent/hire! team :a {:task :inspect}) b (dvergr.agent/hire! team :b {:task {:claim 42}})] @(spin [(-> (await (dvergr.agent/result-spin a)) :run/value) (-> (await (dvergr.agent/result-spin b)) :run/value)]))"]
+   "dvergr.agent"    ["program specialized agents as immutable rosters; exact programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm ...}; hire! starts a durable Run with an explicit result Spin"
+                      "join with result-spin; for a first-result race that really cancels losing Runs: (let [team (-> (dvergr.agent/roster) (dvergr.agent/make-agent {:id :fast :program {:kind :scripted :delay-ms 10 :reply :fast}}) (dvergr.agent/make-agent {:id :slow :program {:kind :scripted :delay-ms 5000 :reply :slow}})) a (dvergr.agent/hire! team :fast {:task :solve}) b (dvergr.agent/hire! team :slow {:task :solve})] @(spin (-> (await (spindel.comb/race (dvergr.agent/owned-result-spin a) (dvergr.agent/owned-result-spin b))) :run/value)))"]
    "dvergr.agents"   ["directory of agents (read-only): who exists / is online"
                       "(dvergr.agents/list)   (dvergr.agents/online? :var)"]
    "dvergr.actors"   ["durable participant identities — register/retire agents or humans and assign skills"

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -23,7 +23,12 @@
    the authority map supplies `:parent-run`, `hire!` uses it as the structural
    parent unless the caller explicitly supplies one.
 
-   Usage:
+   Program data:
+     {:kind :echo :delay-ms 10}
+     {:kind :scripted :delay-ms 10 :reply value}
+     {:kind :llm :max-model-steps 32 :budget-dollars 0.5}
+
+   Join usage:
      (require '[dvergr.agent :as agent]
               '[org.replikativ.spindel.spin.cps :refer [spin]]
               '[org.replikativ.spindel.effects.await :refer [await]])
@@ -34,7 +39,16 @@
                       :program {:kind :echo}}))]
        @(spin (-> (await (agent/result-spin
                           (agent/hire! team :analyst {:task :inspect})))
-                  :run/value)))"
+                  :run/value)))
+
+   Ownership-aware race (the losing Run is cancelled):
+     (require '[spindel.comb :as comb])
+     (let [a (agent/hire! team :fast {:task :solve})
+           b (agent/hire! team :slow {:task :solve})]
+       @(spin
+          (-> (await (comb/race (agent/owned-result-spin a)
+                                (agent/owned-result-spin b)))
+              :run/value)))"
   [sci-ctx room-id spindel-ctx agent-program-ceiling]
   (let [make-roster*   (requiring-resolve 'dvergr.agent.roster/make-roster)
         make-agent*    (requiring-resolve 'dvergr.agent.roster/make-agent)
@@ -108,7 +122,7 @@
         'result-spin  result-spin*
         'owned-result-spin owned-result-spin*}
        '{roster       [([] [opts]) "Create an immutable Roster value. Options may include portable :id, :defaults, :scope, and :metadata data."]
-         make-agent   [([roster spec]) "Return a NEW Roster containing `spec`; use {:id :a :program {:kind :echo}}, {:kind :scripted :reply value}, or {:kind :llm} plus :model-policy and :tools. Pure: input unchanged."]
+         make-agent   [([roster spec]) "Return a NEW Roster containing `spec`. Programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm :max-model-steps n :budget-dollars n} plus :model-policy and :tools. Pure: input unchanged."]
          revise-agent [([roster id patch]) "Return a NEW Roster with AgentDef `id` revised and its version incremented."]
          lookup       [([roster id-or-ref]) "Resolve an AgentDef by keyword id or versioned AgentRef. A stale versioned ref is an error."]
          ref          [([agent-def]) "Return the stable {:agent/id :agent/version} reference for an AgentDef."]

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -3,6 +3,7 @@
    and probabilistic inference. Split out of dvergr.sandbox (Phase 4)."
   (:require [sci.core :as sci]
             [datahike.api :as dh]
+            [dvergr.sandbox.ns.doc :as doc]
             [org.replikativ.spindel.engine.core :as rtc]
             [org.replikativ.spindel.core :as sync]))
 
@@ -29,10 +30,15 @@
                            'post!     (fn [mb v] (mb v))})
       ;; Combinators
       (sci/add-namespace! sci-ctx 'spindel.comb
-                          {'parallel @(ns-resolve comb-ns 'parallel)
-                           'race     @(ns-resolve comb-ns 'race)
-                           'timeout  @(ns-resolve comb-ns 'timeout)
-                           'sleep    @(ns-resolve comb-ns 'sleep)})
+                          (doc/with-docs
+                            {'parallel @(ns-resolve comb-ns 'parallel)
+                             'race     @(ns-resolve comb-ns 'race)
+                             'timeout  @(ns-resolve comb-ns 'timeout)
+                             'sleep    @(ns-resolve comb-ns 'sleep)}
+                            '{parallel [([& spins]) "Run Spins concurrently and produce their values in input order. Cancelling the composition cancels its branches."]
+                              race     [([& spins]) "Produce the first Spin value and cancel losing branches. For hired Runs, pass dvergr.agent/owned-result-spin when branch cancellation must cancel the Run; passive result-spin deliberately leaves shared work alive."]
+                              timeout  [([spin timeout-ms] [spin timeout-ms timeout-value]) "Race a Spin against a timer and cancel the timed-out branch."]
+                              sleep    [([milliseconds]) "Return a Spin that completes after the given duration without blocking the engine thread."]}))
       ;; Signals — signal is a macro; wrap as a function using the underlying record
       (let [signal-ref-ctor (ns-resolve sig-ns '->SignalRef)
             addr-ns (do (require 'org.replikativ.spindel.engine.addressing)
@@ -252,4 +258,3 @@
                        'predict            @(resolve 'org.replikativ.spindel.inference.inference/predict)
                        'pimh-infer         @(resolve 'org.replikativ.spindel.inference.inference/pimh-infer)
                        'pgibbs-infer       @(resolve 'org.replikativ.spindel.inference.inference/pgibbs-infer)}))
-

--- a/src/dvergr/sandbox/ns/intake.clj
+++ b/src/dvergr/sandbox/ns/intake.clj
@@ -11,15 +11,38 @@
    here — currently just `intake.mail` (briefkasten + javax.mail are too heavy)."
   (:require [sci.core :as sci]))
 
+(def ^:private native-mail-vars
+  {'inbox  'list-inbox
+   'search 'search-mail
+   'read   'read-message
+   'sync!  'sync-inbox!})
+
+(defn- resolve-mail-bindings [mail-ns]
+  ;; Resolve against one Namespace snapshot. In a cold/concurrent process an
+  ;; optional `require` can fail in one sandbox setup while another setup sees
+  ;; the library as loaded; a second symbol-based ns-resolve then throws when
+  ;; the partially loaded namespace has already disappeared. Resolve all Vars
+  ;; first, then snapshot their callable roots for SCI.
+  (when mail-ns
+    (let [bindings (into {}
+                         (map (fn [[sandbox-name host-name]]
+                                [sandbox-name (ns-resolve mail-ns host-name)]))
+                         native-mail-vars)]
+      (when (every? var? (vals bindings))
+        (update-vals bindings deref)))))
+
+(defn- load-mail-bindings []
+  (try
+    (require 'dvergr.intake.mail)
+    (resolve-mail-bindings (find-ns 'dvergr.intake.mail))
+    (catch Throwable _
+      nil)))
+
 (defn add-intake-namespaces!
   "Mount the few NATIVE-only intake namespaces. Everything else is sandbox source."
   [sci-ctx]
   ;; intake.mail — OPTIONAL: its clojure-mail/postal/briefkasten deps live in the
   ;; :cli/:tui/:dev aliases, not core. Mounted only when present.
-  (when (try (require 'dvergr.intake.mail) true (catch Throwable _ false))
-    (sci/add-namespace! sci-ctx 'intake.mail
-                        {'inbox  @(ns-resolve 'dvergr.intake.mail 'list-inbox)
-                         'search @(ns-resolve 'dvergr.intake.mail 'search-mail)
-                         'read   @(ns-resolve 'dvergr.intake.mail 'read-message)
-                         'sync!  @(ns-resolve 'dvergr.intake.mail 'sync-inbox!)}))
+  (when-let [bindings (load-mail-bindings)]
+    (sci/add-namespace! sci-ctx 'intake.mail bindings))
   sci-ctx)

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -566,6 +566,33 @@
       (finally
         (d/close-room! room)))))
 
+(deftest nested-structured-race-settles-the-losing-run
+  (let [room (test-room :program-nested-race)
+        team (-> (roster/make-roster)
+                 (roster/make-agent
+                  {:id :fast
+                   :program {:kind :scripted :delay-ms 10 :reply :fast}})
+                 (roster/make-agent
+                  {:id :slow
+                   :program {:kind :scripted :delay-ms 5000 :reply :slow}}))]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [fast (program/hire! room team :fast {:task :solve})
+              slow (program/hire! room team :slow {:task :solve})]
+          (is (= :fast
+                 (:run/value
+                  @(sp/spin
+                    (sp/await
+                     (comb/race (program/owned-result-spin fast)
+                                (program/owned-result-spin slow)))))))
+          (is (wait-until #(= :cancelled
+                              (:run/status (program/observe room slow)))
+                          1000))
+          (is (= :completed (:run/status (program/observe room fast))))
+          (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (d/close-room! room)))))
+
 (deftest passive-result-observers-do-not-own-the-shared-run
   (let [room (test-room :program-passive-observers)
         team (roster/make-agent

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -6,10 +6,19 @@
             [dvergr.room.store.memory :as memory]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.agent :as agent-ns]
+            [dvergr.sandbox.ns.data :as data-ns]
             [dvergr.sandbox.ns.kb :as kb-ns]
             [dvergr.sandbox.ns.room :as room-ns]
             [org.replikativ.spindel.engine.context :as context]
             [org.replikativ.spindel.engine.core :as ec]))
+
+(defn- wait-until [pred timeout-ms]
+  (let [deadline (+ (System/nanoTime) (* timeout-ms 1000000))]
+    (loop []
+      (cond
+        (pred) true
+        (< (System/nanoTime) deadline) (do (Thread/sleep 5) (recur))
+        :else false))))
 
 (deftest immutable-rosters-launch-composable-room-runs-from-sci
   (let [room    (d/make-room {:id :sci-agent-programming
@@ -20,11 +29,18 @@
       ;; the same injector from setup-agent-namespaces!; doc-coverage exercises
       ;; that full wiring and catches any omission there.
       (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room) nil)
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room))
       (testing "progressive help contains an executable composition example"
         (let [guide (sandbox/ns-doc-md sci-ctx 'dvergr.agent)]
-          (is (re-find #":scripted :reply" guide))
+          (is (re-find #":scripted.*:reply" guide))
+          (is (re-find #":delay-ms" guide))
           (is (re-find #"result-spin" guide))
-          (is (re-find #"await" guide))))
+          (is (re-find #"owned-result-spin" guide))
+          (is (re-find #"comb/race" guide))
+          (is (re-find #"await" guide)))
+        (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.comb)]
+          (is (re-find #"cancel losing branches" guide))
+          (is (re-find #"owned-result-spin" guide))))
       (let [result
             (binding [ec/*execution-context* (:ctx room)]
               (sandbox/eval-code
@@ -59,6 +75,39 @@
           (is (uuid? (get-in result [:value :analyst-run])))
           (is (= :completed (get-in result [:value :analyst-status])))
           (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest room-sci-race-cancels-and-settles-its-owned-loser
+  (let [room (d/make-room {:id :sci-agent-owned-race
+                           :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room) nil)
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room))
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                "         '[spindel.comb :as comb]) "
+                "(let [team (-> (agent/roster) "
+                "               (agent/make-agent {:id :fast :program {:kind :scripted :delay-ms 10 :reply :fast}}) "
+                "               (agent/make-agent {:id :slow :program {:kind :scripted :delay-ms 5000 :reply :slow}})) "
+                "      a (agent/hire! team :fast {:task :solve}) "
+                "      b (agent/hire! team :slow {:task :solve})] "
+                "  @(spin (-> (await (comb/race (agent/owned-result-spin a) "
+                "                                (agent/owned-result-spin b))) "
+                "             :run/value)))")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (= :fast (:value result)))
+        (is (wait-until #(empty? (run/active-runs (:id room))) 1000))
+        (let [by-actor (into {} (map (juxt :run/actor identity)) (run/runs room))]
+          (is (= :completed (get-in by-actor [:fast :run/status])))
+          (is (= :cancelled (get-in by-actor [:slow :run/status])))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/sandbox/ns/intake_test.clj
+++ b/test/dvergr/sandbox/ns/intake_test.clj
@@ -1,0 +1,27 @@
+(ns dvergr.sandbox.ns.intake-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox.ns.intake :as intake]))
+
+(deftest optional-mail-namespace-is-resolved-from-one-snapshot
+  (testing "an unavailable or partially loaded optional namespace is skipped"
+    (is (nil? (#'intake/resolve-mail-bindings nil))))
+  (testing "all native callables are captured together"
+    (let [ns-sym (symbol (str "dvergr.test.mail-" (random-uuid)))
+          mail-ns (create-ns ns-sym)]
+      (try
+        (doseq [host-name '[list-inbox search-mail read-message sync-inbox!]]
+          (intern mail-ns host-name (fn [& _] host-name)))
+        (let [bindings (#'intake/resolve-mail-bindings mail-ns)]
+          (is (= #{'inbox 'search 'read 'sync!} (set (keys bindings))))
+          (is (every? fn? (vals bindings))))
+        (finally
+          (remove-ns ns-sym))))))
+
+(deftest incomplete-mail-namespace-is-not-mounted
+  (let [ns-sym (symbol (str "dvergr.test.mail-incomplete-" (random-uuid)))
+        mail-ns (create-ns ns-sym)]
+    (try
+      (intern mail-ns 'list-inbox (fn [] []))
+      (is (nil? (#'intake/resolve-mail-bindings mail-ns)))
+      (finally
+        (remove-ns ns-sym)))))


### PR DESCRIPTION
## Summary

- generalize the opt-in REPL benchmark into named environments with trusted checks and binary reward over durable Room/Run facts
- add a race-v1 environment covering model-authored SCI fan-out, ownership-aware race, structural parentage, durable loser cancellation, and quiescence
- make exact AgentDef program keys and Spindel race ownership discoverable through sandbox documentation
- harden cancellation settlement for a race nested inside another Spin while preserving the existing direct cancel contract
- add provider-free host and SCI regressions for the exact generated workflow

## Experiment

Before the documentation change, Codex and Claude Code both exhausted eight model steps and guessed :wait-ms instead of :delay-ms. The corrected help surface let both construct the intended program. The first successful program then exposed a real lifecycle defect: the cancelled graph could also reap its own durable settlement path.

On the final code:

- Codex subscription Sol: reward 1.0, 3 model steps, 14.5s
- Claude Code subscription: reward 1.0, 5 model steps, 24.2s
- both: exact result, correct structural children, completed winner/root, durably cancelled loser, zero active Runs

## Validation

- clojure -M:format
- clojure -M:test: 514 tests, 2128 assertions, 0 failures
- clojure -T:build harness
- live REPL environments through both subscription providers

## Follow-up

Expected nested cancellation still reveals stale Spindel completion subscriptions as spin-completion-cont-missing warnings. Lifecycle correctness and quiescence are verified here; cleaning those cancellation subscriptions belongs in Spindel.