### PR TITLE
Delegate conserved resources to agent runs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,10 +48,9 @@
         ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
         ;; Substrate for the durable-cursor bus pump + supervisor
         ;; restart.
-        ;; Stacked on spindel#43 (affine partitioned world authority). Replace
-        ;; this exact reviewed commit with its Clojars release after squash.
-        org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "8c038f1a80de094cbd0c066add685bfd2017993f"}
+        ;; 0.1.43 includes structured cancellation and affine partitioned world
+        ;; authority, the substrate used by Run-world adoption and delegation.
+        org.replikativ/spindel     {:mvn/version "0.1.43"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
@@ -73,7 +72,13 @@
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        org.replikativ/datahike    {:mvn/version "0.8.1819"}
+        ;; 0.8.1861 provides writer-internal operation provenance to mandatory
+        ;; transaction predicates. Kontor uses it to keep purge/history
+        ;; validation internal without extending Datahike's public tx report.
+        org.replikativ/datahike    {:mvn/version "0.8.1861"}
+        ;; 0.1.37 provides conserved resource vectors, durable receipts, and
+        ;; mandatory Datahike invariants for Run resource delegation.
+        org.replikativ/kontor      {:mvn/version "0.1.37"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.3.38 adopts the Geschichte adapter (yggdrasil.adapters.geschichte,

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -1,8 +1,9 @@
 # Agent programs in the room REPL
 
-Status: deterministic and native LLM/tool interpreters implemented. The data
-model and Run boundary are intentional; simulation, replay, resource splitting,
-and durable continuation are later interpreters over the same contract.
+Status: deterministic and native LLM/tool interpreters plus conserved resource
+delegation are implemented. The data model and Run boundary are intentional;
+simulation, replay, provider-usage debiting, and durable continuation are later
+interpreters over the same contract.
 
 Dvergr agents can construct specialized workers and compose their executions
 from the SCI REPL. The initial surface separates four concepts:
@@ -76,6 +77,14 @@ durability-first: once `hire!` returns, `observe` and `cancel!` can address the
 Run without a startup race. If trigger persistence or spawning fails, the
 already-admitted Run is durably failed.
 
+A recursive `hire!` is structurally owned by the current Run. Ownership does
+not depend on retaining or awaiting the returned handle: parent cleanup, world
+settlement, and resource return wait until every owned child is durably
+terminal, and parent cancellation propagates to them. This prevents an ignored
+child from returning resources into an already-settled parent wallet. Long-lived
+ambient work will require an explicit detached/service operation with its own
+durable owner and resource grant; dropping a handle is not detachment.
+
 Use `await` on `(agent/result-spin handle)` inside `spin`. This is a passive
 observer: several branches may await one Run, and cancelling one observation
 does not cancel the shared work. Use `(agent/owned-result-spin handle)` for a
@@ -140,12 +149,54 @@ subscription transports—only supply model responses.
 maximum 256). A step is one provider exchange, not a conversational turn and
 not Dvergr's scheduling clock. Reactive attention may queue, merge, observe,
 fork, or switch work around these discrete transport boundaries.
-`:budget-dollars` is a per-execution spending ceiling (default $1), not a Kontor
-resource allocation. When it is exceeded after a tool-bearing model step, the Run
+`:budget-dollars` is still a provider-loop ceiling (default $1), not itself a
+Kontor debit. When it is exceeded after a tool-bearing model step, the Run
 settles as `:waiting` with reason `:budget-exhausted`; no process remains active,
-and its partial world is retained for review.
-A true resumable continuation and affine resource settlement are separate later
-contracts.
+and its partial world is retained for review. Connecting measured provider usage
+to the Run's conserved wallet is a separate next contract.
+
+## Conserved resource delegation
+
+When the Room has a Datahike resource store, `hire!` may atomically split a
+positive resource vector from the current Run (or the Room root at top level):
+
+First, a trusted host provisions the Room root with an idempotent receipt ID;
+this API is deliberately absent from SCI:
+
+```clojure
+(require '[dvergr.resource :as resource])
+
+(resource/mint! room
+                {:id #uuid "3f1e13e2-f5ca-4f88-a847-f45978599d40"
+                 :resources {"microUSD" 1000000}})
+```
+
+The stable `:id` is part of the effect protocol: retrying the same provisioning
+request cannot mint twice. An operator may instead install and fund other
+coordinates through the same trusted host boundary.
+
+The room-bound SCI program can then inspect and split only its available
+authority:
+
+```clojure
+(let [child (agent/hire! team :analyst
+                         {:task "Inspect the evidence"
+                          :resources {"microUSD" 250000}})]
+  {:remaining (agent/balance)
+   :result (await (agent/result-spin child))})
+```
+
+Coordinates are extensible strings; `"microUSD"` is merely the first installed
+unit. Kontor records the allocation and return as balanced, idempotent receipts,
+and its Datahike writer predicate rejects overdrafts or unreceipted changes.
+Allocation happens after durable Run admission but before the trigger or any
+program effect. If it fails, the Run is durably failed and no agent effect
+starts. After all owned work quiesces, unused resources return to the structural
+parent; recursive vectors therefore remain conserved across fork/join.
+
+SCI exposes only `agent/balance` and the `:resources` argument to `hire!`. It
+does not expose connections, minting, arbitrary transfers, or a way to redirect
+`:parent-run`. Installation and minting remain trusted host operations.
 
 ## Execution and world settlement
 
@@ -172,9 +223,9 @@ the SCI `hire!` closure and model-tool adapters resolve them automatically.
 
 An LLM-created sandbox can still build and revise arbitrary immutable rosters,
 but its `hire!` authority currently accepts only provider-free `:echo` and
-`:scripted` children. This prevents a child from minting new provider spend,
-tools, or recursive LLM work before Kontor can split a resource vector from the
-parent Run. A top-level Room REPL has no such program-kind ceiling.
+`:scripted` children. Generic resource vectors can already split recursively;
+paid recursive LLM work remains closed until measured provider usage is debited
+from that wallet. A top-level Room REPL has no such program-kind ceiling.
 
 The `spawn_agent` and `propose_change` model tools are convenience adapters over
 this same boundary. They construct a portable one-agent Roster, call `hire!`,

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -232,7 +232,10 @@ The canonical nested ownership path now exists: SCI `dvergr.agent/hire!` and the
 `spawn_agent` / `propose_change` tool adapters all use Run worlds. Recursive
 `hire-in!` keeps durable facts in the root control Room while forking and settling
 against the immediate work-world parent. Paid recursive LLM delegation remains
-attenuated until resource-vector splitting exists.
+attenuated until measured provider usage is debited from the already-supported
+conserved Run resource vectors. Owned child Runs delay parent settlement and
+resource return even when their handles are ignored; ambient/detached work must
+eventually receive a distinct durable owner rather than arise by accident.
 
 ### Simmis proposal
 

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -15,6 +15,7 @@
             [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as d]
             [dvergr.model.providers :as providers]
+            [dvergr.resource :as resource]
             [dvergr.system.rooms :as system-rooms]
             [dvergr.tools :as tools]
             [hasch.core :as hasch]
@@ -35,18 +36,27 @@
    to a Participant is a separate, explicit speech act."
   :_runs)
 
-(def interpreter-version 3)
+(def interpreter-version 4)
 
 (def ^:private default-max-model-steps 32)
+
+(declare with-owned-child! cancel!)
 
 (defn- child-program-authority
   "Authority made available to code and tools running inside one paid LLM Run.
    Keep this one value shared by the SCI and native-tool surfaces so a model
    cannot bypass delegation attenuation by choosing a different interface."
-  [run-id]
+  [run-id supervisor]
   {:program-kinds #{:echo :scripted}
+   ;; Conserved vectors can now be split recursively, but model calls are not
+   ;; yet debited from the Run wallet. Keep paid recursive effects closed until
+   ;; provider usage and Kontor receipts form one atomic/effectively-once path.
    :provider-effects? false
-   :parent-run run-id})
+   :parent-run run-id
+   ;; Process-local structured ownership. The sandbox may construct immutable
+   ;; rosters freely, but every admitted child execution is leased to this
+   ;; supervisor before `hire!` returns to agent code.
+   :own-child! #(with-owned-child! supervisor %)})
 
 (defn- program-result
   ([status value] {::status status ::value value})
@@ -66,6 +76,7 @@
     :state (atom {:cancelled? false
                   :sealed? false
                   :workers {}
+                  :children {}
                   :cleanup nil
                   :cleanup-phase :pending
                   :cleanup-error nil
@@ -79,9 +90,11 @@
   [supervisor]
   (let [action
         (locking supervisor
-          (let [{:keys [sealed? workers cleanup cleanup-phase quiesced?] :as state}
+          (let [{:keys [sealed? workers children cleanup cleanup-phase quiesced?]
+                 :as state}
                 @(:state supervisor)
-                normal-live? (some #(= :normal (:kind %)) (vals workers))]
+                normal-live? (or (seq children)
+                                 (some #(= :normal (:kind %)) (vals workers)))]
             (cond
               (and sealed? (not normal-live?) (= :pending cleanup-phase) cleanup)
               (do (swap! (:state supervisor) assoc :cleanup-phase :running)
@@ -191,16 +204,27 @@
      worker)))
 
 (defn- cancel-supervisor! [supervisor]
-  (let [tasks
+  (let [[tasks cancel-children]
         (locking supervisor
           (swap! (:state supervisor) assoc :cancelled? true)
-          (->> (get @(:state supervisor) :workers)
-               vals
-               (filter #(= :normal (:kind %)))
-               (map :task)
-               vec))]
+          [(->> (get @(:state supervisor) :workers)
+                vals
+                (filter #(= :normal (:kind %)))
+                (map :task)
+                vec)
+           (->> (get @(:state supervisor) :children)
+                vals
+                (map :cancel!)
+                vec)])]
     (doseq [^FutureTask task tasks]
-      (.cancel task true)))
+      (.cancel task true))
+    (doseq [cancel-child! cancel-children]
+      (try
+        (cancel-child!)
+        (catch Throwable t
+          (tel/log! {:level :warn :id ::child-cancellation-failed
+                     :data {:error (ex-message t)}}
+                    "Owned child cancellation failed")))))
   nil)
 
 (defn- register-cleanup! [supervisor cleanup]
@@ -316,6 +340,66 @@
     (spin-core/set-owned-spins! (spin-core/spin-id observer) [execution])
     observer))
 
+(defn- child-finished! [supervisor lease-id]
+  (locking supervisor
+    (swap! (:state supervisor) update :children dissoc lease-id))
+  (advance-supervisor! supervisor))
+
+(defn- with-owned-child!
+  "Reserve parent ownership before invoking zero-argument `admit-child!`.
+
+   The reservation closes the cancellation/seal race around durable child
+   admission: a parent cannot quiesce while admission is in progress, and a
+   cancellation that arrives before the RunHandle exists is replayed against
+   it immediately afterward. The lease is released only when admission fails
+   or the admitted child reaches its durable terminal state."
+  [supervisor admit-child!]
+  (let [lease-id (random-uuid)
+        cancel-slot (atom nil)
+        watch-key (Object.)
+        acknowledged? (atom false)
+        acknowledge! (fn []
+                       (when (compare-and-set! acknowledged? false true)
+                         (run/unwatch-runs! watch-key)
+                         (child-finished! supervisor lease-id)))]
+    (locking supervisor
+      (let [{:keys [sealed? cancelled?]} @(:state supervisor)]
+        (when (or sealed? cancelled?)
+          (throw (ex-info "Cannot hire an owned child after parent cancellation/seal"
+                          {:type ::supervisor-sealed})))
+        (swap! (:state supervisor) assoc-in [:children lease-id]
+               {:cancel! #(when-let [cancel-child! @cancel-slot]
+                            (cancel-child!))})))
+    (try
+      (let [^RunHandle handle (admit-child!)
+            child-id (run-id handle)
+            owner-ctx (ec/current-execution-context)
+            cancel-child! #(binding [ec/*execution-context* owner-ctx]
+                             (cancel! handle))]
+        (reset! cancel-slot cancel-child!)
+        (locking supervisor
+          (swap! (:state supervisor) assoc-in [:children lease-id :handle] handle))
+        ;; Lifecycle registration and its initial active snapshot share the Run
+        ;; registry lock. We therefore cannot miss a child that terminalizes
+        ;; during registration, and acknowledgement is independent of either
+        ;; execution graph being cancelled.
+        (run/watch-runs!
+         watch-key
+         (fn [{:keys [type runs run]}]
+           (when (or (and (= :runs/snapshot type)
+                          (not-any? #(= child-id (:run/id %)) runs))
+                     (and (= :run/finished type)
+                          (= child-id (:run/id run))))
+             (acknowledge!))))
+        (when (:cancelled? @(:state supervisor))
+          (cancel-child!))
+        handle)
+      (catch Throwable t
+        (acknowledge!)
+        (when-let [cancel-child! @cancel-slot]
+          (try (cancel-child!) (catch Throwable _)))
+        (throw t)))))
+
 (defn- cancelled! [run-id]
   (throw (ex-info "Run cancelled" {:type ::cancelled :run/id run-id})))
 
@@ -371,7 +455,8 @@
                       {:type ::no-provider
                        :agent/id (:agent/id agent)}))))
 
-(defn- new-llm-context [control-room work-room run-id agent budget-dollars chat-id]
+(defn- new-llm-context
+  [control-room work-room run-id agent budget-dollars chat-id supervisor]
   (let [system-id (room-context/room-system-id work-room)
         ;; Model messages, tool results, authorization receipts, and costs are
         ;; control-plane evidence. Keep that trace in the parent even when the
@@ -386,14 +471,14 @@
                    :kb-conn (when system-id (system-rooms/room-kb-conn system-id))
                    :room-id system-id
                    :room-runtime-id (:id work-room)
-                   ;; Until Kontor can split a resource vector, a paid child may
-                   ;; only delegate provider-free work. Pure roster construction
-                   ;; remains available inside SCI.
-                   :agent-program-ceiling (child-program-authority run-id)})]
+                   ;; Generic resource vectors split recursively, but paid model
+                   ;; usage is not debited yet. Permit only provider-free child
+                   ;; programs until that receipt path exists.
+                   :agent-program-ceiling (child-program-authority run-id supervisor)})]
     {:chat-ctx chat-ctx
      :owned-db? (nil? trace-db)}))
 
-(defn- llm-tool-context [control-room room chat-ctx agent run-id]
+(defn- llm-tool-context [control-room room chat-ctx agent run-id supervisor]
   (let [system-id (room-context/room-system-id room)
         tool-map (tools/normalize-tools (or (:agent/tools agent) #{}))
         ;; Ordinary room/task effects target the branched work store. A
@@ -416,7 +501,7 @@
            ;; the SCI API. Carry structural parentage and the identical
            ;; attenuation policy across this boundary explicitly.
            :run-id run-id
-           :agent-program-ceiling (child-program-authority run-id)
+           :agent-program-ceiling (child-program-authority run-id supervisor)
            :actor (:agent/id agent)
            :model-policy (:agent/model-policy agent)})
          (assoc :workspace-roots
@@ -444,12 +529,13 @@
             (fn []
               (let [{:keys [chat-ctx owned-db?]}
                     (new-llm-context control-room work-room run-id agent
-                                     budget-dollars chat-id)
+                                     budget-dollars chat-id supervisor)
                     _ (when owned-db?
                         (register-cleanup!
                          supervisor #(chat-context/close-chat! chat-ctx)))
                     {:keys [tool-map tool-ctx]}
-                    (llm-tool-context control-room work-room chat-ctx agent run-id)
+                    (llm-tool-context control-room work-room chat-ctx agent run-id
+                                      supervisor)
                     model-spec (resolve-model-spec agent)
                     instructions
                     (prompt/assemble-system-prompt
@@ -561,7 +647,7 @@
                               trigger supervisor)
     (execute-deterministic-program run-id agent task)))
 
-(def ^:private hire-option-keys #{:task :from :parent-run :settlement})
+(def ^:private hire-option-keys #{:task :from :parent-run :settlement :resources})
 
 (defn- validate-program!
   [{:keys [kind delay-ms max-model-steps budget-dollars auto-compact? compaction-model]
@@ -619,7 +705,7 @@
     program))
 
 (defn- validate-hire!
-  [roster agent-ref {:keys [task from parent-run] :as opts}]
+  [roster agent-ref {:keys [task from parent-run resources] :as opts}]
   (when-let [unknown (seq (remove hire-option-keys (keys opts)))]
     (throw (ex-info "Unknown hire! options"
                     {:type ::unknown-hire-options
@@ -634,6 +720,17 @@
   (when (and parent-run (not (uuid? parent-run)))
     (throw (ex-info "hire! :parent-run must be a UUID"
                     {:type ::invalid-parent-run :parent-run parent-run})))
+  (when (and (some? resources)
+             (not (and (map? resources)
+                       (seq resources)
+                       (every? (fn [[coordinate amount]]
+                                 (and (or (string? coordinate)
+                                          (keyword? coordinate))
+                                      (number? amount)
+                                      (pos? amount)))
+                               resources))))
+    (throw (ex-info "hire! :resources must be a non-empty positive resource vector"
+                    {:type ::invalid-resources :resources resources})))
   (when-not (roster/data-value? task)
     (throw (ex-info "Task must be portable data"
                     {:type ::non-portable-task :task task})))
@@ -731,12 +828,32 @@
      :finish-opts (cond-> {:settlement-status status}
                     reason (assoc :settlement-reason reason))}))
 
+(defn- return-unused-resources!
+  "Return a Run's remaining conserved vector after its owned work quiesces.
+
+   The transfer id is stable, so a retry after an uncertain commit is
+   idempotent. A configured resource allocation is never silently abandoned:
+   transient store failures retain the live Run and retry behind the same
+   physical-quiescence fence as durable terminal persistence."
+  [room id parent-run allocated?]
+  (when allocated?
+    (loop []
+      (let [outcome (try
+                      (let [remaining (resource/run-balance room id)]
+                        (when (seq remaining)
+                          (resource/return! room id parent-run remaining))
+                        :returned)
+                      (catch Throwable t t))]
+        (when (instance? Throwable outcome)
+          (Thread/sleep 25)
+          (recur))))))
+
 (defn- finalize-execution-external!
   "Finalize from a process-local watcher only after the orchestration Spin has a
    cached terminal result and the stable supervisor reports every native worker
    and owned cleanup quiescent. World settlement happens behind the same
    physical-quiescence fence."
-  [room run-world id supervisor execution completion outcome]
+  [room control-room run-world id parent-run allocated? supervisor execution completion outcome]
   (future
     ;; `future` conveys dynamic bindings. A cancellation hook normally launches
     ;; this watcher from the losing observer Spin, so retaining its *spin-id*
@@ -757,6 +874,7 @@
               (Thread/sleep 5)
               (recur))))
         (await-supervisor! supervisor)
+        (return-unused-resources! control-room id parent-run allocated?)
         (let [cleanup-error (:cleanup-error @(:state supervisor))
               result (if cleanup-error
                        {:run/id id :run/status :failed
@@ -866,11 +984,12 @@
    - `:from`       triggering actor, default `:repl`
    - `:parent-run` explicit structural parent Run UUID
    - `:settlement`  `:automatic` (default), `:review`, or `:discard`
+   - `:resources`   positive conserved vector split from the parent Run/Room
    Built-in program kinds are deterministic `:scripted` / `:echo` and the
    bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
    interpreters implement the same boundary."
   [control-room world-parent roster agent-ref
-   {:keys [task from parent-run settlement]
+   {:keys [task from parent-run settlement resources]
     :or {from :repl settlement :automatic}
     :as raw-opts}]
   (let [opts      (assoc raw-opts :from from)
@@ -906,6 +1025,15 @@
       (catch Throwable t
         (d/discard work-room)
         (throw t)))
+    (try
+      (resource/allocate-run! control-room id parent-run resources)
+      (catch Throwable t
+        (let [{:keys [status reason]} (world/settle! run-world :failed)]
+          (run/finish! id :failed {:reason :resource-allocation-failed
+                                   :error t
+                                   :settlement-status status
+                                   :settlement-reason reason}))
+        (throw t)))
     (run/register-cancel-hook! id ::native-worker
                                #(cancel-supervisor! supervisor))
     (try
@@ -914,6 +1042,7 @@
       ;; record or an unowned message behind.
       (d/post! control-room trigger)
       (catch Throwable t
+        (return-unused-resources! control-room id parent-run (boolean (seq resources)))
         (let [{:keys [status reason]} (world/settle! run-world :failed)]
           (run/finish! id :failed {:reason :trigger-emission-failed
                                    :error t
@@ -964,10 +1093,12 @@
                         (if (= :cancelled (:run/status result))
                           {:reason :structured-cancellation}
                           {:reason :execution-error :error t})})))})
-        (finalize-execution-external! world-parent run-world id supervisor worker-execution
+        (finalize-execution-external! world-parent control-room run-world id parent-run
+                                      (boolean (seq resources)) supervisor worker-execution
                                       completion outcome-promise)
         handle)
       (catch Throwable t
+        (return-unused-resources! control-room id parent-run (boolean (seq resources)))
         (let [{:keys [status reason]} (world/settle! run-world :failed)]
           (run/finish! id :failed {:reason :spawn-failed :error t
                                    :settlement-status status

--- a/src/dvergr/resource.clj
+++ b/src/dvergr/resource.clj
@@ -1,0 +1,142 @@
+(ns dvergr.resource
+  "Conserved, affine authority for Rooms and Runs.
+
+   Resource facts live in the durable control Room store. Work-world forks may
+   create or discard speculative application state, but they never copy or
+   settle this authority: a child receives resources only through one governed
+   Kontor transfer from its parent wallet."
+  (:require [dvergr.room.store :as store]
+            [kontor.resource :as kontor])
+  (:import [java.nio.charset StandardCharsets]
+           [java.util Date UUID]))
+
+(def microdollars
+  "The initial numeraire coordinate. Other coordinates remain ordinary data and
+   may be installed by the trusted host API."
+  "microUSD")
+
+(defn- stable-id [value]
+  (UUID/nameUUIDFromBytes
+   (.getBytes (str value) StandardCharsets/UTF_8)))
+
+(defn room-wallet-id
+  "Stable wallet UUID for a durable Room keyword."
+  [room-id]
+  (stable-id (str "dvergr/resource/room|" room-id)))
+
+(defn run-wallet-id
+  "A Run's durable UUID is also its wallet identity."
+  [run-id]
+  run-id)
+
+(defn allocation-id [run-id]
+  (stable-id (str "dvergr/resource/allocation|" run-id)))
+
+(defn return-id [run-id]
+  (stable-id (str "dvergr/resource/return|" run-id)))
+
+(defn- resource-store! [room]
+  (let [resource-store (:store room)]
+    (when-not (satisfies? store/PResourceStore resource-store)
+      (throw (ex-info "Room has no durable conserved-resource store"
+                      {:type ::resource-store-unavailable
+                       :room-id (:id room)})))
+    resource-store))
+
+(defn install-connection!
+  "Install the minimal Kontor kernel and the Room's root wallet on `conn`.
+
+   This is a trusted boot boundary, not an SCI capability. The chat entity must
+   already exist so its lookup ref can own the wallet."
+  [conn room-id chat-id]
+  (kontor/install! conn)
+  (kontor/install-unit! conn {:symbol microdollars
+                              :name "Micro US dollars"
+                              :precision 0})
+  (kontor/open-account! conn {:id (room-wallet-id room-id)
+                              :owner [:chat/id chat-id]
+                              :name (str "Room " room-id)})
+  conn)
+
+(defn install-unit!
+  "Trusted host operation: install a resource coordinate in a Room's book."
+  [room spec]
+  (store/-install-resource-unit! (resource-store! room) spec))
+
+(defn balance
+  "Read a Room root wallet, or an explicitly named wallet UUID/ref."
+  ([room]
+   (balance room (kontor/account-ref (room-wallet-id (:id room)))))
+  ([room account]
+   (store/-resource-balance (resource-store! room) account)))
+
+(defn run-balance [room run-id]
+  (balance room (kontor/account-ref (run-wallet-id run-id))))
+
+(defn mint!
+  "Trusted host provisioning operation. `spec` requires a stable UUID `:id`
+   plus a positive `:resources` vector; minting is never exposed inside SCI."
+  [room {:keys [id resources effective-date posted-at actor]}]
+  (store/-transfer-resources!
+   (resource-store! room)
+   (cond-> {:id id
+            :kind :mint
+            :source kontor/source-account
+            :destination (kontor/account-ref (room-wallet-id (:id room)))
+            :resources resources
+            :effective-date (or effective-date (Date.))}
+     posted-at (assoc :posted-at posted-at)
+     actor (assoc :actor actor))))
+
+(defn allocate-run!
+  "Atomically create `run-id`'s wallet and split `resources` from its immediate
+   parent Run wallet, or from the Room root wallet for a top-level Run."
+  [room run-id parent-run resources]
+  (when (seq resources)
+    (let [resource-store (resource-store! room)
+          parent-wallet (if parent-run
+                          (run-wallet-id parent-run)
+                          (room-wallet-id (:id room)))
+          transfer {:id (allocation-id run-id)
+                    :kind :grant
+                    :source (kontor/account-ref parent-wallet)
+                    :destination (kontor/account-ref (run-wallet-id run-id))
+                    :resources resources
+                    :effective-date (Date.)}]
+      {:wallet (kontor/account-ref (run-wallet-id run-id))
+       :receipt (store/-allocate-resource-wallet!
+                 resource-store
+                 {:id (run-wallet-id run-id)
+                  :owner [:run/id run-id]
+                  :name (str "Run " run-id)}
+                 transfer)})))
+
+(defn consume!
+  "Consume resources from one Run into the global sink. A stable UUID `:id` is
+   required so a retried effect cannot charge twice."
+  [room run-id {:keys [id resources effective-date posted-at actor]}]
+  (store/-transfer-resources!
+   (resource-store! room)
+   (cond-> {:id id
+            :kind :consume
+            :source (kontor/account-ref (run-wallet-id run-id))
+            :destination kontor/sink-account
+            :resources resources
+            :effective-date (or effective-date (Date.))}
+     posted-at (assoc :posted-at posted-at)
+     actor (assoc :actor actor))))
+
+(defn return!
+  "Return an explicit positive vector from a Run to its immediate parent/Room."
+  [room run-id parent-run resources]
+  (store/-transfer-resources!
+   (resource-store! room)
+   {:id (return-id run-id)
+    :kind :return
+    :source (kontor/account-ref (run-wallet-id run-id))
+    :destination (kontor/account-ref
+                  (if parent-run
+                    (run-wallet-id parent-run)
+                    (room-wallet-id (:id room))))
+    :resources resources
+    :effective-date (Date.)}))

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -84,6 +84,31 @@
     "Return recent Runs, newest first. Optional :status and :actor filters are
      applied before :limit."))
 
+(defprotocol PResourceStore
+  "Conserved resource authority cohabiting with durable Room control state.
+
+   This deliberately exposes semantic wallet/transfer operations rather than a
+   raw database connection. SCI programs receive still narrower closures over
+   these operations, so they cannot mint authority or bypass the governor."
+
+  (-open-resource-wallet! [this spec]
+    "Open or idempotently re-open a wallet from {:id :owner :name}.")
+
+  (-install-resource-unit! [this spec]
+    "Install or idempotently re-install one conserved resource coordinate.")
+
+  (-allocate-resource-wallet! [this wallet-spec transfer-spec]
+    "Atomically open a child wallet and grant its initial conserved vector.")
+
+  (-resource-balance [this account]
+    "Return the current conserved vector for a wallet/account ref.")
+
+  (-transfer-resources! [this spec]
+    "Commit a governed :mint/:grant/:consume/:return transfer spec.")
+
+  (-resource-receipt [this transfer-id]
+    "Return the durable transfer receipt, or nil."))
+
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -11,6 +11,8 @@
             [dvergr.chat.schema :as schema]
             [dvergr.chat.persist :as persist]
             [dvergr.room.store :as store]
+            [kontor.gate :as kontor-gate]
+            [kontor.resource :as resource]
             [taoensso.telemere :as tel]))
 
 ;; =============================================================================
@@ -494,7 +496,42 @@
                       #(compare %2 %1))
              (take (or limit 100))
              vec)
-        []))))
+        [])))
+
+  store/PResourceStore
+
+  (-open-resource-wallet! [_ spec]
+    (resource/open-account! conn spec))
+
+  (-install-resource-unit! [_ spec]
+    (resource/install-unit! conn spec))
+
+  (-allocate-resource-wallet! [_ wallet-spec transfer-spec]
+    (if-let [existing (resource/receipt conn (:id transfer-spec))]
+      ;; Let Kontor compare the complete semantic command so an id collision is
+      ;; never mistaken for a successful replay.
+      (resource/transfer! conn transfer-spec)
+      (try
+        (kontor-gate/transact-with-validation
+         conn
+         (into (vec (resource/open-account-tx-data wallet-spec))
+               (resource/transfer-tx-data transfer-spec)))
+        (assoc (resource/receipt conn (:id transfer-spec)) :status :committed)
+        (catch Throwable error
+          ;; Resolve the only benign race: another identical allocator may
+          ;; have committed between the optimistic receipt read and this write.
+          (if (resource/receipt conn (:id transfer-spec))
+            (resource/transfer! conn transfer-spec)
+            (throw error))))))
+
+  (-resource-balance [_ account]
+    (resource/balance conn account))
+
+  (-transfer-resources! [_ spec]
+    (resource/transfer! conn spec))
+
+  (-resource-receipt [_ transfer-id]
+    (resource/receipt conn transfer-id)))
 
 (defn make
   "Create a DatahikeStore. `conn` must be an existing Datahike

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -63,6 +63,8 @@
         run-id*        (requiring-resolve 'dvergr.agent.program/run-id)
         result-spin*   (requiring-resolve 'dvergr.agent.program/result-spin)
         owned-result-spin* (requiring-resolve 'dvergr.agent.program/owned-result-spin)
+        room-balance*  (requiring-resolve 'dvergr.resource/balance)
+        run-balance*   (requiring-resolve 'dvergr.resource/run-balance)
         room-lookup*   (requiring-resolve 'dvergr.room.registry/lookup)
         current-room   (fn []
                          (when room-id
@@ -90,7 +92,8 @@
                                control-room (control-room! work-room)
                                definition (lookup-agent* roster agent-ref)
                                kind (get-in definition [:agent/program :kind])
-                               allowed-kinds (:program-kinds agent-program-ceiling)]
+                               allowed-kinds (:program-kinds agent-program-ceiling)
+                               ambient-parent (:parent-run agent-program-ceiling)]
                            (when (and allowed-kinds
                                       (not (contains? allowed-kinds kind)))
                              (throw (ex-info
@@ -99,13 +102,24 @@
                                       :agent-ref agent-ref
                                       :program-kind kind
                                       :allowed-program-kinds allowed-kinds})))
+                           (when (and ambient-parent
+                                      (contains? opts :parent-run)
+                                      (not= ambient-parent (:parent-run opts)))
+                             (throw (ex-info
+                                     "Child parent must be the current Run"
+                                     {:type ::parent-run-exceeds-authority
+                                      :parent-run (:parent-run opts)
+                                      :current-run ambient-parent})))
                            (binding [ec/*execution-context* (:ctx work-room)]
-                             (hire-in* control-room work-room roster agent-ref
-                                       (if (and (:parent-run agent-program-ceiling)
-                                                (not (contains? opts :parent-run)))
-                                         (assoc opts :parent-run
-                                                (:parent-run agent-program-ceiling))
-                                         opts)))))
+                             (let [admit-child!
+                                   #(hire-in* control-room work-room roster agent-ref
+                                              (if (and ambient-parent
+                                                       (not (contains? opts :parent-run)))
+                                                (assoc opts :parent-run ambient-parent)
+                                                opts))]
+                               (if-let [own-child! (:own-child! agent-program-ceiling)]
+                                 (own-child! admit-child!)
+                                 (admit-child!))))))
         observe-fn     (fn [handle-or-id]
                          (let [work-room (room!)
                                control-room (control-room! work-room)]
@@ -118,7 +132,13 @@
                          (let [work-room (room!)
                                control-room (control-room! work-room)]
                            (binding [ec/*execution-context* (:ctx work-room)]
-                             (cancel* control-room handle-or-id))))]
+                             (cancel* control-room handle-or-id))))
+        balance-fn     (fn []
+                         (let [work-room (room!)
+                               control-room (control-room! work-room)]
+                           (if-let [run-id (:parent-run agent-program-ceiling)]
+                             (run-balance* control-room run-id)
+                             (room-balance* control-room))))]
     (sci/add-namespace!
      sci-ctx 'dvergr.agent
      (doc/with-docs
@@ -132,6 +152,7 @@
         'hire!        hire-fn
         'observe      observe-fn
         'cancel!      cancel-fn
+        'balance      balance-fn
         'run-id       run-id*
         'result-spin  result-spin*
         'owned-result-spin owned-result-spin*}
@@ -142,9 +163,10 @@
          ref          [([agent-def]) "Return the stable {:agent/id :agent/version} reference for an AgentDef."]
          list         [([roster]) "All AgentDefs in a Roster, deterministically ordered by id."]
          select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
-         hire!        [([roster agent-ref opts]) "Durably start one AgentDef in the current Room: (hire! team :a {:task value}). Returns a RunHandle; opts may also include :from and structural :parent-run."]
+         hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
          cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]
+         balance      [([]) "Return the conserved resource vector available to the current Run, or the Room root at top level."]
          run-id       [([handle]) "Return the durable Run UUID represented by a RunHandle."]
          result-spin  [([handle]) "Return a passive Spindel observer Spin for a RunHandle. Multiple observers may await it; cancelling an observer does not cancel the Run."]
          owned-result-spin [([handle]) "Return an ownership-coupled result Spin. Cancelling this observer also cancels the underlying Run; use only when the observer owns that child execution."]}))))

--- a/src/dvergr/system/rooms.clj
+++ b/src/dvergr/system/rooms.clj
@@ -21,6 +21,8 @@
             [dvergr.system.db :as sdb]
             [dvergr.kb.schema :as kbs]
             [dvergr.chat.schema :as cschema]
+            [dvergr.resource :as resource]
+            [dvergr.room.store :as room-store]
             [dvergr.search.secondary :as search-secondary]
             [dvergr.scheduler.schema :as sched-schema]
             [dvergr.runtime.ctx :as rctx]
@@ -39,17 +41,24 @@
 ;; RUNS on this ctx (bus/turn/composite = ISOLATION); its identity in the
 ;; registry is Tier-1 shared (root). See `dvergr.runtime.ctx`.
 (defonce ^:private room-ctxs (atom {}))
+(defonce ^:private room-hydration-errors (atom {}))
 
 (defn room-ctx-for
-  "The room's own execution context (created by provision/hydrate), or nil."
+  "The room's own execution context (created by provision/hydrate), or nil.
+   A known hydration failure is not allowed to fall back to the daemon root."
   [room-id]
-  (get @room-ctxs room-id))
+  (if-let [error (get @room-hydration-errors room-id)]
+    (throw (ex-info "Room is unavailable because hydration failed"
+                    {:type ::room-hydration-failed :room/id room-id}
+                    error))
+    (get @room-ctxs room-id)))
 
 (defn clear-room-ctxs!
   "Drop all per-room execution contexts. Call on daemon stop! so a same-process
    restart doesn't reuse stale forked ctxs pointing at the previous daemon root."
   []
-  (reset! room-ctxs {}))
+  (reset! room-ctxs {})
+  (reset! room-hydration-errors {}))
 
 (defn- scope-path [scope] (str (io/file (paths/systems-dir) scope)))
 
@@ -136,6 +145,18 @@
   [slug]
   (java.util.UUID/nameUUIDFromBytes (.getBytes (str "dvergr-room-msgs|" slug))))
 
+(defn- ensure-msgs-resources!
+  "Install/re-register the conserved-resource kernel for one messages store."
+  [conn]
+  (when-let [[slug chat-id]
+             (d/q '[:find [?slug ?chat-id]
+                    :where
+                    [?room :room/slug ?slug]
+                    [?room :chat/id ?chat-id]]
+                  @conn)]
+    (resource/install-connection! conn (room-store/slug->room-id slug) chat-id))
+  conn)
+
 (defn- seed-msgs-store!
   "Create the per-room messages store (if absent), install the chat schema, and
    seed its single `:chat/*`+`:room/*` row so the DatahikeStore can scope messages
@@ -144,12 +165,13 @@
   ;; RF5: schedules are a per-room project artifact — the (transparent)
   ;; :schedule/* schema rides along as :extra-schema so the room's reactive
   ;; scheduler (dvergr.rooms.scheduler) can store + fire them from this store.
-  (sdh/provision! {:cfg (msgs-cfg path)
-                   :extra-schema sched-schema/schema
-                   :seed-tx [(merge (cschema/create-chat-entity
-                                     {:id (msgs-chat-id slug) :title (or name slug)})
-                                    {:room/slug slug :room/type :internal})]
-                   :register? false})
+  (-> (sdh/provision! {:cfg (msgs-cfg path)
+                       :extra-schema sched-schema/schema
+                       :seed-tx [(merge (cschema/create-chat-entity
+                                         {:id (msgs-chat-id slug) :title (or name slug)})
+                                        {:room/slug slug :room/type :internal})]
+                       :register? false})
+      ensure-msgs-resources!)
   ;; Declare the messages fulltext (scriptum) secondary index once, after the
   ;; chat schema is installed. It's schema data in the store, so it forks with
   ;; the room; datahike maintains it on every message transact. Best-effort.
@@ -163,8 +185,9 @@
   [msgs-path kb-path repo-path]
   ;; Schema was installed at creation (seed-msgs-store! / provision-room!) —
   ;; registration is a boot concern, so :schema? false keeps it connect+register.
-  (sdh/provision! {:cfg (msgs-cfg msgs-path) :schema? false
-                   :system-name (msgs-system-name msgs-path)})
+  (-> (sdh/provision! {:cfg (msgs-cfg msgs-path) :schema? false
+                       :system-name (msgs-system-name msgs-path)})
+      ensure-msgs-resources!)
   (sdh/provision! {:cfg (kb-cfg kb-path) :schema? false
                    :system-name (kb-system-name kb-path)})
   (ygg/register! (geschichte/create-system :scope repo-path
@@ -172,12 +195,29 @@
 
 (defn- register-system-into-current!
   "Register one registry system (`{:system/type :system/scope}`) into the bound
-   ctx's composite. Best-effort."
+   ctx's composite. Optional systems remain best-effort; a messages-store
+   resource-governance failure is fatal because publishing that Room would
+   silently remove its mandatory accounting boundary."
   [{:system/keys [type scope]}]
   (try
     (case type
-      :msgs (sdh/provision! {:cfg (msgs-cfg scope) :schema? false
-                             :system-name (msgs-system-name scope)})
+      :msgs (let [conn (sdh/provision! {:cfg (msgs-cfg scope)
+                                        :schema? false
+                                        :register? false})]
+              (try
+                ;; Establish mandatory accounting governance before publishing
+                ;; this connection as a fork-visible Yggdrasil system. A failed
+                ;; install therefore cannot leave a partially registered Room
+                ;; context behind.
+                (ensure-msgs-resources! conn)
+                (sdh/provision! {:conn conn :schema? false
+                                 :system-name (msgs-system-name scope)})
+                (catch Throwable error
+                  ;; Governance is store-global and idempotent, not owned by
+                  ;; this connection attempt. It may protect another live Room
+                  ;; sharing the store, so release only this connection.
+                  (d/release conn)
+                  (throw error))))
       :kb   (sdh/provision! {:cfg (kb-cfg scope) :schema? false
                              :system-name (kb-system-name scope)})
       :repo (ygg/register! (geschichte/create-system :scope scope
@@ -188,7 +228,14 @@
       :data (sdh/provision! {:conn (connect-data-store scope) :schema? false
                              :system-name (str "room-data-" (.getName (io/file scope)))})
       nil)
-    (catch Throwable _ nil)))
+    (catch Throwable error
+      (when (= :msgs type)
+        (throw (ex-info "Messages resource kernel failed to hydrate"
+                        {:type ::resource-hydration-failed
+                         :system/type type
+                         :system/scope scope}
+                        error)))
+      nil)))
 
 (defn hydrate-rooms!
   "Recreate each room's OWN execution context (RF5 S2) on daemon boot and
@@ -199,19 +246,29 @@
    Best-effort per room."
   []
   (doseq [{:room/keys [id]} (sdb/all-rooms)]
-    (try
-      (let [room-ctx (sctx/fork-context (rctx/current-root))]
+    (let [room-ctx (sctx/fork-context (rctx/current-root))]
+      (try
         (binding [ec/*execution-context* room-ctx]
-          (doseq [{:keys [system]} (sdb/systems-for-room id)]
+          ;; The mandatory messages/accounting system is always first. If it
+          ;; cannot be governed, the fresh fork has not registered any Room
+          ;; systems and can be safely withheld without a separate fork-close
+          ;; lifecycle (Spindel forks share their root lifecycle).
+          (doseq [{:keys [system]}
+                  (sort-by #(if (= :msgs (get-in % [:system :system/type])) 0 1)
+                           (sdb/systems-for-room id))]
             (register-system-into-current! system)))
-        (swap! room-ctxs assoc id room-ctx))
-      ;; Never swallow silently: a room that fails to hydrate has NO ctx → callers
-      ;; fall back to the daemon ROOT ctx and lose all per-room isolation. Log loudly.
-      (catch Throwable e
-        ((requiring-resolve 'taoensso.telemere/log!)
-         {:level :error :id :rooms/hydrate-failed
-          :data {:room id :error (.getMessage e)}}
-         "Room hydration failed — room will lack per-room isolation until restart")))))
+        (swap! room-ctxs assoc id room-ctx)
+        (swap! room-hydration-errors dissoc id)
+        (catch Throwable e
+          (swap! room-hydration-errors assoc id e)
+          ;; Fork contexts share the root lifecycle and are not independently
+          ;; closeable. Mandatory messages governance is established before its
+          ;; system is registered, so this fresh unpublished context has no
+          ;; accounting system/capability to retain when that step fails.
+          ((requiring-resolve 'taoensso.telemere/log!)
+           {:level :error :id :rooms/hydrate-failed
+            :data {:room id :error (.getMessage e)}}
+           "Room hydration failed — context was withheld"))))))
 
 (defn provision-room!
   "Create a room/project with its OWN execution context (RF5 S2) holding its own
@@ -259,6 +316,7 @@
         (binding [ec/*execution-context* room-ctx]
           (register-room-systems! msgs-path kb-path repo-path))
         (swap! room-ctxs assoc room-id room-ctx)
+        (swap! room-hydration-errors dissoc room-id)
         (sdb/attach! room-id repo-id :owner)
         (sdb/attach! room-id kb-id   :owner)
         (sdb/attach! room-id msgs-id :owner)

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -1702,11 +1702,15 @@ Note: changes take effect on the next agent restart or reload."
                          :program {:kind :llm
                                    :budget-dollars (or budget 0.50)}})
           handle       (binding [rtc/*execution-context* ctx]
-                         (hire-in! control-room room roster agent-id
-                                   (cond-> {:task task
-                                            :from (or actor :spawn-agent)
-                                            :settlement settlement}
-                                     run-id (assoc :parent-run run-id))))]
+                         (let [admit-child!
+                               #(hire-in! control-room room roster agent-id
+                                          (cond-> {:task task
+                                                   :from (or actor :spawn-agent)
+                                                   :settlement settlement}
+                                            run-id (assoc :parent-run run-id)))]
+                           (if-let [own-child! (:own-child! agent-program-ceiling)]
+                             (own-child! admit-child!)
+                             (admit-child!))))]
       (try
         (let [result (binding [rtc/*execution-context* ctx] @handle)]
           {:type :success

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -12,12 +12,14 @@
             [dvergr.discourse :as d]
             [dvergr.model.chat :as model-chat]
             [dvergr.model.providers :as providers]
+            [dvergr.resource :as resource]
             [dvergr.room.registry :as registry]
             [dvergr.rooms.forks :as forks]
             [dvergr.room.store :as room-store]
             [dvergr.room.store.memory :as memory]
             [dvergr.room.store.datahike :as datahike-store]
             [dvergr.tools :as tools]
+            [kontor.governance :as kontor-governance]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.engine.context :as context]
@@ -45,6 +47,26 @@
     (let [conn (dh/connect cfg)]
       (chat-schema/ensure-full-schema! conn)
       [(d/make-room {:id id :store (datahike-store/make conn)}) conn])))
+
+(defn- resource-test-room [id]
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? true
+             :schema-flexibility :write}
+        chat-id (random-uuid)]
+    (dh/create-database cfg)
+    (let [conn (dh/connect cfg)]
+      (chat-schema/ensure-full-schema! conn)
+      (dh/transact conn
+                   [(merge (chat-schema/create-chat-entity
+                            {:id chat-id :title (name id)})
+                           {:room/slug (room-store/room-id->slug id)
+                            :room/type :internal})])
+      (resource/install-connection! conn id chat-id)
+      [(d/make-room {:id id :store (datahike-store/make conn)}) conn])))
+
+(defn- close-resource-test-room! [room conn]
+  (kontor-governance/ungovern! conn)
+  (d/close-room! room))
 
 (defn- fail-terminal-store [delegate fail-terminal?]
   (reify room-store/PRoomStore
@@ -114,6 +136,189 @@
         (is (empty? (run/active-runs :program-hire))))
       (finally
         (d/close-room! room)))))
+
+(deftest hire-splits-and-returns-a-conserved-resource-vector
+  (let [[room conn] (resource-test-room :program-resources)
+        team (roster/make-agent
+              (roster/make-roster {:id :resource-team})
+              {:id :worker
+               :program {:kind :scripted :delay-ms 250 :reply :done}})]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 10M}})
+      (let [handle (binding [ec/*execution-context* (:ctx room)]
+                     (program/hire! room team :worker
+                                    {:task :work
+                                     :resources {resource/microdollars 4M}}))]
+        (is (wait-until #(= {resource/microdollars 4M}
+                            (resource/run-balance room (program/run-id handle)))
+                        2000))
+        (is (= {resource/microdollars 6M} (resource/balance room)))
+        (is (= :completed
+               (:run/status
+                (binding [ec/*execution-context* (:ctx room)] @handle))))
+        ;; Public completion is durability-first: unused authority has already
+        ;; returned through the stable receipt before the handle resolves.
+        (is (= {resource/microdollars 10M} (resource/balance room)))
+        (is (= {} (resource/run-balance room (program/run-id handle)))))
+      (finally
+        (close-resource-test-room! room conn)))))
+
+(deftest ignored-owned-child-delays-parent-resource-settlement
+  (let [[room conn] (resource-test-room :program-owned-child-resources)
+        team (-> (roster/make-roster {:id :nested-resource-team})
+                 (roster/make-agent
+                  {:id :parent :program {:kind :scripted :reply :parent-done}})
+                 (roster/make-agent
+                  {:id :child :program {:kind :scripted :reply :child-done}}))
+        parent-runtime (promise)
+        status-key (keyword "dvergr.agent.program" "status")
+        value-key (keyword "dvergr.agent.program" "value")
+        execute-program
+        (fn [control-room work-room run-id _chat-id agent _task _trigger supervisor]
+          (if (= :parent (:agent/id agent))
+            (sp/spin
+             (deliver parent-runtime [supervisor work-room])
+             (sp/await (comb/sleep 1500))
+             {status-key :completed value-key :parent-done})
+            (sp/spin
+             (sp/await (comb/sleep 2500))
+             {status-key :completed value-key :child-done})))]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 10M}})
+      (with-redefs-fn
+        {#'program/execute-program execute-program}
+        (fn []
+          (binding [ec/*execution-context* (:ctx room)]
+            (let [parent (program/hire!
+                          room team :parent
+                          {:task :coordinate
+                           :resources {resource/microdollars 10M}})
+                  [supervisor parent-work] (deref parent-runtime 2000
+                                                  [::timeout nil])
+                  child (binding [ec/*execution-context* (:ctx parent-work)]
+                          (#'program/with-owned-child!
+                           supervisor
+                           #(do
+                              (program/hire-in!
+                               room parent-work team :child
+                               {:task :delegated
+                                :parent-run (program/run-id parent)
+                                :resources {resource/microdollars 4M}}))))]
+              (is (not= ::timeout supervisor))
+              (is (= ::timeout (deref parent 1750 ::timeout))
+                  "ignoring an owned handle cannot let the parent settle early")
+              (is (= {} (resource/balance room)))
+              (is (= {resource/microdollars 6M}
+                     (resource/run-balance room (program/run-id parent))))
+              (is (= {resource/microdollars 4M}
+                     (resource/run-balance room (program/run-id child))))
+              (is (= :child-done
+                     (:run/value
+                      (binding [ec/*execution-context* (:ctx parent-work)]
+                        (deref child 5000 ::timeout)))))
+              (is (= :parent-done (:run/value (deref parent 5000 ::timeout))))
+              (is (= {resource/microdollars 10M} (resource/balance room)))
+              (is (= {} (resource/run-balance room (program/run-id parent))))
+              (is (= {} (resource/run-balance room (program/run-id child))))))))
+      (finally
+        (deliver parent-runtime [::closed nil])
+        (close-resource-test-room! room conn)))))
+
+(deftest cancellation-during-child-admission-retains-the-ownership-lease
+  (let [[room conn] (resource-test-room :program-owned-child-cancel-race)
+        team (-> (roster/make-roster {:id :cancel-race-team})
+                 (roster/make-agent
+                  {:id :parent :program {:kind :scripted :reply :parent-done}})
+                 (roster/make-agent
+                  {:id :child :program {:kind :scripted :reply :child-done}}))
+        parent-runtime (promise)
+        admission-entered (promise)
+        release-admission (promise)
+        status-key (keyword "dvergr.agent.program" "status")
+        value-key (keyword "dvergr.agent.program" "value")
+        execute-program
+        (fn [_control-room work-room _run-id _chat-id agent _task _trigger supervisor]
+          (if (= :parent (:agent/id agent))
+            (sp/spin
+             (deliver parent-runtime [supervisor work-room])
+             (sp/await (comb/sleep 5000))
+             {status-key :completed value-key :parent-done})
+            (sp/spin
+             (sp/await (comb/sleep 1000))
+             {status-key :completed value-key :child-done})))]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 10M}})
+      (with-redefs-fn
+        {#'program/execute-program execute-program}
+        (fn []
+          (binding [ec/*execution-context* (:ctx room)]
+            (let [parent (program/hire!
+                          room team :parent
+                          {:task :coordinate
+                           :resources {resource/microdollars 10M}})
+                  [supervisor parent-work] (deref parent-runtime 2000
+                                                  [::timeout nil])
+                  child-future
+                  (future
+                    (binding [ec/*execution-context* (:ctx parent-work)]
+                      (#'program/with-owned-child!
+                       supervisor
+                       #(do
+                          (deliver admission-entered true)
+                          @release-admission
+                          (program/hire-in!
+                           room parent-work team :child
+                           {:task :delegated
+                            :parent-run (program/run-id parent)
+                            :resources {resource/microdollars 4M}})))))]
+              (is (not= ::timeout supervisor))
+              (is (= true (deref admission-entered 2000 ::timeout)))
+              (is (program/cancel! parent))
+              (is (= ::timeout (deref parent 100 ::timeout))
+                  "the admission reservation prevents early parent settlement")
+              (deliver release-admission true)
+              (let [child (deref child-future 3000 ::timeout)]
+                (is (not= ::timeout child))
+                (is (run/cancel-requested? (program/run-id child)))
+                (let [child-result
+                      (binding [ec/*execution-context* (:ctx parent-work)]
+                        (deref child 4000 ::timeout))]
+                  (is (= :cancelled (:run/status child-result))
+                      (pr-str {:result child-result
+                               :durable (program/observe room child)})))
+                (is (= :cancelled (:run/status (deref parent 5000 ::timeout))))
+                (is (= {resource/microdollars 10M} (resource/balance room)))
+                (is (= {} (resource/run-balance room (program/run-id parent))))
+                (is (= {} (resource/run-balance room (program/run-id child)))))))))
+      (finally
+        (deliver parent-runtime [::closed nil])
+        (deliver admission-entered false)
+        (deliver release-admission true)
+        (close-resource-test-room! room conn)))))
+
+(deftest failed-resource-admission-starts-no-agent-effect
+  (let [[room conn] (resource-test-room :program-resource-refusal)
+        team (test-roster)]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 3M}})
+      (is (thrown? Throwable
+                   (binding [ec/*execution-context* (:ctx room)]
+                     (program/hire! room team :analyst
+                                    {:task :too-expensive
+                                     :resources {resource/microdollars 4M}}))))
+      (is (= {resource/microdollars 3M} (resource/balance room)))
+      (is (empty? (d/messages room {:limit 10})))
+      (is (empty? (run/active-runs :program-resource-refusal)))
+      (is (= :failed
+             (:run/status
+              (first (room-store/-list-runs (:store room) (:id room)
+                                            {:limit 1})))))
+      (finally
+        (close-resource-test-room! room conn)))))
 
 (deftest settlement-policy-controls-the-isolated-run-world
   (let [room (test-room :program-settlement)

--- a/test/dvergr/discourse/enrichment_test.clj
+++ b/test/dvergr/discourse/enrichment_test.clj
@@ -55,7 +55,7 @@
         (d/join r (-> (recording-participant :a events nil)
                       (enr/with-self-filter))))
       (d/post! r (d/message :driver :a "hello"))
-      (engine/await-drain-complete! (:ctx r) :timeout-ms 100)
+      (engine/await-drain-complete! (:ctx r) :timeout-ms 1000)
       (is (= 1 (count @events)) "inbox message delivered"))))
 
 (deftest self-filter-drops-self-authored-messages

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.agent.run :as run]
             [dvergr.discourse :as d]
+            [dvergr.resource :as resource]
             [dvergr.room.store.memory :as memory]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.agent :as agent-ns]
@@ -197,6 +198,61 @@
                 "  (:run/parent (agent/observe child)))")))]
         (is (:success result) (pr-str (:error result)))
         (is (= parent-id (:value result))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest sandbox-cannot-redirect-structural-parent-authority
+  (let [room      (d/make-room {:id :sci-agent-parent-authority
+                                :store (memory/make)})
+        sci-ctx   (sandbox/fork-for-session (:ctx room))
+        parent-id (random-uuid)]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room)
+       {:program-kinds #{:echo :scripted}
+        :parent-run parent-id})
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent]) "
+                "(let [team (agent/make-agent (agent/roster) "
+                "                             {:id :child :program {:kind :echo}})] "
+                "  (agent/hire! team :child {:task :work "
+                "                             :parent-run #uuid \""
+                (random-uuid)
+                "\"}))")))]
+        (is (false? (:success result)))
+        (is (re-find #"current Run" (get-in result [:error :message])))
+        (is (empty? (run/active-runs (:id room))))
+        (is (empty? (d/messages room {:limit 10}))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest sandbox-balance-projects-only-the-current-resource-wallet
+  (let [room      (d/make-room {:id :sci-agent-balance
+                                :store (memory/make)})
+        sci-ctx   (sandbox/fork-for-session (:ctx room))
+        parent-id (random-uuid)]
+    (try
+      (with-redefs [resource/balance (fn [actual-room]
+                                       (is (= room actual-room))
+                                       {"cpu-ms" 100M})
+                    resource/run-balance (fn [actual-room actual-run]
+                                           (is (= room actual-room))
+                                           (is (= parent-id actual-run))
+                                           {"cpu-ms" 40M})]
+        (agent-ns/add-programming-ns!
+         sci-ctx (:id room) (:ctx room)
+         {:program-kinds #{:echo}
+          :parent-run parent-id})
+        (let [result (binding [ec/*execution-context* (:ctx room)]
+                       (sandbox/eval-code
+                        sci-ctx
+                        "(require '[dvergr.agent :as agent]) (agent/balance)"))]
+          (is (:success result) (pr-str (:error result)))
+          (is (= {"cpu-ms" 40M} (:value result)))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/system/rooms_test.clj
+++ b/test/dvergr/system/rooms_test.clj
@@ -1,0 +1,108 @@
+(ns dvergr.system.rooms-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as dh]
+            [datahike.tx-preds :as tx-preds]
+            [dvergr.chat.schema :as chat-schema]
+            [dvergr.resource :as resource]
+            [dvergr.room.store.datahike :as datahike-store]
+            [dvergr.substrate.datahike :as substrate-datahike]
+            [dvergr.system.db :as system-db]
+            [dvergr.system.rooms :as rooms]
+            [kontor.governance :as governance]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(deftest resource-kernel-installs-on-provision-and-reconnect
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? true
+             :schema-flexibility :write}
+        slug "resource-bootstrap"
+        room-id (keyword slug)
+        chat-id (random-uuid)]
+    (dh/create-database cfg)
+    (try
+      (doseq [_ [:provision :reconnect]]
+        (let [conn (dh/connect cfg)]
+          (try
+            (chat-schema/ensure-full-schema! conn)
+            (when-not (dh/entity @conn [:chat/id chat-id])
+              (dh/transact conn
+                           [(merge (chat-schema/create-chat-entity
+                                    {:id chat-id :title slug})
+                                   {:room/slug slug :room/type :internal})]))
+            (#'rooms/ensure-msgs-resources! conn)
+            (is (= {} (resource/balance
+                       {:id room-id :store (datahike-store/make conn)})))
+            (finally
+              (governance/ungovern! conn)
+              (dh/release conn)))))
+      (finally
+        (dh/delete-database cfg)))))
+
+(deftest failed-mandatory-hydration-withholds-the-room-context
+  (let [root (context/create-execution-context)
+        room-id (random-uuid)
+        registrations (atom [])]
+    (rooms/clear-room-ctxs!)
+    (try
+      (with-redefs-fn
+        {#'system-db/all-rooms (fn [] [{:room/id room-id}])
+         #'system-db/systems-for-room
+         (fn [_] [{:system {:system/type :kb :system/scope "kb"}}
+                  {:system {:system/type :msgs :system/scope "broken"}}
+                  {:system {:system/type :repo :system/scope "repo"}}])
+         #'rooms/register-system-into-current!
+         (fn [{:system/keys [type]}]
+           (swap! registrations conj type)
+           (when (= :msgs type)
+             (throw (ex-info "governance unavailable" {}))))}
+        #(binding [ec/*execution-context* root]
+           (rooms/hydrate-rooms!)))
+      (is (= [:msgs] @registrations)
+          "mandatory accounting is established before any optional system")
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"hydration failed"
+           (rooms/room-ctx-for room-id)))
+      (finally
+        (rooms/clear-room-ctxs!)
+        (context/close-context! root)))))
+
+(deftest failed-context-registration-preserves-store-global-governance
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? true
+             :schema-flexibility :write}
+        slug "shared-resource-governance"
+        chat-id (random-uuid)]
+    (dh/create-database cfg)
+    (let [conn (dh/connect cfg)
+          released (atom [])]
+      (try
+        (chat-schema/ensure-full-schema! conn)
+        (dh/transact conn
+                     [(merge (chat-schema/create-chat-entity
+                              {:id chat-id :title slug})
+                             {:room/slug slug :room/type :internal})])
+        (#'rooms/ensure-msgs-resources! conn)
+        (let [store-id (get-in cfg [:store :id])
+              installed (tx-preds/tx-pred-for store-id)]
+          (is (ifn? installed))
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Messages resource kernel failed"
+               (with-redefs [substrate-datahike/provision!
+                             (fn [{:keys [register?]}]
+                               (if (false? register?)
+                                 conn
+                                 (throw (ex-info "registration failed" {}))))
+                             dh/release #(swap! released conj %)]
+                 (#'rooms/register-system-into-current!
+                  {:system/type :msgs :system/scope "shared"}))))
+          (is (= [conn] @released)
+              "the failed registration releases its attempted connection")
+          (is (identical? installed (tx-preds/tx-pred-for store-id))
+              "a failed new context cannot ungovern an existing shared store"))
+        (finally
+          (governance/ungovern! conn)
+          (dh/release conn)
+          (dh/delete-database cfg))))))


### PR DESCRIPTION
## Summary

- add a minimal Kontor-backed resource store and durable Room/Run wallets
- allocate positive resource vectors to child Runs and return unused balances only after structured child quiescence
- make child admission cancellation-safe and keep recursive agents structurally owned even when their handles are dropped
- expose attenuated `agent/balance` and `agent/hire! :resources` capabilities in SCI without exposing mint or arbitrary transfer authority
- install mandatory resource governance before publishing the Room message system, and withhold poisoned Room contexts on hydration failure
- document host funding, delegation, conservation, and the boundary between FRP coordination and resource accounting

## Semantics

A Room wallet funds top-level Runs. A parent Run may partition its balance into structurally owned child Runs. Kontor records allocation/return receipts and Datahike mandatory predicates enforce non-negative balances and conserved postings. Run completion, cleanup, world settlement, and resource return are ordered so resources cannot return into an already-settled parent.

Paid provider calls remain blocked from recursive resource accounting until measured usage can be debited; generic resource coordinates work now.

## Verification

- independent review: no medium-or-higher findings
- focused integration: 45 tests, 257 assertions, 0 failures
- full suite: 539 tests, 2319 assertions, 0 failures
- format and `git diff --check` pass
- verified against released `org.replikativ/kontor 0.1.37` from Clojars
