### PR TITLE
Partition adopted world settlement authority

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,7 +48,10 @@
         ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
         ;; Substrate for the durable-cursor bus pump + supervisor
         ;; restart.
-        org.replikativ/spindel     {:mvn/version "0.1.41"}
+        ;; Stacked on spindel#43 (affine partitioned world authority). Replace
+        ;; this exact reviewed commit with its Clojars release after squash.
+        org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
+                                    :git/sha "8c038f1a80de094cbd0c066add685bfd2017993f"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -252,11 +252,28 @@ The prepared descriptor includes `:dvergr/room-id`,
 `:dvergr/parent-fork-id`. The durable owner must retain that ancestry until the
 child settles; Dvergr's shared topology is its immediate in-process projection.
 
-This bridge is deliberately whole-world only. Simmis must not accept or dismiss
-descriptor-named systems independently through raw branches. Per-scope review
-first requires an affine partition/split primitive that consumes the original
-handle and returns disjoint system capabilities; each partition can then be
-settled exactly once without bypassing Spindel's lifecycle.
+Adoption starts as whole-world authority. `partition-adoption!` can then consume
+that aggregate handle into an exhaustive tree of disjoint system capabilities.
+Each leaf settles exactly once; Dvergr releases the retained structural ancestry
+only after every leaf is terminal and the supplied tree proves that no partition
+was omitted. A durable adopter prepares the intended plan before partitioning
+and commits the exact child descriptors afterward. If that commit fails, the
+API returns the error together with all live child handles so recovery cannot
+silently lose authority. No proposal layer may accept or dismiss systems by
+mutating raw branches outside this capability tree.
+
+Each durable leaf decision goes through `settle-adoption!`: governance prepares
+the intent, Spindel consumes the affine capability, and governance commits the
+terminal descriptor as Spindel's single-execution post-commit callback. A
+failed durable commit leaves terminal authority and its receipt available to
+`retry-settlement-commit!`; it never recreates an actionable review. Structural
+release rejects failed partition persistence, duplicate/substituted handles,
+and any durable leaf whose terminal commit is incomplete. Commit callbacks see
+only portable operation/descriptor data—never execution contexts or live
+systems from Spindel's internal settlement payload. Failed compensation is
+returned as explicit recovery state with the durable receipt still attached;
+`retry-settlement-abort!` repairs that durable intent before the still-open
+capability can receive a new decision.
 
 Simmis still needs to supply the durable half: store the descriptor as a GC
 root, index its systems into the existing ForkSet, and journal per-system

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -10,8 +10,8 @@
    Algebra (combinators returning Spins):
      ask, fan-out, race, quorum, pipeline
 
-   Fork (one canonical spindel.yggdrasil/ForkHandle):
-     fork-room, merge-room, discard
+   Fork (canonical Spindel authority, optionally partitioned into a tree):
+     fork-room, merge-room, discard, transfer-fork!, partition-transferred-fork!
 
    Patterns (decomposing to the algebra):
      iterative-refinement, debate, moderate, align-on
@@ -1481,12 +1481,8 @@
            :fork/room-id (:id fork)
            :fork/parent-id (:parent-id fork)})))))
 
-(defn release-transferred-fork!
-  "Release a transferred child's structural parent claim after settlement.
-
-   Accepts the map returned by `transfer-fork!`. The adopted handle must already
-   be merged or discarded; an open handle cannot release ancestry."
-  [{:fork/keys [handle room-id descriptor]}]
+(defn- assert-transferred-node-identity!
+  [{:fork/keys [handle descriptor room-id]}]
   (when-not (and (ygg/fork-handle? handle)
                  (= (:fork/id descriptor) (:fork-id handle)))
     (throw (ex-info "Transferred fork handle does not match its descriptor"
@@ -1499,14 +1495,302 @@
                     {:type ::transferred-fork-identity-mismatch
                      :fork/id room-id
                      :fork/descriptor-room-id (:dvergr/room-id descriptor)})))
-  (let [{:keys [status token]} @(:authority handle)]
-    (when-not (and (contains? #{:merged :discarded} status)
-                   (= token (:token handle)))
+  (let [authoritative (ygg/fork-descriptor handle)
+        identity-keys [:fork/id :fork/settlement-id :fork/partition-of
+                       :fork/world-systems :fork/systems]]
+    (when-not (= (select-keys authoritative identity-keys)
+                 (select-keys descriptor identity-keys))
+      (throw (ex-info "Transferred fork descriptor does not name this settlement capability"
+                      {:type ::transferred-fork-capability-mismatch
+                       :fork/id room-id
+                       :fork/descriptor (select-keys descriptor identity-keys)
+                       :fork/authoritative (select-keys authoritative identity-keys)})))))
+
+(defn partition-transferred-fork!
+  "Consume a transferred world's aggregate authority into disjoint scopes.
+
+   `transfer` is the value returned by `transfer-fork!` (or a partition node
+   returned here). `partitions` has Spindel's exhaustive shape:
+
+     [{:systems #{system-id ...} :owner owner-id :purpose optional-tag} ...]
+
+   The optional lifecycle callbacks make the destructive authority transition
+   honest at a durable boundary:
+
+   - `prepare!` durably records the intended partition plan before Spindel
+     consumes the aggregate handle and returns a receipt.
+   - `abort!` compensates that preparation if partition validation/CAS fails.
+   - `commit!` records the exact child descriptors after their settlement IDs
+     exist. A commit failure cannot undo partitioning, so it is retained under
+     `:fork/partition-commit` alongside every live child capability and receipt.
+
+   With no callbacks, partitioning is intentionally ephemeral. If `prepare!`
+   is supplied, `abort!` and `commit!` are required. The result is a persistent
+   capability tree; callers may recursively partition a child node and replace
+   that node in the tree. Never persist any `:fork/handle`."
+  ([transfer partitions]
+   (partition-transferred-fork! transfer partitions {}))
+  ([{:fork/keys [handle descriptor room-id] :as transfer}
+    partitions
+    {:keys [prepare! abort! commit!]}]
+   (assert-transferred-node-identity! transfer)
+   (when (and (or abort! commit!) (not prepare!))
+     (throw (ex-info "Partition lifecycle callbacks require prepare!"
+                     {:type ::invalid-partition-lifecycle
+                      :fork/id room-id})))
+   (when (and prepare! (not (and (fn? prepare!) (fn? abort!) (fn? commit!))))
+     (throw (ex-info "Durable partitioning requires prepare!, abort!, and commit! callbacks"
+                     {:type ::invalid-partition-lifecycle
+                      :fork/id room-id})))
+   (locking (:authority handle)
+     (let [plan {:fork/descriptor descriptor
+                 :fork/partitions (vec partitions)}
+           prepared? (volatile! false)
+           receipt* (volatile! nil)
+           handles
+           (try
+             (when prepare!
+               (vreset! receipt* (prepare! plan))
+               (vreset! prepared? true))
+             (ygg/partition-fork! handle partitions)
+             (catch Throwable error
+               (when @prepared?
+                 (try
+                   (abort! @receipt*)
+                   (catch Throwable abort-error
+                     (throw (ex-info "Fork partition compensation failed; recovery is required"
+                                     {:type ::fork-partition-recovery-required
+                                      :fork/id room-id
+                                      :fork/receipt @receipt*
+                                      :partition-error (ex-message error)
+                                      :abort-error (ex-message abort-error)}
+                                     abort-error)))))
+               (throw error)))
+           ancestry (select-keys descriptor [:dvergr/room-id
+                                             :dvergr/parent-room-id
+                                             :dvergr/parent-fork-id])
+           nodes (mapv (fn [part-handle]
+                         {:fork/handle part-handle
+                          :fork/descriptor (merge (ygg/fork-descriptor part-handle)
+                                                  ancestry)
+                          :fork/room-id room-id
+                          :fork/parent-id (:fork/parent-id transfer)})
+                       handles)
+           result (assoc transfer
+                         :fork/descriptor (merge (ygg/fork-descriptor handle) ancestry)
+                         :fork/partitions nodes)
+           commit-error (when commit!
+                          (try
+                            (commit! @receipt* (mapv :fork/descriptor nodes))
+                            nil
+                            (catch Throwable error error)))]
+       (cond-> result
+         commit!
+         (assoc :fork/partition-commit
+                (cond-> {:status (if commit-error :failed :committed)
+                         :receipt @receipt*}
+                  commit-error (assoc :error commit-error))))))))
+
+(defn retry-partition-commit!
+  "Retry the durable exact-descriptor commit after partitioning succeeded.
+
+   Returns the same capability tree with a committed durability marker. No
+   substrate authority changes during this operation."
+  [{:fork/keys [partitions partition-commit] :as transfer} commit!]
+  (when-not (= :failed (:status partition-commit))
+    (throw (ex-info "Fork partition has no failed durable commit to retry"
+                    {:type ::partition-commit-not-retryable
+                     :fork/status (:status partition-commit)})))
+  (commit! (:receipt partition-commit) (mapv :fork/descriptor partitions))
+  (assoc transfer :fork/partition-commit
+         {:status :committed :receipt (:receipt partition-commit)}))
+
+(defn settle-transferred-fork!
+  "Settle one transferred leaf through an optional durable governance boundary.
+
+   `operation` is `:merge` or `:discard`. With lifecycle callbacks, `prepare!`
+   durably claims the decision before substrate mutation, `commit!` runs as
+   Spindel's exactly-once post-commit callback, and `abort!` compensates only a
+   failed preflight that left the capability open. A post-mutation or durable
+   commit failure is returned with the live terminal/incomplete capability and
+   receipt; it is never disguised as an open review world.
+
+   `retry-settlement-commit!` re-drives only the durable commit. The returned
+   node must replace its predecessor in the capability tree before release."
+  ([transfer operation]
+   (settle-transferred-fork! transfer operation {}))
+  ([{:fork/keys [handle descriptor room-id] :as transfer}
+    operation
+    {:keys [prepare! abort! commit!] :as lifecycle}]
+   (assert-transferred-node-identity! transfer)
+   (when-not (contains? #{:merge :discard} operation)
+     (throw (ex-info "Unknown transferred fork settlement operation"
+                     {:type ::invalid-transferred-settlement
+                      :operation operation})))
+   (when (seq (:fork/partitions transfer))
+     (throw (ex-info "Settle partition leaves, not their aggregate handle"
+                     {:type ::partition-aggregate-cannot-settle
+                      :fork/id room-id})))
+   (when (and (seq lifecycle)
+              (not (and (fn? prepare!) (fn? abort!) (fn? commit!))))
+     (throw (ex-info "Durable settlement requires prepare!, abort!, and commit! callbacks"
+                     {:type ::invalid-settlement-lifecycle
+                      :fork/id room-id})))
+   ;; Durable intent and the Spindel CAS form one Dvergr-owned frontier. Raw
+   ;; handle calls remain trusted-host internals and must not bypass this API.
+   (locking (:authority handle)
+     (when-not (ygg/open-fork? handle)
+       (throw (ex-info "Transferred fork leaf is not open"
+                       {:type ::transferred-fork-not-open
+                        :fork/id room-id
+                        :fork/status (:status (ygg/fork-disposition handle))})))
+     (let [ancestry (select-keys descriptor [:dvergr/room-id
+                                             :dvergr/parent-room-id
+                                             :dvergr/parent-fork-id])
+           plan {:fork/operation operation
+                 :fork/descriptor (merge (ygg/fork-descriptor handle) ancestry)}
+           receipt (when prepare! (prepare! plan))
+           commit-value* (atom nil)
+           commit-callback
+           (when commit!
+             (fn [_payload]
+               (let [value {:fork/operation operation
+                            :fork/descriptor (merge (ygg/fork-descriptor handle) ancestry)}]
+                 (reset! commit-value* value)
+                 (commit! receipt value))))]
+       (try
+         (let [result (case operation
+                        :merge (ygg/merge-fork! handle {:on-merge commit-callback})
+                        :discard (ygg/discard-fork! handle {:on-discard commit-callback}))]
+           (cond-> (assoc transfer
+                          :fork/descriptor (merge (ygg/fork-descriptor handle) ancestry)
+                          :fork/result result)
+             commit! (assoc :fork/settlement
+                            {:status :committed
+                             :operation operation
+                             :receipt receipt
+                             :commit-value @commit-value*})))
+         (catch Throwable error
+           (let [{:keys [status]} (ygg/fork-disposition handle)]
+             (if (= :open status)
+               (if abort!
+                 (if-let [abort-error (try
+                                        (abort! receipt)
+                                        nil
+                                        (catch Throwable abort-error abort-error))]
+                   (assoc transfer
+                          :fork/descriptor (merge (ygg/fork-descriptor handle) ancestry)
+                          :fork/settlement
+                          {:status :abort-failed
+                           :operation operation
+                           :receipt receipt
+                           :error error
+                           :abort-error abort-error})
+                   (throw error))
+                 (throw error))
+               (assoc transfer
+                      :fork/descriptor (merge (ygg/fork-descriptor handle) ancestry)
+                      :fork/settlement
+                      {:status (if (contains? #{:merged :discarded} status)
+                                 :commit-failed
+                                 :incomplete)
+                       :operation operation
+                       :receipt receipt
+                       :commit-value @commit-value*
+                       :error error})))))))))
+
+(defn retry-settlement-commit!
+  "Retry only the durable commit of a terminal transferred leaf."
+  [{:fork/keys [settlement] :as transfer} commit!]
+  (when-not (= :commit-failed (:status settlement))
+    (throw (ex-info "Fork settlement has no failed durable commit to retry"
+                    {:type ::settlement-commit-not-retryable
+                     :fork/status (:status settlement)})))
+  (commit! (:receipt settlement) (:commit-value settlement))
+  (assoc transfer :fork/settlement
+         (-> settlement
+             (assoc :status :committed)
+             (dissoc :error))))
+
+(defn retry-settlement-abort!
+  "Retry compensation after a preflight failure left authority open.
+
+   A successful retry removes the failed intent marker and returns the original
+   open capability, which may then receive a fresh governed decision."
+  [{:fork/keys [settlement] :as transfer} abort!]
+  (when-not (= :abort-failed (:status settlement))
+    (throw (ex-info "Fork settlement has no failed compensation to retry"
+                    {:type ::settlement-abort-not-retryable
+                     :fork/status (:status settlement)})))
+  (abort! (:receipt settlement))
+  (dissoc transfer :fork/settlement))
+
+(defn- assert-transferred-node-settled!
+  [{:fork/keys [handle room-id partitions partition-commit settlement] :as node}
+   seen
+   durable-required?]
+  (assert-transferred-node-identity! node)
+  (when (contains? seen (:token handle))
+    (throw (ex-info "Transferred fork capability occurs more than once in its tree"
+                    {:type ::duplicate-transferred-fork-capability
+                     :fork/id room-id
+                     :fork/settlement-id (get-in node [:fork/descriptor
+                                                       :fork/settlement-id])})))
+  (when (and partition-commit (not= :committed (:status partition-commit)))
+    (throw (ex-info "Transferred fork partition descriptors are not durably committed"
+                    {:type ::partition-commit-incomplete
+                     :fork/id room-id
+                     :fork/status (:status partition-commit)})))
+  (let [seen (conj seen (:token handle))
+        {:keys [status token] :as disposition} @(:authority handle)
+        current? (= token (:token handle))
+        durable-children? (or durable-required? (some? partition-commit))]
+    (cond
+      (and current? (contains? #{:merged :discarded} status))
+      (if (and (or durable-required? (some? settlement))
+               (not= :committed (:status settlement)))
+        (throw (ex-info "Transferred fork leaf settlement is not durably committed"
+                        {:type ::settlement-commit-incomplete
+                         :fork/id room-id
+                         :fork/status (:status settlement)}))
+        seen)
+
+      (and current? (= :partitioned status))
+      (let [_ (when (and durable-required? (nil? partition-commit))
+                (throw (ex-info "Nested fork partition descriptors are not durably committed"
+                                {:type ::partition-commit-incomplete
+                                 :fork/id room-id
+                                 :fork/status :missing})))
+            expected (set (:partitions disposition))
+            actual (set (map #(get-in % [:fork/descriptor :fork/settlement-id])
+                             partitions))]
+        (when-not (= expected actual)
+          (throw (ex-info "Transferred fork partition tree is incomplete"
+                          {:type ::transferred-fork-partitions-incomplete
+                           :fork/id room-id
+                           :expected expected
+                           :actual actual})))
+        (reduce (fn [seen part]
+                  (assert-transferred-node-settled! part seen durable-children?))
+                seen
+                partitions))
+
+      :else
       (throw (ex-info "Transferred fork has not settled with this authority"
                       {:type ::transferred-fork-not-settled
                        :fork/id room-id
                        :fork/status status
-                       :fork/current-authority? (= token (:token handle))}))))
+                       :fork/current-authority? current?})))))
+
+(defn release-transferred-fork!
+  "Release a transferred child's structural parent claim after settlement.
+
+   Accepts the capability tree returned by `transfer-fork!` and optionally
+   `partition-transferred-fork!`. Every leaf must have settled with its exact
+   affine authority and every partition node must list all children before the
+   structural ancestry claim is released."
+  [{:fork/keys [handle room-id] :as transfer}]
+  (assert-transferred-node-settled! transfer #{} false)
   (binding [ec/*execution-context* (:parent-ctx handle)]
     (rreg/untrack-fork! room-id (:fork-id handle)))
   nil)

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -347,9 +347,9 @@
    durable projection is correlated as `:adopted`; a projection failure is
    reported without hiding the already-transferred capability.
 
-   Adoption transfers the whole world. Per-system decisions require a future
-   affine partition primitive; callers must not settle descriptor systems by
-   bypassing the returned handle."
+   Adoption initially transfers the whole world. Use `partition-adoption!` to
+   split its settlement authority before making per-system decisions; callers
+   must never settle descriptor systems by bypassing those handles."
   [fork new-owner opts]
   (try
     (let [parent (rreg/lookup (:parent-id fork))
@@ -368,3 +368,36 @@
                :projection-error (ex-message projection-error))))
     (catch Throwable error
       {:ok? false :error (ex-message error)})))
+
+(defn partition-adoption!
+  "Split an adopted world's settlement authority into exhaustive system scopes.
+
+   This is the Room-facing wrapper over `discourse/partition-transferred-fork!`.
+   See that function for partition shape and optional durability callbacks."
+  ([adoption partitions]
+   (d/partition-transferred-fork! adoption partitions))
+  ([adoption partitions lifecycle]
+   (d/partition-transferred-fork! adoption partitions lifecycle)))
+
+(defn settle-adoption!
+  "Settle one adopted leaf with optional durable governance callbacks."
+  ([adoption operation]
+   (d/settle-transferred-fork! adoption operation))
+  ([adoption operation lifecycle]
+   (d/settle-transferred-fork! adoption operation lifecycle)))
+
+(def retry-partition-commit!
+  "Retry durable persistence of an adoption's exact partition descriptors."
+  d/retry-partition-commit!)
+
+(def retry-settlement-commit!
+  "Retry durable terminal persistence without touching substrate authority."
+  d/retry-settlement-commit!)
+
+(def retry-settlement-abort!
+  "Retry durable compensation after settlement preflight left authority open."
+  d/retry-settlement-abort!)
+
+(def release-adoption!
+  "Release Dvergr ancestry after the whole governed capability tree is durable."
+  d/release-transferred-fork!)

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -12,6 +12,7 @@
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.discourse :as d]
             [dvergr.intake.bash :as b]
+            [dvergr.substrate.geschichte :as geschichte]
             [dvergr.room.registry :as registry]
             [dvergr.runtime.peer-bus :as peer-bus]
             [org.replikativ.spindel.engine.core :as ec]
@@ -195,6 +196,210 @@
         (let [events (peer-events-of-type :dvergr/fork-transferred)]
           (is (= 1 (count events)))
           (is (= owner (:fork/owner (first events)))))))))
+
+(deftest transferred-world-partitions-into-exhaustive-affine-authority
+  (binding [ec/*execution-context* *base-ctx*]
+    ;; The fixture has one Geschichte system. A second independent repository
+    ;; gives this world two real settlement scopes without a mock substrate.
+    (ygg/register! (geschichte/create-system
+                    :scope (str *sandbox-dir* "/second-repository")
+                    :system-name :second-repository))
+    (let [parent (d/room :partition-transfer-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          transfer (d/transfer-fork! fork :proposal
+                                     {:prepare! (constantly :adoption-receipt)
+                                      :abort! (fn [_])})
+          systems (vec (keys (get-in transfer [:fork/descriptor :fork/systems])))
+          prepared (atom nil)
+          committed (atom nil)
+          partitioned
+          (d/partition-transferred-fork!
+           transfer
+           [{:systems #{(first systems)} :owner :reviewer-a :purpose :component}
+            {:systems #{(second systems)} :owner :reviewer-b :purpose :component}]
+           {:prepare! (fn [plan]
+                        (reset! prepared plan)
+                        :partition-receipt)
+            :abort! (fn [_])
+            :commit! (fn [receipt descriptors]
+                       (reset! committed [receipt descriptors]))})
+          parts (:fork/partitions partitioned)
+          settlement-commits (atom [])]
+      (is (= 2 (count systems)))
+      (is (= 2 (count parts)))
+      (is (= :partitioned
+             (:fork/status (:fork/descriptor partitioned))))
+      (is (= systems
+             (->> @prepared :fork/descriptor :fork/systems keys vec)))
+      (is (= :partition-receipt (first @committed)))
+      (is (= (set systems)
+             (->> (second @committed)
+                  (mapcat (comp keys :fork/systems))
+                  set)))
+      (is (every? #(= (:id fork)
+                      (get-in % [:fork/descriptor :dvergr/room-id]))
+                  parts))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"has not settled"
+                            (d/release-transferred-fork! partitioned)))
+      (let [lifecycle {:prepare! (fn [plan] (:fork/operation plan))
+                       :abort! (fn [_])
+                       :commit! (fn [receipt terminal]
+                                  (swap! settlement-commits conj
+                                         [receipt (:fork/descriptor terminal)]))}
+            settled [(d/settle-transferred-fork! (first parts) :merge lifecycle)
+                     (d/settle-transferred-fork! (second parts) :discard lifecycle)]
+            settled-tree (assoc partitioned :fork/partitions settled)]
+        (is (= 2 (count @settlement-commits)))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"incomplete"
+                              (d/release-transferred-fork!
+                               (assoc settled-tree :fork/partitions
+                                      [(first settled)]))))
+        (let [forged (assoc (first settled)
+                            :fork/descriptor (:fork/descriptor (second settled)))
+              error (try
+                      (d/release-transferred-fork!
+                       (assoc settled-tree :fork/partitions
+                              [(first settled) forged]))
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= ::d/transferred-fork-capability-mismatch
+                 (:type (ex-data error)))))
+        (is (nil? (d/release-transferred-fork! settled-tree)))))))
+
+(deftest partition-commit-failure-returns-every-live-capability
+  (binding [ec/*execution-context* *base-ctx*]
+    (ygg/register! (geschichte/create-system
+                    :scope (str *sandbox-dir* "/commit-failure-repository")
+                    :system-name :commit-failure-repository))
+    (let [parent (d/room :partition-commit-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          transfer (d/transfer-fork! fork :proposal
+                                     {:prepare! (constantly :adoption-receipt)
+                                      :abort! (fn [_])})
+          systems (vec (keys (get-in transfer [:fork/descriptor :fork/systems])))
+          partitioned
+          (d/partition-transferred-fork!
+           transfer
+           [{:systems #{(first systems)} :owner :a}
+            {:systems #{(second systems)} :owner :b}]
+           {:prepare! (constantly :partition-receipt)
+            :abort! (fn [_])
+            :commit! (fn [_ _] (throw (ex-info "store unavailable" {})))})
+          parts (:fork/partitions partitioned)]
+      (is (= :failed (get-in partitioned [:fork/partition-commit :status])))
+      (is (= "store unavailable"
+             (ex-message (get-in partitioned [:fork/partition-commit :error]))))
+      (is (= 2 (count parts)))
+      (is (every? (comp ygg/open-fork? :fork/handle) parts))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not durably committed"
+                            (d/release-transferred-fork! partitioned)))
+      (let [partitioned (d/retry-partition-commit! partitioned (fn [_ _] :ok))
+            first-settled
+            (d/settle-transferred-fork!
+             (first (:fork/partitions partitioned)) :discard
+             {:prepare! (constantly :first-receipt)
+              :abort! (fn [_])
+              :commit! (fn [_ _] (throw (ex-info "terminal store unavailable" {})))})
+            second-settled
+            (d/settle-transferred-fork!
+             (second (:fork/partitions partitioned)) :discard
+             {:prepare! (constantly :second-receipt)
+              :abort! (fn [_])
+              :commit! (fn [_ _] :ok)})
+            failed-tree (assoc partitioned :fork/partitions
+                               [first-settled second-settled])]
+        (is (= :commit-failed (get-in first-settled [:fork/settlement :status])))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not durably committed"
+                              (d/release-transferred-fork! failed-tree)))
+        (let [recovered (d/retry-settlement-commit! first-settled (fn [_ _] :ok))
+              recovered-tree (assoc failed-tree :fork/partitions
+                                    [recovered second-settled])]
+          (d/release-transferred-fork! recovered-tree))))))
+
+(deftest governed-settlement-prepares-exactly-one-concurrent-decision
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :governed-settlement-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          transfer (d/transfer-fork! fork :governance
+                                     {:prepare! (constantly :adoption-receipt)
+                                      :abort! (fn [_])})
+          ready (java.util.concurrent.CountDownLatch. 2)
+          start (java.util.concurrent.CountDownLatch. 1)
+          prepares (atom [])
+          lifecycle (fn [decision]
+                      {:prepare! (fn [_]
+                                   (swap! prepares conj decision)
+                                   decision)
+                       :abort! (fn [_])
+                       :commit! (fn [_ _] :ok)})
+          decide (fn [decision]
+                   (future
+                     (.countDown ready)
+                     (.await start)
+                     (try
+                       (d/settle-transferred-fork!
+                        transfer decision (lifecycle decision))
+                       (catch clojure.lang.ExceptionInfo error error))))
+          merge-result (decide :merge)
+          discard-result (decide :discard)]
+      (.await ready)
+      (.countDown start)
+      (let [results [@merge-result @discard-result]
+            winner (first (filter map? results))
+            loser (first (filter #(instance? clojure.lang.ExceptionInfo %) results))]
+        (is (= 1 (count @prepares)))
+        (is (map? winner))
+        (is (= ::d/transferred-fork-not-open (:type (ex-data loser))))
+        (is (= :committed (get-in winner [:fork/settlement :status])))
+        (d/release-transferred-fork! winner)))))
+
+(deftest whole-world-governance-retries-only-portable-durable-commit
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :whole-world-governance-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          transfer (d/transfer-fork! fork :governance
+                                     {:prepare! (constantly :adoption-receipt)
+                                      :abort! (fn [_])})
+          settled (d/settle-transferred-fork!
+                   transfer :discard
+                   {:prepare! (constantly :settlement-receipt)
+                    :abort! (fn [_])
+                    :commit! (fn [_ _]
+                               (throw (ex-info "terminal store unavailable" {})))})]
+      (is (= :commit-failed (get-in settled [:fork/settlement :status])))
+      (is (= #{:fork/operation :fork/descriptor}
+             (set (keys (get-in settled [:fork/settlement :commit-value]))))
+          "the retry value contains no live Spindel settlement payload")
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not durably committed"
+                            (d/release-transferred-fork! settled)))
+      (let [recovered (d/retry-settlement-commit! settled (fn [_ _] :ok))]
+        (d/release-transferred-fork! recovered)))))
+
+(deftest failed-settlement-compensation-retains-recovery-receipt
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :settlement-abort-parent *base-ctx*)
+          fork (d/fork-room parent {:isolation :ctx})
+          transfer (d/transfer-fork! fork :governance
+                                     {:prepare! (constantly :adoption-receipt)
+                                      :abort! (fn [_])})
+          result (with-redefs [ygg/merge-fork! (fn [& _]
+                                                 (throw (ex-info "preflight failed" {})))]
+                   (d/settle-transferred-fork!
+                    transfer :merge
+                    {:prepare! (constantly :settlement-receipt)
+                     :abort! (fn [_]
+                               (throw (ex-info "abort store unavailable" {})))
+                     :commit! (fn [_ _] :ok)}))]
+      (is (= :abort-failed (get-in result [:fork/settlement :status])))
+      (is (= :settlement-receipt (get-in result [:fork/settlement :receipt])))
+      (is (ygg/open-fork? (:fork/handle result)))
+      (let [recovered (d/retry-settlement-abort! result (fn [_] :ok))
+            discarded (d/settle-transferred-fork!
+                       recovered :discard
+                       {:prepare! (constantly :discard-receipt)
+                        :abort! (fn [_])
+                        :commit! (fn [_ _] :ok)})]
+        (is (nil? (:fork/settlement recovered)))
+        (d/release-transferred-fork! discarded)))))
 
 (deftest failed-transfer-preparation-preserves-the-review-world
   (binding [ec/*execution-context* *base-ctx*]


### PR DESCRIPTION
## Summary
- consume an adopted aggregate ForkHandle into an exhaustive persistent capability tree
- preserve Dvergr ancestry and require all affine leaves to settle before structural release
- add prepare/commit/abort durability hooks, returning live authority on commit failure
- expose the Room-facing partition-adoption! wrapper and document the unified model

## Dependency
Stacked on dvergr#68 and exact reviewed spindel#43 head until its Clojars release is available.

## Verification
- focused peer bus / world transfer suite: 20 tests, 89 assertions
- cljfmt check