### PR TITLE
Structure conversational attention decisions

### DIFF
--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -38,11 +38,12 @@ The current surface deliberately reuses Spindel's algebra:
 | context fork | explore a copy-on-write alternative or particle |
 | cancellation | withdraw attention and terminate owned effects |
 
-Queueing, merging observations, switch-to-latest steering, approval gates, and
-long-lived output/effect streams should be derived attention combinators over
-the same substrate. They must not be encoded as special cases of a global turn
-loop. `:llm` is the first convenient process interpreter, not the definition of
-an agent.
+Structured attention decisions now separate memory, activation, control, and
+execution-boundary requests. Queueing, merging observations, switch-to-latest
+steering, approval gates, and long-lived output/effect streams should be derived
+work-admission combinators over the same substrate. They must not be encoded as
+special cases of a global turn loop. `:llm` is the first convenient process
+interpreter, not the definition of an agent.
 
 ## Construct and compose
 
@@ -256,7 +257,9 @@ levels:
 The initial model-facing task set should include pure roster specialization,
 parallel research/review and reduction, race-with-loser-cancellation, explicit
 structural child Runs, delegation-ceiling recognition, and creation of a nested
-durable Room. Later attention combinators add queue/observe/steer/switch tests.
+durable Room. Structured queue/observe/steer compatibility and reactive-boundary
+tests cover the first attention seam; later `latest`/`serial`/`busy`/`parallel`
+work-admission combinators extend it.
 Passing only one model is not sufficient evidence that the programming surface
 is clear.
 

--- a/doc/programming-model.md
+++ b/doc/programming-model.md
@@ -191,6 +191,37 @@ Swap adapters to change F's shape without touching the agent's G-side
 spin. The distributive law is *named and pluggable* rather than baked
 into one closure.
 
+## Attention decisions and execution boundaries
+
+An utterance is a durable Room fact; it is not ambient process-control
+authority. Each participant may interpret the same fact differently through a
+pure attention policy. Policies now return a validated product rather than
+having to choose one overloaded action:
+
+```clojure
+{:memory     :remember       ; :ignore | :remember | :include
+ :activation :enqueue        ; :none | :enqueue | :wake
+ :control    :continue       ; :continue | :integrate | :restart | :suspend | :cancel
+ :at         :quiescent
+ :priority   0
+ :reason     :conversation/different-thread}
+```
+
+The axes are independent: a fact can update awareness and enqueue later work
+without interrupting the active computation. The standard boundary vocabulary
+is `:now`, `:next-safe-boundary`, `:before-model`, `:token`, `:before-tool`,
+`:after-tool`, `:after-model`, and `:quiescent`. An interpreter advertises and
+honors only the boundaries it actually supports.
+
+The current LLM participant implements the former behavior as a compatibility
+subset: same-thread `restart` projects to steer; `enqueue` projects to FIFO
+queue; passive `continue` projects to observe. The former `:steer`, `:queue`, and
+`:observe` policy results remain accepted. Future work-admission combinators
+(`latest`, `serial`, `busy`, and `parallel`) will consume these decisions rather
+than adding more branches to the LLM turn loop. A valid richer decision that the
+current adapter cannot honor is queued conservatively; its unsupported axes are
+never silently discarded.
+
 ## Built-in directives
 
 `llm-agent` already handles a small set of tagged messages:
@@ -270,6 +301,7 @@ discards — the parent's state is provably untouched.
 | Delegate from a model tool call | `spawn_agent` or `propose_change`, thin adapters over `dvergr.agent/hire!` |
 | Swap an LLM's decision shape | `(llm-agent {:run-turn-fn ...})` using a GenerationHandle adapter |
 | Observe cost / budget | read the chat-ctx `:budget-signal` (a tracked signal), or `dvergr.rooms.stats` |
+| Classify conversational activity | return `dvergr.discourse.attention/decision` data from an attention policy |
 
 ## Further reading
 

--- a/doc/rooms-and-agents.md
+++ b/doc/rooms-and-agents.md
@@ -81,9 +81,12 @@ preserved automatically:
 Thread identity also informs the attention boundary for an LLM agent. The default
 policy lets a direct same-thread message steer its active execution, while a
 direct message rooted elsewhere queues a separate execution without cancellation
-or topic mixing. `llm-agent` accepts an `:attention-policy` returning `:steer`,
-`:queue`, or `:observe`, so deployments can distinguish direct human correction
-from peer-agent chatter using their authoritative actor and addressing data.
+or topic mixing. `llm-agent` accepts an `:attention-policy` returning a validated
+`dvergr.discourse.attention` decision with independent memory, activation,
+control, boundary, and priority axes. The former `:steer`, `:queue`, and
+`:observe` results remain accepted, so deployments can migrate while refining
+human correction versus peer-agent chatter using authoritative identity and
+addressing data.
 Tool activity and telemetry remain non-waking observations.
 
 When a topic needs separate participants, permissions, budget, or a branched

--- a/src/dvergr/discourse/attention.clj
+++ b/src/dvergr/discourse/attention.clj
@@ -1,0 +1,168 @@
+(ns dvergr.discourse.attention
+  "Pure attention decisions for reactive conversational programs.
+
+   A speech act says what happened in the Room. An attention decision says how
+   one participant treats that fact. The executor then interprets the decision
+   at a boundary it actually supports. Keeping these layers separate prevents
+   message tags from becoming ambient process-control authority.")
+
+(def execution-boundaries
+  "Provider-neutral observation/integration boundaries. An interpreter reports
+   only the boundaries it can actually honor. `:next-safe-boundary` is the
+   portable request used when the policy does not depend on a provider-specific
+   step."
+  #{:now
+    :next-safe-boundary
+    :before-model
+    :token
+    :before-tool
+    :after-tool
+    :after-model
+    :quiescent})
+
+(def memory-modes #{:ignore :remember :include})
+(def activation-modes #{:none :enqueue :wake})
+(def control-modes #{:continue :integrate :restart :suspend :cancel})
+
+(def ^:private decision-keys
+  #{:memory :activation :control :at :priority :reason :metadata})
+
+(def default-decision
+  "The identity-like decision: retain awareness without waking or changing the
+   active execution."
+  {:memory :remember
+   :activation :none
+   :control :continue
+   :at :next-safe-boundary
+   :priority 0})
+
+(defn decision
+  "Validate and complete an attention decision map.
+
+   The axes are intentionally independent: one fact may be remembered, enqueue
+   later work, and leave the current execution alone. `:reason` is explanatory
+   data, never process authority."
+  [m]
+  (when-not (map? m)
+    (throw (ex-info "Attention decision must be a map"
+                    {:type ::invalid-decision :decision m})))
+  (let [unknown (seq (remove decision-keys (keys m)))
+        d (merge default-decision m)]
+    (when unknown
+      (throw (ex-info "Attention decision has unknown keys"
+                      {:type ::invalid-decision
+                       :unknown-keys (vec unknown)
+                       :decision m})))
+    (when-not (memory-modes (:memory d))
+      (throw (ex-info "Invalid attention memory mode"
+                      {:type ::invalid-decision :axis :memory
+                       :value (:memory d) :decision m})))
+    (when-not (activation-modes (:activation d))
+      (throw (ex-info "Invalid attention activation mode"
+                      {:type ::invalid-decision :axis :activation
+                       :value (:activation d) :decision m})))
+    (when-not (control-modes (:control d))
+      (throw (ex-info "Invalid attention control mode"
+                      {:type ::invalid-decision :axis :control
+                       :value (:control d) :decision m})))
+    (when-not (execution-boundaries (:at d))
+      (throw (ex-info "Invalid attention execution boundary"
+                      {:type ::invalid-decision :axis :at
+                       :value (:at d) :decision m})))
+    (when-not (number? (:priority d))
+      (throw (ex-info "Attention priority must be numeric"
+                      {:type ::invalid-decision :axis :priority
+                       :value (:priority d) :decision m})))
+    (when (and (contains? d :reason) (some? (:reason d))
+               (not (keyword? (:reason d))))
+      (throw (ex-info "Attention reason must be a keyword or nil"
+                      {:type ::invalid-decision :axis :reason
+                       :value (:reason d) :decision m})))
+    (when (and (contains? d :metadata) (some? (:metadata d))
+               (not (map? (:metadata d))))
+      (throw (ex-info "Attention metadata must be a map or nil"
+                      {:type ::invalid-decision :axis :metadata
+                       :value (:metadata d) :decision m})))
+    d))
+
+(defn observe
+  "Remember a fact without waking or changing the active execution."
+  ([] (observe nil))
+  ([reason]
+   (decision (cond-> {} reason (assoc :reason reason)))))
+
+(defn enqueue
+  "Retain a fact as later work without preempting the active execution."
+  ([] (enqueue nil))
+  ([reason]
+   (decision (cond-> {:activation :enqueue :at :quiescent}
+               reason (assoc :reason reason)))))
+
+(defn restart
+  "Include a fact and request replacement of the active computation at its next
+   safe boundary. The executor decides how replacement is implemented."
+  ([] (restart nil))
+  ([reason]
+   (decision (cond-> {:memory :include
+                      :control :restart
+                      :at :next-safe-boundary}
+               reason (assoc :reason reason)))))
+
+(def ^:private legacy-decisions
+  {:observe (observe :legacy/observe)
+   :queue (enqueue :legacy/queue)
+   :steer (restart :legacy/steer)})
+
+(defn normalize
+  "Return a validated decision. The former `:observe`, `:queue`, and `:steer`
+   values remain accepted so existing deployment policies migrate without a
+   flag day."
+  [x]
+  (if-let [d (and (keyword? x) (legacy-decisions x))]
+    d
+    (decision x)))
+
+(defn legacy-action
+  "Project the subset implemented by the current LLM arbiter back to its former
+   action vocabulary. Returns nil for valid decisions requiring a newer
+   interpreter (wake, integrate, suspend, or cancel).
+
+   This function is a compatibility boundary, not the conversational algebra."
+  [x]
+  (let [shape (select-keys (normalize x)
+                           [:memory :activation :control :at :priority])]
+    (case shape
+      {:memory :include
+       :activation :none
+       :control :restart
+       :at :next-safe-boundary
+       :priority 0} :steer
+
+      {:memory :remember
+       :activation :enqueue
+       :control :continue
+       :at :quiescent
+       :priority 0} :queue
+
+      {:memory :remember
+       :activation :none
+       :control :continue
+       :at :next-safe-boundary
+       :priority 0} :observe
+
+      nil)))
+
+(defn boundary-event
+  "Construct a provider-neutral live boundary event. Boundary events are
+   process-local observations; durable Run/activity facts may reference them,
+   but this constructor does not persist anything."
+  ([type] (boundary-event type nil))
+  ([type data]
+   (when-not (execution-boundaries type)
+     (throw (ex-info "Unknown execution boundary"
+                     {:type ::invalid-boundary :boundary type})))
+   (when-not (or (nil? data) (map? data))
+     (throw (ex-info "Execution boundary data must be a map or nil"
+                     {:type ::invalid-boundary :boundary type :data data})))
+   (cond-> {:attention.boundary/type type}
+     data (assoc :attention.boundary/data data))))

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -43,6 +43,7 @@
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
             [dvergr.discourse :as d]
+            [dvergr.discourse.attention :as attention]
             [dvergr.discourse.enrichment :as enr]
             [dvergr.discourse.generation :as gen]
             [dvergr.chat.context :as cc]
@@ -136,13 +137,16 @@
   "Classify conversational input arriving during an active generation.
 
    The policy receives {:active-message :incoming-message :participant :room}
-   and returns :steer, :queue, or :observe. The default preserves the current
+   and returns a structured attention decision. The former :steer, :queue, and
+   :observe keywords remain accepted for compatibility. The default preserves the current
    direct-conversation behavior: same-thread input steers, while another thread
    queues a separate execution. Products with durable actor identity can refine
    this by sender/addressing (for example, human correction versus peer-agent
    chatter) without changing the Room/thread contract."
   [{:keys [active-message incoming-message]}]
-  (if (d/same-thread? active-message incoming-message) :steer :queue))
+  (if (d/same-thread? active-message incoming-message)
+    (attention/restart :conversation/same-thread)
+    (attention/enqueue :conversation/different-thread)))
 
 (defn llm-agent
   "Construct a discourse Participant backed by an LLM.
@@ -175,10 +179,12 @@
                   agent's outbound reply (e.g. resolve references) and returns
                   system notes injected into the chat-ctx for the next turn.
    :attention-policy — (fn [{:active-message :incoming-message :participant
-                             :room}] → :steer | :queue | :observe).
+                             :room}] → AttentionDecision).
                   Defaults to same-thread steer and different-thread queue.
+                  Legacy :steer/:queue/:observe returns remain accepted.
                   Override to distinguish human correction from peer chatter
-                  using the deployment's authoritative actor identity.
+                  using the deployment's authoritative actor identity. See
+                  dvergr.discourse.attention.
    :ctx         — discourse room's execution context
                   (default: `*execution-context*`)"
   [{:keys [id spec tools db-conn budget compaction
@@ -520,25 +526,42 @@
                                                  (do
                                                    (when mid
                                                      (swap! seen-inflight-ids conj mid))
-                                                   (let [attention
+                                                   (let [attention-decision
                                                          (attention-policy
                                                           {:active-message msg
                                                            :incoming-message m
                                                            :participant p
-                                                           :room room})]
-                                                     (case attention
+                                                           :room room})
+                                                         action
+                                                         (try
+                                                           (attention/legacy-action
+                                                            attention-decision)
+                                                           (catch Throwable error
+                                                             (tel/log!
+                                                              {:level :warn
+                                                               :id ::invalid-attention-decision
+                                                               :data {:agent id
+                                                                      :decision attention-decision
+                                                                      :error (.getMessage error)}}
+                                                              "Invalid attention decision; queued conservatively")
+                                                             ::invalid-attention-decision))]
+                                                     (case action
                                                        :steer {:tag :steer :msg m}
                                                        :observe (recur)
                                                        :queue (do
                                                                 (swap! queued-other-threads conj m)
                                                                 (recur))
+                                                       ::invalid-attention-decision
+                                                       (do
+                                                         (swap! queued-other-threads conj m)
+                                                         (recur))
                                                        (do
                                                          (tel/log!
                                                           {:level :warn
                                                            :id ::invalid-attention-decision
                                                            :data {:agent id
-                                                                  :decision attention}}
-                                                          "Invalid attention decision; queued conservatively")
+                                                                  :decision attention-decision}}
+                                                          "Unsupported attention decision; queued conservatively")
                                                          (swap! queued-other-threads conj m)
                                                          (recur)))))))))))
                                    ;; No inbox (room-less participant that was

--- a/test/dvergr/discourse/attention_test.clj
+++ b/test/dvergr/discourse/attention_test.clj
@@ -1,0 +1,93 @@
+(ns dvergr.discourse.attention-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.discourse.attention :as attention]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as engine]))
+
+(deftest decisions-keep-observation-activation-and-control-independent
+  (is (= {:memory :remember
+          :activation :none
+          :control :continue
+          :at :next-safe-boundary
+          :priority 0
+          :reason :test/passive}
+         (attention/observe :test/passive)))
+  (is (= :enqueue (:activation (attention/enqueue :test/later))))
+  (is (= :quiescent (:at (attention/enqueue :test/later))))
+  (is (= :include (:memory (attention/restart :test/correction))))
+  (is (= :restart (:control (attention/restart :test/correction)))))
+
+(deftest former-actions-lift-and-project-through-the-compatibility-boundary
+  (is (= :steer (attention/legacy-action :steer)))
+  (is (= :queue (attention/legacy-action :queue)))
+  (is (= :observe (attention/legacy-action :observe)))
+  (is (= :steer (attention/legacy-action
+                 (attention/restart :test/structured))))
+  (is (nil? (attention/legacy-action
+             (attention/decision {:activation :wake})))
+      "valid future decisions remain explicit instead of acquiring guessed semantics")
+  (is (nil? (attention/legacy-action
+             (attention/decision {:memory :ignore
+                                  :control :restart})))
+      "restart does not silently discard the requested memory semantics")
+  (is (nil? (attention/legacy-action
+             (attention/decision {:control :restart :at :quiescent})))
+      "restart does not silently discard the requested boundary")
+  (is (nil? (attention/legacy-action
+             (attention/decision {:control :restart :priority 10})))
+      "the compatibility executor does not pretend to implement priority"))
+
+(deftest malformed-decisions-fail-at-the-pure-boundary
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown keys"
+                        (attention/decision {:wake? true})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"control mode"
+                        (attention/decision {:control :explode})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"priority"
+                        (attention/decision {:priority :high})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"reason"
+                        (attention/decision {:reason "because"}))))
+
+(deftest execution-boundaries-are-provider-neutral-data
+  (is (= {:attention.boundary/type :after-tool
+          :attention.boundary/data {:tool-call :search}}
+         (attention/boundary-event :after-tool {:tool-call :search})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown execution boundary"
+                        (attention/boundary-event :provider/private-step))))
+
+(deftest attention-composes-reactively-with-execution-boundaries
+  (testing "continuous observation can defer integration until a safe boundary"
+    (let [ctx (context/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [incoming (sp/signal nil)
+                boundary (sp/signal :before-model)
+                plan (sp/spin
+                      (let [message (:new (sp/track incoming))
+                            at (:new (sp/track boundary))]
+                        (cond
+                          (nil? message) (attention/observe :test/idle)
+                          (= :urgent (:force message))
+                          (attention/decision {:memory :include
+                                               :control :cancel
+                                               :at :now
+                                               :reason :test/urgent})
+                          (= :after-tool at)
+                          (attention/decision {:memory :include
+                                               :control :integrate
+                                               :at :after-tool
+                                               :reason :test/boundary})
+                          :else (attention/observe :test/deferred))))]
+            (is (= :continue (:control @plan)))
+            (reset! incoming {:force :ordinary})
+            (engine/await-drain-complete! ctx :timeout-ms 1000)
+            (is (= :continue (:control @plan)) "message is retained but does not preempt")
+            (reset! boundary :after-tool)
+            (engine/await-drain-complete! ctx :timeout-ms 1000)
+            (is (= :integrate (:control @plan)) "same fact integrates at the boundary")
+            (reset! incoming {:force :urgent})
+            (engine/await-drain-complete! ctx :timeout-ms 1000)
+            (is (= :cancel (:control @plan)) "authorized urgency can preempt immediately")))
+        (finally
+          (context/close-context! ctx))))))

--- a/test/dvergr/discourse/llm_test.clj
+++ b/test/dvergr/discourse/llm_test.clj
@@ -5,6 +5,7 @@
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
             [dvergr.discourse :as d]
+            [dvergr.discourse.attention :as attention]
             [dvergr.discourse.llm :as llm]
             [dvergr.chat.context :as cc]
             [dvergr.agent.run :as run]
@@ -54,6 +55,19 @@
         (pred) true
         (>= (System/currentTimeMillis) deadline) false
         :else (do (Thread/sleep 5) (recur))))))
+
+(deftest default-attention-policy-is-structured-and-thread-aware
+  (let [root (d/message :human :agent "root")
+        same (d/reply :human :agent "correction" root)
+        other (d/message :human :agent "another topic")
+        same-decision (llm/default-attention-policy
+                       {:active-message root :incoming-message same})
+        other-decision (llm/default-attention-policy
+                        {:active-message root :incoming-message other})]
+    (is (= :restart (:control same-decision)))
+    (is (= :steer (attention/legacy-action same-decision)))
+    (is (= :enqueue (:activation other-decision)))
+    (is (= :queue (attention/legacy-action other-decision)))))
 
 (defn- fail-output-store [delegate actor]
   (reify store/PRoomStore
@@ -320,7 +334,8 @@
                                #(d/iterative-refinement % :coder :reviewer
                                                         {:content "build login"}
                                                         {:accept? (fn [m] (re-find #"(?i)lgtm" (:content m)))
-                                                         :max-iter 4}))]
+                                                         :max-iter 4})
+                               15000)]
         (is (= :accepted (:result result)))
         (is (= "draft v2 with fix" (:content (:draft result))))
         (is (= "lgtm" (:content (:review result))))))))
@@ -474,7 +489,7 @@
           policy  (fn [{:keys [active-message incoming-message] :as context}]
                     (if (and (d/same-thread? active-message incoming-message)
                              (= :peer (:from incoming-message)))
-                      :queue
+                      (attention/enqueue :test/peer-chatter)
                       (llm/default-attention-policy context)))]
       (binding [ec/*execution-context* (:ctx r)]
         (d/join r (llm/llm-agent {:id :policy-worker


### PR DESCRIPTION
## Summary

- add a pure, validated conversational `AttentionDecision` product with independent memory, activation, control, boundary, priority, reason, and metadata axes
- define a small provider-neutral execution-boundary vocabulary and process-local boundary events
- make the default LLM policy return structured decisions while retaining legacy `:steer`, `:queue`, and `:observe` policy compatibility
- project only the three exact semantics the current LLM arbiter implements; richer valid decisions queue conservatively instead of silently losing unsupported axes
- add provider-free laws and a Spindel signal test showing continuous observation deferred until a safe integration boundary
- document the seam without adding a workflow/stream DSL

## Current semantics

The existing behavior is unchanged:

- same thread: include the correction and restart at the next safe boundary
- different thread: remember and enqueue FIFO work for quiescence
- passive observation: remember without waking or changing active work

An utterance remains a durable discourse fact, not ambient process-control authority. A participant-local policy produces a decision; an interpreter executes only the subset it can honestly honor.

## Verification

- independent review, two passes: no remaining medium-or-higher findings
- focused attention/LLM slice: 22 tests, 83 assertions, 0 failures
- final attention laws: 5 tests, 23 assertions, 0 failures
- full suite: 545 tests, 2346 assertions, 0 failures
- formatting and `git diff --check` pass
- new attention namespace/tests: zero clj-kondo warnings

## Follow-up, deliberately excluded

Research supports four explicit work-admission strategies—latest, serial, busy, and parallel—around work-producing functions. Those belong in a later Spindel/Dvergr combinator slice with structured cancellation, demand/backpressure, and resource admission; they are not extra values in this decision enum.
