### PR TITLE
Transfer run worlds to durable governance

### DIFF
--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -239,10 +239,30 @@ attenuated until resource-vector splitting exists.
 A standalone Run completes in review mode. Promotion transfers its open fork to
 a durable ForkSet and persists the descriptor as a GC root. The Run becomes a
 contributor and loses settlement authority. Review may survive restart and
-eventually settle selected systems.
+settles the adopted world as one affine unit.
 
-Needs: transfer/adopt, portable descriptor, durable GC ownership, and a
-settlement journal.
+The live bridge is `dvergr.rooms.forks/adopt!`. Its `:prepare!` callback must
+persist the prospective descriptor/owner before Spindel transfers authority.
+Successful transfer detaches the transient Room and returns the adopter's sole
+process-local `ForkHandle`; preparation failure leaves the review world open.
+If the affine CAS loses a race after preparation, the required `:abort!`
+compensates the prepared durable row. The handle is never persisted.
+The prepared descriptor includes `:dvergr/room-id`,
+`:dvergr/parent-room-id`, and (for a nested isolated world)
+`:dvergr/parent-fork-id`. The durable owner must retain that ancestry until the
+child settles; Dvergr's shared topology is its immediate in-process projection.
+
+This bridge is deliberately whole-world only. Simmis must not accept or dismiss
+descriptor-named systems independently through raw branches. Per-scope review
+first requires an affine partition/split primitive that consumes the original
+handle and returns disjoint system capabilities; each partition can then be
+settled exactly once without bypassing Spindel's lifecycle.
+
+Simmis still needs to supply the durable half: store the descriptor as a GC
+root, index its systems into the existing ForkSet, and journal per-system
+settlement. After restart it reopens the named Datahike/Geschichte branches
+under that durable ownership claim; it does not deserialize the old Spindel
+reactive context.
 
 ### Multi-agent campaign
 
@@ -362,7 +382,9 @@ it:
    `dvergr.discourse/hire`, and the independent `chat.context/fork-sub-chat`
    hierarchy. All bounded delegation and executable branching is Run-backed;
    conversational branches remain message/thread projections.
-8. Implement durable transfer/adoption and settlement journaling for Simmis.
+8. **Partial:** Dvergr now exposes durability-first affine adoption. Implement
+   the Simmis GC root, whole-world ForkSet projection, and recoverable settlement
+   journal. Add affine world partitioning before exposing per-scope settlement.
 9. Replace boot-time blanket orphan cleanup with descriptor/owner-aware GC.
 10. Build SMC, MCTS, resource-aware campaigns, and training environments on the
     same world policy.

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -85,6 +85,21 @@
       (ec/swap-state! (admission-path room-id) (constantly :open))))
   nil)
 
+(defn initialize-unpublished-room-admission!
+  "Initialize admission for a fresh Room before it is published.
+
+   This deliberately does not acquire `lifecycle-lock`: callers may be holding
+   a parent Room's metadata lock while constructing the child. It is only safe
+   for a unique Room ID that is not registered, shared, or running yet."
+  [room-id execution-ctx]
+  (when (some #(= room-id (get-in % [:run :run/room])) (vals @active))
+    (throw (ex-info "Cannot initialize admission for a Room with active Runs"
+                    {:type ::room-already-active
+                     :room-id room-id})))
+  (binding [ec/*execution-context* execution-ctx]
+    (ec/swap-state! (admission-path room-id) (constantly :open)))
+  nil)
+
 (defn close-room-admission!
   "Atomically close fork-local Run admission for `room` and return the fixed set
    admitted before the fence. Teardown drains exactly this set."
@@ -98,6 +113,39 @@
                    (when (= room-id (get-in entry [:run :run/room]))
                      (get-in entry [:run :run/id]))))
            set))))
+
+(defn fence-room-admission!
+  "Close Run admission and invoke `install-fence!` with the fixed admitted Run
+   IDs and their public snapshots while holding the lifecycle frontier.
+
+   `install-fence!` may acquire a Room lifecycle lock. This establishes the
+   only nested order as Run lifecycle -> Room lifecycle; it must not publish
+   Run events or invoke lifecycle subscribers."
+  [room install-fence!]
+  (let [room-id (:id room)]
+    (locking lifecycle-lock
+      (binding [ec/*execution-context* (:ctx room)]
+        (ec/swap-state! (admission-path room-id) (constantly :closed)))
+      (let [entries (->> (vals @active)
+                         (filter #(= room-id (get-in % [:run :run/room]))))
+            admitted (into #{} (map #(get-in % [:run :run/id])) entries)
+            runs (ordered-runs entries)]
+        (install-fence! admitted runs)
+        admitted))))
+
+(defn recover-room-admission!
+  "Atomically reopen a fenced Room when `recover-fence!` confirms and removes
+   the exact Room lifecycle fence being recovered.
+
+   The callback runs under the Run lifecycle lock and may acquire Room metadata,
+   preserving the sole nested order Run lifecycle -> Room metadata. It must
+   return truthy only when it removed the expected fence generation."
+  [room recover-fence!]
+  (locking lifecycle-lock
+    (when (recover-fence!)
+      (binding [ec/*execution-context* (:ctx room)]
+        (ec/swap-state! (admission-path (:id room)) (constantly :open)))
+      true)))
 
 (defn start!
   "Persist and publish one live Run before execution begins.

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -195,10 +195,14 @@
     (bus/post! (:bus room) msg')
     msg'))
 
+(declare ensure-room-work-admitted!)
+
 (defn post!
   "Route a Message into the room. Safe to call from any thread."
   [room msg]
-  (route-and-log! room msg))
+  (locking (:meta room)
+    (ensure-room-work-admitted! room :post msg)
+    (route-and-log! room msg)))
 
 (defn room-target
   "The canonical addressing target for user input into `room`, derived from
@@ -220,8 +224,10 @@
 (defn post-batch!
   "Route msgs into the room in order."
   [room msgs]
-  (bus/post-many! (:bus room) msgs)
-  msgs)
+  (locking (:meta room)
+    (ensure-room-work-admitted! room :post-batch)
+    (bus/post-many! (:bus room) msgs)
+    msgs))
 
 (defn log
   "Return the room's full message log (vector). Mirrors `bus/log`."
@@ -546,6 +552,55 @@
   [room]
   (or (some-> room :meta deref :conversation-id) (:id room)))
 
+(def ^:private fork-transfer-state-key :dvergr/fork-transfer-state)
+
+(defn- install-room-listener!
+  [room f]
+  (binding [ec/*execution-context* (:ctx room)]
+    (let [sub (bus/subscribe! (:bus room) [:type :user/message])
+          lifecycle (atom {:status :open})
+          listener (sp/spin
+                    (loop [s (:aseq sub)]
+                      (when-let [r (sp/await (anext s))]
+                        (let [[msg rest-s] r
+                              done (promise)
+                              claimed?
+                              (loop []
+                                (let [state @lifecycle]
+                                  (if (= :open (:status state))
+                                    (if (compare-and-set! lifecycle state
+                                                          {:status :active :done done})
+                                      true
+                                      (recur))
+                                    false)))]
+                          (when claimed?
+                            (try
+                              (when (map? msg) (f msg))
+                              (catch Throwable t
+                                (tel/log! {:level :error :id :room/listener-failed
+                                           :data {:room (:id room) :error (.getMessage t)}}))
+                              (finally
+                                (swap! lifecycle
+                                       (fn [state]
+                                         {:status (if (= :closing (:status state))
+                                                    :closed
+                                                    :open)}))
+                                (deliver done true))))
+                          (recur rest-s)))))
+          _ (sp/spawn! listener
+                       {:on-error
+                        (fn [error]
+                          (when-not (= spin-core/spin-cancelled (:type (ex-data error)))
+                            (tel/log! {:level :error :id ::room-listener-error
+                                       :data {:room (:id room)
+                                              :error (ex-message error)}}
+                                      "Room listener process failed")))})
+          owned (or (:dvergr/owned-listeners @(:meta room)) (atom #{}))
+          entry {:subscription sub :spin listener :lifecycle lifecycle :callback f}]
+      (swap! owned conj entry)
+      (swap! (:meta room) assoc :dvergr/owned-listeners owned)
+      listener)))
+
 (defn on-each-message
   "Spawn a listener that calls `(f msg)` for EVERY conversational message posted
    to `room` (every `[:type :user/message]` on the bus), in order — the whole
@@ -553,18 +608,135 @@
    reflect the entire room (a channel egress that shows what a rich UI shows).
    Errors in `f` are logged, never swallowed, and don't stop the listener."
   [room f]
-  (binding [ec/*execution-context* (:ctx room)]
-    (let [sub (bus/subscribe! (:bus room) [:type :user/message])]
-      (sp/spawn!
-       (sp/spin
-        (loop [s (:aseq sub)]
-          (when-let [r (sp/await (anext s))]
-            (let [[msg rest-s] r]
-              (try (when (map? msg) (f msg))
-                   (catch Throwable t
-                     (tel/log! {:level :error :id :room/listener-failed
-                                :data {:room (:id room) :error (.getMessage t)}})))
-              (recur rest-s)))))))))
+  (locking (:meta room)
+    (ensure-room-work-admitted! room :on-each-message)
+    (install-room-listener! room f)))
+
+(declare fork-handle)
+
+(defn- begin-room-quiescence!
+  [room operation]
+  (let [token (random-uuid)]
+    (agent-run/fence-room-admission!
+     room
+     (fn [admitted active]
+       (locking (:meta room)
+         (if-let [state (get @(:meta room) fork-transfer-state-key)]
+           (throw (ex-info "Room is already fenced for lifecycle work"
+                           {:type ::room-lifecycle-in-progress
+                            :fork/id (:id room)
+                            :operation operation
+                            :fork/transfer-state state}))
+           (swap! (:meta room) assoc fork-transfer-state-key
+                  {:state :tearing-down
+                   :token token
+                   :operation operation
+                   :admitted-run-ids admitted
+                   :admitted-trigger-ids (into #{} (keep :run/trigger) active)})))))))
+
+(defn- drain-room-listeners!
+  "Stop Room-owned listeners and wait for active callbacks to physically exit.
+   Returns their callbacks so a recoverable transfer failure can reinstall them."
+  [room operation]
+  (begin-room-quiescence! room operation)
+  (if-let [owned (:dvergr/owned-listeners @(:meta room))]
+    (let [entries (vec @owned)]
+      (doseq [{:keys [subscription spin lifecycle]} entries]
+        (bus/unsubscribe! subscription)
+        (let [state (swap! lifecycle
+                           (fn [state]
+                             (case (:status state)
+                               :open {:status :closed}
+                               :active (assoc state :status :closing)
+                               state)))]
+          (cleanup-owned-spin! room spin)
+          (when-let [done (:done state)]
+            (when (= ::timeout (deref done 5000 ::timeout))
+              (swap! (:meta room) update fork-transfer-state-key
+                     assoc
+                     :state :recovery-required
+                     :operation operation
+                     :error "listener callback drain timed out")
+              (throw (ex-info "Timed out waiting for a Room listener callback"
+                              {:type ::listener-drain-timeout
+                               :room-id (:id room)}))))))
+      (reset! owned #{})
+      (mapv :callback entries))
+    []))
+
+(defn- seal-room-quiescence!
+  "Retire the causal-post handoff after every admitted Run has acknowledged
+   cancellation. No Room write may cross this boundary into settlement."
+  [room operation]
+  (locking (:meta room)
+    (let [state (get @(:meta room) fork-transfer-state-key)]
+      (when (= :tearing-down (:state state))
+        (swap! (:meta room) update fork-transfer-state-key
+               assoc :state :settling :operation operation))))
+  nil)
+
+(defn- restore-room-listeners!
+  [room callbacks]
+  (locking (:meta room)
+    (doseq [f callbacks]
+      (install-room-listener! room f))))
+
+(defn- recover-room-quiescence!
+  [room callbacks error]
+  (let [handle (fork-handle room)
+        token (get-in @(:meta room) [fork-transfer-state-key :token])]
+    (if (or (nil? handle) (ygg/open-fork? handle))
+      (let [restore-error (try
+                            (restore-room-listeners! room callbacks)
+                            nil
+                            (catch Throwable listener-error listener-error))]
+        (if restore-error
+          (do
+            (swap! (:meta room) update fork-transfer-state-key
+                   assoc :state :recovery-required :error (ex-message restore-error))
+            (throw (ex-info "Room listener restoration failed; recovery is required"
+                            {:type ::fork-transfer-recovery-required
+                             :fork/id (:id room)
+                             :operation :teardown
+                             :error (ex-message error)
+                             :restore-error (ex-message restore-error)}
+                            restore-error)))
+          (let [recovered?
+                (agent-run/recover-room-admission!
+                 room
+                 (fn []
+                   (locking (:meta room)
+                     (when (= token (get-in @(:meta room)
+                                            [fork-transfer-state-key :token]))
+                       (swap! (:meta room) dissoc fork-transfer-state-key)
+                       true))))]
+            (if recovered?
+              (throw error)
+              (throw (ex-info "Room lifecycle changed during recovery"
+                              {:type ::fork-transfer-recovery-required
+                               :fork/id (:id room)
+                               :operation :teardown
+                               :error (ex-message error)}
+                              error))))))
+      (do
+        (swap! (:meta room) update fork-transfer-state-key
+               assoc :state :recovery-required :error (ex-message error))
+        (throw error)))))
+
+(defn- mark-room-recovery-if-owned!
+  "Mark a failed lifecycle operation without overwriting a newer contender's
+   fence. A nil or stale token owns no lifecycle state."
+  [room token operation error]
+  (when token
+    (locking (:meta room)
+      (when (= token (get-in @(:meta room)
+                             [fork-transfer-state-key :token]))
+        (swap! (:meta room) update fork-transfer-state-key
+               assoc
+               :state :recovery-required
+               :operation operation
+               :error (ex-message error)))))
+  nil)
 
 (defn messages
   "Return a Room's message history.
@@ -608,6 +780,21 @@
                             :meta new-meta}))
     new-meta))
 
+(defn- ensure-room-work-admitted!
+  [room operation & [payload]]
+  (when-let [state (get @(:meta room) fork-transfer-state-key)]
+    (let [run-id (some-> payload :metadata :run-id)
+          admitted-trigger? (and (= :post operation)
+                                 (= :tearing-down (:state state))
+                                 (or (contains? (:admitted-trigger-ids state) (:id payload))
+                                     (contains? (:admitted-run-ids state) run-id)))]
+      (when-not admitted-trigger?
+        (throw (ex-info "Room is fenced for fork authority transfer"
+                        {:type ::fork-transfer-in-progress
+                         :fork/id (:id room)
+                         :operation operation
+                         :fork/transfer-state state}))))))
+
 (defn join
   "Register participant in room, subscribe its inbox + drivers on the bus,
    and start its spin. Returns the participant with :inbox-sub, :inbox-mbx
@@ -621,40 +808,42 @@
    participant sees every broadcast post; targeted posts only the
    addressed one\" — falls out naturally."
   [room p]
-  (binding [ec/*execution-context* (:ctx room)]
-    (let [inbox-sub     (bus/subscribe! (:bus room) [:to (:id p)])
-          broadcast-sub (bus/subscribe! (:bus room) [:to nil])
+  (locking (:meta room)
+    (ensure-room-work-admitted! room :join)
+    (binding [ec/*execution-context* (:ctx room)]
+      (let [inbox-sub     (bus/subscribe! (:bus room) [:to (:id p)])
+            broadcast-sub (bus/subscribe! (:bus room) [:to nil])
           ;; A Participant may be explicitly left and then joined again. Re-open
           ;; its active-handler slot before the new process can receive work.
-          _ (reset! (:active p) nil)
+            _ (reset! (:active p) nil)
           ;; Merge all subscriptions into one mailbox so the spin awaits
           ;; a single source. Each sub gets a small pump.
-          merge-mbx (sync/create-mailbox (:ctx room))
-          inbox-pump (drain-into! inbox-sub merge-mbx)
-          broadcast-pump (drain-into! broadcast-sub merge-mbx)
-          p' (-> p
-                 (assoc :inbox-sub inbox-sub
-                        :inbox-mbx merge-mbx
+            merge-mbx (sync/create-mailbox (:ctx room))
+            inbox-pump (drain-into! inbox-sub merge-mbx)
+            broadcast-pump (drain-into! broadcast-sub merge-mbx)
+            p' (-> p
+                   (assoc :inbox-sub inbox-sub
+                          :inbox-mbx merge-mbx
                         ;; The participant carries the room it is JOINED to, so a
                         ;; handler operates on its actual room — not one baked
                         ;; into a closure. Critical for fork clones: the same
                         ;; on-message, joined to a fork, must rehydrate/account
                         ;; against the FORK, not the parent it was built for.
-                        :room room)
-                 (update :subs (fn [s] (swap! s assoc [:to nil] broadcast-sub) s)))
-          proc (participant-spin p' room merge-mbx)]
-      (swap! (:pumps p') assoc ::direct inbox-pump [:to nil] broadcast-pump)
-      (sp/spawn! proc
-                 {:on-error
-                  (fn [error]
-                    (when-not (= spin-core/spin-cancelled (:type (ex-data error)))
-                      (tel/log! {:level :error :id ::participant-process-error
-                                 :data {:participant (:id p')
-                                        :error (.getMessage ^Throwable error)}}
-                                "participant process failed")))})
-      (let [p'' (assoc p' :process proc)]
-        (swap! (:participants room) assoc (:id p) p'')
-        p''))))
+                          :room room)
+                   (update :subs (fn [s] (swap! s assoc [:to nil] broadcast-sub) s)))
+            proc (participant-spin p' room merge-mbx)]
+        (swap! (:pumps p') assoc ::direct inbox-pump [:to nil] broadcast-pump)
+        (sp/spawn! proc
+                   {:on-error
+                    (fn [error]
+                      (when-not (= spin-core/spin-cancelled (:type (ex-data error)))
+                        (tel/log! {:level :error :id ::participant-process-error
+                                   :data {:participant (:id p')
+                                          :error (.getMessage ^Throwable error)}}
+                                  "participant process failed")))})
+        (let [p'' (assoc p' :process proc)]
+          (swap! (:participants room) assoc (:id p) p'')
+          p'')))))
 
 ;; ============================================================================
 ;; Dynamic subscriptions — let participants listen to extra tagged channels
@@ -673,16 +862,18 @@
   ([room p topic]
    (subscribe! room p topic nil))
   ([room p topic buffer]
-   (or (get @(:subs p) topic)
-       (let [sub (binding [ec/*execution-context* (:ctx room)]
-                   (if buffer
-                     (bus/subscribe! (:bus room) topic buffer)
-                     (bus/subscribe! (:bus room) topic)))
-             pump (binding [ec/*execution-context* (:ctx room)]
-                    (drain-into! sub (:inbox-mbx p)))]
-         (swap! (:subs p) assoc topic sub)
-         (swap! (:pumps p) assoc topic pump)
-         sub))))
+   (locking (:meta room)
+     (ensure-room-work-admitted! room :subscribe)
+     (or (get @(:subs p) topic)
+         (let [sub (binding [ec/*execution-context* (:ctx room)]
+                     (if buffer
+                       (bus/subscribe! (:bus room) topic buffer)
+                       (bus/subscribe! (:bus room) topic)))
+               pump (binding [ec/*execution-context* (:ctx room)]
+                      (drain-into! sub (:inbox-mbx p)))]
+           (swap! (:subs p) assoc topic sub)
+           (swap! (:pumps p) assoc topic pump)
+           sub)))))
 
 (defn unsubscribe!
   "Remove a previously added subscription on `topic` for `p`. The drain
@@ -796,17 +987,29 @@
 
    No-op on already-closed rooms."
   [room]
-  (when room
-    (drain-room-runs! room)
-    (leave-all! room)
-    (binding [ec/*execution-context* (room-home-ctx room)]
-      (rreg/unregister! (:id room)))
-    ;; A branchless fork carries the exact root ctx, so Spindel cannot infer from
-    ;; the context alone that closing it here would kill the parent. The durable
-    ;; room marker is the ownership boundary.
-    (when-not (fork-room? room)
-      (when-let [room-ctx (:ctx room)]
-        (ctx/close-context! room-ctx))))
+  (when (and room (not= :closed (get-in @(:meta room)
+                                        [fork-transfer-state-key :state])))
+    (let [fence-token* (volatile! nil)]
+      (try
+        (drain-room-listeners! room :close)
+        (vreset! fence-token*
+                 (get-in @(:meta room) [fork-transfer-state-key :token]))
+        (drain-room-runs! room)
+        (seal-room-quiescence! room :close)
+        (leave-all! room)
+        (binding [ec/*execution-context* (room-home-ctx room)]
+          (rreg/unregister! (:id room)))
+        ;; A branchless fork carries the exact root ctx, so Spindel cannot infer from
+        ;; the context alone that closing it here would kill the parent. The durable
+        ;; room marker is the ownership boundary.
+        (when-not (fork-room? room)
+          (when-let [room-ctx (:ctx room)]
+            (ctx/close-context! room-ctx)))
+        (swap! (:meta room) assoc fork-transfer-state-key
+               {:state :closed :operation :close})
+        (catch Throwable error
+          (mark-room-recovery-if-owned! room @fence-token* :close error)
+          (throw error)))))
   nil)
 
 ;; ============================================================================
@@ -844,11 +1047,15 @@
   [room target-id msg-spec]
   (sp/spin
    (let [asker-id (keyword (str "ask-" (random-uuid)))
-         asker-sub (binding [ec/*execution-context* (:ctx room)]
-                     (bus/subscribe! (:bus room) [:to asker-id]))]
-      ;; Register a stub so the participants map can be inspected if needed.
-     (swap! (:participants room) assoc asker-id
-            {:id asker-id :inbox-sub asker-sub})
+         asker-sub (locking (:meta room)
+                     (ensure-room-work-admitted! room :ask)
+                     (let [sub (binding [ec/*execution-context* (:ctx room)]
+                                 (bus/subscribe! (:bus room) [:to asker-id]))]
+                        ;; Register the stub under the same lifecycle lock, so
+                        ;; transfer either sees it or fences the ask first.
+                       (swap! (:participants room) assoc asker-id
+                              {:id asker-id :inbox-sub sub})
+                       sub))]
       ;; try/finally so the transient subscription + stub are reclaimed on BOTH
       ;; a normal reply AND cancellation. spindel's cancel-spin! unwinds a spin
       ;; suspended at this `await` through the finally — and reaches here even
@@ -945,27 +1152,29 @@
   ([room] (fork-room room {}))
   ([room {:keys [isolation clone-participants? fork-opts]
           :or {isolation :none clone-participants? true}}]
-   (let [short-uuid (subs (str (random-uuid)) 0 8)
-         new-slug   (str (:slug room) "/fork-" short-uuid)
+   (locking (:meta room)
+     (ensure-room-work-admitted! room :fork-room)
+     (let [short-uuid (subs (str (random-uuid)) 0 8)
+           new-slug   (str (:slug room) "/fork-" short-uuid)
          ;; Use the canonical slug→id encoding so id ↔ slug stay in
          ;; lock-step across the entire system (registry, store,
          ;; peer-bus events).
-         new-id     (rstore/slug->room-id new-slug)
-         parent-log (log room)
-         fork-handle (when (= :ctx isolation)
-                       (binding [ec/*execution-context* (:ctx room)]
-                         (ygg/fork! (merge {:purpose :workroom
-                                            :owner new-id}
-                                           fork-opts))))
-         child-ctx  (case isolation
-                      :none (:ctx room)
-                      :ctx  (:child-ctx fork-handle))
+           new-id     (rstore/slug->room-id new-slug)
+           parent-log (log room)
+           fork-handle (when (= :ctx isolation)
+                         (binding [ec/*execution-context* (:ctx room)]
+                           (ygg/fork! (merge {:purpose :workroom
+                                              :owner new-id}
+                                             fork-opts))))
+           child-ctx  (case isolation
+                        :none (:ctx room)
+                        :ctx  (:child-ctx fork-handle))
          ;; Mark a `:ctx` fork TRANSIENT so create-room-db! defers the GLOBAL
          ;; system-db grant (reconciled on merge / dropped on discard) — a fork's
          ;; agent-created DB must not resurrect on restart (P2).
-         _          (when (= :ctx isolation)
-                      (binding [ec/*execution-context* child-ctx]
-                        (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
+           _          (when (= :ctx isolation)
+                        (binding [ec/*execution-context* child-ctx]
+                          (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
          ;; `:isolation :ctx` forks BRANCH the parent's conversation. The fork
          ;; gets its OWN store wrapping the fork ctx's BRANCHED chat-db conn
          ;; (NOT the parent's fixed-conn store), and persists under the parent's
@@ -973,42 +1182,45 @@
          ;; the same logical conversation on a datahike branch, and
          ;; merge-fork! collapses them natively (no append-log!). It writes
          ;; no separate :chat entity. (doc/unified-fork-conversation.md)
-         conv-id    (conversation-id room)
+           conv-id    (conversation-id room)
          ;; RF5: the fork's store wraps the PARENT room's OWN messages conn under
          ;; the fork ctx (branched), so fork messages ride the per-room store's
          ;; branch and merge-fork! collapses them natively. (RF5 S4.3: no
          ;; chat-db fallback — every room is provisioned with its own :msgs system.)
-         fork-store (when (= :ctx isolation)
-                      (some-> (binding [ec/*execution-context* child-ctx]
-                                (srooms/msgs-conn-for-slug (:slug room)))
-                              store-dh/make))
+           fork-store (when (= :ctx isolation)
+                        (some-> (binding [ec/*execution-context* child-ctx]
+                                  (srooms/msgs-conn-for-slug (:slug room)))
+                                store-dh/make))
          ;; Durability-first for the fork too: fork-local messages persist
          ;; onto the BRANCH (under the root conversation id) inside post!,
          ;; before visibility — replacing the fork's persistence listener.
-         child-bus  (bus-with-peer-relay child-ctx new-id :fork
-                                         (when fork-store
-                                           {:durable-append!
-                                            (fn [msg]
-                                              (when (rstore/message-shape? msg)
-                                                (rstore/-store-message! fork-store conv-id msg)))}))
+           child-bus  (bus-with-peer-relay child-ctx new-id :fork
+                                           (when fork-store
+                                             {:durable-append!
+                                              (fn [msg]
+                                                (when (rstore/message-shape? msg)
+                                                  (rstore/-store-message! fork-store conv-id msg)))}))
          ;; Seed the fork's bus log with parent history so log-based
          ;; consumers see a continuous record (the cursor starts past it —
          ;; history is never re-delivered). Forks have their OWN bus so
          ;; live messages do not leak between parent and fork.
-         _          (bus/seed-log! child-bus parent-log)
-         new-room   (->Room new-id new-slug
-                            (str (:title room) " · fork " short-uuid)
-                            (:id room)
-                            (atom {})
-                            child-bus
-                            child-ctx
-                            (count parent-log)
-                            fork-store
-                            (atom (assoc @(:meta room)
-                                         :forked-from (:id room)
-                                         :conversation-id conv-id))
-                            (when fork-handle (atom fork-handle)))]
-     (agent-run/open-room-admission! new-id child-ctx)
+           _          (bus/seed-log! child-bus parent-log)
+           new-room   (->Room new-id new-slug
+                              (str (:title room) " · fork " short-uuid)
+                              (:id room)
+                              (atom {})
+                              child-bus
+                              child-ctx
+                              (count parent-log)
+                              fork-store
+                              (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
+                                           :forked-from (:id room)
+                                           :conversation-id conv-id))
+                              (when fork-handle (atom fork-handle)))]
+       ;; The child is not registered or otherwise visible yet. Initializing its
+       ;; admission without the global lifecycle lock avoids parent-meta ->
+       ;; lifecycle lock inversion during concurrent parent teardown.
+       (agent-run/initialize-unpublished-room-admission! new-id child-ctx)
      ;; (Fork-local persistence rides the bus's durable-append! hook now —
      ;; wired at child-bus construction above.)
      ;; Register the fork in the PARENT ctx — where the daemon UI reads the
@@ -1016,24 +1228,26 @@
      ;; (CoW), so registering there would hide the fork from the tree (and it
      ;; would render empty). The Room still carries its child-ctx in `:ctx`
      ;; for merge/diff/git. For `:none`, child-ctx == parent ctx (no change).
-     (binding [ec/*execution-context* (:ctx room)]
-       (rreg/register! new-room))
-     (when clone-participants?
-       (doseq [[_id p] @(:participants room)]
-         (when-let [fac (:factory p)]
-           (binding [ec/*execution-context* child-ctx]
-             (join new-room (fac child-ctx))))))
+       (binding [ec/*execution-context* (:ctx room)]
+         (rreg/register! new-room)
+         (when (= :ctx isolation)
+           (rreg/track-fork! new-id (:id room) (:fork-id fork-handle))))
+       (when clone-participants?
+         (doseq [[_id p] @(:participants room)]
+           (when-let [fac (:factory p)]
+             (binding [ec/*execution-context* child-ctx]
+               (join new-room (fac child-ctx))))))
      ;; Control-plane: announce the fork on the peer-bus so dashboards,
      ;; audit logs, and oversight agents see it without subscribing to
      ;; the fork's bus directly.
-     (binding [ec/*execution-context* child-ctx]
-       (peer-bus/post! {:type            :dvergr/fork-created
-                        :dvergr/origin   new-id
-                        :dvergr/parent   (:id room)
-                        :isolation       isolation
-                        :workspace-id    (when (= :ctx isolation)
-                                           (:id (geschichte/current-workspace)))}))
-     new-room)))
+       (binding [ec/*execution-context* child-ctx]
+         (peer-bus/post! {:type            :dvergr/fork-created
+                          :dvergr/origin   new-id
+                          :dvergr/parent   (:id room)
+                          :isolation       isolation
+                          :workspace-id    (when (= :ctx isolation)
+                                             (:id (geschichte/current-workspace)))}))
+       new-room))))
 
 (defn fork-handle
   "Return an isolated Room fork's process-local canonical ForkHandle, or nil.
@@ -1045,6 +1259,257 @@
   "Return the portable world descriptor for an isolated Room fork, or nil."
   [room]
   (some-> (fork-handle room) ygg/fork-descriptor))
+
+(declare fork-home-ctx)
+
+(defn- fork-transfer-children [home fork-id]
+  (binding [ec/*execution-context* home]
+    (rreg/structural-children fork-id)))
+
+(defn- assert-fork-quiescent! [fork home]
+  (when-let [run-id (some-> fork :meta deref :run-id)]
+    (when (some #(= run-id (:run/id %)) (agent-run/active-runs))
+      (throw (ex-info "A Run world cannot transfer while its executor is live"
+                      {:type ::fork-not-quiescent :fork/id (:id fork) :run/id run-id}))))
+  (when (seq @(:participants fork))
+    (throw (ex-info "Fork must be quiescent before authority transfer"
+                    {:type ::fork-not-quiescent
+                     :fork/id (:id fork)
+                     :participants (vec (keys @(:participants fork)))})))
+  (when-let [children (seq (fork-transfer-children home (:id fork)))]
+    (throw (ex-info "Settle transferred child worlds before their parent"
+                    {:type ::fork-has-open-children
+                     :fork/id (:id fork)
+                     :children (mapv :fork/id children)}))))
+
+(defn- detach-transferred-room! [fork home owner]
+  (swap! (:meta fork) assoc fork-transfer-state-key
+         {:state :transferred :owner owner})
+  (binding [ec/*execution-context* home]
+    (rreg/mark-fork-transferred! (:id fork) owner)
+    (rreg/unregister! (:id fork))))
+
+(defn transfer-fork!
+  "Transfer an isolated Room fork's settlement authority to a durable owner.
+
+   `prepare!` is the durability boundary. It is called with the prospective
+   portable descriptor (already naming `new-owner`) *before* live authority is
+   transferred. It must durably record the owner/descriptor as a retained GC
+   root, or throw. A preparation failure leaves the Room registered and its
+   original ForkHandle open.
+
+   On success the executor is quiesced, the original handle becomes stale, and
+   the transient Room disappears from the registry so its Merge/Discard UI
+   cannot compete with the adopter. The returned `:fork/handle` is the sole
+   process-local settlement capability; callers must never persist it. The
+   returned `:fork/descriptor` is data and is the canonical durable identity.
+
+   `abort!` is required and is called with the preparation receipt if the live
+   affine transfer fails. A failed compensation leaves the Room fenced in a
+   visible recovery-required state. Once transfer succeeds the durable owner is
+   authoritative; later projection/event failures never roll it back."
+  [fork new-owner prepare-or-opts]
+  (let [{:keys [prepare! abort!]}
+        (if (fn? prepare-or-opts)
+          {:prepare! prepare-or-opts}
+          prepare-or-opts)]
+    (when-not (fn? prepare!)
+      (throw (ex-info "Fork transfer requires a durable prepare! callback"
+                      {:type ::durable-prepare-required
+                       :fork/id (:id fork)})))
+    (when-not (fn? abort!)
+      (throw (ex-info "Fork transfer requires a durable abort! callback"
+                      {:type ::durable-abort-required
+                       :fork/id (:id fork)})))
+    (when (nil? new-owner)
+      (throw (ex-info "Fork transfer owner cannot be nil"
+                      {:type ::invalid-fork-owner
+                       :fork/id (:id fork)})))
+    (let [home (fork-home-ctx fork)]
+      (when-not (binding [ec/*execution-context* home]
+                  (rreg/lookup (:id fork)))
+        (throw (ex-info "Fork is not live in its parent registry"
+                        {:type ::fork-not-live
+                         :fork/id (:id fork)})))
+      (let [handle (or (fork-handle fork)
+                       (throw (ex-info "Only an isolated context fork can transfer"
+                                       {:type ::fork-not-isolated
+                                        :fork/id (:id fork)})))]
+        (when-not (ygg/open-fork? handle)
+          (throw (ex-info "Fork no longer owns open settlement authority"
+                          {:type ::fork-not-open
+                           :fork/id (:id fork)
+                           :fork/descriptor (ygg/fork-descriptor handle)})))
+        (let [prepared? (volatile! false)
+              receipt* (volatile! nil)
+              listeners* (volatile! [])
+              fence-token* (volatile! nil)
+              {:keys [adopted receipt descriptor]}
+              (try
+                ;; No worker may retain a capability into a substrate once
+                ;; ownership moves. Listener drain atomically installs the Room
+                ;; fence and closes Run admission at one lifecycle frontier.
+                (vreset! listeners* (drain-room-listeners! fork :transfer))
+                (vreset! fence-token*
+                         (get-in @(:meta fork) [fork-transfer-state-key :token]))
+                (drain-room-runs! fork)
+                ;; Once every admitted Run has physically stopped, retire its
+                ;; causal-post allowance before durable preparation or authority
+                ;; transfer can observe/move the branch.
+                (seal-room-quiescence! fork :transfer)
+                (assert-fork-quiescent! fork home)
+                (let [parent (binding [ec/*execution-context* home]
+                               (rreg/lookup (:parent-id fork)))
+                      parent-fork-id (some-> parent fork-handle ygg/fork-descriptor :fork/id)
+                      portable-ancestry {:dvergr/room-id (:id fork)
+                                         :dvergr/parent-room-id (:parent-id fork)
+                                         :dvergr/parent-fork-id parent-fork-id}
+                      prospective (merge (ygg/fork-descriptor handle)
+                                         portable-ancestry
+                                         {:fork/owner new-owner
+                                          :fork/status :open})
+                      receipt (prepare! prospective)]
+                  (vreset! prepared? true)
+                  (vreset! receipt* receipt)
+                  ;; Defense in depth against code bypassing public APIs and
+                  ;; mutating participant/topology state during preparation.
+                  (assert-fork-quiescent! fork home)
+                  (let [adopted (ygg/transfer-fork! handle new-owner)]
+                    {:adopted adopted
+                     :receipt receipt
+                     :descriptor (merge (ygg/fork-descriptor adopted)
+                                        portable-ancestry)}))
+                (catch Throwable error
+                  (let [abort-error (when @prepared?
+                                      (try
+                                        (abort! @receipt*)
+                                        nil
+                                        (catch Throwable compensation-error
+                                          compensation-error)))]
+                    (cond
+                      (= ::listener-drain-timeout (:type (ex-data error)))
+                      (do
+                        (swap! (:meta fork) update fork-transfer-state-key
+                               assoc
+                               :state :recovery-required
+                               :owner new-owner
+                               :error (ex-message error))
+                        (throw error))
+
+                      abort-error
+                      (do
+                        (swap! (:meta fork) update fork-transfer-state-key
+                               assoc
+                               :state :recovery-required
+                               :owner new-owner
+                               :error (ex-message abort-error))
+                        (throw (ex-info "Fork transfer compensation failed; recovery is required"
+                                        {:type ::fork-transfer-recovery-required
+                                         :fork/id (:id fork)
+                                         :fork/owner new-owner
+                                         :transfer-error (ex-message error)
+                                         :abort-error (ex-message abort-error)}
+                                        abort-error)))
+
+                      (ygg/open-fork? handle)
+                      (let [restore-error (try
+                                            (restore-room-listeners! fork @listeners*)
+                                            nil
+                                            (catch Throwable listener-error
+                                              listener-error))]
+                        (if restore-error
+                          (do
+                            (swap! (:meta fork) update fork-transfer-state-key
+                                   assoc
+                                   :state :recovery-required
+                                   :owner new-owner
+                                   :error (ex-message restore-error))
+                            (throw (ex-info "Fork listener restoration failed; recovery is required"
+                                            {:type ::fork-transfer-recovery-required
+                                             :fork/id (:id fork)
+                                             :fork/owner new-owner
+                                             :transfer-error (ex-message error)
+                                             :restore-error (ex-message restore-error)}
+                                            restore-error)))
+                          (let [recovered?
+                                (agent-run/recover-room-admission!
+                                 fork
+                                 (fn []
+                                   (locking (:meta fork)
+                                     (when (= @fence-token*
+                                              (get-in @(:meta fork)
+                                                      [fork-transfer-state-key :token]))
+                                       (swap! (:meta fork) dissoc fork-transfer-state-key)
+                                       true))))]
+                            (if recovered?
+                              (throw error)
+                              (throw (ex-info "Fork lifecycle changed during transfer recovery"
+                                              {:type ::fork-transfer-recovery-required
+                                               :fork/id (:id fork)
+                                               :fork/owner new-owner
+                                               :transfer-error (ex-message error)}
+                                              error))))))
+
+                      :else
+                      (do
+                        ;; Another claimant owns the affine capability. Keep
+                        ;; the stale Room inert and detach it from execution.
+                        (detach-transferred-room! fork home :external-claimant)
+                        (throw error))))))]
+         ;; Keep the stale original handle on the detached Room object. Any
+         ;; leaked reference fails affine authority checks instead of silently
+         ;; becoming a store-less conversational fork.
+          (detach-transferred-room! fork home new-owner)
+          (swap! (:meta fork) assoc :fork-transferred-to new-owner)
+          (binding [ec/*execution-context* home]
+            (try
+              (peer-bus/post! {:type :dvergr/fork-transferred
+                               :dvergr/origin (:id fork)
+                               :dvergr/parent (:parent-id fork)
+                               :fork/id (:fork/id descriptor)
+                               :fork/owner new-owner})
+              (catch Throwable error
+                (tel/log! {:level :warn
+                           :id ::fork-transfer-event-failed
+                           :data {:fork (:id fork)
+                                  :owner new-owner
+                                  :error (ex-message error)}}
+                          "Fork authority transferred but its peer event failed"))))
+          {:fork/handle adopted
+           :fork/descriptor descriptor
+           :fork/receipt receipt
+           :fork/room-id (:id fork)
+           :fork/parent-id (:parent-id fork)})))))
+
+(defn release-transferred-fork!
+  "Release a transferred child's structural parent claim after settlement.
+
+   Accepts the map returned by `transfer-fork!`. The adopted handle must already
+   be merged or discarded; an open handle cannot release ancestry."
+  [{:fork/keys [handle room-id descriptor]}]
+  (when-not (and (ygg/fork-handle? handle)
+                 (= (:fork/id descriptor) (:fork-id handle)))
+    (throw (ex-info "Transferred fork handle does not match its descriptor"
+                    {:type ::transferred-fork-identity-mismatch
+                     :fork/id room-id
+                     :fork/descriptor-id (:fork/id descriptor)
+                     :fork/handle-id (some-> handle :fork-id)})))
+  (when-not (= room-id (:dvergr/room-id descriptor))
+    (throw (ex-info "Transferred fork Room identity does not match its descriptor"
+                    {:type ::transferred-fork-identity-mismatch
+                     :fork/id room-id
+                     :fork/descriptor-room-id (:dvergr/room-id descriptor)})))
+  (let [{:keys [status token]} @(:authority handle)]
+    (when-not (and (contains? #{:merged :discarded} status)
+                   (= token (:token handle)))
+      (throw (ex-info "Transferred fork has not settled with this authority"
+                      {:type ::transferred-fork-not-settled
+                       :fork/id room-id
+                       :fork/status status
+                       :fork/current-authority? (= token (:token handle))}))))
+  (binding [ec/*execution-context* (:parent-ctx handle)]
+    (rreg/untrack-fork! room-id (:fork-id handle)))
+  nil)
 
 (defmacro with-fork-ctx
   "Execute `body` with the fork's execution context bound. Required for
@@ -1099,20 +1564,26 @@
   ;; Idempotence: once unregistered, the fork is a zombie — re-discarding would
   ;; double-delete the yggdrasil branch (which errors). Guard on registry.
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
-    (drain-room-runs! fork)                    ; stop work before removing its substrate
-    (leave-all! fork)
-    (when-let [handle (fork-handle fork)]
-      ;; P2: settle the substrate first, then drop deferred grants explicitly.
-      ;; If grant cleanup fails, retrying `discard` replays the cached settlement
-      ;; and retries only this idempotent integration step.
-      (let [pending (binding [ec/*execution-context* (:ctx fork)]
-                      (ec/get-state [:dvergr/pending-grants]))]
-        (ygg/discard-fork! handle)
-        (srooms/drop-fork-grants! pending)))
-    (binding [ec/*execution-context* (fork-home-ctx fork)]
-      (rreg/unregister! (:id fork))
-      (peer-bus/post! {:type :dvergr/fork-discarded
-                       :dvergr/origin (:id fork)})))
+    (let [callbacks (drain-room-listeners! fork :discard)]
+      (try
+        (drain-room-runs! fork)                ; stop work before removing its substrate
+        (seal-room-quiescence! fork :discard)
+        (when-let [handle (fork-handle fork)]
+          ;; P2: settle the substrate first, then drop deferred grants explicitly.
+          ;; If grant cleanup fails, retrying `discard` replays the cached settlement
+          ;; and retries only this idempotent integration step.
+          (let [pending (binding [ec/*execution-context* (:ctx fork)]
+                          (ec/get-state [:dvergr/pending-grants]))]
+            (ygg/discard-fork! handle)
+            (srooms/drop-fork-grants! pending)))
+        (leave-all! fork)
+        (binding [ec/*execution-context* (fork-home-ctx fork)]
+          (rreg/untrack-fork! (:id fork) (some-> fork fork-handle :fork-id))
+          (rreg/unregister! (:id fork))
+          (peer-bus/post! {:type :dvergr/fork-discarded
+                           :dvergr/origin (:id fork)}))
+        (catch Throwable error
+          (recover-room-quiescence! fork callbacks error)))))
   fork)
 
 (defn merge-room
@@ -1132,7 +1603,10 @@
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
   ([parent fork {:keys [merge-opts]}]
-   (drain-room-runs! fork)                     ; stop work before merging its substrate
+   (let [callbacks (drain-room-listeners! fork :merge)]
+     (try
+       (drain-room-runs! fork)                 ; stop work before merging its substrate
+       (seal-room-quiescence! fork :merge)
    ;; (1) SUBSTRATE merge — branched yggdrasil systems (CRDTs, datahike, git) fold
    ;; back whenever the ctx was forked (`:isolation :ctx`), INDEPENDENT of any
    ;; conversation store. These are orthogonal: a room can carry shared CRDTs with
@@ -1141,47 +1615,50 @@
    ;; branch also collapses here (bringing its messages into the parent's
    ;; conversation under the shared :chat/id); its deferred data-DB grants commit on
    ;; accept via :on-merge (store forks only). (doc/unified-fork-conversation.md)
-   (when-let [handle (fork-handle fork)]
-     (try
-       (let [pending (when (:store fork)
-                       (binding [ec/*execution-context* (:ctx fork)]
-                         (ec/get-state [:dvergr/pending-grants])))]
-         (ygg/merge-fork! handle (or merge-opts {}))
+       (when-let [handle (fork-handle fork)]
+         (try
+           (let [pending (when (:store fork)
+                           (binding [ec/*execution-context* (:ctx fork)]
+                             (ec/get-state [:dvergr/pending-grants])))]
+             (ygg/merge-fork! handle (or merge-opts {}))
          ;; Grant integration is deliberately outside substrate settlement. A
          ;; failure leaves the handle truthfully :merged and a retry replays the
          ;; cached merge before retrying this idempotent commit.
-         (when (:store fork)
-           (srooms/commit-fork-grants! pending)))
-       (catch Throwable e
-         (tel/log! {:level :error :id :dvergr/merge-failed
-                    :data {:fork (:id fork) :parent (:id parent) :error (str e)}}
-                   "merge-room: affine yggdrasil settlement failed")
-         (binding [ec/*execution-context* (fork-home-ctx fork)]
-           (peer-bus/post! {:type :dvergr/merge-failed :dvergr/origin (:id fork)
-                            :dvergr/parent (:id parent) :error (str e)}))
-         (throw e))))
+             (when (:store fork)
+               (srooms/commit-fork-grants! pending)))
+           (catch Throwable e
+             (tel/log! {:level :error :id :dvergr/merge-failed
+                        :data {:fork (:id fork) :parent (:id parent) :error (str e)}}
+                       "merge-room: affine yggdrasil settlement failed")
+             (binding [ec/*execution-context* (fork-home-ctx fork)]
+               (peer-bus/post! {:type :dvergr/merge-failed :dvergr/origin (:id fork)
+                                :dvergr/parent (:id parent) :error (str e)}))
+             (throw e))))
    ;; (2) CONVERSATION merge — for STORE-LESS forks (`:isolation :none`, or a `:ctx`
    ;; fork without a message store), absorb the fork's post-fork bus entries into the
    ;; parent's log (merge-as-history; no re-firing of live handlers, separate buses).
    ;; A `:store` fork's messages already arrived via the datahike collapse in (1).
-   (when-not (:store fork)
-     (let [forked-at   (or (:forked-at-len fork) 0)
-           fork-log    (log fork)
-           new-entries (when (> (count fork-log) forked-at) (subvec fork-log forked-at))]
-       (when (seq new-entries)
-         (bus/append-log! (:bus parent) new-entries))))
+       (when-not (:store fork)
+         (let [forked-at   (or (:forked-at-len fork) 0)
+               fork-log    (log fork)
+               new-entries (when (> (count fork-log) forked-at) (subvec fork-log forked-at))]
+           (when (seq new-entries)
+             (bus/append-log! (:bus parent) new-entries))))
   ;; Surface the merged conversation: re-seed the parent's shared message signal
   ;; (no-op if the parent has no signal) so every frontend re-renders — the merge
   ;; is a datahike collapse / log append, not a bus post.
-   (try ((requiring-resolve 'dvergr.rooms.messages/refresh!) parent)
-        (catch Throwable _ nil))
-   (leave-all! fork)
-   (binding [ec/*execution-context* (fork-home-ctx fork)]
-     (rreg/unregister! (:id fork))
-     (peer-bus/post! {:type            :dvergr/fork-merged
-                      :dvergr/origin   (:id fork)
-                      :dvergr/parent   (:id parent)}))
-   parent))
+       (try ((requiring-resolve 'dvergr.rooms.messages/refresh!) parent)
+            (catch Throwable _ nil))
+       (leave-all! fork)
+       (binding [ec/*execution-context* (fork-home-ctx fork)]
+         (rreg/untrack-fork! (:id fork) (some-> fork fork-handle :fork-id))
+         (rreg/unregister! (:id fork))
+         (peer-bus/post! {:type            :dvergr/fork-merged
+                          :dvergr/origin   (:id fork)
+                          :dvergr/parent   (:id parent)}))
+       parent
+       (catch Throwable error
+         (recover-room-quiescence! fork callbacks error))))))
 
 ;; ============================================================================
 ;; PR-style merge review

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -17,6 +17,7 @@
   (:require [dvergr.runtime.ctx :as rctx]))
 
 (def ^:private registry-path [:dvergr/rooms])
+(def ^:private fork-topology-path [:dvergr/fork-topology])
 
 ;; Callbacks run (with the room-id) AFTER a room is unregistered. Lets
 ;; dependents (e.g. dvergr.agent.room-context) tear down per-room resources
@@ -88,6 +89,65 @@
   "Rooms whose :parent-id matches the given id. Order undefined."
   [parent-id]
   (list-rooms :where #(= parent-id (:parent-id %))))
+
+(defn track-fork!
+  "Record structural ownership of an isolated child world independently of
+   transient Room/UI registration. The link survives authority transfer and is
+   removed only after the child world has actually settled."
+  [child-id parent-id ygg-fork-id]
+  (rctx/shared-swap-state!
+   fork-topology-path
+   (fn [topology]
+     (assoc (or topology {}) child-id
+            {:fork/id child-id
+             :fork/parent-id parent-id
+             :fork/ygg-id ygg-fork-id
+             :fork/state :local})))
+  nil)
+
+(defn mark-fork-transferred!
+  "Mark a tracked child as externally owned without releasing its parent link."
+  [child-id owner]
+  (rctx/shared-swap-state!
+   fork-topology-path
+   (fn [topology]
+     (update (or topology {}) child-id
+             (fn [entry]
+               (assoc (or entry {:fork/id child-id})
+                      :fork/state :transferred
+                      :fork/owner owner)))))
+  nil)
+
+(defn untrack-fork!
+  "Release a structural child link only when its Yggdrasil fork identity
+   matches. Missing entries are idempotent; mismatches are rejected."
+  [child-id expected-ygg-fork-id]
+  (let [result (volatile! :missing)]
+    (rctx/shared-swap-state!
+     fork-topology-path
+     (fn [topology]
+       (let [topology (or topology {})
+             entry (get topology child-id)]
+         (cond
+           (nil? entry) topology
+           (= expected-ygg-fork-id (:fork/ygg-id entry))
+           (do (vreset! result :released) (dissoc topology child-id))
+           :else
+           (do (vreset! result entry) topology)))))
+    (when (map? @result)
+      (throw (ex-info "Structural fork identity mismatch"
+                      {:type ::fork-identity-mismatch
+                       :fork/id child-id
+                       :fork/expected-ygg-id (:fork/ygg-id @result)
+                       :fork/actual-ygg-id expected-ygg-fork-id}))))
+  nil)
+
+(defn structural-children
+  "Return open structural child-world projections for `parent-id`."
+  [parent-id]
+  (->> (vals (or (rctx/shared-get-state fork-topology-path) {}))
+       (filter #(= parent-id (:fork/parent-id %)))
+       vec))
 
 (defn roots
   "Rooms with no parent (top-level)."

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -337,3 +337,34 @@
                                               :review-rejected))
       {:ok? true})
     (catch Throwable t {:ok? false :error (.getMessage t)})))
+
+(defn adopt!
+  "Promote a retained isolated fork into an external durable owner.
+
+   `opts` is passed to `discourse/transfer-fork!` and must contain durable
+   `:prepare!` and compensating `:abort!` callbacks. The returned ForkHandle is live
+   process-local authority for the adopter. When this is a Run world, its
+   durable projection is correlated as `:adopted`; a projection failure is
+   reported without hiding the already-transferred capability.
+
+   Adoption transfers the whole world. Per-system decisions require a future
+   affine partition primitive; callers must not settle descriptor systems by
+   bypassing the returned handle."
+  [fork new-owner opts]
+  (try
+    (let [parent (rreg/lookup (:parent-id fork))
+          run-id (some-> fork :meta deref :run-id)
+          transfer (d/transfer-fork! fork new-owner opts)
+          projection-error
+          (when (and parent run-id)
+            (try
+              (agent-run/update-durable-settlement! parent run-id :adopted
+                                                    :governance-transfer)
+              nil
+              (catch Throwable error error)))]
+      (cond-> (assoc transfer :ok? true)
+        projection-error
+        (assoc :warning "Fork transferred, but the Run settlement projection was not updated"
+               :projection-error (ex-message projection-error))))
+    (catch Throwable error
+      {:ok? false :error (ex-message error)})))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -22,7 +22,8 @@
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.engine.context :as context]
             [org.replikativ.spindel.engine.core :as ec]
-            [org.replikativ.spindel.spin.combinators :as comb]))
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.yggdrasil :as ygg]))
 
 (defn- test-roster []
   (-> (roster/make-roster {:id :test-team})
@@ -141,6 +142,29 @@
           (is (= :merged (:fork/status (d/fork-descriptor fork))))
           (is (= :merged (:run/settlement-status
                           (program/observe room handle))))))
+      (testing "review authority can be promoted to durable governance"
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire! room team :analyst
+                                      {:task "governed proposal" :settlement :review}))
+              _result (binding [ec/*execution-context* (:ctx room)] @handle)
+              durable (program/observe room handle)
+              fork (binding [ec/*execution-context* (:ctx room)]
+                     (registry/lookup (:run/world durable)))
+              proposal-id (random-uuid)
+              prepared (atom nil)
+              transfer (binding [ec/*execution-context* (:ctx room)]
+                         (forks/adopt! fork proposal-id
+                                       {:prepare! #(reset! prepared %)
+                                        :abort! (fn [_])}))]
+          (is (:ok? transfer) (pr-str transfer))
+          (is (= proposal-id (:fork/owner @prepared)))
+          (is (= :adopted (:run/settlement-status
+                           (program/observe room handle))))
+          (is (binding [ec/*execution-context* (:ctx room)]
+                (nil? (registry/lookup (:run/world durable)))))
+          ;; The governance owner, not the detached Run world, now settles it.
+          (is (nil? (ygg/discard-fork! (:fork/handle transfer))))
+          (d/release-transferred-fork! transfer)))
       (testing "discard removes a successful work plane"
         (let [handle (binding [ec/*execution-context* (:ctx room)]
                        (program/hire! room team :analyst
@@ -516,10 +540,10 @@
         (let [hiring (future
                        (binding [ec/*execution-context* (:ctx room)]
                          (program/hire! room team :worker {:task "stop"})))
-              _ (is (= true (deref entered-post 1000 ::timeout)))
+              _ (is (= true (deref entered-post 5000 ::timeout)))
               run-id (:run/id (first (run/active-runs (:id room))))
               closing (future (d/close-room! room))]
-          (is (wait-until #(run/cancel-requested? run-id) 1000))
+          (is (wait-until #(run/cancel-requested? run-id) 5000))
           (deliver release-post true)
           (let [handle (deref hiring 2000 ::timeout)]
             (is (not= ::timeout handle))
@@ -694,10 +718,10 @@
               (future
                 (binding [ec/*execution-context* (:ctx room)]
                   (program/hire! room team :slow {:task "racing close"})))
-              _ (is (= true (deref entered-post 1000 ::timeout)))
+              _ (is (= true (deref entered-post 5000 ::timeout)))
               admitted-id (:run/id (first (run/active-runs (:id room))))
               close-future (future (d/close-room! room))]
-          (is (wait-until #(run/cancel-requested? admitted-id) 1000)
+          (is (wait-until #(run/cancel-requested? admitted-id) 5000)
               "close fenced admission and found the reserved Run")
           (is (false? (realized? close-future))
               "teardown waits rather than removing the substrate")

--- a/test/dvergr/agent/run_test.clj
+++ b/test/dvergr/agent/run_test.clj
@@ -159,6 +159,42 @@
       (finally
         (d/close-room! room)))))
 
+(deftest recovery-reopens-only-the-exact-room-fence
+  (let [[room _st] (run-room :admission-recovery)
+        meta (:meta room)
+        old-token (random-uuid)
+        newer-token (random-uuid)
+        trigger (d/message :alice :agent "work")]
+    (try
+      (run/close-room-admission! room)
+      (swap! meta assoc :test/fence {:token newer-token})
+      (is (nil?
+           (run/recover-room-admission!
+            room
+            (fn []
+              (locking meta
+                (when (= old-token (get-in @meta [:test/fence :token]))
+                  (swap! meta dissoc :test/fence)
+                  true))))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"admission is closed"
+           (run/start! room :agent trigger (live-ctx)))
+          "stale recovery cannot reopen admission beneath a newer fence")
+      (is (true?
+           (run/recover-room-admission!
+            room
+            (fn []
+              (locking meta
+                (when (= newer-token (get-in @meta [:test/fence :token]))
+                  (swap! meta dissoc :test/fence)
+                  true))))))
+      (let [started (run/start! room :agent trigger (live-ctx))]
+        (is (nil? (:test/fence @meta)))
+        (run/finish! (:run/id started) :completed))
+      (finally
+        (d/close-room! room)))))
+
 (deftest lifecycle-publication-requires-durable-receipts
   (let [base (memory/make)
         receipts? (atom false)

--- a/test/dvergr/discourse_test.clj
+++ b/test/dvergr/discourse_test.clj
@@ -267,6 +267,47 @@
                           parent-owned))))
       (is (nil? (d/close-room! parent)) "close is idempotent"))))
 
+(deftest concurrent-close-contender-does-not-corrupt-owner-fence
+  (let [room (d/room :concurrent-close-fence)
+        entered (promise)
+        release (promise)]
+    (try
+      (d/on-each-message room
+                         (fn [_]
+                           (deliver entered true)
+                           @release))
+      (d/post! room (d/message :human nil "hold close drain"))
+      (is (= true (deref entered 2000 ::timeout)))
+      (let [owner (future (d/close-room! room))
+            deadline (+ (System/currentTimeMillis) 2000)
+            owner-fence
+            (loop []
+              (let [state (:dvergr/fork-transfer-state @(:meta room))]
+                (cond
+                  (= :tearing-down (:state state)) state
+                  (< (System/currentTimeMillis) deadline)
+                  (do (Thread/yield) (recur))
+                  :else ::timeout)))]
+        (is (map? owner-fence))
+        (let [contender-error
+              (try
+                (d/close-room! room)
+                nil
+                (catch clojure.lang.ExceptionInfo error error))]
+          (is (= ::d/room-lifecycle-in-progress
+                 (:type (ex-data contender-error))))
+          (is (= owner-fence
+                 (:dvergr/fork-transfer-state @(:meta room)))
+              "a losing close preserves the owner's token and causal allowlist"))
+        (deliver release true)
+        (is (nil? (deref owner 5000 ::timeout)))
+        (is (= :closed
+               (get-in @(:meta room)
+                       [:dvergr/fork-transfer-state :state]))))
+      (finally
+        (deliver release true)
+        (d/close-room! room)))))
+
 (deftest forked-participant-operates-on-its-joined-room
   (testing "a participant cloned into a fork sees the FORK as its room
             (discourse/join sets :room on the participant), not the parent it

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -7,10 +7,12 @@
    - discard emits :dvergr/fork-discarded
    - pending-proposals scans a room's log"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [dvergr.agent.run :as agent-run]
             [dvergr.runtime.bus :as bus]
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.discourse :as d]
             [dvergr.intake.bash :as b]
+            [dvergr.room.registry :as registry]
             [dvergr.runtime.peer-bus :as peer-bus]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]))
@@ -130,6 +132,360 @@
       (let [evts (peer-events-of-type :dvergr/fork-discarded)]
         (is (= 1 (count evts)))
         (is (= (:id fork) (:dvergr/origin (first evts))))))))
+
+(deftest fork-transfer-is-durability-first-and-affine
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :transfer-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          original (d/fork-handle fork)
+          owner (random-uuid)
+          prepared (atom nil)
+          sealed-post-error (atom nil)
+          admitted-run (agent-run/start!
+                        fork :worker (d/message :human :worker "work") nil)
+          admitted-run-id (:run/id admitted-run)
+          _cancel-hook (agent-run/register-cancel-hook!
+                        admitted-run-id :test-finish
+                        #(agent-run/finish! admitted-run-id :cancelled))
+          listener (d/on-each-message fork (fn [_]))]
+      (bash (:ctx fork) "echo adopted > adopted.txt && git add . && git commit -q -m adopted")
+      (let [{:fork/keys [handle descriptor receipt] :as transfer}
+            (d/transfer-fork! fork owner
+                              {:prepare! (fn [prospective]
+                                           (reset! prepared prospective)
+                                           (reset! sealed-post-error
+                                                   (try
+                                                     (d/post! fork
+                                                              (d/message
+                                                               :worker nil "too late"
+                                                               nil {:run-id admitted-run-id}))
+                                                     nil
+                                                     (catch clojure.lang.ExceptionInfo error
+                                                       error)))
+                                           {:proposal owner})
+                               :abort! (fn [_])})]
+        (is (= @prepared descriptor))
+        (is (= {:proposal owner} receipt))
+        (is (= owner (:fork/owner descriptor)))
+        (is (= (:id fork) (:dvergr/room-id descriptor)))
+        (is (= (:id parent) (:dvergr/parent-room-id descriptor)))
+        (is (= ::d/fork-transfer-in-progress
+               (:type (ex-data @sealed-post-error)))
+            "durable preparation starts after admitted Run posting is sealed")
+        (is (not (ygg/open-fork? original))
+            "the Run/Room capability is stale after transfer")
+        (is (ygg/open-fork? handle))
+        (is (nil? (registry/lookup (:id fork)))
+            "raw Room merge/discard controls disappear")
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transferred"
+                              (ygg/discard-fork! original)))
+        (is (= ::d/fork-transfer-in-progress
+               (:type (ex-data (try
+                                 (d/post! fork (d/message :human nil "late"))
+                                 (catch clojure.lang.ExceptionInfo error error))))))
+        (is (= ::d/fork-transfer-in-progress
+               (:type (ex-data (try
+                                 (binding [ec/*execution-context* (:ctx fork)]
+                                   @(d/ask fork :nobody {:content "late"}))
+                                 (catch clojure.lang.ExceptionInfo error error))))))
+        (ygg/merge-fork! handle)
+        (d/release-transferred-fork! transfer)
+        (is (= "adopted\n" (:stdout (bash (:ctx parent) "cat adopted.txt"))))
+        (Thread/sleep 50)
+        (let [events (peer-events-of-type :dvergr/fork-transferred)]
+          (is (= 1 (count events)))
+          (is (= owner (:fork/owner (first events)))))))))
+
+(deftest failed-transfer-preparation-preserves-the-review-world
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :failed-transfer-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          original (d/fork-handle fork)
+          relayed (promise)
+          _listener (d/on-each-message fork (fn [_] (deliver relayed true)))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"prepare failed"
+                            (d/transfer-fork! fork (random-uuid)
+                                              {:prepare! (fn [_]
+                                                           (throw (ex-info "prepare failed" {})))
+                                               :abort! (fn [_])})))
+      (is (ygg/open-fork? original))
+      (is (identical? fork (registry/lookup (:id fork))))
+      (is (= :open (binding [ec/*execution-context* (:ctx fork)]
+                     (ec/get-state [:dvergr/run-admissions (:id fork)])))
+          "failed preparation reopens Run admission")
+      (d/post! fork (d/message :human nil "listener restored"))
+      (is (= true (deref relayed 2000 ::timeout))
+          "recoverable transfer failure reinstalls Room-owned listeners")
+      (d/discard fork))))
+
+(deftest transfer-waits-for-an-active-listener-callback
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :transfer-listener-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          entered (promise)
+          release (promise)
+          _listener (d/on-each-message
+                     fork
+                     (fn [_]
+                       (deliver entered true)
+                       @release))]
+      (d/post! fork (d/message :human nil "block relay"))
+      (is (= true (deref entered 2000 ::timeout)))
+      (let [transfer-future
+            (future
+              (binding [ec/*execution-context* *base-ctx*]
+                (d/transfer-fork! fork :owner
+                                  {:prepare! (fn [_] :row)
+                                   :abort! (fn [_])})))]
+        (Thread/sleep 100)
+        (is (not (realized? transfer-future))
+            "authority cannot move while callback code is still executing")
+        (deliver release true)
+        (let [transfer (deref transfer-future 5000 ::timeout)]
+          (is (map? transfer))
+          (ygg/discard-fork! (:fork/handle transfer))
+          (d/release-transferred-fork! transfer))))))
+
+(deftest transfer-requires-compensation-before-fencing-the-room
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :transfer-contract-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          error (try
+                  (d/transfer-fork! fork :owner {:prepare! identity})
+                  (catch clojure.lang.ExceptionInfo error error))]
+      (is (= ::d/durable-abort-required (:type (ex-data error))))
+      (is (ygg/open-fork? (d/fork-handle fork)))
+      (is (identical? fork (registry/lookup (:id fork))))
+      (d/discard fork))))
+
+(deftest transfer-fence-rejects-participants-and-children-during-prepare
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :transfer-fence-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          join-error (atom nil)
+          child-error (atom nil)
+          post-error (atom nil)
+          ask-error (atom nil)
+          listener-error (atom nil)
+          transfer
+          (d/transfer-fork!
+           fork :governance
+           {:prepare!
+            (fn [_]
+              (reset! join-error
+                      (try
+                        (d/join fork (d/participant {:id :late
+                                                     :on-message (fn [_ _] nil)}))
+                        (catch clojure.lang.ExceptionInfo error error)))
+              (reset! child-error
+                      (try
+                        (d/fork-room fork {:isolation :ctx})
+                        (catch clojure.lang.ExceptionInfo error error)))
+              (reset! post-error
+                      (try
+                        (d/post! fork (d/message :human nil "late"))
+                        (catch clojure.lang.ExceptionInfo error error)))
+              (reset! ask-error
+                      (try
+                        (binding [ec/*execution-context* (:ctx fork)]
+                          @(d/ask fork :nobody {:content "late"}))
+                        (catch clojure.lang.ExceptionInfo error error)))
+              (reset! listener-error
+                      (try
+                        (d/on-each-message fork (fn [_]))
+                        (catch clojure.lang.ExceptionInfo error error)))
+              :prepared)
+            :abort! (fn [_])})]
+      (is (= ::d/fork-transfer-in-progress
+             (:type (ex-data @join-error))))
+      (is (= ::d/fork-transfer-in-progress
+             (:type (ex-data @child-error))))
+      (is (= ::d/fork-transfer-in-progress
+             (:type (ex-data @post-error))))
+      (is (= ::d/fork-transfer-in-progress
+             (:type (ex-data @ask-error))))
+      (is (= ::d/fork-transfer-in-progress
+             (:type (ex-data @listener-error))))
+      (ygg/discard-fork! (:fork/handle transfer))
+      (d/release-transferred-fork! transfer))))
+
+(deftest failed-compensation-keeps-the-world-fenced-for-recovery
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :transfer-recovery-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          original (d/fork-handle fork)
+          error (try
+                  (d/transfer-fork!
+                   fork :owner
+                   {:prepare! (fn [_]
+                                (ygg/transfer-fork! original :winner)
+                                :prepared)
+                    :abort! (fn [_]
+                              (throw (ex-info "durable rollback failed" {})))})
+                  (catch clojure.lang.ExceptionInfo error error))]
+      (is (= ::d/fork-transfer-recovery-required (:type (ex-data error))))
+      (is (= :closed (binding [ec/*execution-context* (:ctx fork)]
+                       (ec/get-state [:dvergr/run-admissions (:id fork)]))))
+      (is (= :recovery-required
+             (get-in @(:meta fork) [:dvergr/fork-transfer-state :state])))
+      ;; The test deliberately lost the winner handle; this verifies fencing,
+      ;; not cleanup of a simulated external claimant.
+      (registry/unregister! (:id fork)))))
+
+(deftest transfer-race-aborts-the-durable-preparation
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :transfer-race-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          original (d/fork-handle fork)
+          winner (atom nil)
+          aborted (atom nil)
+          result (try
+                   (d/transfer-fork!
+                    fork (random-uuid)
+                    {:prepare!
+                     (fn [_]
+                       ;; Models another claimant winning after our durable
+                       ;; prepare but before our affine CAS.
+                       (reset! winner (ygg/transfer-fork! original :winner))
+                       :prepared-row)
+                     :abort! #(reset! aborted %)})
+                   (catch clojure.lang.ExceptionInfo error error))]
+      (is (= :prepared-row @aborted))
+      (is (= :winner (:fork/owner (ygg/fork-descriptor @winner))))
+      (is (ygg/open-fork? @winner))
+      (is (nil? (registry/lookup (:id fork)))
+          "a stale claimant is detached from executable Room lookup")
+      (is (= :closed (binding [ec/*execution-context* (:ctx fork)]
+                       (ec/get-state [:dvergr/run-admissions (:id fork)]))))
+      (ygg/discard-fork! @winner)
+      (d/release-transferred-fork! {:fork/handle @winner
+                                    :fork/room-id (:id fork)
+                                    :fork/descriptor (assoc (ygg/fork-descriptor @winner)
+                                                            :dvergr/room-id (:id fork))})
+      (is (= ::ygg/stale-fork-handle (:type (ex-data result)))))))
+
+(deftest parent-transfer-requires-children-to-settle-first
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [root (d/room :transfer-tree-root *base-ctx*)
+          parent (d/fork-room root {:isolation :ctx})
+          child (binding [ec/*execution-context* (:ctx parent)]
+                  (d/fork-room parent {:isolation :ctx}))
+          prepared? (atom false)
+          error (try
+                  (d/transfer-fork! parent (random-uuid)
+                                    {:prepare! #(do (reset! prepared? true) %)
+                                     :abort! (fn [_])})
+                  (catch clojure.lang.ExceptionInfo error error))]
+      (is (= ::d/fork-has-open-children (:type (ex-data error))))
+      (is (false? @prepared?)
+          "structural ownership is checked before durable proposal creation")
+      (is (ygg/open-fork? (d/fork-handle parent)))
+      (is (ygg/open-fork? (d/fork-handle child)))
+      (binding [ec/*execution-context* (:ctx parent)]
+        (d/discard child))
+      (d/discard parent))))
+
+(deftest transferred-child-remains-structurally-owned-until-settlement
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [root (d/room :transfer-adopted-tree-root *base-ctx*)
+          parent (d/fork-room root {:isolation :ctx})
+          child (binding [ec/*execution-context* (:ctx parent)]
+                  (d/fork-room parent {:isolation :ctx}))
+          child-transfer
+          (d/transfer-fork! child :child-owner
+                            {:prepare! (fn [_] :child-row)
+                             :abort! (fn [_])})
+          blocked (try
+                    (d/transfer-fork! parent :parent-owner
+                                      {:prepare! (fn [_] :parent-row)
+                                       :abort! (fn [_])})
+                    (catch clojure.lang.ExceptionInfo error error))]
+      (is (= ::d/fork-has-open-children (:type (ex-data blocked))))
+      (let [stale (:fork/handle child-transfer)
+            successor (ygg/transfer-fork! stale :successor)]
+        (is (= ::d/transferred-fork-not-settled
+               (:type (ex-data (try
+                                 (d/release-transferred-fork! child-transfer)
+                                 (catch clojure.lang.ExceptionInfo error error))))))
+        (ygg/discard-fork! successor)
+        (is (= ::d/transferred-fork-identity-mismatch
+               (:type (ex-data
+                       (try
+                         (d/release-transferred-fork!
+                          (assoc child-transfer
+                                 :fork/handle successor
+                                 :fork/room-id (:id parent)))
+                         (catch clojure.lang.ExceptionInfo error error))))))
+        (d/release-transferred-fork! (assoc child-transfer :fork/handle successor)))
+      (let [parent-transfer
+            (d/transfer-fork! parent :parent-owner
+                              {:prepare! (fn [_] :parent-row)
+                               :abort! (fn [_])})]
+        (ygg/discard-fork! (:fork/handle parent-transfer))
+        (d/release-transferred-fork! parent-transfer)))))
+
+(deftest transferred-ancestry-requires-a-terminal-authority-state
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [root (d/room :transfer-terminal-root *base-ctx*)
+          fork (d/fork-room root {:isolation :ctx})
+          transfer (d/transfer-fork! fork :owner
+                                     {:prepare! (fn [_] :row)
+                                      :abort! (fn [_])})
+          handle (:fork/handle transfer)
+          authority (:authority handle)
+          open-state @authority]
+      (doseq [status [:settling :incomplete]]
+        (swap! authority assoc :status status)
+        (is (= ::d/transferred-fork-not-settled
+               (:type (ex-data (try
+                                 (d/release-transferred-fork! transfer)
+                                 (catch clojure.lang.ExceptionInfo error error)))))))
+      (reset! authority open-state)
+      (ygg/discard-fork! handle)
+      (d/release-transferred-fork! transfer))))
+
+(deftest failed-merge-reopens-listener-admission
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :failed-merge-listener-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          relayed (promise)
+          _listener (d/on-each-message fork (fn [_] (deliver relayed true)))
+          error (try
+                  (with-redefs [ygg/merge-fork! (fn [& _]
+                                                  (throw (ex-info "preflight conflict" {})))]
+                    (d/merge-room parent fork))
+                  (catch clojure.lang.ExceptionInfo error error))]
+      (is (= "preflight conflict" (ex-message error)))
+      (is (ygg/open-fork? (d/fork-handle fork)))
+      (d/post! fork (d/message :human nil "relay after failed merge"))
+      (is (= true (deref relayed 2000 ::timeout)))
+      (d/discard fork))))
+
+(deftest concurrent-merge-has-one-integration-owner
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :single-merge-owner-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :none :clone-participants? false})
+          entered (promise)
+          release (promise)
+          _listener (d/on-each-message
+                     fork
+                     (fn [_]
+                       (deliver entered true)
+                       @release))]
+      (d/post! fork (d/message :human nil "merge exactly once"))
+      (is (= true (deref entered 2000 ::timeout)))
+      (let [first-merge (future
+                          (binding [ec/*execution-context* *base-ctx*]
+                            (d/merge-room parent fork)))
+            _ (Thread/sleep 50)
+            contender (try
+                        (d/merge-room parent fork)
+                        (catch clojure.lang.ExceptionInfo error error))]
+        (is (= ::d/room-lifecycle-in-progress (:type (ex-data contender))))
+        (deliver release true)
+        (is (identical? parent (deref first-merge 5000 ::timeout)))
+        (is (= 1 (count (filter #(= "merge exactly once" (:content %))
+                                (d/log parent)))))))))
 
 (deftest room-messages-relay-to-peer-bus-with-scope-tag
   (binding [ec/*execution-context* *base-ctx*]


### PR DESCRIPTION
## Summary

- add a durability-first `dvergr.discourse/transfer-fork!` boundary for transferring a quiescent isolated Room's affine Spindel `ForkHandle`
- add `dvergr.rooms.forks/adopt!` for Run-world promotion, including durable Run settlement correlation
- detach successfully adopted worlds from the Room registry so raw Merge/Discard controls cannot compete with governance
- preserve the original review world when durable preparation fails, compensate a lost transfer race through `:abort!`, and reopen Run admission on every pre-transfer failure
- reject transfer while the owning Run is active, participants remain installed, or structurally owned child worlds remain open
- document the Dvergr/Simmis ownership and restart boundary

## Contract

1. `:prepare!` durably records the prospective descriptor and owner as a GC root.
2. Spindel transfers the live affine authority; the old handle becomes stale.
3. Dvergr removes the transient Room projection and emits `:dvergr/fork-transferred`.
4. The caller retains the returned handle only process-locally. Simmis persists the descriptor/ForkSet and owns restart settlement.

The descriptor is data; the reactive execution context and affine token are never serialized.

## Verification

- focused transfer/adoption laws: 5 tests, 40 assertions, 0 failures
- focused affected namespaces before the final hardening: 37 tests, 207 assertions; the only initial assertion typo was corrected and the affected tests rerun green
- format check: clean
- full suite: 512 tests, 2,174 assertions; one unrelated order-sensitive failure in `dvergr.discourse-test/leave-releases-the-whole-participant-lifecycle`
- exact failing var rerun with the full-suite seed: 1 test, 13 assertions, 0 failures

## Next dependency

Simmis can now implement its existing ForkSet as the durable owner: map descriptor systems to registered scopes, persist GC roots and per-system settlement phases, and insert the canonical proposal message/projections without inventing another fork implementation.
