### PR TITLE
Isolate every AgentDef Run in a forked work world

### DIFF
--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -115,9 +115,12 @@ the same Run boundary:
   @(spin (await (agent/result-spin work))))
 ```
 
-Every hire receives a fresh ChatContext in the Room's Spindel execution context.
-Parallel hires therefore have independent dialogue and budget state while seeing
-the same fork-local Geschichte/Datahike substrate. The AgentDef tool set is both
+Every hire opens a cheap isolated Run world. The orchestration graph, trigger,
+tool-activity summaries, output, and durable Run projection remain in the parent
+Room's control plane; database, Geschichte/filesystem, SCI, and nested-agent
+effects resolve through the world's forked Room/context. Parallel hires therefore
+have independent dialogue and budget state while starting from the same parent
+substrate. The AgentDef tool set is both
 the schema shown to the model and the authoritative execution allowlist. An
 omitted tool set means no tools.
 
@@ -139,9 +142,27 @@ not Dvergr's scheduling clock. Reactive attention may queue, merge, observe,
 fork, or switch work around these discrete transport boundaries.
 `:budget-dollars` is a per-execution spending ceiling (default $1), not a Kontor
 resource allocation. When it is exceeded after a tool-bearing model step, the Run
-settles as `:waiting` with reason `:budget-exhausted`; no process remains active.
+settles as `:waiting` with reason `:budget-exhausted`; no process remains active,
+and its partial world is retained for review.
 A true resumable continuation and affine resource settlement are separate later
 contracts.
+
+## Execution and world settlement
+
+Execution and settlement are independent durable axes. `:run/status` describes
+what the program did (`:completed`, `:waiting`, `:failed`, or `:cancelled`).
+`:run/settlement-status` describes what happened to its isolated effects
+(`:merged`, `:review`, or `:discarded`). `hire!` accepts:
+
+- `:settlement :automatic` (default): merge completed work;
+- `:settlement :review`: retain completed work in the Room tree;
+- `:settlement :discard`: execute for its result/trace, then drop its effects.
+
+Failure and cancellation always discard the work plane. Waiting and automatic
+merge conflicts retain it for review. A later merge/discard through
+`dvergr.rooms.forks` updates the owning Run's settlement projection. World
+settlement runs only after the executor and native-worker supervisor have
+physically quiesced, outside the Spindel drain graph that used the fork.
 
 An LLM-created sandbox can still build and revise arbitrary immutable rosters,
 but its `hire!` authority currently accepts only provider-free `:echo` and

--- a/doc/orchestration.md
+++ b/doc/orchestration.md
@@ -470,7 +470,9 @@ Implemented for `:agent-turn` Runs; see [runs.md](runs.md):
    membership through the trigger rather than duplicating it on the Run.
 3. Key live control by Run ID while preserving room-level convenience APIs.
 4. Expose an initial-snapshot lifecycle subscription and targeted cancellation.
-5. Do not introduce a universal workflow-run aggregate in this stage.
+5. Keep execution and world settlement as separate Run axes. Every AgentDef hire
+   gets an internal forked work plane; only retained review worlds need the
+   heavyweight user-visible proposal workflow.
 
 ### Stage 3: durable delegated tasks
 
@@ -483,8 +485,10 @@ Implemented for `:agent-turn` Runs; see [runs.md](runs.md):
 
 The provider-free functional-programming precursor is implemented now: immutable
 AgentDefs/Rosters compose in room SCI, and `hire!` starts a Run-backed Spindel
-computation. See [agent-programs.md](agent-programs.md). Its `:roster/scope` is
-data only until this stage supplies enforceable attenuation/accounting.
+computation whose effects execute in an isolated Run world. Automatic settlement
+is the common path; review retains the world as a normal inspectable fork. See
+[agent-programs.md](agent-programs.md). Its `:roster/scope` is data only until
+this stage supplies enforceable attenuation/accounting.
 
 ### Stage 4: recursive workrooms
 

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -10,6 +10,7 @@
             [dvergr.agent.room-context :as room-context]
             [dvergr.agent.run :as run]
             [dvergr.agent.turn :as turn]
+            [dvergr.agent.world :as world]
             [dvergr.chat.agent :as chat-agent]
             [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as d]
@@ -22,7 +23,8 @@
             [org.replikativ.spindel.atom :as ratom]
             [org.replikativ.spindel.spin.combinators :as comb]
             [org.replikativ.spindel.spin.core :as spin-core]
-            [org.replikativ.spindel.spin.sync :as sync])
+            [org.replikativ.spindel.spin.sync :as sync]
+            [taoensso.telemere :as tel])
   (:import [java.nio.charset StandardCharsets]
            [java.util UUID]
            [java.util.concurrent Callable CountDownLatch FutureTask]))
@@ -47,17 +49,20 @@
 
 (declare start-worker!)
 
-(defn- make-supervisor [execution-ctx]
-  {:execution-ctx execution-ctx
-   :state (atom {:cancelled? false
-                 :sealed? false
-                 :workers {}
-                 :cleanup nil
-                 :cleanup-phase :pending
-                 :cleanup-error nil
-                 :quiesced? false})
-   :quiesced (sync/deferred)
-   :quiesced-latch (CountDownLatch. 1)})
+(defn- make-supervisor
+  ([execution-ctx] (make-supervisor execution-ctx execution-ctx))
+  ([execution-ctx worker-ctx]
+   {:execution-ctx execution-ctx
+    :worker-ctx worker-ctx
+    :state (atom {:cancelled? false
+                  :sealed? false
+                  :workers {}
+                  :cleanup nil
+                  :cleanup-phase :pending
+                  :cleanup-error nil
+                  :quiesced? false})
+    :quiesced (sync/deferred)
+    :quiesced-latch (CountDownLatch. 1)}))
 
 (defn- advance-supervisor!
   "Advance cleanup/quiescence after an atomic supervisor transition. Cleanup
@@ -125,7 +130,7 @@
          callable   (reify Callable
                       (call [_]
                         (when (compare-and-set! phase :new :running)
-                          (binding [ec/*execution-context* (:execution-ctx supervisor)]
+                          (binding [ec/*execution-context* (:worker-ctx supervisor)]
                             (try
                               (reset! result (f))
                               (catch Throwable t
@@ -134,11 +139,13 @@
                                 (reset! phase :terminated)
                                ;; Publish the per-worker result before removing
                                ;; its live lease from the stable supervisor.
-                                (try
-                                  (done @result)
-                                  (finally
-                                    (worker-finished! supervisor worker-id kind
-                                                      @result)))))))))
+                                (binding [ec/*execution-context*
+                                          (:execution-ctx supervisor)]
+                                  (try
+                                    (done @result)
+                                    (finally
+                                      (worker-finished! supervisor worker-id kind
+                                                        @result))))))))))
          task       (proxy [FutureTask] [callable]
                       (done []
                        ;; Cancellation before the executor begins means the
@@ -211,7 +218,7 @@
   (.await ^CountDownLatch (:quiesced-latch supervisor))
   nil)
 
-(deftype RunHandle [id room-id owner-fork-id execution completion]
+(deftype RunHandle [id room-id owner-fork-id execution completion worker-execution]
   clojure.lang.ILookup
   (valAt [_ k]
     (case k
@@ -284,7 +291,7 @@
    to the hired Run. Prefer passive `result-spin` for ordinary or shared reads."
   [^RunHandle handle]
   (ensure-owner-context! handle)
-  (let [execution (.-execution handle)
+  (let [execution (.-worker-execution handle)
         id (:run/id handle)
         room-id (:run/room handle)
         observer (sp/spin
@@ -355,18 +362,21 @@
                       {:type ::no-provider
                        :agent/id (:agent/id agent)}))))
 
-(defn- new-llm-context [room run-id agent budget-dollars chat-id]
-  (let [system-id (room-context/room-system-id room)
-        borrowed-db (some-> room :store :conn)
+(defn- new-llm-context [control-room work-room run-id agent budget-dollars chat-id]
+  (let [system-id (room-context/room-system-id work-room)
+        ;; Model messages, tool results, authorization receipts, and costs are
+        ;; control-plane evidence. Keep that trace in the parent even when the
+        ;; work plane is later discarded.
+        trace-db (some-> control-room :store :conn)
         chat-ctx (turn/new-working-ctx
-                  {:execution-ctx (:ctx room)
+                  {:execution-ctx (:ctx work-room)
                    :chat-id chat-id
                    :title (str "agent-task " (name (:agent/id agent)))
                    :budget-dollars budget-dollars
-                   :db-conn borrowed-db
+                   :db-conn trace-db
                    :kb-conn (when system-id (system-rooms/room-kb-conn system-id))
                    :room-id system-id
-                   :room-runtime-id (:id room)
+                   :room-runtime-id (:id work-room)
                    ;; Until Kontor can split a resource vector, a paid child may
                    ;; only delegate provider-free work. Pure roster construction
                    ;; remains available inside SCI.
@@ -374,15 +384,21 @@
                                            :provider-effects? false
                                            :parent-run run-id}})]
     {:chat-ctx chat-ctx
-     :owned-db? (nil? borrowed-db)}))
+     :owned-db? (nil? trace-db)}))
 
-(defn- llm-tool-context [room chat-ctx agent]
+(defn- llm-tool-context [control-room room chat-ctx agent]
   (let [system-id (room-context/room-system-id room)
-        tool-map (tools/normalize-tools (or (:agent/tools agent) #{}))]
+        tool-map (tools/normalize-tools (or (:agent/tools agent) #{}))
+        ;; Ordinary room/task effects target the branched work store. A
+        ;; store-less Room uses the per-Run ephemeral DB, which is itself owned
+        ;; by the work context and closed before settlement.
+        work-db (or (some-> room :store :conn)
+                    (when-not (some-> control-room :store :conn)
+                      (:db-conn chat-ctx)))]
     {:tool-map tool-map
      :tool-ctx
      (-> (tools/make-context
-          {:db-conn (:db-conn chat-ctx)
+          {:db-conn work-db
            :chat-ctx chat-ctx
            :sci-ctx (:sci-ctx chat-ctx)
            :tools tool-map
@@ -398,7 +414,7 @@
   "Run a bounded Dvergr-native model/tool loop. Each blocking model round-trip
    runs under a supervised worker; this Spin retains orchestration, activity
    correlation, cleanup, and cancellation in the Room's execution graph."
-  [room run-id chat-id agent task trigger supervisor]
+  [control-room work-room run-id chat-id agent task trigger supervisor]
   (let [{:keys [max-model-steps budget-dollars auto-compact? compaction-model]
          :or {max-model-steps default-max-model-steps
               budget-dollars 1.0
@@ -412,12 +428,13 @@
             supervisor
             (fn []
               (let [{:keys [chat-ctx owned-db?]}
-                    (new-llm-context room run-id agent budget-dollars chat-id)
+                    (new-llm-context control-room work-room run-id agent
+                                     budget-dollars chat-id)
                     _ (when owned-db?
                         (register-cleanup!
                          supervisor #(chat-context/close-chat! chat-ctx)))
                     {:keys [tool-map tool-ctx]}
-                    (llm-tool-context room chat-ctx agent)
+                    (llm-tool-context control-room work-room chat-ctx agent)
                     model-spec (resolve-model-spec agent)
                     instructions
                     (prompt/assemble-system-prompt
@@ -464,7 +481,7 @@
                       :tools tool-map
                       :tool-ctx tool-ctx
                       :cancel? (turn/cancel?-fn
-                                chat-ctx (:ctx room)
+                                chat-ctx (:ctx work-room)
                                 (fn [] (run/cancel-requested? run-id)))
                       :auto-compact? auto-compact?
                       :compaction-model compaction-model
@@ -474,7 +491,7 @@
                       :turn-number model-step
                       :run-id run-id})))
                  outcome (sp/await (worker-result-spin call))]
-             (turn/post-turn-activity! room (:agent/id agent) chat-ctx posted
+             (turn/post-turn-activity! control-room (:agent/id agent) chat-ctx posted
                                        run-id trigger)
              (cond
                (or (= ::worker-cancelled outcome)
@@ -523,12 +540,13 @@
                (recur (inc model-step))))))))))
 
 (defn- execute-program
-  [room run-id chat-id agent task trigger supervisor]
+  [control-room work-room run-id chat-id agent task trigger supervisor]
   (case (get-in agent [:agent/program :kind])
-    :llm (execute-llm-program room run-id chat-id agent task trigger supervisor)
+    :llm (execute-llm-program control-room work-room run-id chat-id agent task
+                              trigger supervisor)
     (execute-deterministic-program run-id agent task)))
 
-(def ^:private hire-option-keys #{:task :from :parent-run})
+(def ^:private hire-option-keys #{:task :from :parent-run :settlement})
 
 (defn- validate-program!
   [{:keys [kind delay-ms max-model-steps budget-dollars auto-compact? compaction-model]
@@ -650,10 +668,7 @@
            (recur))
 
          retained
-         (try
-           (completion result)
-           (finally
-             (run/release-finished! id)))
+         (run/publish-finished! id completion result)
 
          ;; Another exactly-once settlement path already retained/released it.
          :else nil)))
@@ -678,19 +693,35 @@
           (recur))
 
         retained
-        (try
-          (completion result)
-          (finally
-            (run/release-finished! id)))
+        (run/publish-finished! id completion result)
 
         :else nil)))
   result)
 
-(defn- settle-external!
-  "Settle from a process-local watcher only after the orchestration Spin has a
+(defn- settlement-result [run-world result]
+  (let [{:keys [status reason]}
+        (try
+          (world/settle! run-world (:run/status result))
+          (catch Throwable t
+            (tel/log! {:level :error :id ::world-settlement-failed
+                       :data {:run/id (:run/id result)
+                              :run/world (:id run-world)
+                              :error (ex-message t)}}
+                      "Run world settlement failed; retaining it for review")
+            {:status :review :reason :settlement-failed}))]
+    {:result (assoc result
+                    :run/world (:id run-world)
+                    :run/settlement-status status
+                    :run/settlement-reason reason)
+     :finish-opts (cond-> {:settlement-status status}
+                    reason (assoc :settlement-reason reason))}))
+
+(defn- finalize-execution-external!
+  "Finalize from a process-local watcher only after the orchestration Spin has a
    cached terminal result and the stable supervisor reports every native worker
-   and owned cleanup quiescent."
-  [room id supervisor execution completion result]
+   and owned cleanup quiescent. World settlement happens behind the same
+   physical-quiescence fence."
+  [room run-world id supervisor execution completion outcome]
   (future
     ;; `future` conveys dynamic bindings. A cancellation hook normally launches
     ;; this watcher from the losing observer Spin, so retaining its *spin-id*
@@ -698,34 +729,40 @@
     ;; graph being reaped. Keep the Room memory context but detach graph identity.
     (binding [ec/*execution-context* (:ctx room)
               ec/*spin-id* nil]
-      ;; Keep the durable cancellation token/live lease until the executor has
+      ;; Wait until the executor has published either its ordinary outcome or
+      ;; its graph-level cancellation/failure through the process-local bridge.
+      (let [outcome @outcome]
+        ;; Keep the durable cancellation token/live lease until the executor has
       ;; acknowledged termination. Direct cancellation relies on that token at
       ;; its next cooperative checkpoint; releasing it merely because a pure
       ;; program has no native workers would let the body continue to effects.
-      (let [execution-id (spin-core/spin-id execution)]
-        (loop []
-          (when-not (ec/spin-current-result execution-id)
-            (Thread/sleep 5)
-            (recur))))
-      (await-supervisor! supervisor)
-      (let [cleanup-error (:cleanup-error @(:state supervisor))
-            result (if cleanup-error
-                     {:run/id id :run/status :failed
-                      :run/error (ex-message cleanup-error)}
-                     result)
-            finish-opts (if (= :cancelled (:run/status result))
-                          {:reason :structured-cancellation}
-                          {:reason (if cleanup-error :cleanup-error :execution-error)
-                           :error (or cleanup-error (:run/error result))})]
-        (publish-result-and-release! id completion result finish-opts)))))
+        (let [execution-id (spin-core/spin-id execution)]
+          (loop []
+            (when-not (ec/spin-current-result execution-id)
+              (Thread/sleep 5)
+              (recur))))
+        (await-supervisor! supervisor)
+        (let [cleanup-error (:cleanup-error @(:state supervisor))
+              result (if cleanup-error
+                       {:run/id id :run/status :failed
+                        :run/error (ex-message cleanup-error)}
+                       (:result outcome))
+              execution-opts (merge
+                              (:finish-opts outcome)
+                              (when cleanup-error
+                                {:reason :cleanup-error :error cleanup-error}))
+              {:keys [result finish-opts]} (settlement-result run-world result)]
+          (publish-result-and-release! id completion result
+                                       (merge execution-opts finish-opts)))))))
 
 (defn- execution-spin
-  [room agent task trigger id chat-id completion supervisor]
+  [control-room work-room agent task trigger id chat-id supervisor outcome-promise]
   (sp/spin
    (let [outcome
          (try
            (let [{status ::status value ::value reason ::reason}
-                 (sp/await (execute-program room id chat-id agent task trigger supervisor))
+                 (sp/await (execute-program control-room work-room id chat-id agent
+                                            task trigger supervisor))
                  ;; Seal admits no further provider work, runs owned cleanup
                  ;; after all workers terminate, and publishes one stable
                  ;; quiescence acknowledgement.
@@ -744,7 +781,7 @@
                                      {:role :assistant :run-id id})]
                  ;; Room posting is durability-first. Completion is acknowledged
                  ;; only after the correlated private output exists.
-                 (d/post! room output)
+                 (d/post! control-room output)
                  {:result {:run/id id
                            :run/status :completed
                            :run/value value
@@ -792,13 +829,12 @@
                                                 :program-error)
                                       :error error}})))))))
          result (:result outcome)]
-     ;; Completion is a Spindel Deferred allocated in this Room's execution
-     ;; context, not a JVM promise or host atom. Its value therefore follows
-     ;; Spindel's copy-on-write state semantics. The durable terminal projection
-     ;; retains its live lease until this publication has completed.
-     (sp/await
-      (publish-result-and-release-spin id completion result
-                                       (:finish-opts outcome))))))
+     ;; Settlement must not merge/discard a context from inside the drain graph
+     ;; currently using it. Bridge the computed outcome to the process-local
+     ;; quiescence watcher; the public result still arrives through the
+     ;; context-owned Deferred after durable settlement.
+     (deliver outcome-promise outcome)
+     result)))
 
 (defn hire!
   "Start one AgentDef execution and return an opaque RunHandle.
@@ -809,18 +845,21 @@
    - `:task`       portable task value (required)
    - `:from`       triggering actor, default `:repl`
    - `:parent-run` explicit structural parent Run UUID
+   - `:settlement`  `:automatic` (default), `:review`, or `:discard`
    Built-in program kinds are deterministic `:scripted` / `:echo` and the
    bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
    interpreters implement the same boundary."
-  [room roster agent-ref {:keys [task from parent-run]
-                          :or {from :repl}
+  [room roster agent-ref {:keys [task from parent-run settlement]
+                          :or {from :repl settlement :automatic}
                           :as raw-opts}]
   (let [opts      (assoc raw-opts :from from)
         agent     (validate-hire! roster agent-ref opts)
         actor     (:agent/id agent)
         id        (random-uuid)
         chat-id   (run-chat-id id)
-        supervisor (make-supervisor (:ctx room))
+        run-world (world/open! room id settlement)
+        work-room (:work run-world)
+        supervisor (make-supervisor (:ctx room) (:ctx work-room))
         ;; Private Run facts are still Room messages, but never addressed to an
         ;; installed Participant: direct interpretation and participant routing
         ;; must not execute the same task twice.
@@ -828,16 +867,24 @@
         provenance (cond-> {:run/agent-version (:agent/version agent)
                             :run/program-kind (get-in agent [:agent/program :kind])
                             :run/interpreter-version interpreter-version
-                            :run/agent-def-hash (hasch/uuid agent)}
+                            :run/agent-def-hash (hasch/uuid agent)
+                            :run/world (:id run-world)
+                            :run/isolation :ctx
+                            :run/settlement-policy settlement
+                            :run/settlement-status :open}
                      (= :llm (get-in agent [:agent/program :kind]))
                      (assoc :run/chat-id chat-id)
                      (:roster/id roster) (assoc :run/roster (:roster/id roster)))]
     ;; Reserve durable Run ownership before any trigger effect. Teardown either
     ;; fences us out here or includes this Run in its fixed drain set; it can
     ;; never miss an orphan trigger between posting and admission.
-    (run/start! room actor trigger nil
-                (cond-> {:id id :kind :agent-task :provenance provenance}
-                  parent-run (assoc :parent parent-run)))
+    (try
+      (run/start! room actor trigger nil
+                  (cond-> {:id id :kind :agent-task :provenance provenance}
+                    parent-run (assoc :parent parent-run)))
+      (catch Throwable t
+        (d/discard work-room)
+        (throw t)))
     (run/register-cancel-hook! id ::native-worker
                                #(cancel-supervisor! supervisor))
     (try
@@ -846,39 +893,36 @@
       ;; record or an unowned message behind.
       (d/post! room trigger)
       (catch Throwable t
-        (run/finish! id :failed {:reason :trigger-emission-failed :error t})
+        (let [{:keys [status reason]} (world/settle! run-world :failed)]
+          (run/finish! id :failed {:reason :trigger-emission-failed
+                                   :error t
+                                   :settlement-status status
+                                   :settlement-reason reason}))
         (throw t)))
     (try
       (let [completion (sync/deferred)
-            execution (execution-spin room agent task trigger id chat-id
-                                      completion supervisor)
+            outcome-promise (promise)
+            worker-execution (execution-spin room work-room agent task trigger id chat-id
+                                             supervisor outcome-promise)
+            execution (sp/spin (sp/await completion))
             owner-fork-id (:fork-id (ec/current-execution-context))
-            handle    (RunHandle. id (:id room) owner-fork-id execution completion)
-            settlement-started? (atom false)
-            settle! (fn [result]
-                      (when (compare-and-set! settlement-started? false true)
-                        (settle-external! room id supervisor execution
-                                          completion result)))
+            handle    (RunHandle. id (:id room) owner-fork-id execution completion
+                                  worker-execution)
             cancel! (fn []
                       (cancel-supervisor! supervisor)
                       ;; Cancellation closes admission to further native work.
                       ;; Cleanup may still be registered by an already-running
                       ;; initialization worker while the phase is :pending; the
                       ;; supervisor starts it after that worker terminates.
-                      (seal-supervisor! supervisor)
-                      ;; Run cancellation is an execution boundary in its own
-                      ;; right, not merely a hint to the current graph. Start a
-                      ;; process-local settlement watcher now. A nested parent
-                      ;; may reap the spawned Spin's callback continuation while
-                      ;; cancelling its race arm; the execution result plus the
-                      ;; stable supervisor are the physical-quiescence fence.
-                      (settle! {:run/id id :run/status :cancelled}))]
+                      ;; The already-running process-local watcher settles only
+                      ;; after the execution and supervisor quiescence fences.
+                      (seal-supervisor! supervisor))]
         ;; Replace the early sticky worker hook with the complete cancellation
         ;; boundary. register-cancel-hook! immediately invokes it if cancellation
         ;; won between durable admission and construction of this execution.
         (run/register-cancel-hook! id ::native-worker cancel!)
         (sp/spawn!
-         execution
+         worker-execution
          {:on-error
           (fn [t]
             ;; Graph-level cancellation is settled outside the cancelled Spin:
@@ -893,10 +937,20 @@
                 (run/cancel-room-run! (:id room) id))
               (cancel-supervisor! supervisor)
               (seal-supervisor! supervisor)
-              (settle! result)))})
+              (deliver outcome-promise
+                       {:result result
+                        :finish-opts
+                        (if (= :cancelled (:run/status result))
+                          {:reason :structured-cancellation}
+                          {:reason :execution-error :error t})})))})
+        (finalize-execution-external! room run-world id supervisor worker-execution
+                                      completion outcome-promise)
         handle)
       (catch Throwable t
-        (run/finish! id :failed {:reason :spawn-failed :error t})
+        (let [{:keys [status reason]} (world/settle! run-world :failed)]
+          (run/finish! id :failed {:reason :spawn-failed :error t
+                                   :settlement-status status
+                                   :settlement-reason reason}))
         (throw t)))))
 
 (defn observe

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -17,7 +17,9 @@
 (def provenance-keys
   "Run fields an interpreter may add without changing core causal identity."
   #{:run/roster :run/agent-version :run/program-kind
-    :run/interpreter-version :run/agent-def-hash :run/chat-id})
+    :run/interpreter-version :run/agent-def-hash :run/chat-id
+    :run/world :run/isolation :run/settlement-policy
+    :run/settlement-status :run/settlement-reason})
 
 (defn- store-room-id [room]
   (or (some-> room :meta deref :conversation-id)
@@ -166,7 +168,7 @@
   "End the live execution and persist its final/waiting projection. Idempotent
    after the live entry has gone. `:waiting` has no ended-at; terminal states do."
   ([run-id status] (finish! run-id status {}))
-  ([run-id status {:keys [reason error now]}]
+  ([run-id status {:keys [reason error now settlement-status settlement-reason]}]
    (when-not (contains? finish-statuses status)
      (throw (ex-info "Invalid run finish status"
                      {:type ::invalid-finish-status :status status :run-id run-id})))
@@ -179,6 +181,8 @@
                    (contains? store/terminal-run-statuses status)
                    (assoc :run/ended-at now)
                    reason (assoc :run/reason reason)
+                   settlement-status (assoc :run/settlement-status settlement-status)
+                   settlement-reason (assoc :run/settlement-reason settlement-reason)
                    error (assoc :run/error (or (ex-message error) (str error))))]
          (when-let [room-store (:store entry)]
            (when-not (store/-store-run! room-store (:store-room-id entry) run)
@@ -200,7 +204,7 @@
    This two-phase boundary prevents Room teardown from closing the execution
    context between durable terminal persistence and Deferred publication."
   ([run-id status] (retain-finished! run-id status {}))
-  ([run-id status {:keys [reason error now]}]
+  ([run-id status {:keys [reason error now settlement-status settlement-reason]}]
    (when-not (contains? finish-statuses status)
      (throw (ex-info "Invalid run finish status"
                      {:type ::invalid-finish-status :status status :run-id run-id})))
@@ -216,6 +220,8 @@
                      (contains? store/terminal-run-statuses status)
                      (assoc :run/ended-at now)
                      reason (assoc :run/reason reason)
+                     settlement-status (assoc :run/settlement-status settlement-status)
+                     settlement-reason (assoc :run/settlement-reason settlement-reason)
                      error (assoc :run/error (or (ex-message error) (str error))))]
            (when-let [room-store (:store entry)]
              (when-not (store/-store-run! room-store (:store-room-id entry) run)
@@ -241,6 +247,56 @@
         (swap! active dissoc run-id)
         (notify! {:type :run/finished :run run})
         run))))
+
+(defn publish-finished!
+  "Publish a retained result and release its live lease under one lifecycle
+   fence. Room teardown cannot observe the lease disappear and close the
+   execution context before `publish!` has written the fork-aware result."
+  [run-id publish! result]
+  (locking lifecycle-lock
+    (when-let [entry (get @active run-id)]
+      (let [run (:run entry)]
+        (when-not (contains? finish-statuses (:run/status run))
+          (throw (ex-info "Cannot publish a non-finished Run"
+                          {:type ::run-not-finished
+                           :run/id run-id
+                           :run/status (:run/status run)})))
+        (swap! active dissoc run-id)
+        (try
+          (publish! result)
+          (catch Throwable t
+            ;; Keep the durable terminal lease recoverable if publication into
+            ;; the execution context itself fails.
+            (swap! active assoc run-id entry)
+            (throw t)))
+        (notify! {:type :run/finished :run run})
+        run))))
+
+(defn update-durable-settlement!
+  "Update the settlement axis of an already-quiesced Run. This is the durable
+   half of a later human/agent decision on a retained review world. Execution
+   identity and status are preserved."
+  [room run-id status & [reason]]
+  (when-not (keyword? status)
+    (throw (ex-info "Run settlement status must be a keyword"
+                    {:type ::invalid-settlement-status :status status})))
+  (when-let [room-store (:store room)]
+    (let [room-id (store-room-id room)
+          existing (store/-load-run room-store room-id run-id)]
+      (when-not existing
+        (throw (ex-info "Run settlement owner is not durable in this Room"
+                        {:type ::run-not-found
+                         :run/id run-id
+                         :run/room (:id room)})))
+      (let [updated (cond-> (assoc existing
+                                   :run/settlement-status status
+                                   :run/updated-at (java.util.Date.))
+                      reason (assoc :run/settlement-reason reason))]
+        (or (store/-store-run! room-store room-id updated)
+            (throw (ex-info "Run settlement update was not durable"
+                            {:type ::settlement-not-durable
+                             :run/id run-id
+                             :run/settlement-status status})))))))
 
 (defn cancel-requested?
   "True when targeted cancellation has been requested for this live Run. The

--- a/src/dvergr/agent/world.clj
+++ b/src/dvergr/agent/world.clj
@@ -1,0 +1,75 @@
+(ns dvergr.agent.world
+  "Fork-backed work plane for one durable Run.
+
+   A RunWorld keeps the parent Room as the control plane while exposing an
+   isolated Room/context to the interpreter. Settlement is deliberately a
+   second axis from execution: a completed program may be merged, retained for
+   review, or discarded without rewriting its execution outcome."
+  (:require [dvergr.discourse :as d]))
+
+(def settlement-policies #{:automatic :review :discard})
+
+(defrecord RunWorld [id parent work policy settlement])
+
+(defn open!
+  "Open an isolated work plane for `run-id`. The returned world is visible in
+   the Room registry while open, so an explicitly reviewed world remains
+   inspectable after its executor has quiesced."
+  [parent run-id policy]
+  (when-not (contains? settlement-policies policy)
+    (throw (ex-info "Unknown Run settlement policy"
+                    {:type ::invalid-settlement-policy
+                     :policy policy
+                     :allowed settlement-policies})))
+  (let [work (d/fork-room parent {:isolation :ctx
+                                  ;; A Run world is an internal transaction, not
+                                  ;; a child conversation. Nested agents enter
+                                  ;; only through explicit hire/tool effects.
+                                  :clone-participants? false})]
+    (swap! (:meta work) assoc
+           :run-world? true
+           :run-id run-id
+           :settlement-policy policy)
+    (->RunWorld (:id work) parent work policy (atom nil))))
+
+(defn- settle-once! [world f]
+  (locking (:settlement world)
+    (or @(:settlement world)
+        (let [result (f)]
+          (reset! (:settlement world) result)
+          result))))
+
+(defn settle!
+  "Settle `world` after the executor has quiesced.
+
+   Successful automatic work merges. Explicit review, and partial work that
+   stopped at `:waiting`, remains registered for inspection. Discard policy,
+   cancellation, and failure remove the work plane. An automatic merge failure
+   is retained for review rather than destroying the only inspectable diff."
+  [world execution-status]
+  (settle-once!
+   world
+   (fn []
+     (cond
+       (#{:failed :cancelled} execution-status)
+       (do (d/discard (:work world))
+           {:status :discarded :reason execution-status})
+
+       (= :waiting execution-status)
+       {:status :review :reason :execution-waiting}
+
+       (= :discard (:policy world))
+       (do (d/discard (:work world))
+           {:status :discarded :reason :policy})
+
+       (= :review (:policy world))
+       {:status :review :reason :policy}
+
+       :else
+       (try
+         (d/merge-room (:parent world) (:work world))
+         {:status :merged}
+         (catch Throwable t
+           {:status :review
+            :reason :automatic-merge-failed
+            :error t}))))))

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -592,6 +592,33 @@
     :db/index true
     :db/doc "Durable ChatContext trace identity owned by this Run"}
 
+   {:db/ident :run/world
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Runtime identity of the isolated work plane"}
+
+   {:db/ident :run/isolation
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/doc "Isolation mechanism used by the work plane"}
+
+   {:db/ident :run/settlement-policy
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Requested post-execution policy: automatic, review, or discard"}
+
+   {:db/ident :run/settlement-status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Work-plane outcome, independent from execution status"}
+
+   {:db/ident :run/settlement-reason
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
    {:db/ident :run/status
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -932,11 +932,17 @@
    (proposals, speculative coding-agent work). Use `:none` (default)
    for message-only ToM probes where nothing in the fork commits.
 
+   `:clone-participants?` defaults true for conversational forks. Internal Run
+   worlds pass false: they need an isolated substrate, while any nested agent
+   participation must be an explicit hire rather than an accidental clone of
+   every participant in the parent Room.
+
    `:ctx` requires that subsequent operations on the fork (e.g.
    `(ask fork :agent …)` from outside the fork's body) bind
    `*execution-context*` to the fork's ctx — see `with-fork-ctx`."
   ([room] (fork-room room {}))
-  ([room {:keys [isolation] :or {isolation :none}}]
+  ([room {:keys [isolation clone-participants?]
+          :or {isolation :none clone-participants? true}}]
    (let [short-uuid (subs (str (random-uuid)) 0 8)
          new-slug   (str (:slug room) "/fork-" short-uuid)
          ;; Use the canonical slug→id encoding so id ↔ slug stay in
@@ -1004,10 +1010,11 @@
      ;; for merge/diff/git. For `:none`, child-ctx == parent ctx (no change).
      (binding [ec/*execution-context* (:ctx room)]
        (rreg/register! new-room))
-     (doseq [[_id p] @(:participants room)]
-       (when-let [fac (:factory p)]
-         (binding [ec/*execution-context* child-ctx]
-           (join new-room (fac child-ctx)))))
+     (when clone-participants?
+       (doseq [[_id p] @(:participants room)]
+         (when-let [fac (:factory p)]
+           (binding [ec/*execution-context* child-ctx]
+             (join new-room (fac child-ctx))))))
      ;; Control-plane: announce the fork on the peer-bus so dashboards,
      ;; audit logs, and oversight agents see it without subscribing to
      ;; the fork's bus directly.

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -97,12 +97,15 @@
   #{:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error
+    :run/world :run/isolation :run/settlement-policy
+    :run/settlement-status :run/settlement-reason
     :run/roster :run/agent-version :run/program-kind
     :run/interpreter-version :run/agent-def-hash :run/chat-id})
 
 (def immutable-run-keys
   [:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
    :run/created-at :run/started-at
+   :run/world :run/isolation :run/settlement-policy
    :run/roster :run/agent-version :run/program-kind
    :run/interpreter-version :run/agent-def-hash :run/chat-id])
 
@@ -151,6 +154,12 @@
   (when (and (:run/chat-id run) (not (uuid? (:run/chat-id run))))
     (throw (ex-info ":run/chat-id must be a UUID"
                     {:type :room-store/invalid-run :key :run/chat-id :run run})))
+  (doseq [k [:run/world :run/isolation :run/settlement-policy
+             :run/settlement-status :run/settlement-reason]
+          :let [v (get run k)]
+          :when (and (some? v) (not (keyword? v)))]
+    (throw (ex-info (str k " must be a keyword")
+                    {:type :room-store/invalid-run :key k :run run})))
   (doseq [k [:run/created-at :run/started-at :run/updated-at]
           :when (not (instance? java.util.Date (get run k)))]
     (throw (ex-info (str k " must be an instant")

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -167,6 +167,8 @@
   '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
     :run/roster :run/agent-version :run/program-kind :run/interpreter-version
     :run/agent-def-hash :run/chat-id
+    :run/world :run/isolation :run/settlement-policy
+    :run/settlement-status :run/settlement-reason
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error])
 
@@ -189,6 +191,14 @@
     (assoc :run/interpreter-version (:run/interpreter-version run))
     (:run/agent-def-hash run) (assoc :run/agent-def-hash (:run/agent-def-hash run))
     (:run/chat-id run) (assoc :run/chat-id (:run/chat-id run))
+    (:run/world run) (assoc :run/world (:run/world run))
+    (:run/isolation run) (assoc :run/isolation (:run/isolation run))
+    (:run/settlement-policy run)
+    (assoc :run/settlement-policy (:run/settlement-policy run))
+    (:run/settlement-status run)
+    (assoc :run/settlement-status (:run/settlement-status run))
+    (:run/settlement-reason run)
+    (assoc :run/settlement-reason (:run/settlement-reason run))
     (:run/ended-at run) (assoc :run/ended-at (:run/ended-at run))
     (:run/reason run)   (assoc :run/reason (:run/reason run))
     (:run/error run)    (assoc :run/error (str (:run/error run)))))

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -10,6 +10,7 @@
    - `:isolation :none` — shares the parent context; \"merge\" is just a
      conversation-log append, and there is no git history to browse."
   (:require [dvergr.room.registry :as rreg]
+            [dvergr.agent.run :as agent-run]
             [dvergr.discourse :as d]
             [dvergr.substrate.geschichte :as git]
             [clojure.string :as str]
@@ -151,8 +152,11 @@
   [fork]
   (try
     (if-let [parent (rreg/lookup (:parent-id fork))]
-      (do (d/merge-room parent fork)
-          {:ok? true :parent-slug (:slug parent) :parent-id (:id parent)})
+      (let [run-id (some-> fork :meta deref :run-id)]
+        (d/merge-room parent fork)
+        (when run-id
+          (agent-run/update-durable-settlement! parent run-id :merged :review-approved))
+        {:ok? true :parent-slug (:slug parent) :parent-id (:id parent)})
       {:ok? false :error "fork has no live parent in the registry"})
     (catch Throwable t {:ok? false :error (.getMessage t)})))
 
@@ -324,5 +328,12 @@
   "Discard a fork (`discourse/discard`) — deletes its branches. Returns
    {:ok? true} or {:ok? false :error ...}."
   [fork]
-  (try (d/discard fork) {:ok? true}
-       (catch Throwable t {:ok? false :error (.getMessage t)})))
+  (try
+    (let [parent (rreg/lookup (:parent-id fork))
+          run-id (some-> fork :meta deref :run-id)]
+      (d/discard fork)
+      (when (and parent run-id)
+        (agent-run/update-durable-settlement! parent run-id :discarded
+                                              :review-rejected))
+      {:ok? true})
+    (catch Throwable t {:ok? false :error (.getMessage t)})))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -1,17 +1,21 @@
 (ns dvergr.agent.program-test
   (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as dh]
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
             [dvergr.agent.turn :as turn]
             [dvergr.chat.agent :as chat-agent]
             [dvergr.chat.context :as chat-context]
+            [dvergr.chat.schema :as chat-schema]
             [dvergr.discourse :as d]
             [dvergr.model.chat :as model-chat]
             [dvergr.model.providers :as providers]
             [dvergr.room.registry :as registry]
+            [dvergr.rooms.forks :as forks]
             [dvergr.room.store :as room-store]
             [dvergr.room.store.memory :as memory]
+            [dvergr.room.store.datahike :as datahike-store]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.engine.context :as context]
@@ -29,6 +33,15 @@
 
 (defn- test-room [id]
   (d/make-room {:id id :store (memory/make)}))
+
+(defn- datahike-test-room [id]
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? false
+             :schema-flexibility :write}]
+    (dh/create-database cfg)
+    (let [conn (dh/connect cfg)]
+      (chat-schema/ensure-full-schema! conn)
+      [(d/make-room {:id id :store (datahike-store/make conn)}) conn])))
 
 (defn- fail-terminal-store [delegate fail-terminal?]
   (reify room-store/PRoomStore
@@ -86,12 +99,50 @@
         (is (= :scripted (:run/program-kind durable)))
         (is (= program/interpreter-version (:run/interpreter-version durable)))
         (is (uuid? (:run/agent-def-hash durable)))
+        (is (= :ctx (:run/isolation durable)))
+        (is (= :automatic (:run/settlement-policy durable)))
+        (is (= :merged (:run/settlement-status durable)))
+        (is (keyword? (:run/world durable)))
         (is (= "investigate" (:content trigger)))
         (is (= program/run-sink (:to trigger)))
         (is (= "evidence" (:content output)))
         (is (= program/run-sink (:to output)))
         (is (= (:id trigger) (:in-reply-to output)))
         (is (empty? (run/active-runs :program-hire))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest settlement-policy-controls-the-isolated-run-world
+  (let [room (test-room :program-settlement)
+        team (test-roster)]
+    (try
+      (testing "review retains an inspectable fork after execution"
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire! room team :analyst
+                                      {:task "proposal" :settlement :review}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)
+              durable (program/observe room handle)
+              fork (binding [ec/*execution-context* (:ctx room)]
+                     (registry/lookup (:run/world durable)))]
+          (is (= :completed (:run/status result)))
+          (is (= :review (:run/settlement-status result)))
+          (is (= :review (:run/settlement-status durable)))
+          (is (= (:run/id durable) (some-> fork :meta deref :run-id)))
+          (let [action (binding [ec/*execution-context* (:ctx room)]
+                         (forks/merge! fork))]
+            (is (:ok? action) (pr-str action)))
+          (is (= :merged (:run/settlement-status
+                          (program/observe room handle))))))
+      (testing "discard removes a successful work plane"
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire! room team :analyst
+                                      {:task "ephemeral" :settlement :discard}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)
+              durable (program/observe room handle)]
+          (is (= :discarded (:run/settlement-status result)))
+          (is (= :policy (:run/settlement-reason durable)))
+          (is (binding [ec/*execution-context* (:ctx room)]
+                (nil? (registry/lookup (:run/world durable)))))))
       (finally
         (d/close-room! room)))))
 
@@ -208,6 +259,39 @@
       (finally
         (d/close-room! room)))))
 
+(deftest discarded-world-retains-the-parent-owned-model-trace
+  (let [[room conn] (datahike-test-room :program-trace-control-plane)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :audited
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 1}})]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [chat-ctx _]
+                      (chat-context/add-message!
+                       chat-ctx {:role :assistant :content "audited result"})
+                      :complete)]
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire! room team :audited
+                                      {:task "inspect" :settlement :discard}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)
+              durable (program/observe room handle)
+              roles (dh/q '[:find [?role ...]
+                            :in $ ?chat-id
+                            :where
+                            [?chat :chat/id ?chat-id]
+                            [?message :message/chat ?chat]
+                            [?message :message/role ?role]]
+                          @conn (:run/chat-id durable))]
+          (is (= :discarded (:run/settlement-status result)))
+          (is (= #{:system :user :assistant} (set roles))
+              "discard drops work effects, not the model/tool audit trace")))
+      (finally
+        (d/close-room! room)
+        (dh/release conn)))))
+
 (deftest llm-program-settles-at-budget-boundary
   (let [room (test-room :program-llm-budget)
         team (roster/make-agent
@@ -224,12 +308,16 @@
               result (binding [ec/*execution-context* (:ctx room)] @handle)]
           (is (= {:run/id (program/run-id handle)
                   :run/status :waiting
-                  :run/reason :budget-exhausted}
-                 result))
+                  :run/reason :budget-exhausted
+                  :run/settlement-status :review
+                  :run/settlement-reason :execution-waiting}
+                 (dissoc result :run/world)))
           (is (= :waiting (:run/status (program/observe room handle))))
           (is (empty? (filter #(= (program/run-id handle)
                                   (get-in % [:metadata :run-id]))
-                              (d/messages room {:limit 10}))))))
+                              (d/messages room {:limit 10}))))
+          (binding [ec/*execution-context* (:ctx room)]
+            (d/discard (registry/lookup (:run/world result))))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -70,6 +70,7 @@
           ended (java.util.Date. 1787860801000)
           definition-hash (random-uuid)
           chat-id (random-uuid)
+          world-id :runs_fork_fork-contract
           running {:run/id run-id
                    :run/kind :agent-turn
                    :run/room room-id
@@ -82,12 +83,17 @@
                    :run/interpreter-version 2
                    :run/agent-def-hash definition-hash
                    :run/chat-id chat-id
+                   :run/world world-id
+                   :run/isolation :ctx
+                   :run/settlement-policy :automatic
+                   :run/settlement-status :open
                    :run/status :running
                    :run/created-at started
                    :run/started-at started
                    :run/updated-at started}
           completed (assoc running
                            :run/status :completed
+                           :run/settlement-status :merged
                            :run/updated-at ended
                            :run/ended-at ended)]
       (is (= running (store/-store-run! st room-id running)))


### PR DESCRIPTION
## Summary
- split each AgentDef Run into a parent-owned control plane and an isolated forked work plane
- add independent durable execution and settlement axes with automatic, review, and discard policies
- preserve parent-owned model/tool audit traces while database, KB, filesystem, SCI, and nested-agent effects target the fork
- settle only after Spindel/native-worker quiescence; discard failures and cancellation, retain waiting/conflicted work for review
- update retained Run settlement when the ordinary fork UI later merges or discards it
- avoid cloning Room participants into internal Run worlds

## Verification
- clojure -M:format
- clojure -M:test
- 518 tests, 2147 assertions, 0 failures