### PR TITLE
Add durable message object references

### DIFF
--- a/doc/discourse-theory.md
+++ b/doc/discourse-theory.md
@@ -20,6 +20,14 @@ speech act they answer** (capability routing), so a room is organised around *wh
 responds to what kind of move* — not by hardcoded sender→receiver wiring. Adding
 a new kind of interaction is adding a new tag, not rewiring the graph.
 
+An utterance may also name one primary application object through durable
+metadata such as `{:object {:kind :proposal :id #uuid "…"}}`. The speech-act
+type still says what the message *does*; the object says what it is *about*.
+Dvergr validates and stores that reference as typed, indexed datoms while
+remaining ignorant of the referenced domain model. Applications can therefore
+render the same proposal, task, artifact or approval in chat and in their own
+projections without encoding identity in prose.
+
 ## Theory of mind: RSA, made reactive
 
 The deepest hook is **theory of mind**. In the Rational Speech Acts model

--- a/src/dvergr/chat/persist.clj
+++ b/src/dvergr/chat/persist.clj
@@ -24,15 +24,12 @@
 ;; surfaced at :error.
 (defonce dead-letters (atom []))
 
-(defn persist-tx!
-  "Transact `tx-data` on `conn` under the ONE message-durability policy: attempt
-   once, retry once on failure, and on a second failure surface at :error and
-   dead-letter the payload rather than dropping it silently or throwing into the
-   caller. Never throws; returns true on success, false on give-up. `ctx` is a
-   small diagnostics map, e.g. {:op :store-message :room-id … :msg-id …}."
-  ([conn tx-data] (persist-tx! conn tx-data {}))
+(defn persist-tx-result!
+  "Apply the shared retry/dead-letter policy, returning the Datahike report on
+   success and false after terminal failure."
+  ([conn tx-data] (persist-tx-result! conn tx-data {}))
   ([conn tx-data {:keys [op room-id msg-id] :as ctx}]
-   (letfn [(attempt [] (d/transact conn tx-data) true)]
+   (letfn [(attempt [] (d/transact conn tx-data))]
      (try
        (attempt)
        (catch Throwable t1
@@ -53,3 +50,10 @@
                                :dead-letter-count (count @dead-letters)}}
                        "message persist failed twice — DEAD-LETTERED (message not durable)")
              false)))))))
+
+(defn persist-tx!
+  "Transact under the shared retry/dead-letter policy. Never throws; returns
+   true on success and false after terminal failure."
+  ([conn tx-data] (persist-tx! conn tx-data {}))
+  ([conn tx-data ctx]
+   (boolean (persist-tx-result! conn tx-data ctx))))

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -227,6 +227,21 @@
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one}
 
+   ;; One primary semantic object named by the speech act. This remains generic:
+   ;; an application can render a Proposal, task, artifact or approval without
+   ;; making Dvergr own any of those domain models.
+   {:db/ident :message/object-kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Application object kind named by this message"}
+
+   {:db/ident :message/object-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Stable application object identity named by this message"}
+
    ;; Background-task notification envelope.
    {:db/ident :message/notification-type
     :db/valueType :db.type/keyword

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -57,7 +57,9 @@
      provenance, notification, tool-use and reasoning fields). Implementations
      replay these envelope fields losslessly and must be first-write-wins
      idempotent on :id — re-stores are no-ops. Unknown durable metadata is an
-     error: extend the typed schema rather than adding an opaque encoding.")
+     error: extend the typed schema rather than adding an opaque encoding.
+     Returns :inserted when this call won the immutable identity, :duplicate
+     when the id already existed, and :failed when durability was unavailable.")
 
   (-message-thread-root [this room-id message-id]
     "Return one message's stable topical-root UUID inside `room-id`, or nil.

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -189,12 +189,14 @@
    before being added here."
   #{:role :source-user :source-username :source-user-id
     :audience :mentions :attachment :provenance
+    :object
     :tool-uses :reasoning :kind :from :source :schedule-id
     :notification/type :notification/agent :notification/task
     :notification/elapsed :run-id})
 
 (def ^:private attachment-metadata-keys #{:blob-id :node-id :mime :name :size})
 (def ^:private provenance-metadata-keys #{:mode :source})
+(def ^:private object-metadata-keys #{:kind :id})
 
 (defn- reject-unknown-metadata! [kind allowed value]
   (let [unknown (seq (remove allowed (keys (or value {}))))]
@@ -227,7 +229,21 @@
         (throw (ex-info "Message provenance metadata must be a map"
                         {:type :room-store/invalid-message-metadata
                          :provenance provenance})))
-      (reject-unknown-metadata! :provenance provenance-metadata-keys provenance)))
+      (reject-unknown-metadata! :provenance provenance-metadata-keys provenance))
+    (when-let [object (:object metadata)]
+      (when-not (map? object)
+        (throw (ex-info "Message object reference must be a map"
+                        {:type :room-store/invalid-message-metadata
+                         :object object})))
+      (reject-unknown-metadata! :object object-metadata-keys object)
+      (when-not (keyword? (:kind object))
+        (throw (ex-info "Message object :kind must be a keyword"
+                        {:type :room-store/invalid-message-metadata
+                         :object object})))
+      (when-not (uuid? (:id object))
+        (throw (ex-info "Message object :id must be a UUID"
+                        {:type :room-store/invalid-message-metadata
+                         :object object})))))
   (when (and (:run-id metadata) (not (uuid? (:run-id metadata))))
     (throw (ex-info "Message :run-id metadata must be a UUID"
                     {:type :room-store/invalid-message-metadata

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -230,20 +230,21 @@
                         {:type :room-store/invalid-message-metadata
                          :provenance provenance})))
       (reject-unknown-metadata! :provenance provenance-metadata-keys provenance))
-    (when-let [object (:object metadata)]
-      (when-not (map? object)
-        (throw (ex-info "Message object reference must be a map"
-                        {:type :room-store/invalid-message-metadata
-                         :object object})))
-      (reject-unknown-metadata! :object object-metadata-keys object)
-      (when-not (keyword? (:kind object))
-        (throw (ex-info "Message object :kind must be a keyword"
-                        {:type :room-store/invalid-message-metadata
-                         :object object})))
-      (when-not (uuid? (:id object))
-        (throw (ex-info "Message object :id must be a UUID"
-                        {:type :room-store/invalid-message-metadata
-                         :object object})))))
+    (when (contains? metadata :object)
+      (let [object (:object metadata)]
+        (when-not (map? object)
+          (throw (ex-info "Message object reference must be a map"
+                          {:type :room-store/invalid-message-metadata
+                           :object object})))
+        (reject-unknown-metadata! :object object-metadata-keys object)
+        (when-not (keyword? (:kind object))
+          (throw (ex-info "Message object :kind must be a keyword"
+                          {:type :room-store/invalid-message-metadata
+                           :object object})))
+        (when-not (uuid? (:id object))
+          (throw (ex-info "Message object :id must be a UUID"
+                          {:type :room-store/invalid-message-metadata
+                           :object object}))))))
   (when (and (:run-id metadata) (not (uuid? (:run-id metadata))))
     (throw (ex-info "Message :run-id metadata must be a UUID"
                     {:type :room-store/invalid-message-metadata

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -286,16 +286,23 @@
           ;; of the old catch-and-silently-drop — a lost message is now visible
           ;; and recoverable, not swallowed at :warn. The transaction function
           ;; makes the idempotence decision inside Datahike's write serialization.
-          (persist/persist-tx!
-           conn
-           [[:db.fn/call store-message-if-absent
-             entity
-             {:db/id [:chat/id chat-id]
-              :chat/updated-at (java.util.Date.)}]]
-           {:op :store-message :room-id room-id :msg-id (:id msg)}))
-        (tel/log! {:level :error :id :room-store/datahike-missing-room
-                   :data {:room-id room-id :msg-id (:id msg)}}
-                  "message for unknown room — not persisted (dropped)"))))
+          (let [report
+                (persist/persist-tx-result!
+                 conn
+                 [[:db.fn/call store-message-if-absent
+                   entity
+                   {:db/id [:chat/id chat-id]
+                    :chat/updated-at (java.util.Date.)}]]
+                 {:op :store-message :room-id room-id :msg-id (:id msg)})]
+            (cond
+              (false? report) :failed
+              (seq (:tx-data report)) :inserted
+              :else :duplicate)))
+        (do
+          (tel/log! {:level :error :id :room-store/datahike-missing-room
+                     :data {:room-id room-id :msg-id (:id msg)}}
+                    "message for unknown room — not persisted (dropped)")
+          :failed))))
 
   (-message-thread-root [_ room-id message-id]
     (let [slug (store/room-id->slug room-id)]

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -140,6 +140,18 @@
       ;; rehydration and is fed back to the model (see room-context seeding).
       (seq (:reasoning metadata))  (assoc :message/reasoning (:reasoning metadata)))))
 
+(defn- store-message-if-absent
+  "Transaction function implementing PRoomStore first-write-wins atomically.
+
+   Datahike invokes this with the serialized transaction snapshot. A concurrent
+   retry therefore either creates the message or observes the winner and emits
+   no datoms; it can never upsert over an immutable envelope after an unlocked
+   pre-read. The room timestamp belongs to the same decision."
+  [db entity room-touch]
+  (if (dh/entity db [:message/id (:message/id entity)])
+    []
+    [entity room-touch]))
+
 (def ^:private message-pull-pattern
   '[:message/id :message/role :message/content
     :message/created-at :message/source-user
@@ -268,23 +280,19 @@
   (-store-message! [_ room-id msg]
     (let [slug (store/room-id->slug room-id)]
       (if-let [ent (room-by-slug conn slug)]
-        ;; PRoomStore promises first-write-wins idempotence. A lookup-identity
-        ;; upsert alone would silently overwrite content when an adapter retries
-        ;; the same id with a changed envelope.
-        (when-not (dh/q '[:find ?m .
-                          :in $ ?mid
-                          :where [?m :message/id ?mid]]
-                        @conn (:id msg))
-          (let [chat-id (:chat/id ent)
-                entity  (message->entity chat-id msg)]
-            ;; One durability policy (surface + retry-once + dead-letter) instead
-            ;; of the old catch-and-silently-drop — a lost message is now visible
-            ;; and recoverable, not swallowed at :warn.
-            (persist/persist-tx! conn
-                                 [entity
-                                  {:db/id [:chat/id chat-id]
-                                   :chat/updated-at (java.util.Date.)}]
-                                 {:op :store-message :room-id room-id :msg-id (:id msg)})))
+        (let [chat-id (:chat/id ent)
+              entity  (message->entity chat-id msg)]
+          ;; One durability policy (surface + retry-once + dead-letter) instead
+          ;; of the old catch-and-silently-drop — a lost message is now visible
+          ;; and recoverable, not swallowed at :warn. The transaction function
+          ;; makes the idempotence decision inside Datahike's write serialization.
+          (persist/persist-tx!
+           conn
+           [[:db.fn/call store-message-if-absent
+             entity
+             {:db/id [:chat/id chat-id]
+              :chat/updated-at (java.util.Date.)}]]
+           {:op :store-message :room-id room-id :msg-id (:id msg)}))
         (tel/log! {:level :error :id :room-store/datahike-missing-room
                    :data {:room-id room-id :msg-id (:id msg)}}
                   "message for unknown room — not persisted (dropped)"))))

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -83,6 +83,7 @@
         metadata     (store/validate-message-metadata! (:metadata msg))
         attachment   (:attachment metadata)
         provenance   (:provenance metadata)
+        object       (:object metadata)
         blob-id      (:blob-id attachment)
         role         (store/infer-role msg)
         source-user  (or (:source-user metadata)
@@ -118,6 +119,8 @@
       (:size attachment) (assoc :message/attachment-size (long (:size attachment)))
       (:mode provenance) (assoc :message/provenance-mode (:mode provenance))
       (:source provenance) (assoc :message/provenance-source (:source provenance))
+      (:kind object) (assoc :message/object-kind (:kind object))
+      (:id object) (assoc :message/object-id (:id object))
       (:notification/type metadata)
       (assoc :message/notification-type (:notification/type metadata))
       (:notification/agent metadata)
@@ -155,6 +158,7 @@
     :message/attachment-size
     :message/provenance-mode
     :message/provenance-source
+    :message/object-kind :message/object-id
     :message/notification-type
     :message/notification-agent
     :message/notification-task
@@ -365,6 +369,11 @@
                                      (assoc :mode (:message/provenance-mode m))
                                      (:message/provenance-source m)
                                      (assoc :source (:message/provenance-source m)))
+                        object (cond-> {}
+                                 (:message/object-kind m)
+                                 (assoc :kind (:message/object-kind m))
+                                 (:message/object-id m)
+                                 (assoc :id (:message/object-id m)))
                         metadata (cond-> {:role (:message/role m)}
                                    (:message/source-user m)
                                    (assoc :source-user (:message/source-user m))
@@ -378,6 +387,7 @@
                                    (assoc :mentions (set (:message/mention-handles m)))
                                    (seq attachment) (assoc :attachment attachment)
                                    (seq provenance) (assoc :provenance provenance)
+                                   (seq object) (assoc :object object)
                                    (:message/metadata-kind m)
                                    (assoc :kind (:message/metadata-kind m))
                                    (:message/context-from m)

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -34,17 +34,25 @@
 
   (-store-message! [_ room-id msg]
     (let [msg    (store/normalize-message-thread msg)
-          msg-id (:id msg)]
-      (swap! state update-in [:messages room-id]
-             (fn [existing]
-               (let [v (or existing [])]
-                 (if (some #(= (:id %) msg-id) v)
-                   v
-                   (do
-                     (store/validate-message-metadata! (:metadata msg))
-                     (conj v msg))))))
-      (swap! state update-in [:rooms room-id]
-             (fn [m] (when m (assoc m :updated-at (java.util.Date.)))))))
+          msg-id (:id msg)
+          _ (store/validate-message-metadata! (:metadata msg))
+          [before _]
+          (swap-vals! state
+                      (fn [s]
+                        (if (some #(= (:id %) msg-id)
+                                  (get-in s [:messages room-id] []))
+                          s
+                          (-> s
+                              (update-in [:messages room-id] (fnil conj []) msg)
+                              (update-in [:rooms room-id]
+                                         (fn [m]
+                                           (when m
+                                             (assoc m :updated-at
+                                                    (java.util.Date.)))))))))]
+      (if (some #(= (:id %) msg-id)
+                (get-in before [:messages room-id] []))
+        :duplicate
+        :inserted)))
 
   (-message-thread-root [_ room-id message-id]
     (some #(when (= message-id (:id %)) (:thread-root-id %))

--- a/src/dvergr/runtime/bus.clj
+++ b/src/dvergr/runtime/bus.clj
@@ -286,15 +286,24 @@
     ;;    the post loudly and nothing is half-delivered (this inverts
     ;;    the old persistence-listener model, where a store failure
     ;;    silently lost durability while the live message flowed).
-    (when-let [append! (:durable-append! bus)]
-      (append! msg'))
-    ;; 2. The log is the fan-out source of truth. Appending here (not
-    ;;    in a delivery tap) means log order == post order, and a
-    ;;    message is on record before any consumer runs.
-    (swap! (:log bus) update :entries conj msg')
-    ;; 3. Doorbell for the pump.
-    (binding [ec/*execution-context* (:ctx bus)]
-      (sync/post! (:hint-mbx bus) ::hint)))
+    (let [durability (when-let [append! (:durable-append! bus)]
+                       (append! msg'))]
+      (when (= :failed durability)
+        (throw (ex-info "Durable bus append failed"
+                        {:type :bus/durable-append-failed
+                         :message-id (:id msg')})))
+      ;; A duplicate immutable envelope was already made visible by the call
+      ;; that won persistence. Suppress every repeated live effect as well as
+      ;; the durable duplicate. Nil preserves compatibility with custom append
+      ;; hooks that predate insertion-status returns.
+      (when-not (= :duplicate durability)
+        ;; 2. The log is the fan-out source of truth. Appending here (not
+        ;;    in a delivery tap) means log order == post order, and a
+        ;;    message is on record before any consumer runs.
+        (swap! (:log bus) update :entries conj msg')
+        ;; 3. Doorbell for the pump.
+        (binding [ec/*execution-context* (:ctx bus)]
+          (sync/post! (:hint-mbx bus) ::hint)))))
   nil)
 
 (defn post-many!

--- a/src/dvergr/runtime/bus.clj
+++ b/src/dvergr/runtime/bus.clj
@@ -288,7 +288,7 @@
     ;;    silently lost durability while the live message flowed).
     (let [durability (when-let [append! (:durable-append! bus)]
                        (append! msg'))]
-      (when (= :failed durability)
+      (when (or (= :failed durability) (false? durability))
         (throw (ex-info "Durable bus append failed"
                         {:type :bus/durable-append-failed
                          :message-id (:id msg')})))

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -14,6 +14,7 @@
           ts 1787860800123
           metadata {:role :user
                     :source-user "Alice"
+                    :object {:kind :proposal :id (random-uuid)}
                     :attachment {:blob-id (random-uuid) :mime "audio/ogg"}
                     :audience #{:agent/reviewer}
                     :provenance {:mode :live :source :screen}}

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -36,12 +36,14 @@
       (store/-store-room! st room-id {:slug (name room-id) :title "Contract"})
       ;; Imports and distributed replay may see a reply before its parent. The
       ;; stable UUID field must not require the target entity to exist yet.
-      (store/-store-message! st room-id child)
-      (store/-store-message! st room-id grandchild)
-      (store/-store-message! st room-id parent)
-      (store/-store-message! st room-id other)
+      (is (= :inserted (store/-store-message! st room-id child)))
+      (is (= :inserted (store/-store-message! st room-id grandchild)))
+      (is (= :inserted (store/-store-message! st room-id parent)))
+      (is (= :inserted (store/-store-message! st room-id other)))
       ;; A retry carrying mutated data must not rewrite durable history.
-      (store/-store-message! st room-id (assoc child :content "mutated retry"))
+      (is (= :duplicate
+             (store/-store-message! st room-id
+                                    (assoc child :content "mutated retry"))))
       (let [messages (store/-list-messages st room-id {})
             replayed (some #(when (= child-id (:id %)) %) messages)
             replayed-grandchild (some #(when (= grandchild-id (:id %)) %) messages)

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -23,6 +23,43 @@
   (let [[_conn st] (mem-store)]
     (contract/assert-message-envelope! st :envelope-datahike)))
 
+(deftest concurrent-message-writes-are-atomically-first-write-wins
+  (testing "the first committed immutable envelope cannot be overwritten"
+    (let [[_conn st] (mem-store)
+          room-id :concurrent-envelope
+          message-id (random-uuid)
+          ready (java.util.concurrent.CountDownLatch. 2)
+          completed (atom [])
+          transact! dh/transact]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (with-redefs [dh/transact
+                    (fn [conn tx-data]
+                      ;; Force both callers past the old unlocked existence read
+                      ;; before either transaction runs. The transaction function
+                      ;; must still let exactly one immutable envelope win.
+                      (.countDown ready)
+                      (when-not (.await ready 10
+                                        java.util.concurrent.TimeUnit/SECONDS)
+                        (throw (ex-info "concurrent writers did not rendezvous" {})))
+                      (let [content (get-in tx-data [0 2 :message/content])
+                            result (transact! conn tx-data)]
+                        (swap! completed conj content)
+                        result))]
+        (let [first-write (future
+                            (store/-store-message!
+                             st room-id
+                             {:id message-id :from :alice :content "first"}))
+              second-write (future
+                             (store/-store-message!
+                              st room-id
+                              {:id message-id :from :bob :content "second"}))]
+          (is (not= ::timeout (deref first-write 10000 ::timeout)))
+          (is (not= ::timeout (deref second-write 10000 ::timeout)))))
+      (let [stored (first (store/-list-messages st room-id {}))]
+        (is (= 1 (count (store/-list-messages st room-id {}))))
+        (is (= (first @completed) (:content stored))
+            "the later transaction observes the winner instead of upserting")))))
+
 (deftest run-lifecycle-contract
   (let [[_conn st] (mem-store)]
     (contract/assert-run-lifecycle! st :runs-datahike)))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -59,7 +59,8 @@
     (let [[conn st] (mem-store)
           room-id :typed-metadata
           message-id (random-uuid)
-          blob-id (random-uuid)]
+          blob-id (random-uuid)
+          object-id (random-uuid)]
       (store/-store-room! st room-id {:slug (name room-id) :title "T"})
       (store/-store-message!
        st room-id
@@ -68,22 +69,37 @@
         :metadata {:role :user
                    :mentions #{"reviewer"}
                    :audience #{:agent/reviewer}
+                   :object {:kind :proposal :id object-id}
                    :attachment {:blob-id blob-id :mime "audio/ogg"}
                    :provenance {:mode :live :source :screen}}})
       (let [stored (dh/pull @conn
                             [:message/audience :message/mention-handles
                              :message/attachment-store-ref :message/attachment-mime
-                             :message/provenance-mode :message/provenance-source]
+                             :message/provenance-mode :message/provenance-source
+                             :message/object-kind :message/object-id]
                             [:message/id message-id])]
         (is (= #{:agent/reviewer} (set (:message/audience stored))))
         (is (= #{"reviewer"} (set (:message/mention-handles stored))))
         (is (= blob-id (:message/attachment-store-ref stored)))
         (is (= {:message/attachment-mime "audio/ogg"
                 :message/provenance-mode :live
-                :message/provenance-source :screen}
+                :message/provenance-source :screen
+                :message/object-kind :proposal
+                :message/object-id object-id}
                (select-keys stored [:message/attachment-mime
                                     :message/provenance-mode
-                                    :message/provenance-source]))))
+                                    :message/provenance-source
+                                    :message/object-kind
+                                    :message/object-id]))))
+      (is (= message-id
+             (dh/q '[:find ?message-id .
+                     :in $ ?kind ?object-id
+                     :where
+                     [?message :message/object-kind ?kind]
+                     [?message :message/object-id ?object-id]
+                     [?message :message/id ?message-id]]
+                   @conn :proposal object-id))
+          "applications can resolve the speech act from its typed object")
       (is (nil? (dh/q '[:find ?a .
                         :where [?a :db/ident :message/metadata]]
                       @conn))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -29,7 +29,7 @@
           room-id :concurrent-envelope
           message-id (random-uuid)
           ready (java.util.concurrent.CountDownLatch. 2)
-          completed (atom [])
+          reports (atom [])
           transact! dh/transact]
       (store/-store-room! st room-id {:slug (name room-id) :title "T"})
       (with-redefs [dh/transact
@@ -43,7 +43,9 @@
                         (throw (ex-info "concurrent writers did not rendezvous" {})))
                       (let [content (get-in tx-data [0 2 :message/content])
                             result (transact! conn tx-data)]
-                        (swap! completed conj content)
+                        ;; Record the report, not return order: a thread may be
+                        ;; descheduled after commit but before this swap.
+                        (swap! reports conj {:content content :report result})
                         result))]
         (let [first-write (future
                             (store/-store-message!
@@ -55,10 +57,13 @@
                               {:id message-id :from :bob :content "second"}))]
           (is (not= ::timeout (deref first-write 10000 ::timeout)))
           (is (not= ::timeout (deref second-write 10000 ::timeout)))))
-      (let [stored (first (store/-list-messages st room-id {}))]
+      (let [stored (first (store/-list-messages st room-id {}))
+            writers (filter (comp seq :tx-data :report) @reports)]
         (is (= 1 (count (store/-list-messages st room-id {}))))
-        (is (= (first @completed) (:content stored))
-            "the later transaction observes the winner instead of upserting")))))
+        (is (= 1 (count writers))
+            "only the winning transaction emits message datoms")
+        (is (= (:content (first writers)) (:content stored))
+            "the losing transaction observes the winner instead of upserting")))))
 
 (deftest run-lifecycle-contract
   (let [[_conn st] (mem-store)]

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -20,3 +20,16 @@
           st :strict-memory
           {:id (random-uuid) :from :alice :content "hi"
            :metadata {:unmodelled/value 1}})))))
+
+(deftest rejects-malformed-durable-object-references
+  (let [st (memory/make)]
+    (store/-store-room! st :object-memory {:slug "object-memory"})
+    (doseq [[object message]
+            [[{:kind "proposal" :id (random-uuid)} "kind"]
+             [{:kind :proposal :id "not-a-uuid"} "id"]
+             [{:kind :proposal :id (random-uuid) :title "hidden"} "keys"]]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (store/-store-message!
+                    st :object-memory
+                    {:id (random-uuid) :from :alice :content message
+                     :metadata {:object object}}))))))

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -25,7 +25,9 @@
   (let [st (memory/make)]
     (store/-store-room! st :object-memory {:slug "object-memory"})
     (doseq [[object message]
-            [[{:kind "proposal" :id (random-uuid)} "kind"]
+            [[false "false"]
+             [nil "nil"]
+             [{:kind "proposal" :id (random-uuid)} "kind"]
              [{:kind :proposal :id "not-a-uuid"} "id"]
              [{:kind :proposal :id (random-uuid) :title "hidden"} "keys"]]]
       (is (thrown? clojure.lang.ExceptionInfo

--- a/test/dvergr/runtime/durable_cursor_bus_test.clj
+++ b/test/dvergr/runtime/durable_cursor_bus_test.clj
@@ -38,7 +38,12 @@
                               (bus/post! b2 {:to :x :content "lost?"})))
         (is (empty? (bus/log b2)) "nothing on the log")
         (Thread/sleep 150)
-        (is (empty? @got2) "nothing delivered")))))
+        (is (empty? @got2) "nothing delivered"))
+      (testing "legacy boolean failure also fails closed"
+        (let [b3 (bus/create-bus {:durable-append! (constantly false)})]
+          (is (thrown-with-msg? Exception #"Durable bus append failed"
+                                (bus/post! b3 {:to :x :content "lost?"})))
+          (is (empty? (bus/log b3))))))))
 
 (deftest durable-duplicate-is-not-visible-twice
   (testing "first-write-wins covers the live log and subscribers"

--- a/test/dvergr/runtime/durable_cursor_bus_test.clj
+++ b/test/dvergr/runtime/durable_cursor_bus_test.clj
@@ -40,6 +40,28 @@
         (Thread/sleep 150)
         (is (empty? @got2) "nothing delivered")))))
 
+(deftest durable-duplicate-is-not-visible-twice
+  (testing "first-write-wins covers the live log and subscribers"
+    (let [seen (atom #{})
+          append! (fn [message]
+                    (locking seen
+                      (if (contains? @seen (:id message))
+                        :duplicate
+                        (do (swap! seen conj (:id message)) :inserted))))
+          b (bus/create-bus {:durable-append! append!})
+          got (atom [])
+          sub (bus/subscribe! b [:to :x])
+          id (random-uuid)
+          message {:id id :to :x :content "canonical"}]
+      (drain-into! b sub got :content)
+      (bus/post! b message)
+      (bus/post! b message)
+      (is (wait-until #(= ["canonical"] @got) 3000))
+      (Thread/sleep 100)
+      (is (= ["canonical"] @got)
+          "projectors and external relays see only the winning post")
+      (is (= [message] (bus/log b))))))
+
 (deftest cursor-resume-redelivers-in-flight-at-least-once
   (testing "rewinding the cursor by one (simulating a pump crash after
           handoff but before advance) re-delivers exactly that entry —


### PR DESCRIPTION
## Summary

- add one generic primary application object to durable message metadata
- validate object kind and UUID identity at the room-store protocol boundary
- store object kind and identity as typed indexed Datahike datoms and replay them losslessly
- preserve the same contract in the memory store
- document the linguistic distinction between speech-act force and what an utterance is about
- enforce immutable message envelopes atomically under concurrent Datahike writers
- suppress duplicate live bus/projector/relay effects after durable deduplication
- fail closed for both typed and legacy durability failure returns

This lets applications render one canonical Proposal, task, artifact, or approval across chat and other projections without encoding identity in prose or making Dvergr own the domain model.

## Verification

- `clojure -M:test`: 530 tests, 2270 assertions, 0 failures
- affected LLM cancellation namespace: 16 tests, 59 assertions, 0 failures
- affected store/bus namespaces: 20 tests, 84 assertions, 0 failures
- focused durable bus exact head: 5 tests, 21 assertions, 0 failures
- `clojure -M:format`
- `clojure -T:build harness`
- `git diff --check`
- independent exact-head review: clean after fixing atomicity, malformed-object consistency, concurrency-test ordering, duplicate fan-out, and legacy failure compatibility findings
