### PR TITLE
feat: unify room worlds on affine fork handles

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,7 +48,7 @@
         ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
         ;; Substrate for the durable-cursor bus pump + supervisor
         ;; restart.
-        org.replikativ/spindel     {:mvn/version "0.1.35"}
+        org.replikativ/spindel     {:mvn/version "0.1.41"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@ New to dvergr? Start with **[Getting Started](getting-started.md)**.
 - **[Recursive work orchestration](orchestration.md)** — Rooms, threads, tasks, executions, recursive Workrooms, and provider-neutral collaboration
 - **[Runs](runs.md)** — durable execution identity, lifecycle subscription, correlation, and targeted cancellation
 - **[Agent programs](agent-programs.md)** — immutable specialized-agent rosters, Run-backed hiring, Spindel composition, and fork-safe state placement
+- **[Forks, worlds, and settlement](fork-and-world-model.md)** — the cross-project Yggdrasil/Spindel/Dvergr/Simmis fork contract, ownership laws, and use-case coverage
 - **[Discourse Theory](discourse-theory.md)** — why "discourse": speech acts, theory of mind, and the Rational-Speech-Acts/FRP lineage (short, optional)
 - **[Architecture](architecture.md)** — the L0–L7 layer map, subsystem graph, inbound message flow, per-file table
 - **[State Model](state-model.md)** — the three-tier copy-on-write state + workspace model

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -64,7 +64,7 @@ The live handle is a process-local capability. A portable **ForkDescriptor**
              :branch        branch-id
              :head          snapshot-id
              :mode          :frozen|:following
-             :rights        :read|:write|:fork}}
+             :rights        :write}}
  :fork/owner    owner-id}
 ```
 
@@ -195,7 +195,7 @@ World creation needs an explicit policy surface:
 {:purpose :run|:workroom|:particle|:proposal|:experiment
  :systems :all|:none|#{system-id ...}
  :mode :overlay|:snapshot
- :rights {system-id :read|:write|:fork}
+ :rights {system-id :write}
  :effects :live|:record|:stub
  :settlement :automatic|:review|:discard}
 ```
@@ -204,6 +204,10 @@ The default for a normal isolated Dvergr Run can remain all systems granted to
 the Room. Simulations and inference should default to no live external effects
 unless explicitly granted. Eventually Kontor allocations determine both
 resource rights and the maximum fork policy a child may receive.
+
+Today Spindel accepts only the enforceable `:write` right. It rejects `:read` and
+`:fork` instead of placing an unenforced label in the descriptor. Those rights
+belong here once the substrate and SCI capability boundary can enforce them.
 
 ## Representative use cases
 

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -1,0 +1,360 @@
+# Forks, worlds, and settlement
+
+Status: proposed cross-project contract. This document maps the existing
+Yggdrasil, Spindel, Dvergr, and Simmis abstractions before their APIs are
+consolidated. Names marked *provisional* describe semantics, not necessarily the
+next public function names.
+
+## Objective
+
+There must be one implementation of state forking while still allowing each
+layer to add its own meaning:
+
+```text
+Simmis Proposal / ForkSet     durable governance and review
+             │ adopts or references
+Dvergr RunWorld / RoomBranch  discourse, execution policy, quiescence
+             │ wraps
+Spindel ForkHandle            one fork of a reactive execution world
+             │ automatically forks
+Yggdrasil systems             Datahike, Geschichte, CRDTs, other substrates
+```
+
+Higher layers may project, govern, or own a fork. They must not independently
+implement substrate branches, fork identity, or settlement.
+
+## Canonical vocabulary
+
+### Yggdrasil: one system
+
+- A **snapshot** is an immutable identity for one system state.
+- A **branch** is a durable named reference to snapshots.
+- An **overlay** is a transient, abandonable isolated workspace over a parent
+  system, with an observation mode such as `:frozen` or `:following`.
+- A **system merge** combines one lineage into another according to that
+  adapter's semantics.
+
+Yggdrasil does not own Rooms, Runs, agents, proposals, or execution graphs.
+Geschichte workspaces and Datahike branches are implementations of this layer,
+not additional orchestration worlds.
+
+### Spindel: one executing world
+
+An **execution world** is a Spindel `ExecutionContext` containing:
+
+- the reactive graph and its values;
+- fork-local queues, continuations, timers, and subscriptions;
+- context bindings and simulation metadata;
+- Yggdrasil systems registered as forkable signals.
+
+A **world fork** is the existing Spindel Yggdrasil `ForkHandle`. Forking the
+context creates a CoW reactive overlay and automatically forks each selected
+registered Yggdrasil system. Nested forks always fork the effective state of
+their immediate parent.
+
+The live handle is a process-local capability. A portable **ForkDescriptor**
+(*provisional*) records the durable basis of the fork:
+
+```clojure
+{:fork/id       fork-id
+ :fork/parent   parent-world-id
+ :fork/purpose  :run|:workroom|:particle|:proposal|:experiment
+ :fork/systems
+ {system-id {:base-snapshot snapshot-id
+             :branch        branch-id
+             :head          snapshot-id
+             :mode          :frozen|:following
+             :rights        :read|:write|:fork}}
+ :fork/owner    owner-id}
+```
+
+The descriptor schema should extend or reuse Spindel's existing distributed
+workspace checkout/fork descriptor rather than introduce a competing manifest.
+
+### Dvergr: discourse and execution policy
+
+A **Room** is a long-lived social and work environment. It is not a synonym for
+a Spindel fork.
+
+A **discourse branch** is an alternate message/participant projection used for
+an imagined conversation. It need not fork state.
+
+A **RoomBranch** (*provisional*) is a Room facade over a Spindel world fork. It
+adds a bus, conversation projection, participant policy, registration, and
+control-plane events. It does not own a second substrate fork.
+
+A **Run** is the durable identity of one causally bounded execution. It is not a
+fork. A Run may execute in a private world fork, share an ambient world, or
+produce no substrate changes.
+
+A **RunWorld** is a Run's lease and policy over one world fork:
+
+```clojure
+{:run/id             run-id
+ :fork/handle        live-fork-handle
+ :room/view          work-room
+ :settlement/policy  :automatic|:review|:discard}
+```
+
+Its fork identity, parent, child context, and live settlement capability come
+from the canonical Spindel handle and are not recreated in Dvergr.
+
+### Simmis: governance
+
+A **Proposal/ForkSet** is a durable governance object over one or more fork
+contributions. It adds rationale, contributors, checks, comments, conflicts,
+authorization, per-scope decisions, and resolution provenance.
+
+It does not implement another execution fork. Promotion adopts an existing fork
+descriptor and transfers settlement authority. A Proposal message, Tasks,
+Futures, Feed, and Timelines are projections of that same governance object.
+
+## Fork lifecycle and affine ownership
+
+The canonical lifecycle is:
+
+```text
+                         merge
+                    ┌────────────▶ merged
+                    │
+open ────────────────┼── discard ─▶ discarded
+                    │
+                    └── transfer ─▶ adopted by proposal/room
+```
+
+Only an open handle can be settled. Merge, discard, and transfer consume its
+settlement authority exactly once. After transfer, only the adopter may settle
+the fork. A RunWorld cannot retain a hidden second merge/discard path.
+
+The live affine token should not be made copyable merely to make it
+"fork-aware". It is intentionally process-local authority. Durable ownership
+and status are facts in the Room/Simmis store; semantic state remains forkable.
+
+Parent control is structural:
+
+- code executing in a world can fork children;
+- it may settle children it owns into itself;
+- it cannot merge itself into its parent;
+- transferring a child requires explicit authority from its current owner;
+- a nested merge targets the immediate parent, never an inferred ancestor.
+
+## What settlement means
+
+Forking and merging are deliberately asymmetric.
+
+### Durable substrate state
+
+Registered Yggdrasil systems are merged or discarded through their native
+protocols. This includes Datahike data, Geschichte files/history, and registered
+CRDT systems.
+
+### Reactive runtime state
+
+Spindel's generic `OverlayBackend` contains both semantic values and execution
+machinery. Its child delta must not be wholesale merged into the parent:
+
+- continuations and subscriptions belong to one execution graph;
+- mailbox claims and pending events have single-world delivery semantics;
+- timers, cancellation tokens, provider streams, and native handles are live
+  capabilities;
+- copying cached graph nodes back can corrupt dependency identity.
+
+Pure workflow results therefore return explicitly. When a reactive value should
+contribute to its parent, the program supplies an explicit reducer/join, or the
+value is promoted to a Yggdrasil-managed convergent system. A later
+`PSettletableValue`-like hook may make selected signal settlement convenient,
+but it must remain opt-in and algebra-specific.
+
+### Conversation and execution facts
+
+Room messages, Run lifecycle, activity, accounting receipts, and proposal facts
+are durable control-plane facts written to their authoritative stores. They are
+not recovered by merging arbitrary Spindel engine state.
+
+## Multi-system settlement guarantee
+
+The universal guarantee is **prechecked, journaled, and recoverable**, not
+cross-backend ACID atomicity.
+
+Spindel can preflight every system and then settle them in a deterministic
+order. Because heterogeneous stores do not share a transaction coordinator, a
+failure can occur after one system has merged. Settlement must therefore record
+per-system progress and be safely resumable or compensatable.
+
+A Yggdrasil `CompositeSystem` may provide a single causal visibility gate where
+all readers resolve through that composite, especially for co-located CRDT
+systems. It does not make arbitrary external backends universally rollbackable.
+Dvergr and Simmis must not claim stronger atomicity than the selected systems
+provide.
+
+## Fork policy
+
+World creation needs an explicit policy surface:
+
+```clojure
+{:purpose :run|:workroom|:particle|:proposal|:experiment
+ :systems :all|:none|#{system-id ...}
+ :mode :overlay|:snapshot
+ :rights {system-id :read|:write|:fork}
+ :effects :live|:record|:stub
+ :settlement :automatic|:review|:discard}
+```
+
+The default for a normal isolated Dvergr Run can remain all systems granted to
+the Room. Simulations and inference should default to no live external effects
+unless explicitly granted. Eventually Kontor allocations determine both
+resource rights and the maximum fork policy a child may receive.
+
+## Representative use cases
+
+### Coding Run from the REPL
+
+1. Open one Spindel world fork from the Room.
+2. Execute SCI/model/tool work against fork-resolved Geschichte and Datahike.
+3. Run trusted checks in the same world.
+4. Return the computed result through the Run.
+5. Merge, retain for review, or discard after physical quiescence.
+
+Needs: canonical handle migration and recoverable settlement. The core path
+otherwise exists.
+
+### Recursive team
+
+A lead Run works in world `A`. Hiring a researcher creates `B = fork(A)`; that
+researcher may create `C = fork(B)`. Accepted `C` work merges into `B`, and
+accepted `B` work merges into `A`. Trunk is never an implicit target.
+
+Needs: canonical nested ownership exists in Spindel; Dvergr must route every
+recursive hire through it and replace the legacy subagent path. Resource-vector
+splitting remains future work.
+
+### Simmis proposal
+
+A standalone Run completes in review mode. Promotion transfers its open fork to
+a durable ForkSet and persists the descriptor as a GC root. The Run becomes a
+contributor and loses settlement authority. Review may survive restart and
+eventually settle selected systems.
+
+Needs: transfer/adopt, portable descriptor, durable GC ownership, and a
+settlement journal.
+
+### Multi-agent campaign
+
+Several Runs contribute independent forks. The Proposal may retain each
+contribution for per-agent/per-scope decisions, or construct an additional
+integration world and merge selected contributions into it. The integration
+world is another canonical fork, not a special proposal branch implementation.
+
+Needs: multiple adopted descriptors and explicit contribution edges. ForkSet
+already supplies most governance semantics.
+
+### Thought experiment
+
+Fork a snapshot of selected state, substitute recorded/stubbed effects, execute
+a hypothetical conversation or program, return an explicit result, and discard
+the world. It creates no Proposal unless deliberately promoted.
+
+Needs: selected systems/effect policy. Message-only discourse branching remains
+available as a cheaper operation when no state isolation is required.
+
+### SMC particles
+
+Create `N` snapshot world forks at a checkpoint. Each particle receives an
+independent reactive state and an explicit external-system/effect policy.
+Observe evidence, resample descriptors/contexts, and discard unselected
+particles. Only an explicitly selected particle can be promoted or merged.
+
+Needs: the inference coordinator must stop using raw
+`snapshot-context`/`restore-snapshot` for worlds containing Yggdrasil handles;
+that path does not invoke `PForkable` and may alias external state.
+
+### MCTS
+
+Each tree edge forks its node world, applies an action, runs or simulates effects,
+and accumulates reward/evidence. Pruning consumes and discards the corresponding
+handles. Transpositions may share immutable snapshots but never writable
+capabilities.
+
+Needs: cheap nested handles, deterministic seeds/virtual time, selective/stubbed
+effects, resource accounting, and aggressive lifecycle/GC. No new fork algebra
+is required.
+
+### Continuous reactive cooperation
+
+Long-lived agents observe and communicate in one Room without creating a Run or
+fork for every message. Runs identify bounded computations when useful; Room
+signals and speech acts remain the continuous FRP substrate.
+
+Needs: no additional fork primitive. Attention and steering policies compose
+above the world model.
+
+### Self-programming and verified training
+
+An agent constructs an immutable Roster/workflow, stores durable program or
+skill changes in forked Geschichte/Datahike, executes it in a controlled world,
+and receives a trusted verifier result plus Kontor resource receipts. The world
+and verifier basis make the environment replayable; reward is not inferred from
+model prose.
+
+Needs: versioned environment descriptors, fork basis, resource allocation and
+effect receipts. SCI Vars/atoms may later become more deeply forkable, but
+durable definitions should remain in owned substrates rather than depend on
+serializing live evaluator internals.
+
+### Long-lived child Room
+
+A child Room that needs independent policy and substrate adopts/detaches a world
+fork as its durable root. It is no longer an unsettled speculative fork. On
+restart, it rehydrates from its descriptor and authoritative Room facts.
+
+Needs: adoption and descriptor-based hydration. The current per-Room context
+provisioning is a partial implementation without the unified lifecycle.
+
+## Laws and characterization tests
+
+The implementation should satisfy these laws before higher-level APIs depend on
+it:
+
+1. **Isolation:** a child write is invisible to parent and siblings before
+   settlement.
+2. **Basis:** every system contribution is diffed from the fork-time basis, not
+   from timestamps or a moving parent head.
+3. **Immediate parent:** settling a nested fork changes only its explicit parent.
+4. **Single settlement:** merge, discard, and transfer are mutually exclusive and
+   idempotent at the public boundary.
+5. **Transfer:** after adoption, the previous owner cannot settle.
+6. **Quiescence:** no worker may access a substrate after settlement begins.
+7. **Explicit runtime reduction:** generic child engine state never leaks back by
+   substrate settlement.
+8. **Recoverability:** interruption after any per-system settlement step can be
+   detected and safely resumed or surfaced.
+9. **Restart:** adopted durable branches remain live GC roots; abandoned
+   process-local branches are reclaimable.
+10. **Particle independence:** resampled particle worlds never alias writable
+    external systems unless the policy explicitly declares sharing.
+11. **Attenuation:** a child cannot acquire systems, effects, or resource rights
+    not delegated by its parent.
+12. **Projection identity:** Room, Run, Proposal, UI, and audit projections refer
+    to the same fork ID/descriptor rather than minting parallel fork identities.
+
+## Migration sequence
+
+1. **Done in this pass:** stabilize this vocabulary and its core laws as
+   characterization tests in Spindel.
+2. **Done in this pass:** enrich `ForkHandle` with a portable descriptor and single-settlement/transfer
+   boundary, reusing the distributed descriptor schema.
+3. **Partial:** selected-system and snapshot-world policies exist; repair
+   inference particle isolation next.
+4. **Done in this pass:** change Dvergr `fork-room` to call `ygg/fork!` and retain
+   its handle.
+5. **Done in this pass:** keep `RunWorld` as Run policy plus the canonical
+   handle/Room view (its small atom caches the policy decision, not substrate
+   state).
+6. **Done in this pass:** route `dvergr.rooms.forks` review and settlement through
+   that handle.
+7. Migrate or remove `chat.context/fork-sub-chat` and
+   `dvergr.agent.subagent/hire!`.
+8. Implement durable transfer/adoption and settlement journaling for Simmis.
+9. Replace boot-time blanket orphan cleanup with descriptor/owner-aware GC.
+10. Build SMC, MCTS, resource-aware campaigns, and training environments on the
+    same world policy.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -174,10 +174,13 @@ something inside it (write files, change state in a branched datahike, etc.),
 inspect the result, then **merge** or **discard** atomically.
 
 ```clojure
-;; Fork the room. :ctx forks the spindel execution context — git worktree +
-;; datahike branch under [:external-refs] — so the worker's side effects are
+;; Fork the room. :ctx creates one Spindel ForkHandle over the execution
+;; context + registered git/datahike systems, so the worker's side effects are
 ;; held in isolation until you decide.
 (def fork (d/fork-room room {:isolation :ctx}))
+
+;; Portable identity/ownership/status, without the live settlement capability:
+(d/fork-descriptor fork)
 
 (binding [ec/*execution-context* (:ctx fork)]
   (d/join fork (d/coder {:id :coder}))
@@ -186,8 +189,8 @@ inspect the result, then **merge** or **discard** atomically.
 ;; The worker ran in the branched worktree + datahike. Inspect the fork's log,
 ;; its worktree, its tests…
 
-;; Accept — collapse the fork's git + datahike branch into the parent atomically:
-(d/merge-room fork room)
+;; Accept — settle the fork's git + datahike world into the parent:
+(d/merge-room room fork)
 
 ;; …or discard — drop the branches, nothing leaks into the parent:
 (d/discard fork)

--- a/doc/state-model.md
+++ b/doc/state-model.md
@@ -8,9 +8,9 @@ dvergr is embedded as a library. Companion to `doc/configuration.md`.
 
 ### Tier 1 — Value-semantic / forkable
 Lives in the **spindel execution context** and the **yggdrasil composite workspace**
-(`[:external-refs ::workspace]`). Forking a room with `:isolation :ctx` does
-`ctx/fork-context`, which copy-on-write copies the context **and** branches the
-workspace as a unit; `merge-to-parent!` collapses the branch back.
+(registered Yggdrasil systems). Forking a room with `:isolation :ctx` creates one
+canonical Spindel `ForkHandle`, which copy-on-write copies the context **and**
+branches the workspace as a unit; settling that handle merges or discards it.
 
 - **The chat Datahike DB** (one DB, system `"dvergr-chat-db"`): messages, rooms
   (`:chat/*`), **actors/agents** (`:actor/*`), tool-uses, **ledger** (budget),
@@ -59,8 +59,8 @@ plus the per-session sandbox.
 
 ## What a `:isolation :ctx` fork actually forks
 
-`fork-room` calls `ctx/fork-context`, which CoW-copies the execution context and
-branches **every `[:external-refs]` yggdrasil system as a unit**:
+`fork-room` calls `spindel.yggdrasil/fork!`, retains its process-local
+`ForkHandle`, and branches every selected registered Yggdrasil system as a unit:
 
 - **Datahike `dvergr-chat-db`** → branched — messages, KB, ledger, proposals, all
   isolated until merge. *This is the whole chat state, forked through yggdrasil.*
@@ -74,9 +74,10 @@ branches **every `[:external-refs]` yggdrasil system as a unit**:
 
 The fork's conversation is **seeded from the branched store**, so the agent sees
 inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
-`merge-room` → `yggdrasil/merge-to-parent!` lands the Datahike + git branches
-atomically; `discard` → `discard-from-parent!` deletes them. A fork is thus a fully
-**substrate-isolated world** you can review (`diff`) before committing (`merge!`).
+`merge-room` and `discard` settle that same handle exactly once. A fork is thus a
+fully **substrate-isolated world** you can review (`diff`) before adopting or
+discarding. The live handle is process-local; `dvergr.discourse/fork-descriptor`
+is the portable projection used by Runs, proposals, UIs, and audit state.
 
 ## Personas / agent config — managed, not files
 

--- a/src/dvergr/agent/world.clj
+++ b/src/dvergr/agent/world.clj
@@ -22,6 +22,8 @@
                      :policy policy
                      :allowed settlement-policies})))
   (let [work (d/fork-room parent {:isolation :ctx
+                                  :fork-opts {:purpose :run
+                                              :owner run-id}
                                   ;; A Run world is an internal transaction, not
                                   ;; a child conversation. Nested agents enter
                                   ;; only through explicit hire/tool effects.

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -10,7 +10,7 @@
    Algebra (combinators returning Spins):
      ask, fan-out, race, quorum, pipeline
 
-   Fork (yggdrasil substrate fork via spindel/fork-context):
+   Fork (one canonical spindel.yggdrasil/ForkHandle):
      fork-room, merge-room, discard
 
    Patterns (decomposing to the algebra):
@@ -92,7 +92,11 @@
   ;;                 :durable-append! hook, wired in make-room).
   ;; meta          : atom of arbitrary metadata (:telegram-chat-id,
   ;;                 :type :internal | :telegram-mirror, etc.)
-           [id slug title parent-id participants bus ctx forked-at-len store meta])
+  ;; fork-handle   : nil or atom containing the process-local canonical
+  ;;                 spindel.yggdrasil/ForkHandle for an isolated fork. Durable
+  ;;                 identity is exposed through fork-descriptor; the live
+  ;;                 settlement capability is deliberately never persisted.
+           [id slug title parent-id participants bus ctx forked-at-len store meta fork-handle])
 
 ;; A Room's bus + participants reference back to the Room, so the default record
 ;; printer recurses forever and StackOverflows at the REPL (e.g. when `(d/room …)`
@@ -281,7 +285,7 @@
         b     (bus-with-peer-relay ctx id :room
                                    (when durable-append!
                                      {:durable-append! durable-append!}))
-        room  (->Room id slug title parent-id (atom {}) b ctx 0 store (atom (or meta {})))]
+        room  (->Room id slug title parent-id (atom {}) b ctx 0 store (atom (or meta {})) nil)]
     (agent-run/open-room-admission! id ctx)
     ;; Persist metadata on creation so the store has it for re-hydration.
     (when store
@@ -918,15 +922,13 @@
    parent's spin can `await` the fork's `ask` because both speak the
    same ctx.
 
-   `:ctx` — fork the spindel execution context via `ctx/fork-context`,
-   which automatically branches all yggdrasil systems registered as
-   `[:external-refs]` (datahike, git worktrees, btrfs subvolumes,
-   ZFS datasets, …) via spindel's PForkable extension. The fork
+   `:ctx` — create the canonical `spindel.yggdrasil/ForkHandle`, which forks
+   the execution context and automatically branches all registered yggdrasil
+   systems (datahike, git worktrees, btrfs subvolumes, ZFS datasets, …). The fork
    becomes substrate-isolated: an agent's writes to its chat-ctx
    datahike, KB writes, file edits, etc. happen on branched copies
-   and are only visible inside the fork until `merge-room` atomically
-   merges them back via `spindel.yggdrasil/merge-to-parent!` (or
-   `discard` deletes the branches via `discard-from-parent!`).
+   and are only visible inside the fork until `merge-room` merges them back via
+   that handle (or `discard` deletes the branches).
 
    Use `:ctx` when the fork must hold real side effects in isolation
    (proposals, speculative coding-agent work). Use `:none` (default)
@@ -941,7 +943,7 @@
    `(ask fork :agent …)` from outside the fork's body) bind
    `*execution-context*` to the fork's ctx — see `with-fork-ctx`."
   ([room] (fork-room room {}))
-  ([room {:keys [isolation clone-participants?]
+  ([room {:keys [isolation clone-participants? fork-opts]
           :or {isolation :none clone-participants? true}}]
    (let [short-uuid (subs (str (random-uuid)) 0 8)
          new-slug   (str (:slug room) "/fork-" short-uuid)
@@ -950,9 +952,14 @@
          ;; peer-bus events).
          new-id     (rstore/slug->room-id new-slug)
          parent-log (log room)
+         fork-handle (when (= :ctx isolation)
+                       (binding [ec/*execution-context* (:ctx room)]
+                         (ygg/fork! (merge {:purpose :workroom
+                                            :owner new-id}
+                                           fork-opts))))
          child-ctx  (case isolation
                       :none (:ctx room)
-                      :ctx  (ctx/fork-context (:ctx room)))
+                      :ctx  (:child-ctx fork-handle))
          ;; Mark a `:ctx` fork TRANSIENT so create-room-db! defers the GLOBAL
          ;; system-db grant (reconciled on merge / dropped on discard) — a fork's
          ;; agent-created DB must not resurrect on restart (P2).
@@ -999,7 +1006,8 @@
                             fork-store
                             (atom (assoc @(:meta room)
                                          :forked-from (:id room)
-                                         :conversation-id conv-id)))]
+                                         :conversation-id conv-id))
+                            (when fork-handle (atom fork-handle)))]
      (agent-run/open-room-admission! new-id child-ctx)
      ;; (Fork-local persistence rides the bus's durable-append! hook now —
      ;; wired at child-bus construction above.)
@@ -1026,6 +1034,17 @@
                         :workspace-id    (when (= :ctx isolation)
                                            (:id (geschichte/current-workspace)))}))
      new-room)))
+
+(defn fork-handle
+  "Return an isolated Room fork's process-local canonical ForkHandle, or nil.
+   The handle owns settlement authority and must never be stored durably."
+  [room]
+  (some-> room :fork-handle deref))
+
+(defn fork-descriptor
+  "Return the portable world descriptor for an isolated Room fork, or nil."
+  [room]
+  (some-> (fork-handle room) ygg/fork-descriptor))
 
 (defmacro with-fork-ctx
   "Execute `body` with the fork's execution context bound. Required for
@@ -1059,8 +1078,8 @@
 
 (defn- ctx-was-forked?
   "True if `fork`'s ctx is a child of some parent ctx — i.e. it was
-   created via `ctx/fork-context`. Determines whether merge/discard
-   should also merge/discard yggdrasil branches."
+   created by the canonical ForkHandle (or the legacy direct context path).
+   Determines whether settlement includes Yggdrasil branches."
   [fork]
   (some? (:parent-ctx (:ctx fork))))
 
@@ -1075,10 +1094,10 @@
 
 (defn discard
   "Discard a fork: deregister its participants, drop it from the
-   registry, and if the fork's ctx was forked (`:isolation :ctx`),
-   delete all branched yggdrasil systems via
-   `spindel.yggdrasil/discard-from-parent!`. Participant processes and
-   subscription pumps are cancelled in both isolation modes.
+   registry, and if the fork's ctx was forked (`:isolation :ctx`), settle its
+   canonical ForkHandle by discarding every branched Yggdrasil system.
+   Participant processes and subscription pumps are cancelled in both
+   isolation modes.
 
    Emits `:dvergr/fork-discarded` on the peer-bus. Idempotent — a second
    discard of the same fork is a no-op (the branched systems are deleted only
@@ -1094,9 +1113,13 @@
       ;; delete the stores it created — they were never granted, so on discard they
       ;; must not linger. :on-discard fires inside discard-from-parent!.
       (let [pending (binding [ec/*execution-context* (:ctx fork)]
-                      (ec/get-state [:dvergr/pending-grants]))]
-        (ygg/discard-from-parent! (:ctx fork)
-                                  {:on-discard (fn [_] (srooms/drop-fork-grants! pending))})))
+                      (ec/get-state [:dvergr/pending-grants]))
+            opts {:on-discard (fn [_] (srooms/drop-fork-grants! pending))}]
+        (if-let [handle (fork-handle fork)]
+          (ygg/discard-fork! handle opts)
+          ;; Compatibility for Room values constructed before ForkHandle became
+          ;; canonical. New forks never take this path.
+          (ygg/discard-from-parent! (:ctx fork) opts))))
     (binding [ec/*execution-context* (fork-home-ctx fork)]
       (rreg/unregister! (:id fork))
       (peer-bus/post! {:type :dvergr/fork-discarded
@@ -1108,10 +1131,9 @@
 
    1. Append the fork's new log entries (those added after the fork
       point) to the parent's log.
-   2. If the fork's ctx was forked (`:isolation :ctx`), merge all
-      branched yggdrasil systems back into the parent via
-      `spindel.yggdrasil/merge-to-parent!` — datahike branches collapse,
-      git branches fast-forward or three-way merge, etc.
+   2. If the fork's ctx was forked (`:isolation :ctx`), settle its canonical
+      ForkHandle by merging all branched Yggdrasil systems into the parent —
+      datahike branches collapse, git branches fast-forward or three-way merge.
    3. Deregister the fork's participants.
 
    Concurrent sibling forks UNION (identity-keyed datahike merge); a genuine
@@ -1135,10 +1157,13 @@
        (let [pending (when (:store fork)
                        (binding [ec/*execution-context* (:ctx fork)]
                          (ec/get-state [:dvergr/pending-grants])))]
-         (ygg/merge-to-parent! (:ctx fork)
-                               (merge (or merge-opts {})
-                                      (when (:store fork)
-                                        {:on-merge (fn [_] (srooms/commit-fork-grants! pending))}))))
+         (let [opts (merge (or merge-opts {})
+                           (when (:store fork)
+                             {:on-merge (fn [_] (srooms/commit-fork-grants! pending))}))]
+           (if-let [handle (fork-handle fork)]
+             (ygg/merge-fork! handle opts)
+             ;; Compatibility for pre-ForkHandle Room values only.
+             (ygg/merge-to-parent! (:ctx fork) opts))))
        (catch Throwable e
          (tel/log! {:level :error :id :dvergr/merge-failed
                     :data {:fork (:id fork) :parent (:id parent) :error (str e)}}

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -541,7 +541,7 @@
    its own `:id`. A fork BRANCHES a conversation rather than starting a new one,
    so a fork persists under the ROOT of its fork chain — stored in the room's
    meta as `:conversation-id`. Messages are thus one logical conversation that a
-   fork's datahike branch isolates, and `merge-to-parent!` collapses natively
+   fork's datahike branch isolates, and `merge-fork!` collapses natively
    (no out-of-band `append-log!`). See doc/unified-fork-conversation.md."
   [room]
   (or (some-> room :meta deref :conversation-id) (:id room)))
@@ -971,12 +971,12 @@
          ;; (NOT the parent's fixed-conn store), and persists under the parent's
          ;; CONVERSATION id (root of the fork chain) — so a fork's messages are
          ;; the same logical conversation on a datahike branch, and
-         ;; merge-to-parent! collapses them natively (no append-log!). It writes
+         ;; merge-fork! collapses them natively (no append-log!). It writes
          ;; no separate :chat entity. (doc/unified-fork-conversation.md)
          conv-id    (conversation-id room)
          ;; RF5: the fork's store wraps the PARENT room's OWN messages conn under
          ;; the fork ctx (branched), so fork messages ride the per-room store's
-         ;; branch and merge-to-parent! collapses them natively. (RF5 S4.3: no
+         ;; branch and merge-fork! collapses them natively. (RF5 S4.3: no
          ;; chat-db fallback — every room is provisioned with its own :msgs system.)
          fork-store (when (= :ctx isolation)
                       (some-> (binding [ec/*execution-context* child-ctx]
@@ -1076,13 +1076,6 @@
      (binding [ec/*execution-context* (or (:ctx r#) r#)]
        ~@body)))
 
-(defn- ctx-was-forked?
-  "True if `fork`'s ctx is a child of some parent ctx — i.e. it was
-   created by the canonical ForkHandle (or the legacy direct context path).
-   Determines whether settlement includes Yggdrasil branches."
-  [fork]
-  (some? (:parent-ctx (:ctx fork))))
-
 (defn- fork-home-ctx
   "The ctx where a fork's registry entry + control-plane events live — its
    PARENT ctx, matching `fork-room`'s registration (a `:ctx` fork's own
@@ -1108,18 +1101,14 @@
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
     (drain-room-runs! fork)                    ; stop work before removing its substrate
     (leave-all! fork)
-    (when (ctx-was-forked? fork)
-      ;; P2: read the fork's deferred data-DB grants (fork-local ctx-state) and
-      ;; delete the stores it created — they were never granted, so on discard they
-      ;; must not linger. :on-discard fires inside discard-from-parent!.
+    (when-let [handle (fork-handle fork)]
+      ;; P2: settle the substrate first, then drop deferred grants explicitly.
+      ;; If grant cleanup fails, retrying `discard` replays the cached settlement
+      ;; and retries only this idempotent integration step.
       (let [pending (binding [ec/*execution-context* (:ctx fork)]
-                      (ec/get-state [:dvergr/pending-grants]))
-            opts {:on-discard (fn [_] (srooms/drop-fork-grants! pending))}]
-        (if-let [handle (fork-handle fork)]
-          (ygg/discard-fork! handle opts)
-          ;; Compatibility for Room values constructed before ForkHandle became
-          ;; canonical. New forks never take this path.
-          (ygg/discard-from-parent! (:ctx fork) opts))))
+                      (ec/get-state [:dvergr/pending-grants]))]
+        (ygg/discard-fork! handle)
+        (srooms/drop-fork-grants! pending)))
     (binding [ec/*execution-context* (fork-home-ctx fork)]
       (rreg/unregister! (:id fork))
       (peer-bus/post! {:type :dvergr/fork-discarded
@@ -1138,7 +1127,7 @@
 
    Concurrent sibling forks UNION (identity-keyed datahike merge); a genuine
    field clash (same entity+attr changed differently on both sides) is a 3-way
-   CONFLICT that `merge-to-parent!` refuses by default. Pass `{:merge-opts
+   CONFLICT that `merge-fork!` refuses by default. Pass `{:merge-opts
    {:force true}}` (the agent reconciler does, after resolving) to force past it.
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
@@ -1152,22 +1141,21 @@
    ;; branch also collapses here (bringing its messages into the parent's
    ;; conversation under the shared :chat/id); its deferred data-DB grants commit on
    ;; accept via :on-merge (store forks only). (doc/unified-fork-conversation.md)
-   (when (ctx-was-forked? fork)
+   (when-let [handle (fork-handle fork)]
      (try
        (let [pending (when (:store fork)
                        (binding [ec/*execution-context* (:ctx fork)]
                          (ec/get-state [:dvergr/pending-grants])))]
-         (let [opts (merge (or merge-opts {})
-                           (when (:store fork)
-                             {:on-merge (fn [_] (srooms/commit-fork-grants! pending))}))]
-           (if-let [handle (fork-handle fork)]
-             (ygg/merge-fork! handle opts)
-             ;; Compatibility for pre-ForkHandle Room values only.
-             (ygg/merge-to-parent! (:ctx fork) opts))))
+         (ygg/merge-fork! handle (or merge-opts {}))
+         ;; Grant integration is deliberately outside substrate settlement. A
+         ;; failure leaves the handle truthfully :merged and a retry replays the
+         ;; cached merge before retrying this idempotent commit.
+         (when (:store fork)
+           (srooms/commit-fork-grants! pending)))
        (catch Throwable e
          (tel/log! {:level :error :id :dvergr/merge-failed
                     :data {:fork (:id fork) :parent (:id parent) :error (str e)}}
-                   "merge-room: yggdrasil merge-to-parent! failed — parent state may be partial")
+                   "merge-room: affine yggdrasil settlement failed")
          (binding [ec/*execution-context* (fork-home-ctx fork)]
            (peer-bus/post! {:type :dvergr/merge-failed :dvergr/origin (:id fork)
                             :dvergr/parent (:id parent) :error (str e)}))
@@ -1219,7 +1207,7 @@
 
    Returns the proposal payload."
   [fork & {:keys [from note] :or {from :worker note ""}}]
-  (let [diff      (when (ctx-was-forked? fork)
+  (let [diff      (when (fork-handle fork)
                     (geschichte/diff-since-fork (:ctx fork)))
         proposal  (cond-> {:fork-id (:id fork)
                            :note    note}

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -128,9 +128,15 @@
           (is (= :review (:run/settlement-status result)))
           (is (= :review (:run/settlement-status durable)))
           (is (= (:run/id durable) (some-> fork :meta deref :run-id)))
+          (is (= {:fork/purpose :run
+                  :fork/owner (:run/id durable)
+                  :fork/status :open}
+                 (select-keys (d/fork-descriptor fork)
+                              [:fork/purpose :fork/owner :fork/status])))
           (let [action (binding [ec/*execution-context* (:ctx room)]
                          (forks/merge! fork))]
             (is (:ok? action) (pr-str action)))
+          (is (= :merged (:fork/status (d/fork-descriptor fork))))
           (is (= :merged (:run/settlement-status
                           (program/observe room handle))))))
       (testing "discard removes a successful work plane"

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -12,7 +12,8 @@
             [dvergr.discourse :as d]
             [dvergr.intake.bash :as b]
             [dvergr.runtime.peer-bus :as peer-bus]
-            [org.replikativ.spindel.engine.core :as ec]))
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.yggdrasil :as ygg]))
 
 ;; ============================================================================
 ;; Sandbox fixture (reuses pattern from bash_isolation_test)
@@ -74,6 +75,12 @@
   (binding [ec/*execution-context* *base-ctx*]
     (let [parent (d/room :parent *base-ctx*)
           fork   (d/fork-room parent {:isolation :ctx})]
+      (is (= {:fork/purpose :workroom
+              :fork/owner (:id fork)
+              :fork/status :open}
+             (select-keys (d/fork-descriptor fork)
+                          [:fork/purpose :fork/owner :fork/status]))
+          "the Room projects the canonical world descriptor")
       (Thread/sleep 50)                                ; let drain catch up
       (let [evts (peer-events-of-type :dvergr/fork-created)]
         (is (= 1 (count evts)) "exactly one fork-created event")
@@ -102,9 +109,11 @@
 (deftest merge-room-emits-fork-merged
   (binding [ec/*execution-context* *base-ctx*]
     (let [parent (d/room :p *base-ctx*)
-          fork   (d/fork-room parent {:isolation :ctx})]
+          fork   (d/fork-room parent {:isolation :ctx})
+          handle (d/fork-handle fork)]
       (bash (:ctx fork) "echo m > m.txt && git add . && git commit -q -m wip")
       (d/merge-room parent fork)
+      (is (= :merged (:status (ygg/fork-disposition handle))))
       (Thread/sleep 50)
       (let [evts (peer-events-of-type :dvergr/fork-merged)]
         (is (= 1 (count evts)))
@@ -113,8 +122,10 @@
 (deftest discard-emits-fork-discarded
   (binding [ec/*execution-context* *base-ctx*]
     (let [parent (d/room :p *base-ctx*)
-          fork   (d/fork-room parent {:isolation :ctx})]
+          fork   (d/fork-room parent {:isolation :ctx})
+          handle (d/fork-handle fork)]
       (d/discard fork)
+      (is (= :discarded (:status (ygg/fork-disposition handle))))
       (Thread/sleep 50)
       (let [evts (peer-events-of-type :dvergr/fork-discarded)]
         (is (= 1 (count evts)))


### PR DESCRIPTION
## Summary

- represent isolated room worlds with Spindel `ForkHandle`s instead of parallel Dvergr fork state
- route merge/discard through Spindel’s affine settlement API and keep deferred grant integration retryable
- expose canonical fork descriptors and dispositions to room/runtime consumers
- document the unified execution/world/proposal boundary and current enforceable authority
- update the production dependency to the released Spindel 0.1.41 artifact

## Verification

- `clojure -M:format`
- `clojure -M:test --focus dvergr.discourse-test` (31 tests, 100 assertions)
- `clojure -M:test --focus dvergr.agent.program-test --focus dvergr.agent.subagent-test --focus dvergr.runtime.peer-bus-review-test` (41 tests, 185 assertions)

All tests above resolve Spindel from Clojars rather than the sibling checkout.