### PR TITLE
feat: expose structured work admission in sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,17 +279,14 @@ The standalone, runnable scenarios these import live in [`examples/`](examples/)
 | [hato](https://github.com/gnarroway/hato) | HTTP client for provider APIs |
 | [Telemere](https://github.com/taoensso/telemere) | Structured logging + observability |
 
-> **SCI fork note (Clojars library consumers only).** dvergr pins a fork of SCI
-> (`whilo/sci`, branch `resource-check`) for the `:interrupt-fn` cancellation the
-> sandbox relies on, pending an upstream PR. tools.build's `write-pom` emits only
-> Maven coords, so this git dep is **not** in the published pom. The uberjar/CLI
-> and git-dep consumers get it transitively and need nothing extra; a pure-Clojars
-> library consumer must add it themselves:
+> **SCI fork note.** dvergr directly depends on the published replikativ SCI
+> build for resource interruption and forkable interpreter worlds while the
+> corresponding changes are reviewed upstream. Maven and git consumers resolve
+> the same implementation:
 > ```clojure
-> org.babashka/sci {:git/url "https://github.com/whilo/sci"
->                   :git/sha "24762a163ef5b25c692d0e5cd4ea63a5bd6b0a16"}
+> org.replikativ/sci {:mvn/version "0.15.59-replikativ.1"}
 > ```
-> (Goes away once the fork lands upstream or is published to Maven.)
+> This returns to `org.babashka/sci` once the fork lands upstream.
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure       {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure       {:mvn/version "1.12.5"}
 
         ;; HTTP client for provider APIs
         hato/hato                  {:mvn/version "1.0.0"}
@@ -25,12 +25,13 @@
         ;; Async utilities
         org.clojure/core.async     {:mvn/version "1.6.681"}
 
-        ;; SCI — Small Clojure Interpreter for sandboxing.
-        org.babashka/sci           {:mvn/version "0.15.56"}
+        ;; SCI — Small Clojure Interpreter for sandboxing. The replikativ build
+        ;; carries forkable interpreter worlds while sci#1084 is upstreamed.
+        org.replikativ/sci         {:mvn/version "0.15.59-replikativ.1"}
 
-        ;; partial-cps (CPS transform for the SCI spin macro) comes TRANSITIVELY
-        ;; via spindel — not declared here, so spindel is the single source of its
-        ;; version. The `:local` alias's `../spindel` override carries it too.
+        ;; Dvergr uses the async sequence/CPS namespaces directly; keep this a
+        ;; direct dependency instead of relying on Spindel's implementation deps.
+        is.simm/partial-cps        {:mvn/version "0.1.60"}
 
         ;; Spindel — Reactive runtime with CoW forking.
         ;; 0.1.35 (#27 lost-wakeup redesign + follow-ups): continuation
@@ -48,14 +49,9 @@
         ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
         ;; Substrate for the durable-cursor bus pump + supervisor
         ;; restart.
-        ;; 0.1.43 includes structured cancellation and affine partitioned world
-        ;; authority, the substrate used by Run-world adoption and delegation.
-        ;; Structured work admission and its cancellation hand-back fix are
-        ;; currently stacked on spindel#44/#45. Pin the reviewed commit until
-        ;; that release reaches Clojars, then return this to an ordinary version
-        ;; coordinate.
-        org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "cfc17674ff7d154e5e3f2643d89b0db34646bc0a"}
+        ;; 0.1.44 includes structured work admission, cancellation hand-back,
+        ;; canonical inference worlds, and forkable SCI world components.
+        org.replikativ/spindel     {:mvn/version "0.1.44"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
@@ -65,53 +61,44 @@
         ;; API this branch's agent workspaces are built on (isolated worktrees,
         ;; checkout semantics delegated to Geschichte, Git served from a virtual
         ;; GeschichteFS base) — so no local root is needed to build it.
-        org.replikativ/muschel     {:mvn/version "0.2.19"}
+        org.replikativ/muschel     {:mvn/version "0.2.19"
+                                    :exclusions  [org.babashka/sci]}
 
         ;; Geschichte — authoritative virtual filesystem + Git compatibility.
-        ;; 0.1.12 is the release where the Yggdrasil adapter MOVED OUT (#8), so
-        ;; there is exactly one GeschichteSystem record on the classpath — the
-        ;; one in yggdrasil.adapters.geschichte. No local root needed.
-        org.replikativ/geschichte  {:mvn/version "0.1.12"}
+        ;; Geschichte remains the authoritative virtual filesystem; its
+        ;; Yggdrasil adapter lives only in Yggdrasil.
+        org.replikativ/geschichte  {:mvn/version "0.1.15"}
 
         ;; rewrite-clj for structural editing
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        ;; 0.8.1861 provides writer-internal operation provenance to mandatory
-        ;; transaction predicates. Kontor uses it to keep purge/history
-        ;; validation internal without extending Datahike's public tx report.
-        org.replikativ/datahike    {:mvn/version "0.8.1861"}
+        ;; Keep the direct dependency current: Dvergr uses Datahike's API and
+        ;; transaction predicates itself, not merely through Geschichte.
+        org.replikativ/datahike    {:mvn/version "0.8.1865"}
         ;; 0.1.37 provides conserved resource vectors, durable receipts, and
         ;; mandatory Datahike invariants for Run resource delegation.
         org.replikativ/kontor      {:mvn/version "0.1.37"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
-        ;; 0.3.38 adopts the Geschichte adapter (yggdrasil.adapters.geschichte,
-        ;; PR #16) and gives it the p/Mergeable it never had, so a room repo can
-        ;; finally produce a FILE diff instead of a datom count over
-        ;; Geschichte's internal schema.
-        org.replikativ/yggdrasil   {:mvn/version "0.3.38"}
+        ;; 0.3.41 includes the Geschichte content-level merge adapter and the
+        ;; current persistent-sorted-set substrate.
+        org.replikativ/yggdrasil   {:mvn/version "0.3.41"
+                                    :exclusions  [org.babashka/sci]}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
-        org.replikativ/scriptum    {:mvn/version "0.1.30"}
+        org.replikativ/scriptum    {:mvn/version "0.1.32"}
 
         ;; Briefkasten (local IMAP mirror) is OPTIONAL — it backs dvergr.intake.mail
         ;; only, and pulls the jakarta-mail tree, so it lives in the
         ;; :dev/:test/:cli/:tui aliases (with clojure-mail), not core.
 
-        ;; Kabel — WebSocket peer-to-peer transport. 0.3.98 pins javac --release 11
-        ;; (0.3.97 shipped Java-25 bytecode → UnsupportedClassVersionError on JDK <25).
-        org.replikativ/kabel       {:mvn/version "0.3.98"}
-        ;; Compatibility alignment: Yggdrasil 0.3.38 still loads
-        ;; hasch.benc.HashRef, which was removed in Hasch 0.4.102. Drop this
-        ;; override when Yggdrasil moves to the new reference representation.
-        org.replikativ/hasch       {:mvn/version "0.4.101"}
+        ;; Dvergr derives stable activity and environment identities directly.
+        ;; Match Datahike's current array-hashing implementation.
+        org.replikativ/hasch       {:mvn/version "0.4.104"}
         ;; Dvergr's drive blob store uses Konserve directly. Keep this aligned
         ;; with Datahike rather than relying on Datahike's transitive API.
-        org.replikativ/konserve    {:mvn/version "0.9.385"}
-
-        ;; Distributed-scope — remote function invocation over Kabel
-        is.simm/distributed-scope  {:mvn/version "0.1.2"}
+        org.replikativ/konserve    {:mvn/version "0.9.391"}
 
         ;; tools.analyzer for code indexing
         org.clojure/tools.analyzer.jvm {:mvn/version "1.3.0"}
@@ -188,7 +175,7 @@
   ;; `:local/root "../datahike"` override uses datahike's DEFAULT :paths (which
   ;; exclude src-secondary), so we add it here for the source-override dev path.
   :local {:extra-paths ["../datahike/src-secondary"]
-          :extra-deps {org.babashka/sci           {:local/root "../sci"}
+          :extra-deps {org.replikativ/sci         {:local/root "../sci"}
                        org.replikativ/datahike    {:local/root "../datahike"}
                        org.replikativ/scriptum    {:local/root "../scriptum"}
                        org.replikativ/yggdrasil   {:local/root "../yggdrasil"}

--- a/deps.edn
+++ b/deps.edn
@@ -50,7 +50,12 @@
         ;; restart.
         ;; 0.1.43 includes structured cancellation and affine partitioned world
         ;; authority, the substrate used by Run-world adoption and delegation.
-        org.replikativ/spindel     {:mvn/version "0.1.43"}
+        ;; Structured work admission and its cancellation hand-back fix are
+        ;; currently stacked on spindel#44/#45. Pin the reviewed commit until
+        ;; that release reaches Clojars, then return this to an ordinary version
+        ;; coordinate.
+        org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
+                                    :git/sha "cfc17674ff7d154e5e3f2643d89b0db34646bc0a"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -7,11 +7,20 @@
    reward never depends on trusting the model's prose. The corresponding
    language and lifecycle contracts live in ordinary deterministic tests."
   (:require [clojure.edn :as edn]
+            [datahike.api :as dh]
+            [dvergr.activity :as activity]
+            [dvergr.agent.environment :as environment]
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
+            [dvergr.chat.schema :as chat-schema]
             [dvergr.discourse :as d]
+            [dvergr.resource :as resource]
+            [dvergr.room.store :as room-store]
+            [dvergr.room.store.datahike :as datahike-store]
             [dvergr.room.store.memory :as memory]
+            [kontor.governance :as kontor-governance]
+            [kontor.resource :as kontor-resource]
             [org.replikativ.spindel.engine.core :as ec])
   (:import [java.io PushbackReader StringReader]))
 
@@ -36,6 +45,47 @@
        "value: :fast. Do not merely describe the code; execute it."))
 
 (def expected-race-v1 :fast)
+
+(def resource-task-v1
+  (str "Use clojure_eval to solve this task. Your Run owns 10000 microUSD. "
+       "Construct an immutable roster with two scripted specialists: an "
+       ":analyst that waits 1000 milliseconds and replies \"evidence\", and a "
+       ":reviewer that waits 1000 milliseconds and replies {:claim 42}. Hire "
+       "the analyst with 2000 microUSD and the reviewer with 3000 microUSD. "
+       "Compositionally await both result Spins, then record (agent/balance) "
+       "after both resources have returned. Your final answer must be exactly "
+       "this EDN value: {:analyst \"evidence\" :reviewer {:claim 42} "
+       ":returned {\"microUSD\" 10000M}}. "
+       "Do not merely describe the code; execute it."))
+
+(def expected-resource-v1
+  {:analyst "evidence"
+   :reviewer {:claim 42}
+   :returned {resource/microdollars 10000M}})
+
+(def self-programming-task-v1
+  (str "Use clojure_eval to author and execute a recursive Dvergr program. "
+       "Use the exact namespaces `[dvergr.agent :as agent]`, "
+       "`[org.replikativ.spindel.spin.cps :refer [spin]]`, "
+       "`[org.replikativ.spindel.effects.await :refer [await]]`, and "
+       "`[spindel.comb :as comb]`; compose the three result Spins with "
+       "`comb/parallel`. "
+       "Construct an immutable roster with three cheap simulated specialists. "
+       "A :mod-five particle is scripted to return [8 23 38 53 68 83 98]. "
+       "A :mod-seven particle is scripted to return "
+       "[2 9 16 23 30 37 44 51 58 65 72 79 86 93]. "
+       "A :verifier specialist is scripted to return the independent data "
+       "{:moduli [[3 2] [5 3] [7 2]] :upper-bound 100}. Hire all three and "
+       "compositionally await their result Spins in parallel. Intersect the "
+       "particle candidates, interpret the verifier data as executable checks, "
+       "and select the unique positive integer satisfying every remainder and "
+       "the bound. Return only an EDN map shaped like "
+       "{:answer <computed-integer> :particles 2 :verified <boolean>}. Do not "
+       "merely describe the program; create the specialists, await their "
+       "results, and execute it."))
+
+(def expected-self-programming-v1
+  {:answer 23 :particles 2 :verified true})
 
 (defn- parse-edn [value]
   (when (string? value)
@@ -75,18 +125,215 @@
       :winner-completed? (= :completed (get-in by-actor [:fast :run/status]))
       :loser-cancelled? (= :cancelled (get-in by-actor [:slow :run/status]))})))
 
+(defn- self-programming-checks
+  [{:keys [root-run-id root-causes child-runs] :as observation}]
+  (let [by-actor (into {} (map (juxt :run/actor identity)) child-runs)
+        child-ids (into #{} (map :run/id) child-runs)]
+    (merge
+     (common-checks observation expected-self-programming-v1)
+     {:three-specialists? (= 3 (count child-runs))
+      :expected-specialists? (= #{:mod-five :mod-seven :verifier}
+                                (set (keys by-actor)))
+      :structural-parentage? (every? #(= root-run-id (:run/parent %)) child-runs)
+      :all-results-observed? (= child-ids root-causes)
+      :specialists-completed? (every? #(= :completed (:run/status %)) child-runs)
+      :specialists-merged? (every? #(= :merged (:run/settlement-status %))
+                                   child-runs)})))
+
+(defn- receipt-view [receipt]
+  (select-keys receipt [:id :kind :source :destination :resources]))
+
+(defn- resource-checks
+  [{:keys [room-id root-run-id child-runs room-balance root-balance child-balances
+           resource-receipts]
+    :as observation}]
+  (let [by-actor (into {} (map (juxt :run/actor identity)) child-runs)
+        analyst-id (get-in by-actor [:analyst :run/id])
+        reviewer-id (get-in by-actor [:reviewer :run/id])
+        room-wallet (resource/room-wallet-id room-id)
+        receipt-contract
+        {:root-allocation
+         {:id (resource/allocation-id root-run-id)
+          :kind :grant :source room-wallet :destination root-run-id
+          :resources {resource/microdollars 10000M}}
+         :analyst-allocation
+         {:id (resource/allocation-id analyst-id)
+          :kind :grant :source root-run-id :destination analyst-id
+          :resources {resource/microdollars 2000M}}
+         :reviewer-allocation
+         {:id (resource/allocation-id reviewer-id)
+          :kind :grant :source root-run-id :destination reviewer-id
+          :resources {resource/microdollars 3000M}}
+         :analyst-return
+         {:id (resource/return-id analyst-id)
+          :kind :return :source analyst-id :destination root-run-id
+          :resources {resource/microdollars 2000M}}
+         :reviewer-return
+         {:id (resource/return-id reviewer-id)
+          :kind :return :source reviewer-id :destination root-run-id
+          :resources {resource/microdollars 3000M}}
+         :root-return
+         {:id (resource/return-id root-run-id)
+          :kind :return :source root-run-id :destination room-wallet
+          :resources {resource/microdollars 10000M}}}]
+    (merge
+     (common-checks observation expected-resource-v1)
+     {:two-children? (= 2 (count child-runs))
+      :expected-actors? (= #{:analyst :reviewer} (set (keys by-actor)))
+      :structural-parentage? (every? #(= root-run-id (:run/parent %)) child-runs)
+      :children-completed? (every? #(= :completed (:run/status %)) child-runs)
+      :children-merged? (every? #(= :merged (:run/settlement-status %)) child-runs)
+      :room-resources-conserved? (= {resource/microdollars 20000M} room-balance)
+      :root-wallet-returned? (empty? root-balance)
+      :child-wallets-returned? (every? empty? (vals child-balances))
+      :canonical-resource-receipts? (= receipt-contract resource-receipts)})))
+
+(defn- memory-environment [room-id _definition]
+  (let [room (d/make-room {:id room-id :store (memory/make)})]
+    {:room room
+     :close! #(d/close-room! room)}))
+
+(defn- close-resource-environment! [cfg conn room]
+  (try
+    (when room (d/close-room! room))
+    (finally
+      (try
+        (kontor-governance/ungovern! conn)
+        (finally
+          (dh/release conn)
+          (dh/delete-database cfg))))))
+
+(defn- resource-environment [room-id definition]
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? true
+             :schema-flexibility :write}
+        chat-id (random-uuid)
+        {:keys [room-resources run-resources]}
+        (:environment/limits definition)]
+    (dh/create-database cfg)
+    (let [conn (try
+                 (dh/connect cfg)
+                 (catch Throwable error
+                   (try
+                     (dh/delete-database cfg)
+                     (catch Throwable cleanup-error
+                       (.addSuppressed error cleanup-error)))
+                   (throw error)))
+          room* (atom nil)]
+      (try
+        (chat-schema/ensure-full-schema! conn)
+        (dh/transact conn
+                     [(merge (chat-schema/create-chat-entity
+                              {:id chat-id :title (name room-id)})
+                             {:room/slug (room-store/room-id->slug room-id)
+                              :room/type :internal})])
+        (resource/install-connection! conn room-id chat-id)
+        (let [room (d/make-room {:id room-id
+                                 :store (datahike-store/make conn)})]
+          (reset! room* room)
+          (resource/mint! room {:id (random-uuid)
+                                :resources room-resources})
+          {:room room
+           :hire-opts {:resources run-resources}
+           :resource-observation
+           (fn [root-run-id child-runs]
+             (let [by-actor (into {} (map (juxt :run/actor identity)) child-runs)
+                   analyst-id (get-in by-actor [:analyst :run/id])
+                   reviewer-id (get-in by-actor [:reviewer :run/id])
+                   receipt (fn [id]
+                             (some-> (kontor-resource/receipt conn id)
+                                     receipt-view))]
+               {:room-balance (resource/balance room)
+                :root-balance (resource/run-balance room root-run-id)
+                :child-balances
+                (into {}
+                      (map (fn [child]
+                             [(:run/id child)
+                              (resource/run-balance room (:run/id child))]))
+                      child-runs)
+                :resource-receipts
+                {:root-allocation (receipt (resource/allocation-id root-run-id))
+                 :analyst-allocation (receipt (resource/allocation-id analyst-id))
+                 :reviewer-allocation (receipt (resource/allocation-id reviewer-id))
+                 :analyst-return (receipt (resource/return-id analyst-id))
+                 :reviewer-return (receipt (resource/return-id reviewer-id))
+                 :root-return (receipt (resource/return-id root-run-id))}}))
+           :close! #(close-resource-environment! cfg conn room)})
+        (catch Throwable error
+          (try
+            (close-resource-environment! cfg conn @room*)
+            (catch Throwable cleanup-error
+              (.addSuppressed error cleanup-error)))
+          (throw error))))))
+
+(def ^:private memory-setup-ref
+  {:setup/id :dvergr.environment/memory-room :setup/version 1})
+
+(def ^:private resource-setup-ref
+  {:setup/id :dvergr.environment/resource-room :setup/version 1})
+
+(def ^:private trusted-setups
+  {memory-setup-ref memory-environment
+   resource-setup-ref resource-environment})
+
+(def ^:private trusted-verifiers
+  {#:verifier{:id :programming/join-checks-v1 :version 1} join-checks
+   #:verifier{:id :programming/race-checks-v1 :version 1} race-checks
+   #:verifier{:id :programming/self-programming-checks-v1 :version 1}
+   self-programming-checks
+   #:verifier{:id :programming/resource-delegation-checks-v1 :version 1}
+   resource-checks})
+
+(defn- environment-case
+  [id task verifier-id expected & [{:keys [setup limits world metadata]}]]
+  {:definition
+   (environment/make-environment
+    {:id id
+     :version 1
+     :task task
+     :verifier {:id verifier-id :version 1}
+     :limits (merge {:timeout-ms 120000
+                     :cancel-timeout-ms 10000
+                     ;; Resource/time limits govern normal execution. This is
+                     ;; only a runaway fuse for a malfunctioning provider loop.
+                     :max-model-steps 16
+                     :budget-dollars 1.0}
+                    limits)
+     :world (merge {:isolation :ctx
+                    :settlement :automatic
+                    :setup (or setup memory-setup-ref)}
+                   world)
+     :metadata metadata})
+   :expected expected})
+
 (def ^:private environments
   {:programming/join-v1
-   {:task task-v1
-    :expected expected-v1
-    :max-model-steps 8
-    :verify join-checks}
+   (environment-case :programming/join-v1 task-v1
+                     :programming/join-checks-v1 expected-v1)
 
    :programming/race-v1
-   {:task race-task-v1
-    :expected expected-race-v1
-    :max-model-steps 8
-    :verify race-checks}})
+   (environment-case :programming/race-v1 race-task-v1
+                     :programming/race-checks-v1 expected-race-v1)
+
+   :programming/self-programming-v1
+   (environment-case :programming/self-programming-v1 self-programming-task-v1
+                     :programming/self-programming-checks-v1
+                     expected-self-programming-v1
+                     {:metadata {:kind :recursive-agent-program}})
+
+   :programming/resource-delegation-v1
+   (environment-case :programming/resource-delegation-v1 resource-task-v1
+                     :programming/resource-delegation-checks-v1
+                     expected-resource-v1
+                     {:setup resource-setup-ref
+                      :limits {:room-resources {resource/microdollars 20000M}
+                               :run-resources {resource/microdollars 10000M}}
+                      :metadata {:kind :conserved-resource-delegation}})})
+
+(defn environment-definition
+  "Return the exact portable definition for a named benchmark environment."
+  [environment-id]
+  (some-> (get environments environment-id) :definition))
 
 (defn run-environment!
   "Run a named programming environment through `provider`/`model`.
@@ -102,13 +349,34 @@
      (run-environment! :programming/race-v1 :claude-code
                        \"claude-code-sonnet\")"
   [environment-id provider model]
-  (let [{:keys [task expected max-model-steps verify]}
+  (let [{:keys [definition expected]}
         (or (get environments environment-id)
             (throw (ex-info "Unknown programming environment"
                             {:environment-id environment-id
                              :known (set (keys environments))})))
+        definition (environment/validate-environment definition)
+        task (:environment/task definition)
+        verifier-ref (:environment/verifier definition)
+        verify (or (get trusted-verifiers verifier-ref)
+                   (throw (ex-info "Environment names an untrusted verifier"
+                                   {:environment-id environment-id
+                                    :verifier verifier-ref
+                                    :trusted (set (keys trusted-verifiers))})))
+        {:keys [timeout-ms cancel-timeout-ms max-model-steps budget-dollars]}
+        (:environment/limits definition)
+        {:keys [isolation settlement setup]} (:environment/world definition)
+        _ (when-not (= :ctx isolation)
+            (throw (ex-info "Benchmark runner only supports isolated ctx worlds"
+                            {:environment-id environment-id
+                             :isolation isolation})))
+        setup-environment (or (get trusted-setups setup)
+                              (throw (ex-info "Environment names an untrusted setup"
+                                              {:environment-id environment-id
+                                               :setup setup
+                                               :trusted (set (keys trusted-setups))})))
         room-id (keyword (str "programming-bench-" (random-uuid)))
-        room (d/make-room {:id room-id :store (memory/make)})
+        {:keys [room hire-opts resource-observation close!]}
+        (setup-environment room-id definition)
         team (roster/make-agent
               (roster/make-roster {:id :benchmark})
               {:id :orchestrator
@@ -118,24 +386,28 @@
                :model-policy {:provider provider :model model}
                :program {:kind :llm
                          :max-model-steps max-model-steps
-                         :budget-dollars 1.0
+                         :budget-dollars budget-dollars
                          :auto-compact? false}})
-        started (System/nanoTime)]
+        started-at (System/currentTimeMillis)
+        started-nanos (System/nanoTime)]
     (try
       (let [handle (binding [ec/*execution-context* (:ctx room)]
-                     (program/hire! room team :orchestrator {:task task}))
+                     (program/hire! room team :orchestrator
+                                    (merge hire-opts
+                                           {:task task :settlement settlement})))
             initial-result (binding [ec/*execution-context* (:ctx room)]
-                             (deref handle 120000 ::timeout))
+                             (deref handle timeout-ms ::timeout))
             timed-out? (= ::timeout initial-result)
             _ (when timed-out?
                 (binding [ec/*execution-context* (:ctx room)]
                   (program/cancel! handle)))
             result (if timed-out?
                      (binding [ec/*execution-context* (:ctx room)]
-                       (deref handle 10000
+                       (deref handle cancel-timeout-ms
                               {:run/id (program/run-id handle)
                                :run/status :failed
-                               :run/error "Cancellation did not quiesce within 10s"}))
+                               :run/error (str "Cancellation did not quiesce within "
+                                               cancel-timeout-ms "ms")}))
                      initial-result)
             durable (program/observe room handle)
             all-runs (run/runs room {:limit 20})
@@ -147,39 +419,73 @@
             observation {:result result
                          :parsed-value parsed
                          :durable-status (:run/status durable)
+                         :root-causes (set (:run/caused-by durable))
+                         :room-id room-id
                          :root-run-id root-run-id
                          :child-runs child-runs
                          :active-after (count (run/active-runs room-id))}
+            observation (merge observation
+                               (when resource-observation
+                                 (resource-observation root-run-id child-runs)))
             checks (verify observation)
-            passed? (every? true? (vals checks))]
-        {:environment environment-id
-         :provider provider
-         :model model
-         :task task
-         :expected expected
-         :checks checks
-         :reward (if passed? 1.0 0.0)
-         :passed? passed?
-         :timed-out? timed-out?
-         :elapsed-ms (long (/ (- (System/nanoTime) started) 1000000))
-         ;; Each activity row is a tool-bearing provider exchange. A successful
-         ;; exact answer requires one final, non-tool provider exchange as well.
-         :model-steps (cond-> (count activity)
-                        (= :completed (:run/status result)) inc)
-         :result result
-         :parsed-value parsed
-         :durable-status (:run/status durable)
-         :runs (mapv #(select-keys % [:run/id :run/parent :run/actor
-                                     :run/status :run/error])
-                     all-runs)
-         :tool-calls
-         (mapv (fn [message]
-                 (mapv #(select-keys % [:tool-use/name :tool-use/input])
-                       (get-in message [:metadata :tool-uses])))
-               activity)
-         :active-after (:active-after observation)})
+            passed? (every? true? (vals checks))
+            reward (if passed? 1.0 0.0)
+            elapsed-ms (long (/ (- (System/nanoTime) started-nanos) 1000000))
+            run-trace (mapv #(select-keys % [:run/id :run/parent :run/caused-by
+                                             :run/actor :run/status :run/error
+                                             :run/settlement-status])
+                            all-runs)
+            tool-trace
+            (mapv activity/tool-trace-entry activity)
+            resources (when resource-observation
+                        (select-keys observation
+                                     [:room-balance :root-balance :child-balances
+                                      :resource-receipts]))
+            receipt-opts
+            (cond-> {:run-id root-run-id
+                     :provider provider
+                     :model model
+                     :status (:run/status result)
+                     :started-at started-at
+                     :elapsed-ms elapsed-ms
+                     :metrics (merge (:run/metrics result)
+                                     {:timed-out? timed-out?})
+                     :checks checks
+                     :reward reward
+                     :result parsed
+                     :trace {:runs run-trace :tool-calls tool-trace}}
+              resources (assoc :resources resources))
+            attempt-receipt
+            (environment/make-attempt-receipt definition receipt-opts)]
+        (cond->
+         {:environment environment-id
+          :environment-ref (environment/environment-ref definition)
+          :environment-definition definition
+          :provider provider
+          :model model
+          :task task
+          :expected expected
+          :checks checks
+          :reward reward
+          :passed? passed?
+          :timed-out? timed-out?
+          :elapsed-ms elapsed-ms
+          :attempt-receipt attempt-receipt
+          :prompt-id (get-in result [:run/metrics :prompt-id])
+          :usage (get-in result [:run/metrics :usage])
+          ;; Each activity row is a tool-bearing provider exchange. A successful
+          ;; exact answer requires one final, non-tool provider exchange as well.
+          :model-steps (cond-> (count activity)
+                         (= :completed (:run/status result)) inc)
+          :result result
+          :parsed-value parsed
+          :durable-status (:run/status durable)
+          :runs run-trace
+          :tool-calls tool-trace
+          :active-after (:active-after observation)}
+          resources (assoc :resources resources)))
       (finally
-        (d/close-room! room)))))
+        (close!)))))
 
 (defn run-v1!
   "Compatibility entry point for the original parallel-join environment."
@@ -190,3 +496,13 @@
   "Run the ownership-aware race and loser-cancellation environment."
   [provider model]
   (run-environment! :programming/race-v1 provider model))
+
+(defn run-resource-v1!
+  "Run conserved sibling delegation and affine resource-return environment."
+  [provider model]
+  (run-environment! :programming/resource-delegation-v1 provider model))
+
+(defn run-self-programming-v1!
+  "Run the model-authored particle and verifier environment."
+  [provider model]
+  (run-environment! :programming/self-programming-v1 provider model))

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -89,7 +89,13 @@ Attention is the conversational policy layer above this mechanism. A policy may
 remember an utterance without admission, enqueue it for serial work, or request
 switch-to-latest integration at a supported execution boundary. That mapping is
 an interpreter owned by the participant; message tags themselves never acquire
-cancellation authority.
+cancellation authority. Native LLM attention decisions are durable typed Room
+projections rather than synthetic speech: `include` admits model input at the
+next supported boundary, `remember` preserves awareness outside provider
+context, and unsupported plans remain explicitly deferred for a future capable
+interpreter. Stable decision facts and separate applied dispositions make crash
+windows observable without pretending that replaying a model/tool effect is
+always safe; recovery reconciles unapplied decisions with durable Runs first.
 
 ## Construct and compose
 
@@ -255,6 +261,8 @@ what the program did (`:completed`, `:waiting`, `:failed`, or `:cancelled`).
 - `:settlement :automatic` (default): merge completed work;
 - `:settlement :review`: retain completed work in the Room tree;
 - `:settlement :discard`: execute for its result/trace, then drop its effects.
+- `:settlement :deferred`: host-owned two-phase gate; retain the world but
+  reject merge/adoption until the host explicitly releases it.
 
 Failure and cancellation always discard the work plane. Waiting and automatic
 merge conflicts retain it for review. A later merge/discard through
@@ -284,6 +292,106 @@ Run must first receive an eventual Kontor-backed provider allocation.
 
 ## Evaluation ladder
 
+An evaluation environment is an immutable `EnvironmentDef`, separate from any
+attempt to execute it:
+
+```clojure
+(agent/environment
+ {:id :programming/review-v1
+  :task {:artifact "candidate.edn"}
+  :verifier {:id :checks/review-v1 :version 1
+             :basis "git:<verifier-commit>"}
+  :limits {:timeout-ms 120000 :max-model-steps 8}
+  :world {:isolation :ctx :settlement :review}})
+```
+
+The value has a Hasch-derived `:environment/content-id`; map ordering does not
+affect it, while changing the task, verifier reference, limits, or world policy
+does. A verifier is deliberately a versioned reference rather than an embedded
+function: untrusted SCI can author and fork definitions, but only the trusted
+runner resolves exact verifier and world-setup references and computes reward.
+The benchmark interpreter derives its timeout, cancellation grace, restrictive
+model-step and dollar limits, settlement policy, and resource grants from that
+validated definition. It rejects unsupported policy keys instead of silently
+certifying a different scenario. In particular, world `:setup` remains closed
+until the host supplies a versioned trusted setup resolver. Each attempt still
+receives a fresh Run ID, so content identity never collapses distinct
+executions. The current REPL benchmark reports retain both the exact definition
+and its compact reference.
+
+Every opt-in REPL attempt returns a content-addressed `:attempt-receipt`. It binds the
+unique root Run to the exact EnvironmentDef, provider/model, exact assembled
+system-prompt ID, per-resource usage, timing, trusted checks/reward, Run/tool
+trace, and Kontor receipts when present. SCI does not receive the receipt
+constructor or verifier registry, so an evaluated agent can propose an
+environment but cannot certify its own reward.
+
+When the Room has a store, trusted certification persists an immutable Attempt
+before the world can become reviewable or be discarded. The typed Datahike row
+indexes Run, environment, verifier, provider/model, status, timing, reward,
+checks, prompt/program/interpreter provenance, and evidence references. The
+exact EnvironmentDef, AgentDef, receipt, and portable evidence live together in
+Dvergr's immutable blob CAS; the row holds the content reference rather than an
+opaque EDN/JSON column. SCI can query this projection but its Datahike surface
+rejects writes or retractions in the `:attempt/*` and `:attempt.check/*`
+namespaces. A Hasch identity detects content mutation; it does not authenticate
+an external writer, so cross-process imports require a trusted manifest or
+signature before their rewards are admitted.
+
+The reusable host boundary is `dvergr.agent.evaluation/evaluate`. It returns a
+Spin rather than starting a second scheduler: when executed, it admits an
+ordinary Run in an ordinary isolated RunWorld, waits for physical quiescence,
+then invokes a version-matched host `Evaluator` to produce portable evidence,
+checks, reward, and the receipt. Successful evaluation worlds may be retained
+for review or discarded, but first settle as `:deferred`; ordinary merge and
+adoption/discard reject that same world until trusted scoring atomically claims
+release or trusted cleanup. Observer and verifier callbacks run on an external
+worker rather than Spindel's drain path. Cancellation and certification race at
+the settlement claim: a cancelled evaluation can never later make its world
+landable, even if an uncooperative callback returns late. Certification failure
+discards the uncertified world while preserving the Run ID in the structured
+error. The evaluator capability contains functions and therefore remains
+process-local and absent from SCI; SCI can author the portable EnvironmentDef
+it names.
+
+An Episode is a pure export/read projection, not another durable lifecycle:
+
+```text
+Episode = immutable certified Attempt
+        + current durable Run settlement
+        + referenced Runs/messages/activity/resource facts
+```
+
+Review may later merge or discard the Run world. That changes the joined Run
+projection while the historical AttemptReceipt stays content-identical.
+Dataset acceptance, train/eval splits, rankings, particles, and proposal status
+are separate later projections; none mutate certification.
+
+An ensemble is composition, not another primitive:
+
+```clojure
+(let [attempts (mapv #(evaluation/evaluate room team % environment evaluator)
+                     candidate-agent-refs)]
+  @(apply comb/parallel attempts))
+```
+
+Pure policy can rank/select the resulting receipts. Existing room-fork
+merge/discard/adoption remains the only settlement authority. SMC, MCTS,
+Anglican-style inference, and Raster training can consume this same boundary
+without changing Run, Room, or world semantics.
+
+For training, an accepted episode is a projection across the exact
+EnvironmentDef, AgentDef/interpreter identity, Run/tool trajectory, conserved
+resources, checks/reward, and world/memory basis. Raster can consume that
+projection, while a `pretrained-rstr` git-like memory is simply another forked
+system in the episode world. Neither training nor a particular inference
+algorithm changes the execution algebra.
+
+Dollar/token, elapsed-time, and conserved resource limits are the ordinary
+governors. `:max-model-steps` remains only a high emergency fuse for a provider
+loop that keeps returning tool continuations; it is not the conversational or
+FRP unit of progress.
+
 The API and the instructions that teach it are evaluated together at three
 levels:
 
@@ -296,16 +404,18 @@ levels:
    Code, API models, and local models. A trusted host verifier scores the exact
    result plus durable Room/Run facts; model prose is never the reward source.
    Reports retain individual checks, binary reward, generated SCI, leaked
-   Runs/resources, model steps, wall time, task version, and model. Token/cost
-   receipts and a stable hash of the assembled system prompt remain reporting
-   follow-ups.
+   Runs/resources, model steps, token/cost usage, wall time, task version,
+   model, and a stable ID of the exact assembled system prompt. Durable receipt
+   persistence, trusted-writer authorization, and settlement against a retained
+   benchmark world remain follow-ups.
 
 The initial model-facing task set should include pure roster specialization,
 parallel research/review and reduction, race-with-loser-cancellation, explicit
 structural child Runs, delegation-ceiling recognition, and creation of a nested
-durable Room. Structured queue/observe/steer compatibility and reactive-boundary
-tests cover the first attention seam; later `latest`/`serial`/`busy`/`parallel`
-work-admission combinators extend it.
+durable Room. Provider-free attention tests cover capability negotiation,
+queue/observe/restart, run-local cancellation, and reactive boundaries;
+`latest`/`serial`/`busy`/`parallel` work admission covers computation overlap as
+a separate FRP layer.
 Passing only one model is not sufficient evidence that the programming surface
 is clear.
 
@@ -318,6 +428,8 @@ their reports:
 (require '[dvergr.agent.program-bench :as bench])
 (bench/run-v1! :codex-subscription "codex-subscription-sol")
 (bench/run-race-v1! :claude-code "claude-code-sonnet")
+(bench/run-resource-v1! :codex-subscription "codex-subscription-sol")
+(bench/run-self-programming-v1! :codex-subscription "codex-subscription-sol")
 
 ;; The generic entry point makes the task/version explicit.
 (bench/run-environment! :programming/race-v1
@@ -342,6 +454,28 @@ On 2026-08-28, after that correction, Codex Sol solved
 `:programming/race-v1` in three model exchanges and Claude Code in five. Every
 verifier check passed: exact `:fast` result, completed winner, durably cancelled
 loser, structural parentage, completed root, and zero active Runs.
+
+The resource-delegation environment adds a Datahike/Kontor control plane. The
+root Run receives a conserved vector, splits it between two specialists from
+SCI, and joins their result Spins. Its trusted verifier checks the canonical
+Kontor allocation and return receipts for every wallet edge, durable child
+parentage and settlement, empty terminal Run wallets, the restored Room balance,
+and global quiescence. In the 2026-08-30 Codex Sol probe it passed all checks in
+three model exchanges. This evaluates affine delegation and return; it does not
+pretend the provider call itself has been debited yet.
+
+The self-programming environment asks the root model to construct two cheap
+simulated particles plus an independent verifier specification, join all three
+through Spindel, and interpret the verifier data as a pure check. Trusted host
+code scores the exact answer, structural parentage, child completion and
+settlement, durable causal observation of every child result, durable root
+completion, and global quiescence. This deliberately
+uses stubbed child effects: it tests whether a model can author recursive
+orchestration before paid recursive LLM delegation is enabled. In the
+2026-08-30 Codex Sol probe, the model discovered the programming API through
+the REPL, authored and executed the three-specialist program, and passed every
+check in six model exchanges and 31.823 seconds. The durable root's causal
+inputs exactly matched the three child Runs.
 
 This is only the seed of a training environment, not yet a reinforcement
 learning system. The intended general contract is: initialize a forked Room and
@@ -382,12 +516,74 @@ A Roster is a value, not a hidden registry. Thread it through functions or carry
 it as a Spin result. Forked computations can therefore use different derived
 rosters without synchronization or leakage.
 
+The evaluation path follows the same placement rule end to end:
+
+| State | Representation |
+|---|---|
+| workflow dependency, awaiting, cancellation | Spin nodes and continuations in the execution context |
+| changing beliefs, populations, queues, or search policy | Spindel signals/runtime atoms in the execution context |
+| Room, Run, message, ledger, and certified Attempt facts | the Datahike Yggdrasil system registered in that context |
+| files and other world substrates | their registered Yggdrasil systems |
+| Roster, AgentDef, EnvironmentDef, evidence, receipt | immutable values flowing through Spins |
+| provider stream, native worker, verifier function, live Run/Fork handle | process-local capability, never semantic or portable state |
+
+Consequently `evaluate` is a lazy Spin rather than another scheduler. It hires
+an ordinary Run in a Yggdrasil-forked world, awaits that Run through Spindel,
+and returns values. Certification writes one immutable Attempt into the
+branch-correct Room store while the affine world-settlement gate is held.
+`episode/export` is only a read projection joining that Attempt to current Run
+facts; it introduces no lifecycle, clock, mutable cell, or settlement authority.
+
+Probabilistic programs use the same placement rule. In SCI, Dvergr defaults
+`infer/smc-infer`, `infer/importance-sampling`, and `infer/kernel-infer` to
+Spindel's `:world-policy :fork`. Each particle and resampling descendant owns a
+canonical Yggdrasil fork. Before a result crosses into SCI, Dvergr removes the
+execution contexts and exposes only portable results, weights, statistics, and
+world descriptors. `infer/predict` likewise receives values rather than native
+contexts. For example:
+
+```clojure
+(spin
+  (let [posterior (await (infer/smc-infer (scenario-model) 64))]
+    {:values  (infer/values posterior)
+     :weights (infer/log-weights posterior)
+     :ess     (infer/ess posterior)
+     :worlds  (infer/worlds posterior)}))
+```
+
+Pass `{:world-policy :fresh}` only when the model is proven not to touch Room,
+Datahike, repository, accounting, or other registered world state. Inference
+does not introduce an `AgentParticle` entity and does not turn every sample into
+a Run. A Run remains the durable identity of an application-level computation;
+particles are its internal execution placements unless the program explicitly
+launches separately audited evaluations.
+
+Particle-independent Metropolis-Hastings and particle Gibbs are not exposed in
+SCI yet. Their repeated-sweep ownership and settlement contract must be made
+canonical before they become part of this surface.
+
+The current canonical fork covers Spindel execution state and every registered
+Yggdrasil system. It does not yet fork mutable cells allocated inside SCI: a
+captured SCI atom or Var is shared by model invocations. Treat SCI closures as
+pure apart from the fork-aware operations above. Full interpreter-state
+isolation depends on the forkable SCI runtime work and will strengthen this
+contract without changing the portable posterior shape.
+
+Small JVM atoms used inside a native-worker supervisor or verifier hand-off are
+short-lived synchronization primitives for non-forkable capabilities. They may
+decide which already-durable transition wins, but their contents are not the
+workflow's recoverable meaning. If a value must survive a continuation, affect
+branch semantics, or be available after restart, it belongs in Spindel state or
+one of the registered Yggdrasil systems instead.
+
 If a workflow needs changing state, allocate it through Spindel's fork-aware
 state vocabulary (signals or reactive atoms) in the relevant execution context.
 Do not place semantic workflow state in a JVM atom, dynamic singleton, or
-process-global registry. SCI Var forkability is a separate runtime project; do
-not rely on a top-level `def` as the portable state boundary until that work is
-complete.
+process-global registry. SCI vars, atoms, bindings, and continuations now fork
+with the interpreter world, so top-level definitions are valid transient
+branch-local program state. They are deliberately discarded rather than merged;
+durable or reviewable meaning still belongs in Room substrates and Run/effect
+records.
 
 A RunHandle is intentionally not durable state and should not be stored inside
 an AgentDef. Its awaitable result/cache belongs to the Spindel execution graph;

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -45,6 +45,52 @@ work-admission combinators over the same substrate. They must not be encoded as
 special cases of a global turn loop. `:llm` is the first convenient process
 interpreter, not the definition of an agent.
 
+## Admit activity over time
+
+`hire!` starts one causally bounded Run. For a source that keeps producing work,
+compose the same Run-producing or provider-free programs with `spindel.work`:
+
+```clojure
+(require '[spindel.work :as work]
+         '[org.replikativ.spindel.spin.cps :refer [spin]]
+         '[org.replikativ.spindel.effects.await :refer [await]])
+
+(def revisions
+  (work/latest
+   (fn [request]
+     (work/task
+       ;; This body may await Spins, hire agents, query the room, or update
+       ;; fork-local state. Every accepted request gets fresh Spin identity.
+       (solve request)))))
+
+(work/submit! revisions message-id request)
+(work/close! revisions)
+@(spin (await (work/completion revisions)))
+```
+
+Choose policy from semantics rather than from an LLM loop shape:
+
+| Policy | Meaning |
+|---|---|
+| `latest` | New evidence supersedes active work; replacement waits for actual hand-back. |
+| `serial` | Preserve every accepted value in FIFO order. |
+| `busy` | Admit only while idle; explicitly suppress overlap. |
+| `parallel` | Gather independent work up to a declared concurrency bound. |
+
+Controllers expose a hot event stream (`events` plus `next-event`) and a
+fork-local `snapshot`. `close!` drains accepted work; `cancel!` cancels owned
+work; `completion` joins real quiescence. They are intentionally process-local
+reactive machinery. Durable intent, Run identity, messages, and accounting stay
+in the Room store. Reconstructing a controller after restart means replaying the
+durable admitted intent under an explicit recovery policy, not serializing live
+continuations.
+
+Attention is the conversational policy layer above this mechanism. A policy may
+remember an utterance without admission, enqueue it for serial work, or request
+switch-to-latest integration at a supported execution boundary. That mapping is
+an interpreter owned by the participant; message tags themselves never acquire
+cancellation authority.
+
 ## Construct and compose
 
 Inside a room-bound agent sandbox:

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -310,9 +310,19 @@ independent reactive state and an explicit external-system/effect policy.
 Observe evidence, resample descriptors/contexts, and discard unselected
 particles. Only an explicitly selected particle can be promoted or merged.
 
-Needs: the inference coordinator must stop using raw
-`snapshot-context`/`restore-snapshot` for worlds containing Yggdrasil handles;
-that path does not invoke `PForkable` and may alias external state.
+Spindel's inference coordinator now accepts `:world-policy :fork`: initial and
+resampled particles are frozen canonical Yggdrasil forks, and the complete
+speculative tree is discarded after immutable particle results have been
+captured. Dvergr's SCI `infer/smc-infer`, `infer/importance-sampling`, and
+`infer/kernel-infer` wrappers select that policy by default. A caller may pass
+`:world-policy :fresh` only for a model known to be pure. `infer/values`,
+`infer/log-weights`, `infer/ess`, and `infer/worlds` project results and portable
+world descriptors without exposing live settlement handles.
+
+This solves isolation and affine cleanup for one inference population. It does
+not promote a posterior particle automatically: promotion remains an explicit
+Run/proposal operation, and PGAS ancestor scoring is rejected for canonical
+worlds until retained-world ancestry has a sound ownership contract.
 
 ### MCTS
 

--- a/doc/orchestration.md
+++ b/doc/orchestration.md
@@ -313,6 +313,15 @@ Activity facts add structured semantics where known:
  :activity/critical?  true}
 ```
 
+The first durable projection is intentionally smaller than the eventual generic
+event envelope. Canonical `:_activity` room messages carry an `:activities`
+vector of typed component facts. Each fact inherits room, thread, actor, and
+message identity from the enclosing message and may repeat its `:activity/run-id`
+only for an indexed join to the owning Run. Tool facts keep only name and
+provider tool-use id; raw arguments, results, and authorization receipts remain
+in the tool trace. This makes semantic activity composable with conversation
+without creating another lifecycle or effect authority.
+
 Do not add an opaque EDN or JSON payload column to Datahike. Extend typed
 attributes as durable concepts stabilize; put large output behind store refs.
 

--- a/doc/programming-model.md
+++ b/doc/programming-model.md
@@ -216,11 +216,14 @@ honors only the boundaries it actually supports.
 The current LLM participant implements the former behavior as a compatibility
 subset: same-thread `restart` projects to steer; `enqueue` projects to FIFO
 queue; passive `continue` projects to observe. The former `:steer`, `:queue`, and
-`:observe` policy results remain accepted. Future work-admission combinators
-(`latest`, `serial`, `busy`, and `parallel`) will consume these decisions rather
-than adding more branches to the LLM turn loop. A valid richer decision that the
-current adapter cannot honor is queued conservatively; its unsupported axes are
-never silently discarded.
+`:observe` policy results remain accepted. Structured work admission is now
+available directly in native code and the room SCI REPL as `spindel.work/latest`,
+`serial`, `busy`, and bounded `parallel`. These are higher-order FRP policies:
+they turn event values into owned child computations and make cancellation,
+quiescence, backpressure, and completion observable. A valid richer attention
+decision that the compatibility LLM adapter cannot honor is still queued
+conservatively; the next adapter should interpret it through this substrate
+rather than add another private scheduler to the turn loop.
 
 ## Built-in directives
 

--- a/doc/programming-model.md
+++ b/doc/programming-model.md
@@ -213,17 +213,41 @@ is `:now`, `:next-safe-boundary`, `:before-model`, `:token`, `:before-tool`,
 `:after-tool`, `:after-model`, and `:quiescent`. An interpreter advertises and
 honors only the boundaries it actually supports.
 
-The current LLM participant implements the former behavior as a compatibility
-subset: same-thread `restart` projects to steer; `enqueue` projects to FIFO
-queue; passive `continue` projects to observe. The former `:steer`, `:queue`, and
-`:observe` policy results remain accepted. Structured work admission is now
+The native LLM participant negotiates each decision against an explicit
+capability description. It honors memory (`ignore`, `remember`, and
+safe-boundary `include`), activation (`none` and `enqueue`),
+and `continue`, `restart`, `suspend`, or run-local `cancel` at boundaries it can
+implement honestly. Provider-specific integration points and non-zero priority
+remain unsupported and are retained as durable deferred attention; they do not
+silently become ordinary queued Runs. `wake` is part of the provider-neutral
+algebra but is not advertised by this interpreter because it has no durable LLM
+continuation to wake.
+
+Attention is stored as a typed participant projection in the Room store, not as
+a hidden chat message. The shared transcript remains immutable speech. Provider
+working context is reconstructed from the participant's Run triggers, its own
+outputs, and monotone **applied** `include` admissions. Each decision has stable
+identity; a separate append-only disposition proves when all supported axes
+were applied. A ready decision without that disposition is recovery/audit input,
+not a command that may be blindly replayed across external effects. The native
+interpreter keeps live scheduling machinery process-local and exposes unapplied
+facts for an explicit recovery policy.
+
+`remember` stays durable awareness
+without entering model input, while `ignore` excludes the fact from that input.
+Thus live execution and restart/replay apply the same memory decision without
+contaminating thread or message projections. At first upgrade, a deterministic
+applied baseline preserves the existing provider context before new decisions
+take over projection. The former `:steer`, `:queue`, and
+`:observe` policy results remain accepted through normalization. Structured work admission is now
 available directly in native code and the room SCI REPL as `spindel.work/latest`,
 `serial`, `busy`, and bounded `parallel`. These are higher-order FRP policies:
 they turn event values into owned child computations and make cancellation,
-quiescence, backpressure, and completion observable. A valid richer attention
-decision that the compatibility LLM adapter cannot honor is still queued
-conservatively; the next adapter should interpret it through this substrate
-rather than add another private scheduler to the turn loop.
+quiescence, backpressure, and completion observable. Attention decides what an
+activity means to one participant; work admission decides how resulting
+computations overlap. Keeping these layers separate lets another interpreter add
+token- or tool-boundary integration without creating another scheduler or
+changing the decision algebra.
 
 ## Built-in directives
 

--- a/doc/state-model.md
+++ b/doc/state-model.md
@@ -50,7 +50,8 @@ pair (`dvergr.agent.room-context/ensure-ctx!`) — itself a **fold of Tier 1**:
 - `budget-signal` — `{:total :used :by-type}` token accounting
 - `status-signal` — `:active` / `:paused` / `:completed`
 - `db-conn` — the `dvergr-chat-db` connection (in a fork: the *branched* one)
-- `sci-ctx` — the agent's **SCI sandbox** (its `clojure_eval` world)
+- `sci-component` — a stable Spindel component reference selecting the agent's
+  **SCI sandbox** (`clojure_eval` world) in the current execution context
 
 The agent's own ctx is **`:durable? false`** — signal-only. The room store's
 bus→store listener is the *lone* durable writer for the conversation. So the durable
@@ -62,15 +63,30 @@ plus the per-session sandbox.
 `fork-room` calls `spindel.yggdrasil/fork!`, retains its process-local
 `ForkHandle`, and branches every selected registered Yggdrasil system as a unit:
 
-- **Datahike `dvergr-chat-db`** → branched — messages, KB, ledger, proposals, all
-  isolated until merge. *This is the whole chat state, forked through yggdrasil.*
+- **Datahike `dvergr-chat-db`** → branched — messages, Runs, certified Attempt
+  indexes, KB, ledger, proposals, all isolated until merge. Exact Attempt
+  payloads use the immutable global blob CAS; only a branch's typed reference
+  makes one part of that world. *This is the whole semantic chat state, forked
+  through yggdrasil.*
 - **git worktree** → a fresh worktree; the agent's file edits are isolated.
 - **muschel shell session** → its env-atom is CoW-forked alongside, so a worker's
   `cd` / shell state can't leak to the parent.
-- **per-agent SCI sandbox** → on its first turn in the fork, `ensure-ctx!` builds a
-  fresh `ChatContext` whose `sci-ctx` is a `sandbox/fork-for-session` fork —
-  **transient and isolated per fork, never shared** with the parent or siblings
-  (`(def x …)` in one fork is invisible to others).
+- **per-agent SCI sandbox** → the SCI interpreter is a Spindel world component.
+  Forking the execution context forks its heap (vars, atoms, bindings, and
+  continuations) from the effective parent state. The child reuses the stable
+  `ChatContext` identity while resolving an independent interpreter; `(def x …)`
+  in one fork is invisible to its parent and siblings. Discard unregisters the
+  child realization rather than merging transient interpreter state.
+
+Injected host capabilities follow a stricter rule than ordinary SCI values.
+They never close over a Room, Datahike connection, Geschichte workspace, or
+filesystem. Each interpreter component owns a stable capability identity whose
+serializable binding lives in the Spindel execution context. A copied function
+therefore resolves that identity in the currently selected descendant world at
+call time. This is why a helper defined *before* a fork cannot write back into
+its parent even though the helper's SCI function value itself was inherited.
+Namespace refresh after projection exposes new APIs; it is not the isolation
+mechanism.
 
 The fork's conversation is **seeded from the branched store**, so the agent sees
 inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
@@ -78,6 +94,15 @@ inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
 fully **substrate-isolated world** you can review (`diff`) before adopting or
 discarding. The live handle is process-local; `dvergr.discourse/fork-descriptor`
 is the portable projection used by Runs, proposals, UIs, and audit state.
+
+### ChatContext SCI API migration
+
+`ChatContext` no longer exposes a raw `:sci-ctx` field. Embedders must call
+`dvergr.chat.context/sci-context-in` with the intended execution context, or
+`sci-context` while that context is bound. The record now carries
+`:sci-component`, which is an opaque stable reference and must not be passed to
+SCI directly. Tool contexts still use `:sci-ctx`; supply the interpreter returned
+by one of those resolver functions.
 
 ## Personas / agent config — managed, not files
 

--- a/src-clients/dvergr/tui/app.clj
+++ b/src-clients/dvergr/tui/app.clj
@@ -32,6 +32,7 @@
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.effects.track :refer [track]]
             [org.replikativ.spindel.incremental.interval :as iv]
+            [dvergr.activity :as activity]
             [dvergr.audio.record :as rec]
             [dvergr.audio.stt :as stt]
             [dvergr.discourse :as d]
@@ -686,6 +687,21 @@
          (apply str (repeat pad " "))
          (s/render (s/style :fg (s/ansi256 240)) clock))))
 
+(defn- render-activities
+  "Render compact semantic facts. Detailed arguments remain in trace mode."
+  [message inner-w]
+  (let [facts  (activity/message-activities message)
+        run-id (activity/message-run-id message)]
+    (mapcat
+     (fn [fact]
+       (let [run-label (when-let [id (activity/short-id
+                                      (or (:activity/run-id fact) run-id))]
+                         (str " · run " id))
+             label     (str "  ↳ " (activity/summary fact) run-label)]
+         (for [line (wrap-text label inner-w)]
+           (s/render (s/style :fg (s/ansi256 178)) line))))
+     facts)))
+
 (defn- render-room-message
   "Render one room message (unified shape `{:from :content :role :tool-uses}`)
    to styled lines. Three flavors, keyed on `:role`:
@@ -709,7 +725,8 @@
                   trace?               (render-reasoning (:reasoning m) inner-w)
                   (seq (:reasoning m)) [(s/render (s/style :fg (s/ansi256 240))
                                                   "  💭 thinking · ^T to show")]
-                  :else                nil)]
+                  :else                nil)
+        activities (render-activities m inner-w)]
     (cond
       ;; Fork boundary — a centered separator marking where the inherited
       ;; (pre-fork) history ends and the fork's own conversation begins.
@@ -736,6 +753,7 @@
                                        (str speaker " ") "  ")
                                 l)))
                tool-lines)
+              activities
               (when trace? (mapcat #(render-tool-use % inner-w) (:tool-uses m))))))
 
       ;; Agent reply — cyan speaker, markdown body, inline tool calls.
@@ -751,7 +769,8 @@
         ;; wrapped lines (e.g. **bold** whose SGR-open and reset land on
         ;; different lines) can't bleed into the box padding/border.
         (into [(speaker-line speaker (:ts m) (theme/ansi :assistant) inner-w)]
-              (concat reason (map #(str "  " % "\u001b[0m") body-lines) tu-lines)))
+              (concat reason (map #(str "  " % "\u001b[0m") body-lines)
+                      activities tu-lines)))
 
       ;; User / other — green speaker, plain body.
       :else
@@ -759,7 +778,8 @@
             (concat reason
                     (for [raw (str/split-lines content)
                           l   (wrap-text raw (- inner-w 2))]
-                      (s/render (s/style :fg s/white) (str "  " l))))))))
+                      (s/render (s/style :fg s/white) (str "  " l)))
+                    activities)))))
 
 (defn- room-view
   "Render the :room view: header showing the current Room's title +

--- a/src/dvergr/activity.clj
+++ b/src/dvergr/activity.clj
@@ -1,0 +1,97 @@
+(ns dvergr.activity
+  "Small, durable semantic observations attached to canonical room messages.
+
+   Activities are projections of work that already happened. They are not
+   executable effects, lifecycle owners, or a second event log: room messages
+   supply discourse identity and Runs supply execution identity."
+  (:require [clojure.string :as str]
+            [hasch.core :as hasch])
+  (:import [java.util Date]))
+
+(defn- stable-id
+  [parts]
+  (hasch/uuid [:dvergr/activity parts]))
+
+(defn tool-activities
+  "Project the tool requests in an assistant message into compact semantic
+   observations. Raw arguments and results remain in the existing tool trace.
+
+   `source-id` should identify the source assistant message when available.
+   The ordinal keeps repeated provider tool-use ids distinct."
+  [run-id source-id tool-uses]
+  (mapv (fn [ordinal tool-use]
+          (let [tool-id (or (:tool-use/id tool-use) (:id tool-use))
+                name    (or (:tool-use/name tool-use) (:name tool-use))]
+            (cond-> {:activity/id (stable-id [run-id source-id tool-id ordinal])
+                     :activity/kind :tool
+                     :activity/verb :invoke
+                     :activity/at (Date.)}
+              run-id (assoc :activity/run-id run-id)
+              tool-id (assoc :activity/tool-use-id (str tool-id))
+              name (assoc :activity/tool-name (str name)))))
+        (range)
+        tool-uses))
+
+(defn lifecycle-activity
+  "Create a semantic Run lifecycle observation for a visible activity message."
+  [run-id kind verb status outcome]
+  (cond-> {:activity/id (random-uuid)
+           :activity/kind kind
+           :activity/verb verb
+           :activity/status status
+           :activity/critical? true
+           :activity/at (Date.)}
+    run-id (assoc :activity/run-id run-id)
+    outcome (assoc :activity/outcome (str outcome))))
+
+(defn message-activities
+  "Return the semantic activity facts carried by a normalized or raw message."
+  [message]
+  (or (:activities message)
+      (get-in message [:metadata :activities])
+      []))
+
+(defn message-run-id
+  "Return the Run correlated with MESSAGE, accepting normalized and raw shapes."
+  [message]
+  (or (:run-id message)
+      (get-in message [:metadata :run-id])))
+
+(defn- portable-activity [fact]
+  (cond-> (select-keys fact
+                       [:activity/id :activity/kind :activity/verb :activity/at
+                        :activity/run-id :activity/tool-use-id :activity/tool-name
+                        :activity/status :activity/outcome :activity/critical?])
+    (instance? Date (:activity/at fact))
+    (assoc :activity/at (.getTime ^Date (:activity/at fact)))))
+
+(defn tool-trace-entry
+  "Project one normalized or raw tool-activity message into portable causal
+   evidence. Raw inputs remain available for replay while Run/tool-use IDs and
+   semantic activities preserve correlation under interleaving."
+  [message]
+  {:message/id (or (:id message) (:message/id message))
+   :run/id (message-run-id message)
+   :tool-uses
+   (mapv #(select-keys % [:tool-use/id :tool-use/name :tool-use/input])
+         (or (:tool-uses message)
+             (get-in message [:metadata :tool-uses])
+             []))
+   :activities (mapv portable-activity (message-activities message))})
+
+(defn short-id
+  "Compact a UUID-like identity for human-facing correlation labels."
+  [id]
+  (when id
+    (let [s (str id)]
+      (subs s 0 (min 8 (count s))))))
+
+(defn summary
+  "Compact, non-authoritative presentation of one semantic activity fact."
+  [fact]
+  (str/join " · "
+            (keep identity
+                  [(some-> (or (:activity/verb fact) (:activity/kind fact)) name)
+                   (:activity/tool-name fact)
+                   (some-> (:activity/status fact) name)
+                   (:activity/outcome fact)])))

--- a/src/dvergr/agent/attempt.clj
+++ b/src/dvergr/agent/attempt.clj
@@ -1,0 +1,146 @@
+(ns dvergr.agent.attempt
+  "Immutable durable records of trusted evaluation certification.
+
+   A certified Attempt is the write model. An Episode is later derived by
+   joining it with the owning Run and immutable Room evidence; it is not a
+   second lifecycle or settlement authority."
+  (:require [dvergr.agent.environment :as environment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.store :as store]
+            [hasch.core :as hasch]))
+
+(def ^:private attempt-keys
+  #{:attempt/id :attempt/run-id :attempt/environment :attempt/agent
+    :attempt/receipt :attempt/evidence :attempt/evidence-run-ids
+    :attempt/evidence-message-ids :attempt/agent-def-hash
+    :attempt/evidence-content-id :attempt/settlement-intent
+    :attempt/certified-at :attempt/content-id})
+
+(def ^:private required-keys
+  (disj attempt-keys :attempt/evidence-message-ids))
+
+(defn- invalid! [message type data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn- trace-ids [evidence k]
+  (->> (get-in evidence [:trace k])
+       (keep #(when (map? %) (get % (case k :runs :run/id :messages :message/id))))
+       (filter uuid?)
+       set))
+
+(defn make-attempt
+  "Construct the exact immutable record for one certified Attempt.
+
+   `settlement-intent` records the requested post-certification policy. Actual
+   settlement remains on the Run projection and is never copied back here."
+  [definition agent receipt evidence settlement-intent]
+  (environment/validate-environment definition)
+  (environment/validate-attempt-receipt receipt)
+  (when-not (roster/data-value? agent)
+    (invalid! "Attempt AgentDef must be portable data"
+              ::invalid-agent {:agent agent}))
+  (when-not (= (environment/environment-ref definition)
+               (:attempt/environment receipt))
+    (invalid! "Attempt receipt names a different EnvironmentDef"
+              ::environment-mismatch
+              {:expected (environment/environment-ref definition)
+               :actual (:attempt/environment receipt)}))
+  (when-not (and (map? evidence) (roster/data-value? evidence))
+    (invalid! "Attempt evidence must be a portable map"
+              ::invalid-evidence {:evidence evidence}))
+  (when-not (contains? #{:review :discard} settlement-intent)
+    (invalid! "Attempt settlement intent must be :review or :discard"
+              ::invalid-settlement-intent
+              {:settlement-intent settlement-intent}))
+  (doseq [k [:result :trace :resources]]
+    (when-not (= [(contains? evidence k) (get evidence k)]
+                 [(contains? receipt (keyword "attempt" (name k)))
+                  (get receipt (keyword "attempt" (name k)))])
+      (invalid! "Attempt evidence differs from its trusted receipt"
+                ::evidence-receipt-mismatch {:key k})))
+  (let [run-id (:attempt/run-id receipt)
+        agent-hash (hasch/uuid agent)
+        metrics (:attempt/metrics receipt)
+        claimed-agent-hash (get-in receipt [:attempt/metrics :agent-def-hash])
+        _ (when-not (= agent-hash claimed-agent-hash)
+            (invalid! "Attempt AgentDef differs from receipt provenance"
+                      ::agent-mismatch
+                      {:expected claimed-agent-hash :actual agent-hash}))
+        _ (doseq [[metric expected]
+                  [[:agent-version (:agent/version agent)]
+                   [:program-kind (get-in agent [:agent/program :kind])]]]
+            (when-not (= expected (get metrics metric))
+              (invalid! "Attempt AgentDef differs from receipt provenance"
+                        ::agent-mismatch
+                        {:metric metric :expected expected
+                         :actual (get metrics metric)})))
+        _ (when-not (and (integer? (:interpreter-version metrics))
+                         (pos? (:interpreter-version metrics)))
+            (invalid! "Attempt receipt requires an interpreter version"
+                      ::missing-interpreter-version {:metrics metrics}))
+        run-ids (conj (trace-ids evidence :runs) run-id)
+        message-ids (trace-ids evidence :messages)]
+    (cond-> {:attempt/id run-id
+             :attempt/run-id run-id
+             :attempt/environment definition
+             :attempt/agent agent
+             :attempt/receipt receipt
+             :attempt/evidence evidence
+             :attempt/evidence-run-ids run-ids
+             :attempt/agent-def-hash agent-hash
+             :attempt/evidence-content-id
+             (hasch/uuid [:dvergr/evaluation-evidence evidence])
+             :attempt/settlement-intent settlement-intent
+             :attempt/certified-at (+ (:attempt/started-at receipt)
+                                      (:attempt/elapsed-ms receipt))
+             ;; The trusted receipt is the immutable certification identity.
+             :attempt/content-id (:attempt/content-id receipt)}
+      (seq message-ids) (assoc :attempt/evidence-message-ids message-ids))))
+
+(defn validate-attempt
+  "Validate exact certified Attempt content and return it unchanged."
+  [value]
+  (when-not (map? value)
+    (invalid! "Certified Attempt must be a map"
+              ::invalid-attempt {:value value}))
+  (when-let [unknown (seq (remove attempt-keys (keys value)))]
+    (invalid! "Certified Attempt contains unknown keys"
+              ::unknown-attempt-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? value %) required-keys))]
+    (invalid! "Certified Attempt is missing required keys"
+              ::missing-attempt-keys {:missing (set missing)}))
+  (when-not (= (:attempt/id value) (:attempt/run-id value))
+    (invalid! "Attempt identity must equal its root Run identity"
+              ::run-mismatch {:attempt value}))
+  (when-not (and (uuid? (:attempt/id value))
+                 (integer? (:attempt/certified-at value))
+                 (not (neg? (:attempt/certified-at value))))
+    (invalid! "Attempt requires UUID identity and epoch-millisecond certification time"
+              ::invalid-identity {:attempt value}))
+  (let [rebuilt (make-attempt (:attempt/environment value)
+                              (:attempt/agent value)
+                              (:attempt/receipt value)
+                              (:attempt/evidence value)
+                              (:attempt/settlement-intent value))]
+    (when-not (= value rebuilt)
+      (invalid! "Certified Attempt is not canonical"
+                ::non-canonical-attempt
+                {:attempt/id (:attempt/id value)})))
+  value)
+
+(defn persist!
+  "Persist `value` through the Room's Attempt store.
+
+   Rooms without a store intentionally produce ephemeral attempts. A configured
+   store must support durable Attempts; silently returning an unaudited reward
+   would violate the trusted evaluation boundary."
+  [room value]
+  (validate-attempt value)
+  (if-let [room-store (:store room)]
+    (if (satisfies? store/PAttemptStore room-store)
+      (or (store/-store-attempt! room-store (:id room) value)
+          (invalid! "Attempt certification was not durable"
+                    ::not-durable {:attempt/id (:attempt/id value)}))
+      (invalid! "Configured Room store does not support durable Attempts"
+                ::unsupported-store {:store (class room-store)}))
+    value))

--- a/src/dvergr/agent/attempt/governance.clj
+++ b/src/dvergr/agent/attempt/governance.clj
@@ -1,0 +1,215 @@
+(ns dvergr.agent.attempt.governance
+  "Mandatory Datahike writer predicate for certified Attempt projections.
+
+   This composes with an existing store predicate (notably Kontor) and validates
+   fully-resolved datoms. It prevents raw transactions, imports, and remote
+   writers from mutating certification after the trusted transaction function
+   creates it."
+  (:require [datahike.api :as d]))
+
+(def ^:private attempt-required
+  #{:attempt/id :attempt/chat :attempt/run :attempt/content-id
+    :attempt/payload-blob :attempt/payload-codec :attempt/environment-id
+    :attempt/environment-version :attempt/environment-content-id
+    :attempt/verifier-id :attempt/verifier-version :attempt/provider
+    :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
+    :attempt/certified-at :attempt/reward :attempt/agent-def-hash
+    :attempt/program-kind :attempt/interpreter-version
+    :attempt/evidence-content-id :attempt/evidence-runs
+    :attempt/settlement-intent :attempt/checks})
+
+(defn- protected-ident? [ident]
+  (and (keyword? ident)
+       (contains? #{"attempt" "attempt.check"} (namespace ident))))
+
+(defn- datom-ident [db datom]
+  (let [attr (nth datom 1)]
+    (if (keyword? attr)
+      attr
+      (:db/ident (d/entity db attr)))))
+
+(defn- touched [report]
+  (let [db (:db-after report)]
+    (filter #(protected-ident? (datom-ident db %)) (:tx-data report))))
+
+(def ^:private entity-pattern
+  '[*
+    {:attempt/chat [:db/id :chat/id]}
+    {:attempt/run [* {:run/chat [:db/id :chat/id]}]}
+    {:attempt/evidence-runs [* {:run/chat [:db/id :chat/id]}]}
+    {:attempt/evidence-messages [* {:message/chat [:db/id :chat/id]}]}
+    {:attempt/checks [*]}])
+
+(defn- entity-map [db eid]
+  (d/pull db entity-pattern eid))
+
+(defn- attempt? [entity] (uuid? (:attempt/id entity)))
+(defn- check? [entity] (uuid? (:attempt.check/id entity)))
+
+(defn- same-chat? [attempt run]
+  (= (:db/id (:attempt/chat attempt)) (:db/id (:run/chat run))))
+
+(defn- validate-new-attempt! [db entity]
+  (let [missing (remove #(contains? entity %) attempt-required)
+        run (:attempt/run entity)]
+    (when (seq missing)
+      (throw (ex-info "Certified Attempt row is incomplete"
+                      {:type ::incomplete-attempt :missing (set missing)})))
+    (when-not (= (:attempt/id entity) (:run/id run))
+      (throw (ex-info "Certified Attempt identity differs from its Run"
+                      {:type ::attempt-run-mismatch
+                       :attempt/id (:attempt/id entity)
+                       :run/id (:run/id run)})))
+    (when-not (and (contains? #{:completed :failed :cancelled}
+                              (:run/status run))
+                   (= (:attempt/status entity) (:run/status run))
+                   (same-chat? entity run))
+      (throw (ex-info "Certified Attempt requires a same-Room terminal Run"
+                      {:type ::invalid-attempt-run
+                       :attempt/id (:attempt/id entity)})))
+    (doseq [[attempt-key run-key]
+            [[:attempt/agent-def-hash :run/agent-def-hash]
+             [:attempt/program-kind :run/program-kind]
+             [:attempt/interpreter-version :run/interpreter-version]]]
+      (when-not (= (get entity attempt-key) (get run run-key))
+        (throw (ex-info "Certified Attempt provenance differs from its Run"
+                        {:type ::attempt-run-provenance-mismatch
+                         :attempt/key attempt-key}))))
+    (doseq [evidence-run (:attempt/evidence-runs entity)]
+      (when-not (and evidence-run (same-chat? entity evidence-run))
+        (throw (ex-info "Certified Attempt has cross-Room Run evidence"
+                        {:type ::invalid-evidence-run
+                         :attempt/id (:attempt/id entity)}))))
+    (doseq [message (:attempt/evidence-messages entity)]
+      (when-not (= (:db/id (:attempt/chat entity))
+                   (:db/id (:message/chat message)))
+        (throw (ex-info "Certified Attempt has cross-Room message evidence"
+                        {:type ::invalid-evidence-message
+                         :attempt/id (:attempt/id entity)}))))
+    (doseq [check (:attempt/checks entity)]
+      (when-not (and (keyword? (:attempt.check/key check))
+                     (boolean? (:attempt.check/passed? check)))
+        (throw (ex-info "Certified Attempt has malformed checks"
+                        {:type ::invalid-check
+                         :attempt/id (:attempt/id entity)}))))
+    db))
+
+(defonce ^:private authorized-writes (atom {}))
+
+(defn- store-id [conn-or-db]
+  (get-in @conn-or-db [:config :store :id]))
+
+(defn with-authorized-write
+  "Invoke `f` with transaction metadata carrying a one-use trusted writer
+   capability for `attempt-id`. The token is meaningful only while this call is
+   active and is never available through the SCI or store API."
+  [conn attempt-id f]
+  (let [token (random-uuid)
+        key [(store-id conn) token]]
+    (swap! authorized-writes assoc key attempt-id)
+    (try
+      (f {:attempt.writer/token token})
+      (finally
+        (swap! authorized-writes dissoc key)))))
+
+(defn- authorized-attempt-id [report]
+  (when-let [token (get-in report [:tx-meta :attempt.writer/token])]
+    (get @authorized-writes
+         [(get-in report [:db-after :config :store :id]) token])))
+
+(defn validate-report
+  "Reject unauthorized creation and every mutation of certified Attempt facts."
+  [{:keys [db-before db-after tx-data] :as report}]
+  (let [changed (vec (touched report))
+        eids (into #{} (map #(nth % 0)) changed)
+        merge? (seq (get-in db-after [:meta :datahike/merge-parents]))
+        authorized-id (authorized-attempt-id report)]
+    (doseq [eid eids]
+      (let [before (entity-map db-before eid)
+            after (entity-map db-after eid)
+            before-attempt? (attempt? before)
+            after-attempt? (attempt? after)
+            before-check? (check? before)
+            after-check? (check? after)
+            entity-datoms (filter #(= eid (nth % 0)) changed)]
+        (cond
+          (and (not before-attempt?) after-attempt?)
+          (do
+            (when-not (or merge? (= authorized-id (:attempt/id after)))
+              (throw (ex-info "Certified Attempts require the trusted writer"
+                              {:type ::unauthorized-attempt-create
+                               :attempt/id (:attempt/id after)})))
+            (validate-new-attempt! db-after after))
+
+          (and before-attempt? after-attempt?)
+          (when (seq entity-datoms)
+            (throw (ex-info "Certified Attempt rows are immutable"
+                            {:type ::attempt-mutation
+                             :attempt/id (:attempt/id before)})))
+
+          (and before-attempt? (not after-attempt?))
+          (when (:chat/id
+                 (d/pull db-after [:chat/id]
+                         (get-in before [:attempt/chat :db/id])))
+            (throw (ex-info "Certified Attempt deletion requires Room deletion"
+                            {:type ::attempt-deletion
+                             :attempt/id (:attempt/id before)})))
+
+          (and (not before-check?) after-check?)
+          (when-not (or merge? authorized-id)
+            (throw (ex-info "Attempt checks require the trusted writer"
+                            {:type ::unauthorized-check-create})))
+
+          (and before-check? after-check?)
+          (when (seq entity-datoms)
+            (throw (ex-info "Attempt checks are immutable"
+                            {:type ::check-mutation
+                             :check/id (:attempt.check/id before)})))
+
+          (and before-check? (not after-check?))
+          (when-let [owner
+                     (d/q '[:find ?a . :in $ ?check
+                            :where [?a :attempt/checks ?check]]
+                          db-before eid)]
+            (when (attempt? (entity-map db-after owner))
+              (throw (ex-info "Attempt check deletion requires Attempt deletion"
+                              {:type ::check-deletion
+                               :check/id (:attempt.check/id before)})))))))
+    ;; A newly-created check must be owned by an Attempt component edge.
+    (doseq [eid eids
+            :let [before (entity-map db-before eid)
+                  after (entity-map db-after eid)]
+            :when (and (not (check? before)) (check? after))]
+      (when-not (d/q '[:find ?a . :in $ ?check
+                       :where [?a :attempt/checks ?check]] db-after eid)
+        (throw (ex-info "Attempt check is not owned by a certified Attempt"
+                        {:type ::orphan-check :check/id (:attempt.check/id after)}))))
+    report))
+
+(defonce ^:private installed (atom {}))
+
+(defn govern!
+  "Compose Attempt validation with the store's current mandatory predicate."
+  [conn]
+  (let [store-id (get-in @conn [:config :store :id])
+        tx-pred-for (requiring-resolve 'datahike.tx-preds/tx-pred-for)
+        register! (requiring-resolve 'datahike.tx-preds/register-tx-pred!)
+        current (tx-pred-for store-id)
+        entry (get @installed store-id)
+        {:keys [base composed]} entry]
+    (cond
+      (and entry (= current composed)) nil
+
+      ;; An idempotent subsystem install may re-register the same base
+      ;; predicate. Restore the existing composite identity rather than nesting
+      ;; or allocating a new closure.
+      (and entry composed (= current base))
+      (register! store-id composed)
+
+      :else
+      (let [composed' (fn [report]
+                        (when current (current report))
+                        (validate-report report))]
+        (swap! installed assoc store-id {:base current :composed composed'})
+        (register! store-id composed')))
+    store-id))

--- a/src/dvergr/agent/environment.clj
+++ b/src/dvergr/agent/environment.clj
@@ -1,0 +1,303 @@
+(ns dvergr.agent.environment
+  "Portable, content-addressed definitions for verified agent environments.
+
+   An EnvironmentDef describes what may be attempted and names trusted verifier
+   code. It never embeds the verifier function, a live world, or a Run handle.
+   The content ID identifies this exact definition; individual attempts retain
+   fresh Run identities."
+  (:require [dvergr.agent.roster :as roster]
+            [hasch.core :as hasch]))
+
+(def ^:private allowed-keys
+  #{:id :version :task :verifier :limits :world :metadata})
+
+(def ^:private definition-keys
+  #{:environment/id :environment/version :environment/task
+    :environment/verifier :environment/limits :environment/world
+    :environment/metadata :environment/content-id})
+
+(def ^:private required-definition-keys
+  #{:environment/id :environment/version :environment/task
+    :environment/verifier :environment/limits :environment/world
+    :environment/content-id})
+
+(defn- invalid! [message type data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn- positive-version! [label version]
+  (when-not (and (integer? version) (pos? version))
+    (invalid! (str label " must be a positive integer")
+              ::invalid-version
+              {:label label :version version}))
+  version)
+
+(defn- verifier-ref! [verifier]
+  (when-not (map? verifier)
+    (invalid! "Environment :verifier must be a reference map"
+              ::invalid-verifier {:verifier verifier}))
+  (when-let [unknown (seq (remove #{:id :version :basis} (keys verifier)))]
+    (invalid! "Environment :verifier contains unknown keys"
+              ::unknown-verifier-keys {:unknown (set unknown)}))
+  (let [{:keys [id version basis]} verifier]
+    (when-not (keyword? id)
+      (invalid! "Verifier :id must be a keyword"
+                ::invalid-verifier-id {:id id}))
+    (positive-version! "Verifier :version" (or version 1))
+    (when-not (roster/data-value? basis)
+      (invalid! "Verifier :basis must contain only portable data"
+                ::non-portable-verifier-basis {:basis basis}))
+    (cond-> {:verifier/id id
+             :verifier/version (or version 1)}
+      basis (assoc :verifier/basis basis))))
+
+(defn make-environment
+  "Construct a portable, content-addressed EnvironmentDef.
+
+   Required options are keyword `:id`, portable `:task`, and `:verifier` as
+   `{:id keyword :version positive-int}`. Optional `:basis` identifies immutable
+   verifier source. `:limits`, `:world`, and `:metadata` are portable policy
+   data interpreted by the runner."
+  [{:keys [id version task verifier limits world metadata]
+    :or {version 1 limits {} world {}}
+    :as opts}]
+  (when-let [unknown (seq (remove allowed-keys (keys opts)))]
+    (invalid! "Environment contains unknown keys"
+              ::unknown-environment-keys
+              {:unknown (set unknown) :allowed allowed-keys}))
+  (when-not (keyword? id)
+    (invalid! "Environment :id must be a keyword"
+              ::invalid-environment-id {:id id}))
+  (positive-version! "Environment :version" version)
+  (when-not (contains? opts :task)
+    (invalid! "Environment requires :task"
+              ::missing-task {:environment/id id}))
+  (doseq [[label value] [[:task task] [:limits limits] [:world world]
+                         [:metadata metadata]]]
+    (when-not (roster/data-value? value)
+      (invalid! (str "Environment " label " must contain only portable data")
+                ::non-portable-data {:label label :value value})))
+  (when-not (map? limits)
+    (invalid! "Environment :limits must be a map"
+              ::invalid-limits {:limits limits}))
+  (when-not (map? world)
+    (invalid! "Environment :world must be a map"
+              ::invalid-world {:world world}))
+  (when (and metadata (not (map? metadata)))
+    (invalid! "Environment :metadata must be a map"
+              ::invalid-metadata {:metadata metadata}))
+  (let [definition (cond-> {:environment/id id
+                            :environment/version version
+                            :environment/task task
+                            :environment/verifier (verifier-ref! verifier)
+                            :environment/limits limits
+                            :environment/world world}
+                     metadata (assoc :environment/metadata metadata))]
+    (assoc definition
+           :environment/content-id
+           (hasch/uuid [:dvergr/environment-definition definition]))))
+
+(defn validate-environment
+  "Validate that `environment` is canonical portable data and that its content
+   ID still names its exact current value. Returns the unchanged definition."
+  [environment]
+  (when-not (map? environment)
+    (invalid! "EnvironmentDef must be a map"
+              ::invalid-definition {:value environment}))
+  (when-let [unknown (seq (remove definition-keys (keys environment)))]
+    (invalid! "EnvironmentDef contains unknown canonical keys"
+              ::unknown-definition-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? environment %)
+                                  required-definition-keys))]
+    (invalid! "EnvironmentDef is missing canonical keys"
+              ::missing-definition-keys {:missing (set missing)}))
+  (when-not (roster/data-value? environment)
+    (invalid! "EnvironmentDef must contain only portable data"
+              ::non-portable-data {:value environment}))
+  (let [claimed (:environment/content-id environment)
+        content (dissoc environment :environment/content-id)
+        actual (hasch/uuid [:dvergr/environment-definition content])]
+    (when-not (= claimed actual)
+      (invalid! "EnvironmentDef content ID does not match its content"
+                ::content-id-mismatch {:claimed claimed :actual actual})))
+  (let [verifier (:environment/verifier environment)
+        spec (cond-> {:id (:environment/id environment)
+                      :version (:environment/version environment)
+                      :task (:environment/task environment)
+                      :verifier (cond-> {:id (:verifier/id verifier)
+                                         :version (:verifier/version verifier)}
+                                  (contains? verifier :verifier/basis)
+                                  (assoc :basis (:verifier/basis verifier)))
+                      :limits (:environment/limits environment)
+                      :world (:environment/world environment)}
+               (contains? environment :environment/metadata)
+               (assoc :metadata (:environment/metadata environment)))]
+    (when-not (= environment (make-environment spec))
+      (invalid! "EnvironmentDef is not in canonical form"
+                ::non-canonical-definition {:value environment})))
+  environment)
+
+(defn environment-ref
+  "Stable reference to one exact EnvironmentDef."
+  [environment]
+  (select-keys (validate-environment environment)
+               [:environment/id :environment/version :environment/content-id]))
+
+(def ^:private attempt-option-keys
+  #{:run-id :provider :model :status :started-at :elapsed-ms :metrics
+    :checks :reward :result :trace :resources})
+
+(def ^:private attempt-receipt-keys
+  #{:attempt/id :attempt/run-id :attempt/environment :attempt/provider
+    :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
+    :attempt/metrics :attempt/checks :attempt/reward :attempt/result
+    :attempt/trace :attempt/resources :attempt/content-id})
+
+(def ^:private required-attempt-receipt-keys
+  #{:attempt/id :attempt/run-id :attempt/environment :attempt/provider
+    :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
+    :attempt/metrics :attempt/checks :attempt/reward :attempt/content-id})
+
+(def ^:private environment-ref-keys
+  #{:environment/id :environment/version :environment/content-id})
+
+(defn- environment-ref! [ref]
+  (when-not (and (map? ref) (= environment-ref-keys (set (keys ref))))
+    (invalid! "Attempt receipt :environment must be an exact EnvironmentRef"
+              ::invalid-attempt-environment {:environment ref}))
+  (when-not (keyword? (:environment/id ref))
+    (invalid! "EnvironmentRef :environment/id must be a keyword"
+              ::invalid-attempt-environment {:environment ref}))
+  (positive-version! "EnvironmentRef :environment/version"
+                     (:environment/version ref))
+  (when-not (uuid? (:environment/content-id ref))
+    (invalid! "EnvironmentRef :environment/content-id must be a UUID"
+              ::invalid-attempt-environment {:environment ref}))
+  ref)
+
+(defn- finite-number? [value]
+  (and (number? value)
+       (try
+         (Double/isFinite (double value))
+         (catch Throwable _ false))))
+
+(defn- attempt-fields!
+  [{:keys [run-id environment provider model status started-at elapsed-ms metrics
+           checks reward result trace resources]}]
+  (when-not (uuid? run-id)
+    (invalid! "Attempt receipt :run-id must be a UUID"
+              ::invalid-attempt-run {:run-id run-id}))
+  (environment-ref! environment)
+  (when-not (keyword? provider)
+    (invalid! "Attempt receipt :provider must be a keyword"
+              ::invalid-attempt-provider {:provider provider}))
+  (when-not (string? model)
+    (invalid! "Attempt receipt :model must be a string"
+              ::invalid-attempt-model {:model model}))
+  (when-not (keyword? status)
+    (invalid! "Attempt receipt :status must be a keyword"
+              ::invalid-attempt-status {:status status}))
+  (when-not (and (integer? started-at) (not (neg? started-at)))
+    (invalid! "Attempt receipt :started-at must be epoch milliseconds"
+              ::invalid-attempt-start {:started-at started-at}))
+  (when-not (and (integer? elapsed-ms) (not (neg? elapsed-ms)))
+    (invalid! "Attempt receipt :elapsed-ms must be a non-negative integer"
+              ::invalid-attempt-elapsed {:elapsed-ms elapsed-ms}))
+  (when-not (map? metrics)
+    (invalid! "Attempt receipt :metrics must be a map"
+              ::invalid-attempt-metrics {:metrics metrics}))
+  (when-not (and (map? checks) (every? keyword? (keys checks))
+                 (every? boolean? (vals checks)))
+    (invalid! "Attempt receipt :checks must map keywords to booleans"
+              ::invalid-attempt-checks {:checks checks}))
+  (when-not (finite-number? reward)
+    (invalid! "Attempt receipt :reward must be a finite number"
+              ::invalid-attempt-reward {:reward reward}))
+  (doseq [[label value] [[:metrics metrics] [:result result] [:trace trace]
+                         [:resources resources]]]
+    (when-not (roster/data-value? value)
+      (invalid! (str "Attempt receipt " label " must contain only portable data")
+                ::non-portable-attempt-data {:label label :value value})))
+  true)
+
+(defn make-attempt-receipt
+  "Create an immutable verified-attempt receipt for one unique root Run.
+
+   This constructor is intentionally host-only: SCI may author EnvironmentDefs,
+   but the trusted runner supplies checks and reward after observing durable
+   effects. `started-at` is epoch milliseconds; metrics/resources/trace remain
+   portable data so the receipt can live in Datahike or Geschichte."
+  [environment {:keys [run-id provider model status started-at elapsed-ms metrics
+                       checks reward result trace resources]
+                :as opts}]
+  (validate-environment environment)
+  (when-let [unknown (seq (remove attempt-option-keys (keys opts)))]
+    (invalid! "Attempt receipt contains unknown keys"
+              ::unknown-attempt-keys {:unknown (set unknown)}))
+  (let [environment-ref (environment-ref environment)
+        metrics (or metrics {})
+        _ (attempt-fields! {:run-id run-id :environment environment-ref
+                            :provider provider :model model :status status
+                            :started-at started-at :elapsed-ms elapsed-ms
+                            :metrics metrics :checks checks :reward reward
+                            :result result :trace trace :resources resources})
+        receipt (cond-> {:attempt/id run-id
+                         :attempt/run-id run-id
+                         :attempt/environment environment-ref
+                         :attempt/provider provider
+                         :attempt/model model
+                         :attempt/status status
+                         :attempt/started-at started-at
+                         :attempt/elapsed-ms elapsed-ms
+                         :attempt/metrics metrics
+                         :attempt/checks checks
+                         :attempt/reward reward}
+                  (contains? opts :result) (assoc :attempt/result result)
+                  (contains? opts :trace) (assoc :attempt/trace trace)
+                  (contains? opts :resources) (assoc :attempt/resources resources))]
+    (assoc receipt :attempt/content-id
+           (hasch/uuid [:dvergr/environment-attempt receipt]))))
+
+(defn validate-attempt-receipt
+  "Reject a malformed or stale attempt receipt before persistence/projection.
+   Content addressing detects mutation; authorization of the writer remains the
+   durable store's responsibility, not a property of an unsigned value."
+  [receipt]
+  (when-not (map? receipt)
+    (invalid! "Attempt receipt must be a map"
+              ::invalid-attempt-receipt {:value receipt}))
+  (when-let [unknown (seq (remove attempt-receipt-keys (keys receipt)))]
+    (invalid! "Attempt receipt contains unknown canonical keys"
+              ::unknown-attempt-receipt-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? receipt %)
+                                  required-attempt-receipt-keys))]
+    (invalid! "Attempt receipt is missing canonical keys"
+              ::missing-attempt-receipt-keys {:missing (set missing)}))
+  (when-not (roster/data-value? receipt)
+    (invalid! "Attempt receipt must contain only portable data"
+              ::non-portable-attempt-data {:value receipt}))
+  (when-not (= (:attempt/id receipt) (:attempt/run-id receipt))
+    (invalid! "Attempt identity must equal its root Run identity"
+              ::attempt-run-mismatch
+              {:attempt/id (:attempt/id receipt)
+               :attempt/run-id (:attempt/run-id receipt)}))
+  (attempt-fields! {:run-id (:attempt/run-id receipt)
+                    :environment (:attempt/environment receipt)
+                    :provider (:attempt/provider receipt)
+                    :model (:attempt/model receipt)
+                    :status (:attempt/status receipt)
+                    :started-at (:attempt/started-at receipt)
+                    :elapsed-ms (:attempt/elapsed-ms receipt)
+                    :metrics (:attempt/metrics receipt)
+                    :checks (:attempt/checks receipt)
+                    :reward (:attempt/reward receipt)
+                    :result (:attempt/result receipt)
+                    :trace (:attempt/trace receipt)
+                    :resources (:attempt/resources receipt)})
+  (let [claimed (:attempt/content-id receipt)
+        actual (hasch/uuid [:dvergr/environment-attempt
+                            (dissoc receipt :attempt/content-id)])]
+    (when-not (= claimed actual)
+      (invalid! "Attempt receipt content ID does not match its content"
+                ::attempt-content-id-mismatch
+                {:claimed claimed :actual actual})))
+  receipt)

--- a/src/dvergr/agent/episode.clj
+++ b/src/dvergr/agent/episode.clj
@@ -1,0 +1,71 @@
+(ns dvergr.agent.episode
+  "Pure read/export projections over certified Attempts and Room facts.
+
+   Episode has no lifecycle, scheduler, or settlement authority. Its current
+   Run projection is joined at read time; the immutable receipt remains exactly
+   as certified even when review later changes world settlement."
+  (:require [dvergr.agent.attempt :as certified]
+            [dvergr.room.store :as store]))
+
+(defn attempt
+  "Load one exact certified Attempt from `room`, or nil."
+  [room attempt-id]
+  (when-let [room-store (:store room)]
+    (when (satisfies? store/PAttemptStore room-store)
+      (store/-load-attempt room-store (:id room) attempt-id))))
+
+(defn attempts
+  "List exact certified Attempts using the store's bounded typed filters."
+  ([room] (attempts room {}))
+  ([room opts]
+   (if-let [room-store (:store room)]
+     (if (satisfies? store/PAttemptStore room-store)
+       (store/-list-attempts room-store (:id room) opts)
+       [])
+     [])))
+
+(def ^:private run-time-keys
+  [:run/created-at :run/started-at :run/updated-at :run/ended-at])
+
+(defn- portable-run [run]
+  (reduce (fn [projection key]
+            (if-let [instant (get projection key)]
+              (assoc projection key (.getTime ^java.util.Date instant))
+              projection))
+          run run-time-keys))
+
+(defn- required-run [room-store room-id attempt-id run-id kind]
+  (if-let [run (store/-load-run room-store room-id run-id)]
+    (portable-run run)
+    (throw (ex-info "Certified Episode references a missing Run"
+                    {:type ::missing-run
+                     :episode/id attempt-id
+                     :run/id run-id
+                     :run/kind kind}))))
+
+(defn export
+  "Assemble one portable Episode from immutable certification plus current facts.
+
+   `:episode/attempt` is historical and byte/content-stable. `:episode/run` and
+   `:episode/evidence-runs` are current durable projections, so settlement may
+   advance without mutating the certified receipt."
+  [room attempt-id]
+  (when-let [certified (attempt room attempt-id)]
+    (certified/validate-attempt certified)
+    (let [room-store (:store room)
+          room-id (:id room)
+          run-ids (sort-by str (:attempt/evidence-run-ids certified))]
+      {:episode/id attempt-id
+       :episode/attempt certified
+       :episode/environment (:attempt/environment certified)
+       :episode/agent (:attempt/agent certified)
+       :episode/receipt (:attempt/receipt certified)
+       :episode/evidence (:attempt/evidence certified)
+       :episode/run (required-run room-store room-id attempt-id
+                                  (:attempt/run-id certified) :root)
+       :episode/evidence-runs
+       (mapv #(required-run room-store room-id attempt-id % :evidence) run-ids)
+       :episode/evidence-message-ids
+       (or (:attempt/evidence-message-ids certified) #{})
+       :episode/resources
+       (get-in certified [:attempt/receipt :attempt/resources])})))

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -1,0 +1,399 @@
+(ns dvergr.agent.evaluation
+  "Algorithm-neutral execution of verified EnvironmentDefs.
+
+   Evaluation does not introduce another scheduler, world, or inference model.
+   It returns a Spin which admits an ordinary isolated Run, observes its durable
+   outcome, invokes a matching host-owned verifier, and produces an attempt
+   receipt. Parallelism, races, quorums, and later inference policies compose
+   these Spins with the existing Spindel combinators."
+  (:require [dvergr.agent.environment :as environment]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.registry :as registry]
+            [dvergr.rooms.forks :as forks]
+            [hasch.core :as hasch]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.sync :as sync]))
+
+(defrecord Evaluator [ref observe verify])
+
+(defn make-evaluator
+  "Create a process-local trusted evaluator capability.
+
+   `id`, `version`, and optional portable `basis` must exactly match an
+   EnvironmentDef verifier reference. `observe` receives durable execution
+   facts and returns portable evidence. `verify` receives the EnvironmentDef
+   plus that evidence and returns `{:checks {keyword boolean} :reward number}`.
+   Evaluators are deliberately not portable and are never exposed to SCI."
+  [{:keys [id version basis observe verify]
+    :or {version 1}}]
+  (when-not (keyword? id)
+    (throw (ex-info "Evaluator :id must be a keyword"
+                    {:type ::invalid-evaluator-id :id id})))
+  (when-not (and (integer? version) (pos? version))
+    (throw (ex-info "Evaluator :version must be a positive integer"
+                    {:type ::invalid-evaluator-version :version version})))
+  (when-not (fn? observe)
+    (throw (ex-info "Evaluator :observe must be a function"
+                    {:type ::invalid-observer})))
+  (when-not (fn? verify)
+    (throw (ex-info "Evaluator :verify must be a function"
+                    {:type ::invalid-verifier})))
+  (when-not (roster/data-value? basis)
+    (throw (ex-info "Evaluator :basis must contain only portable data"
+                    {:type ::invalid-evaluator-basis :basis basis})))
+  (->Evaluator (cond-> {:verifier/id id :verifier/version version}
+                 (some? basis) (assoc :verifier/basis basis))
+               observe verify))
+
+(defn evaluator-ref
+  "Return the portable verifier reference named by an Evaluator capability."
+  [evaluator]
+  (:ref evaluator))
+
+(defn- require-matching-evaluator! [definition evaluator]
+  (when-not (instance? Evaluator evaluator)
+    (throw (ex-info "Evaluation requires a host Evaluator capability"
+                    {:type ::invalid-evaluator})))
+  (let [expected (:environment/verifier definition)
+        actual (evaluator-ref evaluator)]
+    (when-not (= expected actual)
+      (throw (ex-info "Evaluator does not match the EnvironmentDef verifier"
+                      {:type ::evaluator-mismatch
+                       :expected expected
+                       :actual actual}))))
+  evaluator)
+
+(defn- default-evidence [{:keys [result durable]}]
+  {:result (:run/value result)
+   :trace
+   {:runs [(select-keys durable
+                        [:run/id :run/parent :run/caused-by :run/actor
+                         :run/status :run/error :run/settlement-status
+                         :run/roster :run/agent-version :run/agent-def-hash
+                         :run/program-kind :run/interpreter-version])]}})
+
+(defn- execution-identity [agent result durable]
+  (let [metrics (:run/metrics result)
+        kind (or (:run/program-kind durable)
+                 (get-in agent [:agent/program :kind]))
+        model-policy (:agent/model-policy agent)
+        resolved? (and (:provider metrics) (:model metrics))
+        intended? (and (:provider model-policy) (:model model-policy))]
+    {:provider (or (:provider metrics) (:provider model-policy) :dvergr)
+     :model (or (:model metrics) (:model model-policy) (name kind))
+     :metrics
+     (merge {:program-kind kind
+             :model-resolution (cond resolved? :resolved
+                                     intended? :intended
+                                     :else :not-applicable)
+             :agent-version (or (:run/agent-version durable)
+                                (:agent/version agent))
+             :agent-def-hash (or (:run/agent-def-hash durable)
+                                 (hasch/uuid agent))
+             :interpreter-version (or (:run/interpreter-version durable)
+                                      program/interpreter-version)}
+            (when-let [roster-id (:run/roster durable)]
+              {:roster roster-id})
+            metrics)}))
+
+(defn- positive-timeout! [label value]
+  (when-not (and (integer? value) (pos? value))
+    (throw (ex-info (str label " must be a positive integer")
+                    {:type ::invalid-timeout :label label :value value})))
+  value)
+
+(defn- require-supported-policy! [definition agent]
+  (let [limits (:environment/limits definition)
+        world (:environment/world definition)
+        model-limits (select-keys limits [:max-model-steps :budget-dollars])]
+    (when-let [unknown (seq (remove #{:timeout-ms :cancel-timeout-ms
+                                      :max-model-steps :budget-dollars}
+                                    (keys limits)))]
+      (throw (ex-info "Evaluation environment contains unsupported limits"
+                      {:type ::unsupported-evaluation-limits
+                       :unknown (set unknown)})))
+    (when-let [unknown (seq (remove #{:isolation :settlement :resources}
+                                    (keys world)))]
+      (throw (ex-info
+              "Evaluation environment contains unsupported world policy; setup requires a trusted resolver"
+              {:type ::unsupported-evaluation-world
+               :unknown (set unknown)})))
+    (when (and (seq model-limits)
+               (not= :llm (get-in agent [:agent/program :kind])))
+      (throw (ex-info "Environment model limits require an LLM AgentDef"
+                      {:type ::model-limits-require-llm
+                       :agent/id (:agent/id agent)
+                       :limits model-limits})))
+    model-limits))
+
+(defn- settle-certified! [fork requested claim!]
+  (when-not fork
+    (throw (ex-info "Deferred evaluation world is no longer available"
+                    {:type ::missing-evaluation-world})))
+  (case requested
+    :review
+    (forks/release-deferred! fork :evaluation-certified claim!)
+
+    :discard
+    (let [settled (forks/discard-deferred! fork :evaluation-policy claim!)]
+      (when-not (:ok? settled)
+        (throw (ex-info "Certified evaluation world could not be discarded"
+                        {:type ::settlement-failed
+                         :settlement requested
+                         :fork/id (:id fork)
+                         :error (:error settled)})))))
+  requested)
+
+(defn- discard-uncertified! [fork reason]
+  (when fork
+    (forks/discard-deferred! fork reason)))
+
+(defn- spin-cancelled? [error]
+  (loop [error error]
+    (when error
+      (or (= spin-core/spin-cancelled (:type (ex-data error)))
+          (= "Spin cancelled" (ex-message error))
+          (recur (ex-cause error))))))
+
+(defn- certification-candidate
+  [{:keys [room definition evaluator agent run-id result durable
+           started-at started-nanos timeout?]}]
+  (let [evidence ((:observe evaluator)
+                  {:room room
+                   :environment definition
+                   :run-id run-id
+                   :result result
+                   :durable durable
+                   :default (default-evidence {:result result
+                                               :durable durable})})
+        _ (when-not (and (map? evidence) (roster/data-value? evidence))
+            (throw (ex-info "Evaluator evidence must be a portable map"
+                            {:type ::invalid-evidence :evidence evidence})))
+        {:keys [checks reward]} ((:verify evaluator) definition evidence)
+        {:keys [provider model metrics]} (execution-identity agent result durable)
+        elapsed-ms (long (/ (- (System/nanoTime) started-nanos) 1000000))
+        receipt
+        (environment/make-attempt-receipt
+         definition
+         (cond-> {:run-id run-id
+                  :provider provider
+                  :model model
+                  :status (:run/status result)
+                  :started-at started-at
+                  :elapsed-ms elapsed-ms
+                  :metrics (assoc metrics :timed-out? timeout?)
+                  :checks checks
+                  :reward reward}
+           (contains? evidence :result) (assoc :result (:result evidence))
+           (contains? evidence :trace) (assoc :trace (:trace evidence))
+           (contains? evidence :resources) (assoc :resources
+                                                  (:resources evidence))))]
+    {:evidence evidence :receipt receipt}))
+
+(defn evaluate
+  "Return a Spin which evaluates one AgentDef in one EnvironmentDef.
+
+   The Run is the causal execution identity and its ordinary RunWorld is the
+   isolated scenario. Environment `:world` may specify `:settlement` and a
+   conserved `:resources` vector; `:limits` may specify `:timeout-ms` and
+   `:cancel-timeout-ms`. A timeout requests targeted Run cancellation and no
+   receipt is certified until the Run has physically quiesced.
+
+   Options may provide `:from` and structural `:parent-run`. The returned map
+   contains portable evidence/receipt plus the process-local RunHandle; callers
+   settle a retained world through the existing room-fork APIs."
+  ([room team agent-ref definition evaluator]
+   (evaluate room team agent-ref definition evaluator {}))
+  ([room team agent-ref definition evaluator
+    {:keys [from parent-run] :or {from :environment} :as opts}]
+   (environment/validate-environment definition)
+   (require-matching-evaluator! definition evaluator)
+   (let [agent (roster/agent team agent-ref)
+         {:keys [timeout-ms cancel-timeout-ms]
+          :or {timeout-ms 120000 cancel-timeout-ms 10000}}
+         (:environment/limits definition)
+         {:keys [settlement resources]
+          :or {settlement :review}}
+         (:environment/world definition)
+         model-limits (when agent (require-supported-policy! definition agent))]
+     (when-let [unknown (seq (remove #{:from :parent-run} (keys opts)))]
+       (throw (ex-info "Evaluation contains unknown options"
+                       {:type ::unknown-evaluation-options
+                        :unknown (set unknown)})))
+     (when-not agent
+       (throw (ex-info "Evaluation AgentDef does not exist in the Roster"
+                       {:type ::unknown-agent :agent-ref agent-ref})))
+     (positive-timeout! "Environment :timeout-ms" timeout-ms)
+     (positive-timeout! "Environment :cancel-timeout-ms" cancel-timeout-ms)
+     (when-not (contains? #{nil :ctx}
+                          (get-in definition [:environment/world :isolation]))
+       (throw (ex-info "Evaluation environments currently require :ctx isolation"
+                       {:type ::unsupported-evaluation-isolation
+                        :isolation (get-in definition
+                                           [:environment/world :isolation])})))
+     (when-not (#{:review :discard} settlement)
+       (throw (ex-info
+               "Evaluations must retain successful worlds for review or discard them"
+               {:type ::unsafe-evaluation-settlement
+                :settlement settlement
+                :allowed #{:review :discard}})))
+     (sp/spin
+      (let [started-at (System/currentTimeMillis)
+            started-nanos (System/nanoTime)
+            hire-opts (cond-> {:task (:environment/task definition)
+                               :from from
+                               ;; Verification is a two-phase gate over this
+                               ;; same RunWorld. Existing merge/adoption
+                               ;; operations reject it until trusted scoring.
+                               :settlement :deferred}
+                        parent-run (assoc :parent-run parent-run)
+                        (seq resources) (assoc :resources resources)
+                        (seq model-limits) (assoc :limits model-limits))
+            handle (program/hire! room team agent-ref hire-opts)
+            timed-out ::timed-out
+            initial (sp/await
+                     (comb/timeout (program/owned-result-spin handle)
+                                   timeout-ms timed-out))
+            timeout? (= timed-out initial)
+            _ (when timeout? (program/cancel! room handle))
+            result (if timeout?
+                     (sp/await
+                      (comb/timeout (program/result-spin handle)
+                                    cancel-timeout-ms timed-out))
+                     initial)]
+        (when (= timed-out result)
+          (throw (ex-info "Environment Run did not quiesce after cancellation"
+                          {:type ::cancellation-timeout
+                           :run/id (program/run-id handle)
+                           :cancel-timeout-ms cancel-timeout-ms})))
+        (let [run-id (program/run-id handle)
+              durable (program/observe room handle)
+              fork (some-> (:run/world result) registry/lookup)
+              evaluation-spin-id ec/*spin-id*
+              cancelled-externally?
+              #(and evaluation-spin-id
+                    (ec/spin-current-result evaluation-spin-id))
+              state (atom :scoring)
+              persisted-attempt (atom nil)
+              cleanup-result (atom ::pending)
+              cleanup-once!
+              (fn [reason]
+                (locking cleanup-result
+                  (if (= ::pending @cleanup-result)
+                    (let [cleanup (discard-uncertified! fork reason)]
+                      (reset! cleanup-result cleanup)
+                      cleanup)
+                    @cleanup-result)))
+              done (sync/deferred)
+              certification-failure!
+              (fn [error]
+                (if (cancelled-externally?)
+                  (compare-and-set! state :scoring :cancelled)
+                  (compare-and-set! state :scoring :failed))
+                (let [cleanup
+                      (cleanup-once!
+                       (if (= :cancelled @state)
+                         :evaluation-cancelled
+                         :evaluation-certification-failed))]
+                  (sync/deliver!
+                   done
+                   {:error
+                    (ex-info "Evaluation certification failed"
+                             {:type ::certification-failed
+                              :run/id run-id
+                              :run/world (:run/world result)
+                              :cleanup cleanup}
+                             error)})))
+              settlement-failure!
+              (fn [error]
+                (sync/deliver!
+                 done
+                 {:error
+                  (ex-info "Evaluation was certified but world settlement requires recovery"
+                           {:type ::settlement-recovery-required
+                            :run/id run-id
+                            :run/world (:run/world result)
+                            :attempt @persisted-attempt
+                            :run/settlement-status
+                            (:run/settlement-status result)}
+                           error)}))
+              worker
+              (future
+                (binding [ec/*execution-context* (:ctx room)
+                          ec/*spin-id* nil]
+                  (try
+                    (let [{:keys [evidence receipt]}
+                          (certification-candidate
+                           {:room room :definition definition
+                            :evaluator evaluator :agent agent :run-id run-id
+                            :result result :durable durable
+                            :started-at started-at :started-nanos started-nanos
+                            :timeout? timeout?})
+                          certified-attempt
+                          (attempt/make-attempt definition agent receipt evidence
+                                                settlement)]
+                      (let [deferred? (= :deferred
+                                         (:run/settlement-status result))
+                            claim!
+                            #(if (cancelled-externally?)
+                               (do
+                                 (compare-and-set! state :scoring :cancelled)
+                                 false)
+                               (when (compare-and-set! state :scoring
+                                                       :certifying)
+                                 ;; This write occurs inside the fork's affine
+                                 ;; settlement lock. The world cannot become
+                                 ;; reviewable or disappear before its trusted
+                                 ;; certification is durable.
+                                 (reset! persisted-attempt
+                                         (attempt/persist! room
+                                                           certified-attempt))
+                                 true))]
+                        (when (cancelled-externally?)
+                          (compare-and-set! state :scoring :cancelled))
+                        (if (or deferred? (claim!))
+                          (let [final-settlement
+                                (if deferred?
+                                  (settle-certified! fork settlement claim!)
+                                  (:run/settlement-status result))
+                                result (assoc result
+                                              :run/settlement-status
+                                              (case final-settlement
+                                                :discard :discarded
+                                                :review :review
+                                                final-settlement))]
+                            (reset! state :certified)
+                            (sync/deliver!
+                             done
+                             {:ok {:environment definition
+                                   :attempt @persisted-attempt
+                                   :attempt-receipt receipt
+                                   :evidence evidence
+                                   :run/id run-id
+                                   :run/result result
+                                   :run/handle handle}}))
+                          (cleanup-once! :evaluation-cancelled))))
+                    (catch Throwable error
+                      (if @persisted-attempt
+                        (settlement-failure! error)
+                        (certification-failure! error))))))]
+          (try
+            (let [{:keys [ok error]} (sp/await done)]
+              (if error (throw error) ok))
+            (catch Throwable error
+              (when (and (spin-cancelled? error)
+                         (compare-and-set! state :scoring :cancelled))
+                (future-cancel worker)
+                ;; Cancellation remains non-blocking for the Spindel drain
+                ;; path. The gate is already closed by `state`; cleanup runs
+                ;; externally and the interrupted worker can never certify.
+                (future
+                  (binding [ec/*execution-context* (:ctx room)
+                            ec/*spin-id* nil]
+                    (cleanup-once! :evaluation-cancelled))))
+              (throw error)))))))))

--- a/src/dvergr/agent/process.clj
+++ b/src/dvergr/agent/process.clj
@@ -35,7 +35,7 @@
   "Run f with the chat-ctx's spindel-ctx bound. f sees a stable
    *execution-context* for ec/swap-state! and signal derefs."
   [chat-ctx f]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [ec/*execution-context* (chat-ctx/selected-execution-context chat-ctx)]
     (f)))
 
 (defn- registry
@@ -147,7 +147,8 @@
   "Return the latest progress snapshot for a process — a pure read.
    Does not disturb the parked spin."
   [process]
-  (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+  (binding [ec/*execution-context*
+            (chat-ctx/selected-execution-context (:chat-ctx process))]
     (let [now (System/currentTimeMillis)
           term-at (some-> (:terminated-at-ref process) .get)]
       {:id             (:id process)
@@ -195,7 +196,7 @@
   (if-let [process *current-process*]
     (let [chat-ctx  (:chat-ctx process)
           grace-ms  (:grace-ms process 5000)
-          chat-spc  (:spindel-ctx chat-ctx)]
+          chat-spc  (chat-ctx/selected-execution-context chat-ctx)]
       (binding [ec/*execution-context* chat-spc]
         (reset! (:progress-signal process)
                 (cond-> (or state {})
@@ -256,7 +257,7 @@
           ;; sees the latch — flip status directly so work-owners
           ;; polling (aborted? proc) see the abort.
           (when (and (:tracked-only? process) (= :abort (:type canonical)))
-            (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+            (binding [ec/*execution-context* (chat-ctx/selected-execution-context chat-ctx)]
               (reset! (:status-signal process) :aborted))
             (mark-terminated! process))
           :delivered)
@@ -285,13 +286,15 @@
              :or {grace-ms 5000}}]
   {:pre [(string? description)]}
   (let [pid (or id (random-uuid))
+        world (chat-ctx/selected-execution-context chat-ctx)
+        process-chat-ctx (assoc chat-ctx :spindel-ctx world)
         process
-        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [ec/*execution-context* world]
           (let [s (sig/signal :running)
                 p (sig/signal {})]
             (map->Proc
              {:id              pid
-              :chat-ctx        chat-ctx
+              :chat-ctx        process-chat-ctx
               :description     description
               :grace-ms        grace-ms
               :status-signal   s
@@ -301,13 +304,14 @@
               :started-at        (System/currentTimeMillis)
               :terminated-at-ref (AtomicReference. nil)
               :tracked-only?   true})))]
-    (swap-registry! chat-ctx assoc pid process)
+    (swap-registry! process-chat-ctx assoc pid process)
     process))
 
 (defn progress!
   "Update the progress signal on a tracked process."
   [process state]
-  (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+  (binding [ec/*execution-context*
+            (chat-ctx/selected-execution-context (:chat-ctx process))]
     (reset! (:progress-signal process) state))
   state)
 
@@ -317,7 +321,7 @@
    finishes normally."
   [process]
   (let [cctx (:chat-ctx process)]
-    (binding [ec/*execution-context* (:spindel-ctx cctx)]
+    (binding [ec/*execution-context* (chat-ctx/selected-execution-context cctx)]
       (reset! (:status-signal process) :completed))
     (mark-terminated! process)
     ;; Stays in registry briefly so a manager can still snapshot. We
@@ -357,7 +361,7 @@
    summary is wanted it should be an explicit choice — which is what the
    decision protocol makes it (see .internal/decision-protocol-assessment.md)."
   [agent-id chat-ctx]
-  (let [spc           (:spindel-ctx chat-ctx)
+  (let [spc           (chat-ctx/selected-execution-context chat-ctx)
         budget        (binding [ec/*execution-context* spc]
                         @(:budget-signal chat-ctx))
         used-dollars  (/ (:used budget) (double acct/MICRODOLLARS-PER-DOLLAR))
@@ -381,7 +385,8 @@
    at safe points."
   [process]
   (= :aborted
-     (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+     (binding [ec/*execution-context*
+               (chat-ctx/selected-execution-context (:chat-ctx process))]
        @(:status-signal process))))
 
 (defn ->process
@@ -403,13 +408,15 @@
    body-fn]
   {:pre [(string? description)]}
   (let [pid (or id (random-uuid))
+        world (chat-ctx/selected-execution-context chat-ctx)
+        process-chat-ctx (assoc chat-ctx :spindel-ctx world)
         process
-        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [ec/*execution-context* world]
           (let [s (sig/signal :running)
                 p (sig/signal {})]
             (map->Proc
              {:id              pid
-              :chat-ctx        chat-ctx
+              :chat-ctx        process-chat-ctx
               :description     description
               :grace-ms        grace-ms
               :status-signal   s
@@ -418,10 +425,10 @@
               :directive-latch   (CountDownLatch. 1)
               :started-at        (System/currentTimeMillis)
               :terminated-at-ref (AtomicReference. nil)})))]
-    (swap-registry! chat-ctx assoc pid process)
+    (swap-registry! process-chat-ctx assoc pid process)
     (future
       (binding [*current-process*    process
-                ec/*execution-context* (:spindel-ctx chat-ctx)]
+                ec/*execution-context* world]
         (try
           (let [result (body-fn)]
             (reset! (:status-signal process) :completed)

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -36,7 +36,7 @@
    to a Participant is a separate, explicit speech act."
   :_runs)
 
-(def interpreter-version 4)
+(def interpreter-version 5)
 
 (def ^:private default-max-model-steps 32)
 
@@ -80,9 +80,16 @@
                   :cleanup nil
                   :cleanup-phase :pending
                   :cleanup-error nil
+                  :llm-metrics nil
                   :quiesced? false})
     :quiesced (sync/deferred)
     :quiesced-latch (CountDownLatch. 1)}))
+
+(defn- update-llm-metrics!
+  "Update provider evidence under the same lock as cleanup/quiescence state."
+  [supervisor f & args]
+  (locking supervisor
+    (apply swap! (:state supervisor) update :llm-metrics f args)))
 
 (defn- advance-supervisor!
   "Advance cleanup/quiescence after an atomic supervisor transition. Cleanup
@@ -313,32 +320,46 @@
    Deferred; cancelling one observer never cancels the shared execution or a
    peer observer. Use `owned-result-spin` when structured cancellation should
    propagate from a race arm to the hired Run."
-  [^RunHandle handle]
-  (ensure-owner-context! handle)
-  (let [completion (.-completion handle)]
-    (sp/spin (sp/await completion))))
+  ([^RunHandle handle]
+   (ensure-owner-context! handle)
+   (let [completion (.-completion handle)]
+     (sp/spin (sp/await completion))))
+  ([consumer-run-id ^RunHandle handle]
+   (let [observer (result-spin handle)
+         cause-run-id (run-id handle)]
+     (sp/spin
+      (let [result (sp/await observer)]
+        (run/record-cause! consumer-run-id cause-run-id)
+        result)))))
 
 (defn owned-result-spin
   "An owning Spindel observer for a RunHandle. If a combinator cancels this
    observer (for example, as the losing arm of `race`), cancellation propagates
    to the hired Run. Prefer passive `result-spin` for ordinary or shared reads."
-  [^RunHandle handle]
-  (ensure-owner-context! handle)
-  (let [execution (.-worker-execution handle)
-        id (:run/id handle)
-        room-id (:run/room handle)
-        observer (sp/spin
-                  (try
-                    (sp/await (.-completion handle))
-                    (catch Throwable t
-                      (when (= spin-core/spin-cancelled (:type (ex-data t)))
-                        (run/cancel-room-run! room-id id))
-                      (throw t))))]
-    ;; A race can choose another arm before its executor has started this
-    ;; observer, so no await-cont exists yet. Record the same fork-local
-    ;; ownership edge Spindel's fan-out combinators use for that initial window.
-    (spin-core/set-owned-spins! (spin-core/spin-id observer) [execution])
-    observer))
+  ([^RunHandle handle]
+   (ensure-owner-context! handle)
+   (let [execution (.-worker-execution handle)
+         id (:run/id handle)
+         room-id (:run/room handle)
+         observer (sp/spin
+                   (try
+                     (sp/await (.-completion handle))
+                     (catch Throwable t
+                       (when (= spin-core/spin-cancelled (:type (ex-data t)))
+                         (run/cancel-room-run! room-id id))
+                       (throw t))))]
+     ;; A race can choose another arm before its executor has started this
+     ;; observer, so no await-cont exists yet. Record the same fork-local
+     ;; ownership edge Spindel's fan-out combinators use for that initial window.
+     (spin-core/set-owned-spins! (spin-core/spin-id observer) [execution])
+     observer))
+  ([consumer-run-id ^RunHandle handle]
+   (let [observer (owned-result-spin handle)
+         cause-run-id (run-id handle)]
+     (sp/spin
+      (let [result (sp/await observer)]
+        (run/record-cause! consumer-run-id cause-run-id)
+        result)))))
 
 (defn- child-finished! [supervisor lease-id]
   (locking supervisor
@@ -493,7 +514,7 @@
      (-> (tools/make-context
           {:db-conn work-db
            :chat-ctx chat-ctx
-           :sci-ctx (:sci-ctx chat-ctx)
+           :sci-ctx (chat-context/sci-context-in chat-ctx (:ctx room))
            :tools tool-map
            :isolation :sci
            :execution-ctx (:ctx room)
@@ -515,11 +536,18 @@
   "Run a bounded Dvergr-native model/tool loop. Each blocking model round-trip
    runs under a supervised worker; this Spin retains orchestration, activity
    correlation, cleanup, and cancellation in the Room's execution graph."
-  [control-room work-room run-id chat-id agent task trigger supervisor]
+  [control-room work-room run-id chat-id agent task trigger supervisor limits]
   (let [{:keys [max-model-steps budget-dollars auto-compact? compaction-model]
          :or {max-model-steps default-max-model-steps
               budget-dollars 1.0
-              auto-compact? true}} (:agent/program agent)]
+              auto-compact? true}} (:agent/program agent)
+        max-model-steps (min max-model-steps
+                             (or (:max-model-steps limits) max-model-steps))
+        budget-dollars (min (double budget-dollars)
+                            (double (or (:budget-dollars limits)
+                                        budget-dollars)))
+        effective-limits {:max-model-steps max-model-steps
+                          :budget-dollars budget-dollars}]
     (sp/spin
      ;; Context/schema/SCI construction and credential discovery may block.
      ;; Build the whole runtime bundle under the same supervised worker as
@@ -548,6 +576,16 @@
                           (when-let [agent-prompt (:agent/prompt agent)]
                             (str "\n\n" agent-prompt)))
                      {:tools tool-map :isolation :sci :profile :workflow})]
+                (update-llm-metrics!
+                 supervisor
+                 (constantly
+                  (cond->
+                   {:prompt-id (hasch/uuid [:dvergr/llm-system-prompt instructions])
+                    :provider (:provider model-spec)
+                    :model (:model model-spec)
+                    :model-steps 0
+                    :usage {}}
+                    (seq limits) (assoc :limits effective-limits))))
                 (chat-context/add-message!
                  chat-ctx {:role :system :content instructions})
                 (chat-context/add-message!
@@ -592,7 +630,11 @@
                       ;; integration step, not a conversational turn.
                       :turn-number model-step
                       :run-id run-id})))
-                 outcome (sp/await (worker-result-spin call))]
+                 outcome (sp/await (worker-result-spin call))
+                 budget (chat-context/get-budget chat-ctx)]
+             (update-llm-metrics!
+              supervisor merge {:model-steps (inc model-step)
+                                :usage (select-keys budget [:used :by-type])})
              (turn/post-turn-activity! control-room (:agent/id agent) chat-ctx posted
                                        run-id trigger)
              (cond
@@ -645,10 +687,11 @@
   [control-room work-room run-id chat-id agent task trigger supervisor]
   (case (get-in agent [:agent/program :kind])
     :llm (execute-llm-program control-room work-room run-id chat-id agent task
-                              trigger supervisor)
+                              trigger supervisor (::limits agent))
     (execute-deterministic-program run-id agent task)))
 
-(def ^:private hire-option-keys #{:task :from :parent-run :settlement :resources})
+(def ^:private hire-option-keys
+  #{:task :from :parent-run :settlement :resources :limits})
 
 (defn- validate-program!
   [{:keys [kind delay-ms max-model-steps budget-dollars auto-compact? compaction-model]
@@ -683,6 +726,7 @@
                        :max-model-steps max-model-steps})))
     (when (and (= :llm kind)
                (not (and (number? (or budget-dollars 1.0))
+                         (Double/isFinite (double (or budget-dollars 1.0)))
                          (pos? (double (or budget-dollars 1.0))))))
       (throw (ex-info "LLM program :budget-dollars must be positive"
                       {:type ::invalid-budget :budget-dollars budget-dollars})))
@@ -706,7 +750,7 @@
     program))
 
 (defn- validate-hire!
-  [roster agent-ref {:keys [task from parent-run resources] :as opts}]
+  [roster agent-ref {:keys [task from parent-run resources limits] :as opts}]
   (when-let [unknown (seq (remove hire-option-keys (keys opts)))]
     (throw (ex-info "Unknown hire! options"
                     {:type ::unknown-hire-options
@@ -732,6 +776,25 @@
                                resources))))
     (throw (ex-info "hire! :resources must be a non-empty positive resource vector"
                     {:type ::invalid-resources :resources resources})))
+  (when-not (or (nil? limits) (map? limits))
+    (throw (ex-info "hire! :limits must be a map"
+                    {:type ::invalid-limits :limits limits})))
+  (when-let [unknown (seq (remove #{:max-model-steps :budget-dollars}
+                                  (keys limits)))]
+    (throw (ex-info "hire! :limits contains unknown keys"
+                    {:type ::unknown-limit-options
+                     :unknown (set unknown)
+                     :allowed #{:max-model-steps :budget-dollars}})))
+  (when-let [value (:max-model-steps limits)]
+    (when-not (and (integer? value) (<= 1 value 256))
+      (throw (ex-info "hire! limit :max-model-steps must be an integer from 1 to 256"
+                      {:type ::invalid-max-model-steps :max-model-steps value}))))
+  (when-let [value (:budget-dollars limits)]
+    (when-not (and (number? value)
+                   (Double/isFinite (double value))
+                   (pos? (double value)))
+      (throw (ex-info "hire! limit :budget-dollars must be positive"
+                      {:type ::invalid-budget :budget-dollars value}))))
   (when-not (roster/data-value? task)
     (throw (ex-info "Task must be portable data"
                     {:type ::non-portable-task :task task})))
@@ -739,6 +802,11 @@
                   (throw (ex-info "Unknown AgentRef"
                                   {:type ::unknown-agent :agent-ref agent-ref})))]
     (validate-program! (:agent/program agent) agent-ref agent)
+    (when (and (seq limits) (not= :llm (get-in agent [:agent/program :kind])))
+      (throw (ex-info "hire! model limits require an LLM AgentDef"
+                      {:type ::limits-require-llm
+                       :agent-ref agent-ref
+                       :limits limits})))
     agent))
 
 (defn- cancelled-error? [t run-id]
@@ -876,11 +944,12 @@
               (recur))))
         (await-supervisor! supervisor)
         (return-unused-resources! control-room id parent-run allocated?)
-        (let [cleanup-error (:cleanup-error @(:state supervisor))
-              result (if cleanup-error
-                       {:run/id id :run/status :failed
-                        :run/error (ex-message cleanup-error)}
-                       (:result outcome))
+        (let [{:keys [cleanup-error llm-metrics]} @(:state supervisor)
+              result (cond-> (if cleanup-error
+                               {:run/id id :run/status :failed
+                                :run/error (ex-message cleanup-error)}
+                               (:result outcome))
+                       llm-metrics (assoc :run/metrics llm-metrics))
               execution-opts (merge
                               (:finish-opts outcome)
                               (when cleanup-error
@@ -890,13 +959,16 @@
                                        (merge execution-opts finish-opts)))))))
 
 (defn- execution-spin
-  [control-room work-room agent task trigger id chat-id supervisor outcome-promise]
+  [control-room work-room agent task trigger id chat-id supervisor limits outcome-promise]
   (sp/spin
    (let [outcome
          (try
            (let [{status ::status value ::value reason ::reason}
-                 (sp/await (execute-program control-room work-room id chat-id agent
-                                            task trigger supervisor))
+                 (sp/await
+                  (execute-program control-room work-room id chat-id
+                                   (cond-> agent
+                                     (seq limits) (assoc ::limits limits))
+                                   task trigger supervisor))
                  ;; Seal admits no further provider work, runs owned cleanup
                  ;; after all workers terminate, and publishes one stable
                  ;; quiescence acknowledgement.
@@ -908,28 +980,31 @@
                                cleanup-error)))
              (when (run/cancel-requested? id)
                (cancelled! id))
-             (case status
-               :completed
-               (let [output (d/reply (:agent/id agent) run-sink
-                                     (result-content value) trigger
-                                     {:role :assistant :run-id id})]
+             (let [llm-metrics (:llm-metrics @(:state supervisor))]
+               (case status
+                 :completed
+                 (let [output (d/reply (:agent/id agent) run-sink
+                                       (result-content value) trigger
+                                       {:role :assistant :run-id id})]
                  ;; Room posting is durability-first. Completion is acknowledged
                  ;; only after the correlated private output exists.
-                 (d/post! control-room output)
-                 {:result {:run/id id
-                           :run/status :completed
-                           :run/value value
-                           :run/output output}
-                  :finish-opts {}})
+                   (d/post! control-room output)
+                   {:result (cond-> {:run/id id
+                                     :run/status :completed
+                                     :run/value value
+                                     :run/output output}
+                              llm-metrics (assoc :run/metrics llm-metrics))
+                    :finish-opts {}})
 
-               :waiting
-               {:result {:run/id id :run/status :waiting :run/reason reason}
-                :finish-opts {:reason reason}}
+                 :waiting
+                 {:result (cond-> {:run/id id :run/status :waiting :run/reason reason}
+                            llm-metrics (assoc :run/metrics llm-metrics))
+                  :finish-opts {:reason reason}}
 
-               (throw (ex-info "Interpreter returned an unknown program status"
-                               {:type ::unknown-program-status
-                                :status status
-                                :agent/id (:agent/id agent)}))))
+                 (throw (ex-info "Interpreter returned an unknown program status"
+                                 {:type ::unknown-program-status
+                                  :status status
+                                  :agent/id (:agent/id agent)})))))
            (catch Throwable t
              (let [cancelled? (cancelled-error? t id)
                    graph-cancelled? (graph-cancelled-error? t)
@@ -951,13 +1026,16 @@
                    ;; still valid, so it returns an ordinary cancelled result.
                    (sp/await quiesced)
                    (let [cleanup-error (:cleanup-error @(:state supervisor))
-                         error (or cleanup-error t)]
+                         error (or cleanup-error t)
+                         llm-metrics (:llm-metrics @(:state supervisor))]
                      (if (and cancelled? (nil? cleanup-error))
-                       {:result {:run/id id :run/status :cancelled}
+                       {:result (cond-> {:run/id id :run/status :cancelled}
+                                  llm-metrics (assoc :run/metrics llm-metrics))
                         :finish-opts {:reason :cancel-requested}}
-                       {:result {:run/id id
-                                 :run/status :failed
-                                 :run/error (ex-message error)}
+                       {:result (cond-> {:run/id id
+                                         :run/status :failed
+                                         :run/error (ex-message error)}
+                                  llm-metrics (assoc :run/metrics llm-metrics))
                         :finish-opts {:reason (if cleanup-error
                                                 :cleanup-error
                                                 :program-error)
@@ -984,13 +1062,14 @@
    - `:task`       portable task value (required)
    - `:from`       triggering actor, default `:repl`
    - `:parent-run` explicit structural parent Run UUID
-   - `:settlement`  `:automatic` (default), `:review`, or `:discard`
+   - `:settlement`  `:automatic` (default), `:review`, `:discard`, or host-owned `:deferred`
    - `:resources`   positive conserved vector split from the parent Run/Room
+   - `:limits`      restrictive LLM `:max-model-steps` / `:budget-dollars`
    Built-in program kinds are deterministic `:scripted` / `:echo` and the
    bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
    interpreters implement the same boundary."
   [control-room world-parent roster agent-ref
-   {:keys [task from parent-run settlement resources]
+   {:keys [task from parent-run settlement resources limits]
     :or {from :repl settlement :automatic}
     :as raw-opts}]
   (let [opts      (assoc raw-opts :from from)
@@ -1054,7 +1133,7 @@
       (let [completion (sync/deferred)
             outcome-promise (promise)
             worker-execution (execution-spin control-room work-room agent task trigger id chat-id
-                                             supervisor outcome-promise)
+                                             supervisor limits outcome-promise)
             execution (sp/spin (sp/await completion))
             owner-fork-id (:fork-id (ec/current-execution-context))
             handle    (RunHandle. id (:id control-room) owner-fork-id execution completion

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -471,6 +471,7 @@
                    :kb-conn (when system-id (system-rooms/room-kb-conn system-id))
                    :room-id system-id
                    :room-runtime-id (:id work-room)
+                   :room-incarnation (:incarnation work-room)
                    ;; Generic resource vectors split recursively, but paid model
                    ;; usage is not debited yet. Permit only provider-free child
                    ;; programs until that receipt path exists.

--- a/src/dvergr/agent/room_context.clj
+++ b/src/dvergr/agent/room_context.clj
@@ -1,46 +1,38 @@
 (ns dvergr.agent.room-context
   "Per-[room, agent] working ChatContext (design \"D\").
 
-   Instead of rebuilding a fresh chat-ctx every turn (re-reading + re-writing
-   the whole room log under a throwaway chat-id, all on the engine thread),
-   each (room, agent) pair gets ONE long-lived chat-ctx, created once with a
-   stable chat-id and kept current by a fold over the room bus.
+   Instead of rebuilding a fresh chat-ctx every execution, each (room, agent)
+   pair gets one long-lived provider working context. The shared Room log stays
+   the durable source of facts; explicit attention decisions project which of
+   those facts enter this participant's model input.
 
    ## Consistency model (see doc/per-room-chat-ctx.md)
 
-   The room bus is a per-room, totally-ordered message log. The room store
-   (disk) and this chat-ctx's messages-signal (memory) are two folds of that
-   same log — consistent by construction as long as every durable message
-   write goes through the bus.
-
-   - The signal is SEEDED once from the room store (conversation), then a fold
-     spin appends each new bus message FROM OTHERS (`:from` ≠ self), skipping
-     tool-activity. The agent's own turns are appended by the turn loop; the
-     fold skips self, so there is no double-add.
-   - Dedup is by message `:id` via a synchronized set (`.add` is atomic and
-     returns true only on first insert), so the seed and the live fold are
-     idempotent and race-free regardless of ordering — `append-inbound!` is the
-     single deduped appender, called by both the fold and the turn handler (for
-     the just-arrived message).
-   - Recovery = re-seed from the store. The store is the durable bottom; the
-     signal is always rebuildable from it."
+   - The active discourse interpreter is the sole live admission point. There
+     is deliberately no eager bus fold: observing a Room fact must not make an
+     `:ignore` or `:remember` decision indistinguishable from `:include`.
+   - Attention decisions are typed durable Room activity facts. On recovery,
+     Run triggers, the agent's own outputs, and explicit `:include` decisions
+     rebuild provider input; `:remember` remains Room awareness without being
+     sent to the model.
+   - Dedup is by message `:id` through a synchronized set, so a trigger already
+     present in the seed and its live admission cannot appear twice."
   (:require [dvergr.actors :as actors]
             [dvergr.discourse :as d]
+            [dvergr.agent.run :as run]
             [dvergr.agent.turn :as turn]
             [dvergr.chat.context :as chat-ctx]
             [dvergr.chat.schema :as schema]
             [dvergr.room.registry :as rreg]
+            [dvergr.room.store :as rstore]
             [dvergr.chat.accounting :as acct]
-            [dvergr.runtime.bus :as bus]
             [dvergr.system.db :as sdb]
             [dvergr.system.rooms :as srooms]
-            [org.replikativ.spindel.core :as sp]
-            [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.engine.core :as ec]
-            [is.simm.partial-cps.sequence :refer [anext]]
             [taoensso.telemere :as tel]))
 
-;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set :sub Subscription}
+;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set
+;;                       :execution-ctx ExecutionContext :sandbox-opts map}
 (defonce ^:private room-agent-ctxs (atom {}))
 
 (defn room-system-id
@@ -101,49 +93,52 @@
            (catch Throwable _ nil))
       (some-> from name)))
 
+(defn- append-inbound-to!
+  [chat-ctx seen msg-id role content author ts reasoning]
+  (when (.add ^java.util.Set seen msg-id)
+    (let [decorated (if (and author (not= :system role))
+                      (str "[" author (when-let [t (fmt-clock ts)] (str " · " t)) "] " content)
+                      content)]
+      (append-signal-only! chat-ctx (cond-> {:role role :content decorated}
+                                      (seq reasoning) (assoc :reasoning reasoning))))
+    true))
+
 (defn append-inbound!
-  "Append one inbound conversational message to the (room, agent) ctx's signal,
+  "Append one inbound conversational message to the (room, agent) ctx's signal.
+
+   `room-or-id` should be the Room for lifecycle-safe admission during first
+   hydration; the id form remains for callers that target an already-published
+   cache entry.
+
    EXACTLY ONCE (deduped by `msg-id` via the entry's synchronized set). Used by
-   both the bus fold and the turn handler (for the just-arrived message), so
-   whichever runs first wins and the other no-ops. Signal-only (the room store
-   already holds it durably). Returns true if appended.
+   the attention interpreter. Signal-only (the room store already holds it
+   durably). Returns true if appended.
 
    `author` is the sender's display label (nil for the agent's own messages); when
    present the content is prefixed `[author · HH:mm]` so the agent knows WHO spoke
    and WHEN — essential in multi-party rooms where roles alone are ambiguous."
-  ([room-id agent-id msg-id role content author ts]
-   (append-inbound! room-id agent-id msg-id role content author ts nil))
-  ([room-id agent-id msg-id role content author ts reasoning]
-   (when-let [{:keys [chat-ctx seen]} (get @room-agent-ctxs [room-id agent-id])]
-     (when (.add ^java.util.Set seen msg-id)
-       (let [decorated (if (and author (not= :system role))
-                         (str "[" author (when-let [t (fmt-clock ts)] (str " · " t)) "] " content)
-                         content)]
-         ;; `reasoning` (the agent's OWN prior <think> trace) rides along so
-         ;; reasoning models keep it across a rehydrate — see create-message-entity
-         ;; (:reasoning → :message/reasoning) + messages->api-format.
-         (append-signal-only! chat-ctx (cond-> {:role role :content decorated}
-                                         (seq reasoning) (assoc :reasoning reasoning))))
-       true))))
-
-(defn- start-fold!
-  "Subscribe to `room`'s bus and append each new conversational message FROM
-   OTHERS (≠ self) to `cctx`, deduped by id. Returns the Subscription. The
-   pump exits when the subscription is closed (drop-ctx!)."
-  [room self-id]
-  (binding [ec/*execution-context* (:ctx room)]
-    (let [sub (bus/subscribe! (:bus room) [:type :user/message])]
-      (sp/spawn!
-       (spin
-        (loop [s (:aseq sub)]
-          (when-let [r (sp/await (anext s))]
-            (let [[m rest-s] r]
-              (when (and (not= self-id (:from m)) (conversational? m))
-                (let [role (or (:role m) (:role (:metadata m)) :user)]
-                  (append-inbound! (:id room) self-id (:id m) role (:content m)
-                                   (display-name room (:from m)) (:ts m))))
-              (recur rest-s))))))
-      sub)))
+  ([room-or-id agent-id msg-id role content author ts]
+   (append-inbound! room-or-id agent-id msg-id role content author ts nil))
+  ([room-or-id agent-id msg-id role content author ts reasoning]
+   (let [room? (map? room-or-id)
+         room-id (if room? (:id room-or-id) room-or-id)
+         k [room-id agent-id]
+         room-meta (or (when room? (:meta room-or-id))
+                       (:room-meta (get @room-agent-ctxs k)))]
+     (when room-meta
+       ;; Admission may race first hydration. Sharing the lifecycle fence makes
+       ;; the append wait for the fully seeded cache publication instead of
+       ;; observing an absent/partial entry and dropping a durable attention fact.
+       (locking room-meta
+         (binding [ec/*execution-context* (if room?
+                                            (:ctx room-or-id)
+                                            ec/*execution-context*)]
+           (when (or (not room?) (rreg/admitted-incarnation? room-or-id))
+             (when-let [{:keys [chat-ctx seen]} (get @room-agent-ctxs k)]
+               ;; `reasoning` (the agent's OWN prior <think> trace) rides along so
+               ;; reasoning models keep it across a rehydrate — see create-message-entity
+               ;; (:reasoning → :message/reasoning) + messages->api-format.
+               (append-inbound-to! chat-ctx seen msg-id role content author ts reasoning)))))))))
 
 (defn raise-budget!
   "Set the live budget :total on every cached agent ctx of `room-id` to
@@ -163,94 +158,255 @@
             0
             @room-agent-ctxs)))
 
+(defn- hydration-messages!
+  "Complete all fallible durable hydration before allocating live signals.
+
+   Attention baseline writes are deterministic/idempotent, so an interrupted
+   attempt can retry. The returned messages are pure data ready to project into
+   a newly constructed ChatContext without further store access."
+  [room agent-id limit]
+  (let [messages (d/messages room {:limit (or limit 100)})
+        attention-store? (satisfies? rstore/PAttentionStore (:store room))
+        conversation-id (d/conversation-id room)
+        baseline-message-id
+        (rstore/attention-id conversation-id agent-id nil nil
+                             :legacy-baseline-message)
+        baseline-marker-id
+        (rstore/attention-id conversation-id agent-id baseline-message-id
+                             nil :legacy-baseline-complete)
+        baseline-complete?
+        (and attention-store?
+             (seq (rstore/-list-attention (:store room)
+                                          conversation-id
+                                          {:id baseline-marker-id})))
+        ;; Upgrade cutover: pre-attention rooms already have Runs but no
+        ;; participant projection. Materialize their exact provider baseline
+        ;; before any new policy decision can make the projection non-empty.
+        _ (when (and attention-store? (not baseline-complete?))
+            (doseq [m messages :when (conversational? m)]
+              (let [decision-id
+                    (rstore/attention-id conversation-id agent-id (:id m) nil
+                                         :legacy-baseline-decision)
+                    common {:attention/participant agent-id
+                            :attention/message-id (:id m)
+                            :attention/memory :include
+                            :attention/activation :none
+                            :attention/control :continue
+                            :attention/at :now
+                            :attention/priority 0.0
+                            :attention/reason :migration/provider-baseline
+                            :attention/created-at
+                            (java.util.Date. (long (or (:ts m)
+                                                       (System/currentTimeMillis))))}]
+                (rstore/-store-attention!
+                 (:store room) conversation-id
+                 (assoc common
+                        :attention/id decision-id
+                        :attention/status :ready))
+                (rstore/-store-attention!
+                 (:store room) conversation-id
+                 (assoc common
+                        :attention/id
+                        (rstore/attention-id conversation-id agent-id (:id m) nil
+                                             :legacy-baseline-applied)
+                        :attention/decision-id decision-id
+                        :attention/status :applied))))
+            ;; Written last. If any prior write fails, the next hydration
+            ;; retries every deterministic pair and completes the cutover.
+            (rstore/-store-attention!
+             (:store room) conversation-id
+             {:attention/id baseline-marker-id
+              :attention/participant agent-id
+              :attention/message-id baseline-message-id
+              :attention/status :baseline-complete
+              :attention/reason :migration/provider-baseline
+              :attention/created-at (java.util.Date.)}))
+        attention-facts
+        (if attention-store?
+          (rstore/-list-attention (:store room)
+                                  conversation-id
+                                  {:participant agent-id :limit 1000})
+          [])
+        ;; Admission is monotone: once a fact entered provider context (most
+        ;; notably when queued work becomes a Run trigger), a later observation
+        ;; cannot silently erase it. Deliberate forgetting is compaction policy.
+        included-message-ids
+        (into #{}
+              (keep #(when (and (= :applied (:attention/status %))
+                                (= :include (:attention/memory %)))
+                       (:attention/message-id %)))
+              attention-facts)
+        agent-runs (run/runs room {:actor agent-id :limit 1000})
+        trigger-ids (into #{} (map :run/trigger) agent-runs)
+        ;; Ephemeral/custom stores without the projection retain historical
+        ;; full-transcript behavior for compatibility.
+        legacy-history? (not attention-store?)]
+    (into []
+          (filter #(and (conversational? %)
+                        (or (= agent-id (:from %))
+                            (contains? included-message-ids (:id %))
+                            (contains? trigger-ids (:id %))
+                            legacy-history?)))
+          messages)))
+
 (defn ensure-ctx!
   "Get-or-create the long-lived working chat-ctx for `agent-id` in `room`.
 
-   On first call: create the ctx with a stable chat-id, register it (so the
-   fold + seed can find it), subscribe the fold, then SEED the conversation
-   from the room store. Subscribe-before-seed + id-dedup closes the seed/live
-   race. Subsequent calls return the cached ctx — no per-turn rebuild."
+   On first call, create the ctx with a stable chat-id and seed its durable
+   attention projection from the Room store. Subsequent calls return the
+   cached ctx; live facts enter only through explicit interpreter admission."
   [room agent-id {:keys [system-prompt budget-dollars limit]}]
   (let [room-id (:id room)
         k       [room-id agent-id]]
-    (or (:chat-ctx (get @room-agent-ctxs k))
-        (binding [ec/*execution-context* (:ctx room)]
-          (let [;; The room's system-db UUID — the key the system resolvers
+    ;; Room forking and unregister hold the same monitor. Cache reads belong
+    ;; inside it too: a returned handle must remain live through this boundary.
+    (locking (:meta room)
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [_ (when-not (rreg/admitted-incarnation? room)
+                  (throw (ex-info "Working context requested for a closed Room incarnation"
+                                  {:type ::closed-room
+                                   :room-id room-id
+                                   :room/incarnation (:incarnation room)})))]
+          (or (:chat-ctx (get @room-agent-ctxs k))
+              (let [;; The room's system-db UUID — the key the system resolvers
                 ;; (room-kb-conn / room-kbs / room-msgs) want; distinct from the
                 ;; in-memory keyword `room-id`. Threads to the sandbox so `dvergr.room`
                 ;; + the guarded `d/connect`/`list-databases` resolve THIS room's
                 ;; fork-aware databases.
-                room-uuid (room-system-id room)
-                cctx (turn/new-working-ctx
-                      {:execution-ctx  (:ctx room)
-                       :chat-id        (stable-chat-id room-id agent-id)
-                       :title          (str (name agent-id) "-" (name room-id))
-                       :budget-dollars budget-dollars
+                    room-uuid (room-system-id room)
+                    sandbox-opts
+                    {:execution-ctx  (:ctx room)
+                     :chat-id        (stable-chat-id room-id agent-id)
+                     :title          (str (name agent-id) "-" (name room-id))
+                     :budget-dollars budget-dollars
                         ;; RF5 S4: the cost ledger (account-usage!) writes to THIS
                         ;; room's own msgs store — per-room, fork-aware — not the
                         ;; legacy chat-db. nil ⇒ create-chat-context auto-resolves
                         ;; (room-less fallback only).
-                       :db-conn        (some-> room :store :conn)
+                     :db-conn        (some-> room :store :conn)
                         ;; The agent's sandbox reaches its room's OWN knowledge base
                         ;; (fork-aware) through `dvergr.room/*kb*` — resolved here
                         ;; under the room's bound ctx (so a fork hands the branched
                         ;; KB). nil for room-less ctxs. The sandbox must NEVER touch
                         ;; system-db for knowledge; this is how the room KB gets in.
-                       :kb-conn        (some-> room-uuid srooms/room-kb-conn)
-                       :room-id        room-uuid
+                     :kb-conn        (some-> room-uuid srooms/room-kb-conn)
+                     :room-id        room-uuid
                        ;; Room registry identity is distinct from the system-db
                        ;; UUID above. SCI's agent-programming surface needs the
                        ;; former so a hired agent can recursively hire into this
                        ;; exact live Room, including an ephemeral fork.
-                       :room-runtime-id room-id
-                       :room-incarnation (:incarnation room)
+                     :room-runtime-id room-id
+                     :room-incarnation (:incarnation room)
                         ;; Per-agent network egress scope: an actor's optional
                         ;; `:config {:allowed-domains #{"https://…"}}` restricts the
                         ;; sandbox `http` primitive (nil/empty ⇒ open).
-                       :allowed-domains (some-> (actors/lookup (sdb/get-conn) agent-id)
-                                                :config :allowed-domains)
+                     :allowed-domains (some-> (actors/lookup (sdb/get-conn) agent-id)
+                                              :config :allowed-domains)
                         ;; The room store (bus→store listener) is the single durable
                         ;; writer for this conversation; the agent's own turn messages
                         ;; stay signal-only (no redundant datahike write). Token
-                        ;; accounting still persists.
-                       :durable?       false})
-                seen (java.util.Collections/synchronizedSet (java.util.HashSet.))]
-            ;; Register BEFORE the fold/seed so append-inbound! finds the entry.
-            (swap! room-agent-ctxs assoc k {:chat-ctx cctx :seen seen :sub nil})
-            ;; Subscribe first (catch live messages during seeding)…
-            (let [sub (start-fold! room agent-id)]
-              (swap! room-agent-ctxs assoc-in [k :sub] sub))
+                     ;; accounting still persists.
+                     :durable?       false}
+                    messages (hydration-messages! room agent-id limit)
+                    cctx (turn/new-working-ctx sandbox-opts)
+                    bound-sandbox-opts (assoc sandbox-opts
+                                              :capability-id (:capability-id cctx))
+                    seen (java.util.Collections/synchronizedSet (java.util.HashSet.))
+                    entry {:chat-ctx cctx
+                           :seen seen
+                           :execution-ctx (:ctx room)
+                           :room-meta (:meta room)
+                           :sandbox-opts bound-sandbox-opts}]
+                (try
             ;; System prompt once, then seed the conversation from the store.
             ;; Signal-only: the prompt is regenerated each session, not durable.
-            (when system-prompt
-              (append-signal-only! cctx {:role :system :content system-prompt}))
-            ;; Seed the conversation from ONE query: `d/messages` reads the room's
-            ;; (for a fork, branched) store under the conversation :chat/id, so a
-            ;; fork already returns inherited (pre-fork) + its own messages — the
-            ;; agent sees exactly what the UI seeds. (doc/unified-fork-conversation.md)
-            (doseq [m (d/messages room {:limit (or limit 100)})]
-              (when (conversational? m)
-                (append-inbound! room-id agent-id (:id m)
-                                 (or (:role m) (if (= agent-id (:from m)) :assistant :user))
-                                 (:content m)
-                                 ;; author nil for the agent's OWN past messages
-                                 (when (not= agent-id (:from m)) (display-name room (:from m)))
-                                 (:ts m)
-                                 ;; feed back only the agent's OWN prior reasoning,
-                                 ;; not another participant's <think>
-                                 (when (= agent-id (:from m)) (:reasoning m)))))
-            (tel/log! {:level :debug :id ::created
-                       :data {:room room-id :agent agent-id
-                              :seeded (count (chat-ctx/get-messages cctx))}})
-            cctx)))))
+                  (when system-prompt
+                    (append-signal-only! cctx {:role :system :content system-prompt}))
+                  ;; Durable hydration above completed before signal allocation.
+                  ;; Project the staged pure messages into the fresh context.
+                  (doseq [m messages]
+                    (append-inbound-to! cctx seen (:id m)
+                                        (or (:role m) (if (= agent-id (:from m)) :assistant :user))
+                                        (:content m)
+                                        ;; author nil for the agent's own history
+                                        (when (not= agent-id (:from m))
+                                          (display-name room (:from m)))
+                                        (:ts m)
+                                        ;; feed back only the agent's own reasoning
+                                        (when (= agent-id (:from m)) (:reasoning m))))
+                  (tel/log! {:level :debug :id ::created
+                             :data {:room room-id :agent agent-id
+                                    :seeded (count (chat-ctx/get-messages cctx))}})
+                  ;; Publication is the commit point. Before this swap, no
+                  ;; concurrent fast path can observe partially hydrated state.
+                  (swap! room-agent-ctxs assoc k entry)
+                  cctx
+                  (catch Throwable error
+                    (try
+                      (chat-ctx/release-sci-in! cctx (:ctx room))
+                      (catch Throwable cleanup-error
+                        (.addSuppressed error cleanup-error)))
+                    (throw error))))))))))
+
+(defn fork-ctx!
+  "Project an existing parent room/agent working context into `child-room`.
+
+   Yggdrasil has already forked the Spindel world, including the ChatContext's
+   signals and SCI component. The child facade replaces persistence and ambient
+   capabilities without reconstructing the interpreter or replaying history;
+   provider admission remains exclusively controlled by attention."
+  [parent-room child-room agent-id]
+  (let [parent-k [(:id parent-room) agent-id]
+        child-k [(:id child-room) agent-id]]
+    (when-let [{:keys [chat-ctx seen sandbox-opts]} (get @room-agent-ctxs parent-k)]
+      (or (:chat-ctx (get @room-agent-ctxs child-k))
+          (when (try
+                  (chat-ctx/sci-context-in chat-ctx (:ctx child-room))
+                  true
+                  (catch clojure.lang.ExceptionInfo _ false))
+            (let [room-uuid (binding [ec/*execution-context* (:ctx child-room)]
+                              (room-system-id child-room))
+                  child-opts (assoc sandbox-opts
+                                    :execution-ctx (:ctx child-room)
+                                    :db-conn (some-> child-room :store :conn)
+                                    :kb-conn (some-> room-uuid srooms/room-kb-conn)
+                                    :room-id room-uuid
+                                    :room-runtime-id (:id child-room)
+                                    :room-incarnation (:incarnation child-room)
+                                    :fork-projection? true
+                                    :capability-id (:capability-id chat-ctx))
+                  projected (assoc chat-ctx
+                                   :spindel-ctx (:ctx child-room)
+                                   :db-conn (some-> child-room :store :conn))
+                  _ (turn/rebind-working-ctx! projected child-opts)
+                  child-seen (java.util.Collections/synchronizedSet
+                              (locking seen
+                                (java.util.HashSet. ^java.util.Collection seen)))
+                  entry {:chat-ctx projected
+                         :seen child-seen
+                         :execution-ctx (:ctx child-room)
+                         :room-meta (:meta child-room)
+                         :sandbox-opts child-opts}]
+              (swap! room-agent-ctxs
+                     (fn [m]
+                       (if (contains? m child-k) m (assoc m child-k entry))))
+              (:chat-ctx (get @room-agent-ctxs child-k))))))))
+
+(defn- drop-entry! [room-id agent-id]
+  (when-let [{:keys [chat-ctx execution-ctx]}
+             (get @room-agent-ctxs [room-id agent-id])]
+    (when chat-ctx
+      (try (chat-ctx/release-sci-in! chat-ctx
+                                     (or execution-ctx (:spindel-ctx chat-ctx)))
+           (catch Throwable _ nil)))
+    (swap! room-agent-ctxs dissoc [room-id agent-id])))
 
 (defn drop-ctx!
-  "Tear down the (room, agent) ctx: unsubscribe the fold and forget it.
-   Call on agent leave / room delete / fork discard."
+  "Tear down the (room, agent) provider projection."
   [room-id agent-id]
-  (when-let [{:keys [sub]} (get @room-agent-ctxs [room-id agent-id])]
-    (when sub (try (bus/unsubscribe! sub) (catch Throwable _ nil)))
-    (swap! room-agent-ctxs dissoc [room-id agent-id]))
+  (if-let [room-meta (:room-meta (get @room-agent-ctxs [room-id agent-id]))]
+    (locking room-meta (drop-entry! room-id agent-id))
+    (drop-entry! room-id agent-id))
   nil)
 
 (defn drop-room!
@@ -261,10 +417,22 @@
     (drop-ctx! rid aid))
   nil)
 
+(defn- close-room-contexts!
+  "Fence one registered Room incarnation against further context access.
+
+   Runs as a pre-unregister hook while the Room is still authoritative. The
+   shared monitor makes the closed marker and complete component teardown one
+   lifecycle transition, so a stale caller cannot publish after cleanup."
+  [room]
+  (locking (:meta room)
+    (doseq [[rid aid] (keys @room-agent-ctxs)
+            :when (= rid (:id room))]
+      (drop-entry! rid aid)))
+  nil)
+
 (defn clear-all!
   "Drop every cached ctx (daemon stop — the cache is a defonce that survives a
-   same-process restart, so a fresh start must not reuse ctxs whose bus folds
-   point at the previous run's rooms)."
+   same-process restart, so a fresh start must not reuse stale projections)."
   []
   (doseq [[rid aid] (keys @room-agent-ctxs)]
     (drop-ctx! rid aid))
@@ -275,6 +443,7 @@
   [room-id agent-id]
   (:chat-ctx (get @room-agent-ctxs [room-id agent-id])))
 
-;; Tear down a room's cached ctxs whenever it leaves the registry (room delete,
-;; fork discard) — one hook covers all teardown paths. Idempotent across reload.
-(rreg/add-unregister-hook! ::drop-room drop-room!)
+;; Fence + tear down before registry removal. Keeping this in the lifecycle
+;; transaction prevents stale scheduler/MCP callers from recreating a component
+;; after a post-unregister key snapshot.
+(rreg/add-pre-unregister-hook! ::close-room-contexts close-room-contexts!)

--- a/src/dvergr/agent/room_context.clj
+++ b/src/dvergr/agent/room_context.clj
@@ -203,6 +203,7 @@
                        ;; former so a hired agent can recursively hire into this
                        ;; exact live Room, including an ephemeral fork.
                        :room-runtime-id room-id
+                       :room-incarnation (:incarnation room)
                         ;; Per-agent network egress scope: an actor's optional
                         ;; `:config {:allowed-domains #{"https://…"}}` restricts the
                         ;; sandbox `http` primitive (nil/empty ⇒ open).

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -212,6 +212,43 @@
        (notify! {:type :run/started :run run}))
      run)))
 
+(defn record-cause!
+  "Durably add `cause-run-id` to the causal inputs observed by a live Run.
+
+   Structural ownership remains in `:run/parent`; this cardinality-many edge
+   records that `run-id` actually crossed the completion boundary of another
+   Run. Both Runs must have a store, and the cause must already be durable and
+   terminal in that same Room store. Parallel
+   observations serialize through the lifecycle lock, so additions cannot
+   overwrite one another."
+  [run-id cause-run-id]
+  (when-not (and (uuid? run-id) (uuid? cause-run-id) (not= run-id cause-run-id))
+    (throw (ex-info "Run causality requires two distinct Run UUIDs"
+                    {:type ::invalid-cause
+                     :run/id run-id
+                     :cause-run/id cause-run-id})))
+  (locking lifecycle-lock
+    (let [entry (or (get @active run-id)
+                    (throw (ex-info "Causal consumer Run is not live"
+                                    {:type ::run-not-active :run/id run-id})))
+          room-store (:store entry)
+          store-room-id (:store-room-id entry)]
+      (when-not room-store
+        (throw (ex-info "Durable Run causality requires a Room store"
+                        {:type ::causal-store-required :run/id run-id})))
+      (let [now (java.util.Date.)
+            updated (-> (:run entry)
+                        (update :run/caused-by (fnil conj #{}) cause-run-id)
+                        (assoc :run/updated-at now))]
+        (when room-store
+          (when-not (store/-store-run! room-store store-room-id updated)
+            (throw (ex-info "Run causality update was not durable"
+                            {:type ::cause-not-durable
+                             :run/id run-id
+                             :cause-run/id cause-run-id}))))
+        (swap! active assoc-in [run-id :run] updated)
+        updated))))
+
 (defn finish!
   "End the live execution and persist its final/waiting projection. Idempotent
    after the live entry has gone. `:waiting` has no ended-at; terminal states do."

--- a/src/dvergr/agent/tool_commands.clj
+++ b/src/dvergr/agent/tool_commands.clj
@@ -21,6 +21,7 @@
   (:require [clojure.string :as str]
             [dvergr.discourse.commands :as commands]
             [dvergr.agent.room-context :as room-context]
+            [dvergr.chat.context :as chat-context]
             [dvergr.tools :as tools]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -72,7 +73,8 @@
                 (let [tool     (get @tools/registry tool-name)
                       tool-ctx (tools/make-context
                                 {:chat-ctx      cc
-                                 :sci-ctx       (:sci-ctx cc)   ; the agent's OWN session
+                                 :sci-ctx       (chat-context/sci-context-in
+                                                 cc (:ctx room)) ; fork-selected session
                                  :db-conn       (:db-conn cc)
                                  :tools         {tool-name tool} ; allowlist = just this tool
                                  :isolation     :sci

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -11,10 +11,12 @@
    - `post-turn-activity!` — the 🔧 tool-activity play-by-play (→ room `:_activity`)
    - `cancel?-fn` — the SSE-abort predicate threaded into `run-agent-turn!`"
   (:require [clojure.string :as str]
+            [dvergr.activity :as activity]
             [org.replikativ.spindel.engine.core :as rtc]
             [dvergr.discourse :as d]
             [dvergr.chat.context :as chat-ctx]
             [dvergr.agent.run :as run]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.io :as ns-io]
             ;; loaded so add-process-ns! can (find-ns 'dvergr.agent.process)
@@ -34,6 +36,41 @@
 ;; each room's own stores fork-aware off the registry (RF5 S4 — there is no shared
 ;; chat-db). Callers pass the room/agent execution-ctx; setup binds it.
 ;; ----------------------------------------------------------------------------
+(defn rebind-working-ctx!
+  "Refresh the world binding and namespace surface in a working context.
+
+   SCI forks copy the interpreter heap, including host function objects.  Those
+   Injected host functions are stable indirections through `capability-id`, so
+   even functions saved before a fork select the child binding. Namespace
+   refresh keeps newly added APIs visible; it is not the isolation boundary."
+  [cctx {:keys [execution-ctx db-conn kb-conn room-id room-runtime-id
+                room-incarnation capability-id fork-projection?
+                agent-program-ceiling allowed-domains]}]
+  (let [capability-id (or capability-id (:capability-id cctx)
+                          (throw (ex-info "Working context has no capability identity" {})))]
+    (runtime-ctx/install-sandbox-binding!
+     execution-ctx capability-id
+     (cond-> {:capability-id capability-id
+              :room-id room-id
+              :room-runtime-id room-runtime-id
+              :room-incarnation room-incarnation}
+       fork-projection? (assoc :ephemeral-databases {})))
+    (binding [rtc/*execution-context* execution-ctx]
+      (when-let [sci (chat-ctx/sci-context-in cctx execution-ctx)]
+        (sandbox/setup-agent-namespaces! sci execution-ctx
+                                         :room-conn db-conn :kb-conn kb-conn :room-id room-id
+                                         :room-runtime-id room-runtime-id
+                                         :room-incarnation room-incarnation
+                                         :capability-id capability-id
+                                         :agent-program-ceiling agent-program-ceiling
+                                         :allowed-http-domains allowed-domains)
+      ;; These capabilities close over the ChatContext itself, so a projected
+      ;; child facade must replace them as well.
+        (ns-io/add-bash-ns!    sci cctx)
+        (ns-io/add-media-ns!   sci cctx)
+        (ns-io/add-process-ns! sci cctx)))
+    cctx))
+
 (defn new-working-ctx
   "Create a ChatContext whose SCI sandbox has the ctx-bound agent namespaces
    injected (dh/room/intake/search/…). Does NOT seed a system prompt — callers do
@@ -42,40 +79,42 @@
    datahike-write behaviour (room folds pass false: the room store is the durable
    writer). Returns the ChatContext."
   [{:keys [execution-ctx chat-id title budget-dollars db-conn kb-conn room-id
-           room-runtime-id room-incarnation agent-program-ceiling durable? allowed-domains]}]
+           room-runtime-id room-incarnation capability-id agent-program-ceiling
+           durable? allowed-domains]}]
   (binding [rtc/*execution-context* execution-ctx]
-    (let [cctx (cond-> (chat-ctx/create-chat-context
-                        (cond-> {:budget-dollars (or budget-dollars 1.0)
-                                 :db-conn        db-conn
-                                 :with-sci?      true
-                                 :title          (or title "agent")}
-                          chat-id (assoc :chat-id chat-id)))
-                 (some? durable?) (assoc :durable? durable?)
+    (let [capability-id (or capability-id (random-uuid))
+          cctx (assoc (cond-> (chat-ctx/create-chat-context
+                               (cond-> {:budget-dollars (or budget-dollars 1.0)
+                                        :db-conn        db-conn
+                                        :with-sci?      true
+                                        :title          (or title "agent")}
+                                 chat-id (assoc :chat-id chat-id)))
+                        (some? durable?) (assoc :durable? durable?)
                  ;; the ctx knows its room: embedder hooks (e.g. the bash
                  ;; mount provider) resolve room-scoped resources from it
-                 room-id (assoc :room-id room-id))]
+                        room-id (assoc :room-id room-id))
+                      :capability-id capability-id)]
       ;; create-chat-context forks a sci-ctx but does NOT inject the ctx-bound
       ;; namespaces — do it here so clojure_eval has the room/kb/intake nses
       ;; everywhere. `db-conn` is the room's OWN messages store (= `*room*`);
       ;; `kb-conn` its OWN knowledge base (= `*kb*`) — both fork-aware, never sdb.
-      (when-let [sci (:sci-ctx cctx)]
-        (sandbox/setup-agent-namespaces! sci execution-ctx
-                                         :room-conn db-conn :kb-conn kb-conn :room-id room-id
-                                         :room-runtime-id room-runtime-id
-                                         :room-incarnation room-incarnation
-                                         :agent-program-ceiling agent-program-ceiling
-                                         ;; per-agent network egress scoping (nil/empty = open)
-                                         :allowed-http-domains allowed-domains)
-        ;; Two namespaces bound to THIS chat-ctx (not just the spindel ctx), so
-        ;; they can't live in setup-agent-namespaces!: `bash` (the muschel shell
-        ;; session this chat-ctx owns — same one the `shell` tool drives) and
-        ;; `processes` (the turn process registry — list/snapshot/directive! the
-        ;; agent's own work). The daemon path wired these per-turn; now every
-        ;; working ctx gets them at creation.
-        (ns-io/add-bash-ns!    sci cctx)
-        (ns-io/add-media-ns!   sci cctx)
-        (ns-io/add-process-ns! sci cctx))
-      cctx)))
+      (try
+        (rebind-working-ctx! cctx {:execution-ctx execution-ctx
+                                   :db-conn db-conn :kb-conn kb-conn
+                                   :room-id room-id :room-runtime-id room-runtime-id
+                                   :room-incarnation room-incarnation
+                                   :capability-id capability-id
+                                   :agent-program-ceiling agent-program-ceiling
+                                   :allowed-domains allowed-domains})
+        cctx
+        (catch Throwable error
+          ;; Namespace/resource installation is part of construction. A caller
+          ;; must never receive—or lose track of—a half-bound interpreter.
+          (try
+            (chat-ctx/release-sci-in! cctx execution-ctx)
+            (catch Throwable cleanup-error
+              (.addSuppressed error cleanup-error)))
+          (throw error))))))
 
 ;; Reserved `:to` id for agent tool-activity messages posted into a room.
 ;; Nothing subscribes to it, so no participant (agent or egress) receives these
@@ -201,10 +240,14 @@
            (let [uses    (vec (or (:message/tool-uses m) (:tool-uses m)))
                  names   (keep #(or (:tool-use/name %) (:name %)) uses)
                  summary (str "🔧 " (str/join ", " names))
-                 reason  (or (:message/reasoning m) (:reasoning m))]
+                 reason  (or (:message/reasoning m) (:reasoning m))
+                 source-id (or (:message/id m) (:id m))]
              (d/post! room (activity-message
                             agent-id summary run-id trigger
-                            (cond-> {:role :tool :tool-uses uses}
+                            (cond-> {:role :tool
+                                     :tool-uses uses
+                                     :activities (activity/tool-activities
+                                                  run-id source-id uses)}
                               (seq reason) (assoc :reasoning reason)))))))
        (reset! posted (count tool-msgs)))
      nil)))
@@ -230,7 +273,11 @@
                  agent-id
                  (format "⚠️ budget exhausted — $%.2f of $%.2f used. I have stopped and am spending nothing. Raise the room budget and message me to continue."
                          (double used-dollars) (double total-dollars))
-                 run-id trigger {:role :tool}))))
+                 run-id trigger
+                 {:role :tool
+                  :activities [(activity/lifecycle-activity
+                                run-id :budget :exhaust :blocked
+                                "Run budget exhausted")]}))))
    nil))
 
 (defn post-turn-error!
@@ -247,6 +294,9 @@
      (binding [rtc/*execution-context* (:ctx room)]
        (let [detail (or (some-> err ex-message) (some-> err str) "LLM error")]
          (d/post! room
-                  (activity-message agent-id (str "⚠️ turn failed — " detail)
-                                    run-id trigger {:role :tool})))))
+                  (activity-message
+                   agent-id (str "⚠️ turn failed — " detail) run-id trigger
+                   {:role :tool
+                    :activities [(activity/lifecycle-activity
+                                  run-id :run :fail :failed detail)]})))))
    nil))

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -42,7 +42,7 @@
    datahike-write behaviour (room folds pass false: the room store is the durable
    writer). Returns the ChatContext."
   [{:keys [execution-ctx chat-id title budget-dollars db-conn kb-conn room-id
-           room-runtime-id agent-program-ceiling durable? allowed-domains]}]
+           room-runtime-id room-incarnation agent-program-ceiling durable? allowed-domains]}]
   (binding [rtc/*execution-context* execution-ctx]
     (let [cctx (cond-> (chat-ctx/create-chat-context
                         (cond-> {:budget-dollars (or budget-dollars 1.0)
@@ -62,6 +62,7 @@
         (sandbox/setup-agent-namespaces! sci execution-ctx
                                          :room-conn db-conn :kb-conn kb-conn :room-id room-id
                                          :room-runtime-id room-runtime-id
+                                         :room-incarnation room-incarnation
                                          :agent-program-ceiling agent-program-ceiling
                                          ;; per-agent network egress scoping (nil/empty = open)
                                          :allowed-http-domains allowed-domains)

--- a/src/dvergr/agent/world.clj
+++ b/src/dvergr/agent/world.clj
@@ -7,7 +7,7 @@
    review, or discarded without rewriting its execution outcome."
   (:require [dvergr.discourse :as d]))
 
-(def settlement-policies #{:automatic :review :discard})
+(def settlement-policies #{:automatic :review :discard :deferred})
 
 (defrecord RunWorld [id parent work policy settlement])
 
@@ -51,11 +51,20 @@
   [world execution-status]
   (settle-once!
    world
+   ;; Deferred settlement is a generic two-phase gate. The work plane stays
+   ;; inspectable, but cannot be merged or adopted until its host policy
+   ;; explicitly releases it after verification/approval.
    (fn []
      (cond
        (#{:failed :cancelled} execution-status)
-       (do (d/discard (:work world))
+       (do ((if (= :deferred (:policy world))
+              d/discard-deferred
+              d/discard)
+            (:work world))
            {:status :discarded :reason execution-status})
+
+       (= :deferred (:policy world))
+       {:status :deferred :reason :policy}
 
        (= :waiting execution-status)
        {:status :review :reason :execution-waiting}

--- a/src/dvergr/artifact.clj
+++ b/src/dvergr/artifact.clj
@@ -1,0 +1,49 @@
+(ns dvergr.artifact
+  "Content-addressed storage for exact portable values.
+
+   Durable domain projections keep typed, queryable attributes in Datahike and
+   place open-ended immutable values behind these references. The default
+   implementation reuses Dvergr's blob CAS; tests and ephemeral stores may use
+   the in-memory implementation."
+  (:require [clojure.edn :as edn]
+            [dvergr.drive.blobs :as blobs])
+  (:import [java.nio.charset StandardCharsets]))
+
+(defprotocol PArtifactStore
+  (-put-value! [this value]
+    "Store one EDN value and return its immutable string content reference.")
+  (-get-value [this ref]
+    "Load the value named by `ref`, or nil when the content is unavailable."))
+
+(defn- encode [value]
+  (.getBytes (pr-str value) StandardCharsets/UTF_8))
+
+(defn- decode [bytes]
+  (edn/read-string (String. ^bytes bytes StandardCharsets/UTF_8)))
+
+(defrecord BlobArtifactStore []
+  PArtifactStore
+  (-put-value! [_ value]
+    (:blob/id (blobs/store! (encode value) "application/edn")))
+  (-get-value [_ ref]
+    (some-> (blobs/get-bytes ref) decode)))
+
+(defn blob-store [] (->BlobArtifactStore))
+
+(defrecord MemoryArtifactStore [values]
+  PArtifactStore
+  (-put-value! [_ value]
+    (let [bytes (encode value)
+          ref (blobs/sha256-hex bytes)]
+      (swap! values #(if (contains? % ref) % (assoc % ref value)))
+      ref))
+  (-get-value [_ ref]
+    (get @values ref)))
+
+(defn memory-store [] (->MemoryArtifactStore (atom {})))
+
+(defn put-value! [store value]
+  (-put-value! store value))
+
+(defn get-value [store ref]
+  (-get-value store ref))

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -8,7 +8,8 @@
    :continue | :complete | :cancelled | :error. The LOOPING around this core
    is the driver's job — production rooms drive it from
    `dvergr.discourse.llm` (the participant on-message turn loop)."
-  (:require [dvergr.chat.context :as chat-ctx]
+  (:require [clojure.string :as str]
+            [dvergr.chat.context :as chat-ctx]
             [dvergr.chat.compaction :as compaction]
             [dvergr.model.chat :as model-chat]
             [dvergr.model.provider :as model-provider]
@@ -82,16 +83,37 @@
        "executed.\n\n"
        "If you meant to speak to the humans, write prose."))
 
+(def empty-response-nudge
+  "One bounded retry instruction for a model that returned neither content nor
+   tool calls. Without it, a tool-bearing prior assistant message can be mistaken
+   for the final result."
+  (str "Your last response was empty: it contained neither a reply nor a tool "
+       "call. If the work is complete, reply with the concrete result. If more "
+       "work is needed, call an available tool. Do not return an empty response."))
+
+(defn- empty-response-note [chat-ctx run-id]
+  (let [latest-user
+        (->> (chat-ctx/get-messages chat-ctx)
+             reverse
+             (filter #(#{:user "user"} (or (:role %) (:message/role %))))
+             first)
+        latest-user-id (or (:id latest-user) (:message/id latest-user))
+        scope (or run-id latest-user-id (:chat-id chat-ctx))]
+    (str empty-response-nudge "\n\nRetry scope: " scope)))
+
+(defn- has-system-note? [chat-ctx note]
+  (->> (chat-ctx/get-messages chat-ctx)
+       (some (fn [m]
+               (and (#{:system "system"} (or (:role m) (:message/role m)))
+                    (= note (or (:content m) (:message/content m))))))
+       boolean))
+
 (defn- nudged-for-fragment?
   "Have we already told this agent, in this turn loop, that it fumbled code into
    the prose channel? A second identical nudge cannot help — if the model does
    it twice, let the turn end rather than burning budget in a nudge loop."
   [chat-ctx]
-  (->> (chat-ctx/get-messages chat-ctx)
-       (some (fn [m]
-               (and (#{:system "system"} (or (:role m) (:message/role m)))
-                    (= fragment-nudge (or (:content m) (:message/content m))))))
-       boolean))
+  (has-system-note? chat-ctx fragment-nudge))
 
 ;; ============================================================================
 ;; Agent Turn (Non-Reactive Core)
@@ -230,7 +252,7 @@
                                          :important? true))
 
           ;; Add assistant message if there's content
-          _ (when (or (seq content) (seq tool-calls))
+          _ (when (or (not (str/blank? content)) (seq tool-calls))
               (chat-ctx/add-message! chat-ctx
                                      {:role :assistant
                                       :content (if (empty? content)
@@ -376,8 +398,24 @@
         ;; misaddressed a tool call. Name that once and let it try again — the
         ;; turn loop is bounded by BUDGET, not by a turn cap, so one corrective
         ;; turn costs a few cents and rescues the work.
-        (if (and (quirks/code-fragment? content)
-                 (not (nudged-for-fragment? chat-ctx)))
+        (cond
+          (str/blank? content)
+          (let [note (empty-response-note chat-ctx run-id)]
+            (if-not (has-system-note? chat-ctx note)
+              (do
+                (tel/log! {:level :warn :id :agent/empty-response
+                           :data {:turn turn-number :run-id run-id}}
+                          "Model returned no content or tools — requesting one bounded retry")
+                (chat-ctx/add-system-note! chat-ctx note :important? true)
+                :continue)
+              (do
+                (tel/log! {:level :error :id :agent/repeated-empty-response
+                           :data {:turn turn-number :run-id run-id}}
+                          "Model returned an empty response after corrective retry")
+                :error)))
+
+          (and (quirks/code-fragment? content)
+               (not (nudged-for-fragment? chat-ctx)))
           (do
             (tel/log! {:level :warn :id :agent/code-in-prose-channel
                        :data {:turn turn-number
@@ -385,6 +423,8 @@
                       "Model emitted code as content instead of a tool call — nudging")
             (chat-ctx/add-system-note! chat-ctx fragment-nudge :important? true)
             :continue)
+
+          :else
           :complete)))
 
     (catch java.util.concurrent.CancellationException _

--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -20,6 +20,7 @@
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.signal :as sig]
             [org.replikativ.spindel.core :as d]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.accounting :as acct]
             [dvergr.chat.persist :as persist]
@@ -48,8 +49,32 @@
             db-conn           ; Datahike connection for persistence
 
      ;; SCI (optional - for agent computation)
-            sci-ctx           ; SCI context for sandboxed eval
+            sci-component     ; stable ref; resolves to this world's SCI interpreter
             ])
+
+(defn sci-context-in
+  "Resolve `chat-ctx`'s SCI interpreter in explicit `execution-context`.
+
+   The ChatContext retains only a stable world-component reference. A forked
+   Spindel context therefore selects a forked interpreter instead of retaining
+   the parent's mutable SCI heap."
+  [chat-ctx execution-context]
+  (sandbox/sci-context-in execution-context (:sci-component chat-ctx)))
+
+(defn selected-execution-context
+  "The world selected for ChatContext signals and ambient capabilities.
+
+   A bound descendant wins; calls made outside execution fall back to the
+   context's owner. This keeps the ChatContext value stable while its signals
+   and SCI interpreter select fork-local realizations."
+  [chat-ctx]
+  (runtime-ctx/selected-context (:spindel-ctx chat-ctx)))
+
+(defn sci-context
+  "Resolve `chat-ctx`'s SCI interpreter in the bound world, falling back to
+   the ChatContext's owning world when called outside a Spindel binding."
+  [chat-ctx]
+  (sci-context-in chat-ctx (selected-execution-context chat-ctx)))
 ;; ============================================================================
 ;; Signal Accessors (must be called with spindel context bound)
 ;; ============================================================================
@@ -57,19 +82,19 @@
 (defn get-messages
   "Get current messages vector from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:messages-signal chat-ctx)))
 
 (defn get-budget
   "Get current budget map from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:budget-signal chat-ctx)))
 
 (defn get-status
   "Get current status from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:status-signal chat-ctx)))
 
 ;; ============================================================================
@@ -95,7 +120,7 @@
         ;; and a side effect in it would record an abandoned computation. The
         ;; transient `::just-crossed` key always reflects this call (nil if none).
         new-state
-        (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
           (swap! (:budget-signal chat-ctx)
                  (fn [{:keys [total used by-type crossed-thresholds]}]
                    (let [new-used (+ used cost)
@@ -149,7 +174,7 @@
   (let [msg-entity (schema/create-message-entity
                     (assoc message :chat-id (:chat-id chat-ctx)))]
     ;; Update spindel signal (reactive)
-    (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+    (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
       (swap! (:messages-signal chat-ctx) conj msg-entity))
 
     ;; Persist to datahike (durable) — UNLESS this ctx delegates durability to
@@ -191,7 +216,7 @@
      chat-ctx - ChatContext
      new-messages - Complete replacement message vector"
   [chat-ctx new-messages]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     (reset! (:messages-signal chat-ctx) (d/deltaable-vector (vec new-messages)))))
 
 (defn set-status!
@@ -201,7 +226,7 @@
      chat-ctx - ChatContext
      status - :active :paused :completed :cancelled :budget-exceeded"
   [chat-ctx status]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     (reset! (:status-signal chat-ctx) status))
 
   ;; Persist status change
@@ -268,7 +293,7 @@
        :budget-dollars - Budget in dollars (default $1.00)
        :budget - Legacy: budget in microdollars
        :db-path - Path for datahike (default in-memory, or uses Yggdrasil db if registered)
-       :with-sci? - Create SCI context (default true)
+       :with-sci? - Register a fork-selected SCI world component (default true)
 
    Yggdrasil Integration:
      If a DatahikeSystem is registered in the current execution context
@@ -290,9 +315,9 @@
    the unit of work isolation: when a room is forked via
    `d/fork-room :isolation :ctx`, yggdrasil's registered systems
    (git worktree, datahike branch) live on the fork's ctx. The
-   chat-ctx anchoring on that ctx means tools that consult
-   `(:spindel-ctx chat-ctx)` for the workspace see the fork's
-   worktree."
+   ChatContext retains a stable SCI component ref; callers resolve its
+   interpreter through `sci-context-in`, so a fork selects a fork-local heap
+   without reconstructing the interpreter."
   [{:keys [chat-id title budget-dollars budget db-path with-sci?
            db-conn execution-context]
     :or {budget-dollars 1.0
@@ -380,12 +405,6 @@
            :by-type {}
            :crossed-thresholds #{}})
 
-        ;; Create SCI context if requested
-        ;; When *execution-context* is bound, create spindel-backed SCI with
-        ;; full FRP support (spin/await/track). Otherwise plain SCI.
-        sci-ctx (when with-sci?
-                  (sandbox/fork-for-session rtc/*execution-context*))
-
         ;; Create signals within the owning execution context.
         [messages-signal budget-signal status-signal]
         (binding [rtc/*execution-context* spindel-ctx]
@@ -400,7 +419,13 @@
                          [(schema/create-chat-entity
                            {:id chat-id
                             :title (or title "Untitled Chat")
-                            :budget budget-microdollars})]))]
+                            :budget budget-microdollars})]))
+
+        ;; Allocate the process-local interpreter only after every fallible
+        ;; durable/signal initialization step. Once registered, no operation
+        ;; below can strand the component without returning its ChatContext.
+        sci-component (when with-sci?
+                        (sandbox/create-spindel-sci-world! spindel-ctx))]
 
     (->ChatContext
      chat-id
@@ -410,7 +435,7 @@
      budget-signal
      status-signal
      db-conn
-     sci-ctx)))
+     sci-component)))
 
 ;; ============================================================================
 ;; Chat Lifecycle
@@ -432,10 +457,26 @@
   [chat-ctx]
   (set-status! chat-ctx :cancelled))
 
+(defn release-sci-in!
+  "Release `chat-ctx`'s SCI realization from one execution world.
+
+   This is idempotent and does not close the chat's durable connection. Forked
+   room caches use it when a child world is discarded."
+  [chat-ctx execution-context]
+  (try
+    (sandbox/release-agent-resources! execution-context (:capability-id chat-ctx))
+    (finally
+      ;; Disposable-resource cleanup is best-effort with respect to component
+      ;; reachability: even an unexpected backend failure must not strand the
+      ;; interpreter in Spindel after its cache handle is removed.
+      (sandbox/release-spindel-sci-world!
+       execution-context (:sci-component chat-ctx)))))
+
 (defn close-chat!
   "Close chat and release resources."
   [chat-ctx]
   (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+    (release-sci-in! chat-ctx (:spindel-ctx chat-ctx))
     ;; Close datahike connection
     (when-let [conn (:db-conn chat-ctx)]
       (dh/release conn)))
@@ -506,7 +547,7 @@
       (replace-messages! chat-ctx messages))
     ;; Restore budget (overwrite the fresh budget with saved state)
     (when budget
-      (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+      (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
         (reset! (:budget-signal chat-ctx) budget)))
     ;; Restore status
     (when (and status (not= status :active))

--- a/src/dvergr/chat/persist.clj
+++ b/src/dvergr/chat/persist.clj
@@ -28,8 +28,12 @@
   "Apply the shared retry/dead-letter policy, returning the Datahike report on
    success and false after terminal failure."
   ([conn tx-data] (persist-tx-result! conn tx-data {}))
-  ([conn tx-data {:keys [op room-id msg-id] :as ctx}]
-   (letfn [(attempt [] (d/transact conn tx-data))]
+  ([conn tx-data {:keys [op room-id msg-id tx-meta] :as ctx}]
+   (letfn [(attempt []
+             (d/transact conn
+                         (if tx-meta
+                           {:tx-data tx-data :tx-meta tx-meta}
+                           tx-data)))]
      (try
        (attempt)
        (catch Throwable t1

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -294,6 +294,12 @@
     :db/isComponent true
     :db/doc "Tool use requests in this message (references tool-use entities)"}
 
+   {:db/ident :message/activities
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/isComponent true
+    :db/doc "Compact semantic work observations projected into this message"}
+
    ;; Tool result reference (for tool-result messages)
    {:db/ident :message/tool-use-id
     :db/valueType :db.type/string
@@ -324,7 +330,41 @@
 (def tool-call-schema
   "Schema for tool calls within messages.
    Note: Uses :tool-use/ prefix for component entities in messages."
-  [;; Tool call tracking (for analytics)
+  [;; Semantic activity components embedded in canonical room messages.
+   {:db/ident :activity/id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/doc "Semantic observation id; not an upsert identity because the entity is owned by one message"}
+   {:db/ident :activity/run-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+   {:db/ident :activity/kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/verb
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/tool-name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/tool-use-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/outcome
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/critical?
+    :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :activity/at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one}
+
+   ;; Tool call tracking (for analytics)
    {:db/ident :tool-call/id
     :db/valueType :db.type/uuid
     :db/unique :db.unique/identity
@@ -565,6 +605,12 @@
     :db/index true
     :db/doc "Explicit structural parent that spawned/contains this run"}
 
+   {:db/ident :run/caused-by
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/many
+    :db/index true
+    :db/doc "Runs whose resolved results this run explicitly observed; unlike :run/parent, this is a causal dependency and may have many values"}
+
    {:db/ident :run/roster
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one
@@ -655,6 +701,256 @@
    {:db/ident :run/error
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one}])
+
+;; ============================================================================
+;; Verified Attempt Schema
+;; ============================================================================
+
+(def attempt-schema
+  "Immutable typed index for one trusted evaluation certification.
+
+   Exact EnvironmentDef, AgentDef, receipt, and evidence values live in the
+   content-addressed payload. Runs, messages, and checks remain typed joins so
+   benchmark and UI queries never need to scan opaque payloads."
+  [{:db/ident :attempt.writer/token
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/doc "One-use process-local capability attached to a trusted certification transaction"}
+
+   {:db/ident :attempt/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/chat
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/run
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value
+    :db/doc "Terminal root Run; exactly one trusted Attempt per Run"}
+
+   {:db/ident :attempt/content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value
+    :db/doc "Exact trusted AttemptReceipt content identity"}
+
+   {:db/ident :attempt/payload-blob
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "Immutable CAS reference for exact EnvironmentDef, AgentDef, receipt, and evidence"}
+
+   {:db/ident :attempt/payload-codec
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/environment-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/environment-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/environment-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/verifier-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/verifier-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/provider
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/model
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/started-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/elapsed-ms
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/certified-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/reward
+    :db/valueType :db.type/double
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/agent-def-hash
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/program-kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/interpreter-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/prompt-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/model-resolution
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/model-steps
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/evidence-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/evidence-runs
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/index true}
+
+   {:db/ident :attempt/evidence-messages
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/index true}
+
+   {:db/ident :attempt/settlement-intent
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/checks
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/isComponent true}
+
+   {:db/ident :attempt.check/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt.check/key
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt.check/passed?
+    :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one
+    :db/index true}])
+
+;; ============================================================================
+;; Attention Schema
+;; ============================================================================
+
+(def attention-schema
+  "Durable participant-specific control/memory projections over Room messages."
+  [{:db/ident :attention/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/chat
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attention/participant
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attention/message-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attention/decision-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Stable decision identified by an applied disposition fact"}
+
+   {:db/ident :attention/run-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attention/result-run-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true
+    :db/doc "Successor Run whose durable creation discharged an enqueue"}
+
+   {:db/ident :attention/memory
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/activation
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/control
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/at
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/priority
+    :db/valueType :db.type/double
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attention/reason
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attention/metadata-edn
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "Non-authoritative policy metadata; never interpreted as control"}
+
+   {:db/ident :attention/created-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}])
 
 ;; ============================================================================
 ;; Full Schema
@@ -1042,6 +1338,8 @@
   (vec (concat chat-schema
                message-schema
                run-schema
+               attempt-schema
+               attention-schema
                tool-call-schema
                ledger-schema
                budget-schema

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -97,7 +97,8 @@
   ;;                 spindel.yggdrasil/ForkHandle for an isolated fork. Durable
   ;;                 identity is exposed through fork-descriptor; the live
   ;;                 settlement capability is deliberately never persisted.
-           [id slug title parent-id participants bus ctx forked-at-len store meta fork-handle])
+           [id slug title parent-id participants bus ctx forked-at-len store meta fork-handle
+            incarnation])
 
 ;; A Room's bus + participants reference back to the Room, so the default record
 ;; printer recurses forever and StackOverflows at the REPL (e.g. when `(d/room …)`
@@ -292,7 +293,8 @@
         b     (bus-with-peer-relay ctx id :room
                                    (when durable-append!
                                      {:durable-append! durable-append!}))
-        room  (->Room id slug title parent-id (atom {}) b ctx 0 store (atom (or meta {})) nil)]
+        room  (->Room id slug title parent-id (atom {}) b ctx 0 store
+                      (atom (or meta {})) nil (random-uuid))]
     (agent-run/open-room-admission! id ctx)
     ;; Persist metadata on creation so the store has it for re-hydration.
     (when store
@@ -1220,7 +1222,8 @@
                               (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
                                            :forked-from (:id room)
                                            :conversation-id conv-id))
-                              (when fork-handle (atom fork-handle)))]
+                              (when fork-handle (atom fork-handle))
+                              (random-uuid))]
        ;; The child is not registered or otherwise visible yet. Initializing its
        ;; admission without the global lifecycle lock avoids parent-meta ->
        ;; lifecycle lock inversion during concurrent parent teardown.

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -1167,20 +1167,22 @@
          ;; peer-bus events).
            new-id     (rstore/slug->room-id new-slug)
            parent-log (log room)
+           room*       (volatile! nil)
            fork-handle (when (= :ctx isolation)
                          (binding [ec/*execution-context* (:ctx room)]
                            (ygg/fork! (merge {:purpose :workroom
                                               :owner new-id}
-                                             fork-opts))))
-           child-ctx  (case isolation
-                        :none (:ctx room)
-                        :ctx  (:child-ctx fork-handle))
+                                             fork-opts))))]
+       (try
+         (let [child-ctx  (case isolation
+                            :none (:ctx room)
+                            :ctx  (:child-ctx fork-handle))
          ;; Mark a `:ctx` fork TRANSIENT so create-room-db! defers the GLOBAL
          ;; system-db grant (reconciled on merge / dropped on discard) — a fork's
          ;; agent-created DB must not resurrect on restart (P2).
-           _          (when (= :ctx isolation)
-                        (binding [ec/*execution-context* child-ctx]
-                          (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
+               _          (when (= :ctx isolation)
+                            (binding [ec/*execution-context* child-ctx]
+                              (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
          ;; `:isolation :ctx` forks BRANCH the parent's conversation. The fork
          ;; gets its OWN store wrapping the fork ctx's BRANCHED chat-db conn
          ;; (NOT the parent's fixed-conn store), and persists under the parent's
@@ -1188,73 +1190,135 @@
          ;; the same logical conversation on a datahike branch, and
          ;; merge-fork! collapses them natively (no append-log!). It writes
          ;; no separate :chat entity. (doc/unified-fork-conversation.md)
-           conv-id    (conversation-id room)
+               conv-id    (conversation-id room)
          ;; RF5: the fork's store wraps the PARENT room's OWN messages conn under
          ;; the fork ctx (branched), so fork messages ride the per-room store's
          ;; branch and merge-fork! collapses them natively. (RF5 S4.3: no
          ;; chat-db fallback — every room is provisioned with its own :msgs system.)
-           fork-store (when (= :ctx isolation)
-                        (some-> (binding [ec/*execution-context* child-ctx]
-                                  (srooms/msgs-conn-for-slug (:slug room)))
-                                store-dh/make))
+               fork-store (when (= :ctx isolation)
+                            (some-> (binding [ec/*execution-context* child-ctx]
+                                      (srooms/msgs-conn-for-slug (:slug room)))
+                                    store-dh/make))
          ;; Durability-first for the fork too: fork-local messages persist
          ;; onto the BRANCH (under the root conversation id) inside post!,
          ;; before visibility — replacing the fork's persistence listener.
-           child-bus  (bus-with-peer-relay child-ctx new-id :fork
-                                           (when fork-store
-                                             {:durable-append!
-                                              (fn [msg]
-                                                (when (rstore/message-shape? msg)
-                                                  (rstore/-store-message! fork-store conv-id msg)))}))
+               child-bus  (bus-with-peer-relay child-ctx new-id :fork
+                                               (when fork-store
+                                                 {:durable-append!
+                                                  (fn [msg]
+                                                    (when (rstore/message-shape? msg)
+                                                      (rstore/-store-message! fork-store conv-id msg)))}))
          ;; Seed the fork's bus log with parent history so log-based
          ;; consumers see a continuous record (the cursor starts past it —
          ;; history is never re-delivered). Forks have their OWN bus so
          ;; live messages do not leak between parent and fork.
-           _          (bus/seed-log! child-bus parent-log)
-           new-room   (->Room new-id new-slug
-                              (str (:title room) " · fork " short-uuid)
-                              (:id room)
-                              (atom {})
-                              child-bus
-                              child-ctx
-                              (count parent-log)
-                              fork-store
-                              (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
-                                           :forked-from (:id room)
-                                           :conversation-id conv-id))
-                              (when fork-handle (atom fork-handle))
-                              (random-uuid))]
-       ;; The child is not registered or otherwise visible yet. Initializing its
+               _          (bus/seed-log! child-bus parent-log)
+               new-room   (->Room new-id new-slug
+                                  (str (:title room) " · fork " short-uuid)
+                                  (:id room)
+                                  (atom {})
+                                  child-bus
+                                  child-ctx
+                                  (count parent-log)
+                                  fork-store
+                                  (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
+                                               :forked-from (:id room)
+                                               :conversation-id conv-id))
+                                  (when fork-handle (atom fork-handle))
+                                  (random-uuid))
+           ;; The child is not registered or otherwise visible yet. Initializing its
        ;; admission without the global lifecycle lock avoids parent-meta ->
        ;; lifecycle lock inversion during concurrent parent teardown.
-       (agent-run/initialize-unpublished-room-admission! new-id child-ctx)
+               _ (vreset! room* new-room)
+               _ (agent-run/initialize-unpublished-room-admission! new-id child-ctx)]
      ;; (Fork-local persistence rides the bus's durable-append! hook now —
      ;; wired at child-bus construction above.)
-     ;; Register the fork in the PARENT ctx — where the daemon UI reads the
-     ;; registry. A `:ctx` fork's own child-ctx is invisible to the parent
-     ;; (CoW), so registering there would hide the fork from the tree (and it
-     ;; would render empty). The Room still carries its child-ctx in `:ctx`
-     ;; for merge/diff/git. For `:none`, child-ctx == parent ctx (no change).
-       (binding [ec/*execution-context* (:ctx room)]
-         (rreg/register! new-room)
-         (when (= :ctx isolation)
-           (rreg/track-fork! new-id (:id room) (:fork-id fork-handle))))
-       (when clone-participants?
-         (doseq [[_id p] @(:participants room)]
-           (when-let [fac (:factory p)]
-             (binding [ec/*execution-context* child-ctx]
-               (join new-room (fac child-ctx))))))
+     ;; Initialize participant/cache projections before publishing the Room.
+     ;; Otherwise an external registry reader could send work into a partially
+     ;; constructed child and win the inherited-context installation race.
+           (when clone-participants?
+             (doseq [[_id p] @(:participants room)]
+               (when-let [fac (:factory p)]
+             ;; Yggdrasil already forked every registered world component. If
+             ;; this participant has a live room working context, install its
+             ;; child projection before the factory runs so the clone selects
+             ;; that inherited SCI heap instead of constructing a second one.
+             ;; `requiring-resolve` avoids discourse <-> room-context cycles.
+                 (when (= :ctx isolation)
+                   (when-let [fork-working-ctx!
+                              (requiring-resolve 'dvergr.agent.room-context/fork-ctx!)]
+                     (fork-working-ctx! room new-room (:id p))))
+                 (binding [ec/*execution-context* child-ctx]
+                   (join new-room (fac child-ctx))))))
+     ;; Register the fully initialized fork in the PARENT ctx — where the daemon
+     ;; UI reads the registry. A `:ctx` fork's own child-ctx is invisible to the
+     ;; parent (CoW), so registering there would hide the fork from the tree.
+           ;; Publication and its control event share the child's lifecycle
+           ;; monitor. A reader may discover the complete Room+topology pair,
+           ;; but cannot begin settlement until the creation event is posted.
+           (locking (:meta new-room)
+             (binding [ec/*execution-context* (:ctx room)]
+               (if (= :ctx isolation)
+                 (rreg/register-fork! new-room (:id room) (:fork-id fork-handle))
+                 (rreg/register! new-room)))
      ;; Control-plane: announce the fork on the peer-bus so dashboards,
      ;; audit logs, and oversight agents see it without subscribing to
      ;; the fork's bus directly.
-       (binding [ec/*execution-context* child-ctx]
-         (peer-bus/post! {:type            :dvergr/fork-created
-                          :dvergr/origin   new-id
-                          :dvergr/parent   (:id room)
-                          :isolation       isolation
-                          :workspace-id    (when (= :ctx isolation)
-                                             (:id (geschichte/current-workspace)))}))
-       new-room))))
+             (binding [ec/*execution-context* child-ctx]
+               ;; Publication above is the authoritative commit point.  This
+               ;; observability event must therefore never turn successful
+               ;; construction into rollback after another thread has admitted
+               ;; settlement of the published affine handle.
+               (try
+                 (peer-bus/post! {:type            :dvergr/fork-created
+                                  :dvergr/origin   new-id
+                                  :dvergr/parent   (:id room)
+                                  :isolation       isolation
+                                  :workspace-id    (when (= :ctx isolation)
+                                                     (:id (geschichte/current-workspace)))})
+                 (catch Throwable event-error
+                   (tel/log! {:level :error :id ::fork-created-event-failed
+                              :error event-error
+                              :data {:room new-id :parent (:id room)}})))))
+           new-room)
+         (catch Throwable error
+           ;; Construction owns the affine handle until successful return. Any
+           ;; failure before then must settle it and retract every process-local
+           ;; projection; otherwise the caller has no capability with which to
+           ;; recover the unreachable branch.
+           (binding [ec/*execution-context* (:ctx room)]
+             (when-let [constructed @room*]
+               (try (leave-all! constructed)
+                    (catch Throwable cleanup-error
+                      (.addSuppressed error cleanup-error)))
+               (try
+                 (when-let [drop-room!
+                            (requiring-resolve 'dvergr.agent.room-context/drop-room!)]
+                   (drop-room! new-id))
+                 (catch Throwable cleanup-error
+                   (.addSuppressed error cleanup-error)))
+               (when (rreg/lookup new-id)
+                 (try
+                   (when fork-handle
+                     (rreg/untrack-fork! new-id (:fork-id fork-handle)))
+                   (catch Throwable cleanup-error
+                     (.addSuppressed error cleanup-error)))
+                 (rreg/unregister! new-id))))
+           (when fork-handle
+             (let [pending (try
+                             (binding [ec/*execution-context*
+                                       (or (some-> @room* :ctx)
+                                           (:child-ctx fork-handle))]
+                               (ec/get-state [:dvergr/pending-grants]))
+                             (catch Throwable cleanup-error
+                               (.addSuppressed error cleanup-error)
+                               nil))]
+               (try
+                 (ygg/discard-fork! fork-handle)
+                 (srooms/drop-fork-grants! pending)
+                 (catch Throwable cleanup-error
+                   (.addSuppressed error cleanup-error)))))
+           (throw error)))))))
 
 (defn fork-handle
   "Return an isolated Room fork's process-local canonical ForkHandle, or nil.
@@ -1268,6 +1332,23 @@
   (some-> (fork-handle room) ygg/fork-descriptor))
 
 (declare fork-home-ctx)
+
+(def ^:dynamic ^:private *deferred-settlement-authority* nil)
+
+(defn- assert-settlement-released! [fork operation]
+  (locking (:meta fork)
+    (let [meta @(:meta fork)
+          live (binding [ec/*execution-context* (fork-home-ctx fork)]
+                 (rreg/lookup (:id fork)))]
+      (when (and (= :deferred (:settlement-policy meta))
+                 (= fork live)
+                 (not (:settlement-released? meta))
+                 (not= (:id fork) *deferred-settlement-authority*))
+        (throw (ex-info "Deferred Run world must be released before settlement"
+                        {:type ::settlement-deferred
+                         :operation operation
+                         :fork/id (:id fork)
+                         :run/id (:run-id meta)}))))))
 
 (defn- fork-transfer-children [home fork-id]
   (binding [ec/*execution-context* home]
@@ -1311,11 +1392,12 @@
    process-local settlement capability; callers must never persist it. The
    returned `:fork/descriptor` is data and is the canonical durable identity.
 
-   `abort!` is required and is called with the preparation receipt if the live
+  `abort!` is required and is called with the preparation receipt if the live
    affine transfer fails. A failed compensation leaves the Room fenced in a
    visible recovery-required state. Once transfer succeeds the durable owner is
    authoritative; later projection/event failures never roll it back."
   [fork new-owner prepare-or-opts]
+  (assert-settlement-released! fork :transfer)
   (let [{:keys [prepare! abort!]}
         (if (fn? prepare-or-opts)
           {:prepare! prepare-or-opts}
@@ -1861,6 +1943,7 @@
    discard of the same fork is a no-op (the branched systems are deleted only
    once)."
   [fork]
+  (assert-settlement-released! fork :discard)
   ;; Idempotence: once unregistered, the fork is a zombie — re-discarding would
   ;; double-delete the yggdrasil branch (which errors). Guard on registry.
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
@@ -1892,6 +1975,54 @@
           (recover-room-quiescence! fork callbacks @work-fence-token* error)))))
   fork)
 
+(defn discard-deferred
+  "Consume the host-owned discard side of a deferred Run world.
+
+   This is the narrow substrate capability used by evaluation cancellation and
+   failed certification. Ordinary `discard`, merge, and transfer remain gated."
+  ([fork]
+   (discard-deferred fork (constantly true) (constantly nil)))
+  ([fork claim!]
+   (discard-deferred fork claim! (constantly nil)))
+  ([fork claim! abort!]
+   (locking (:meta fork)
+     (let [meta @(:meta fork)
+           live (binding [ec/*execution-context* (fork-home-ctx fork)]
+                  (rreg/lookup (:id fork)))]
+       (when-not (and (= fork live)
+                      (= :deferred (:settlement-policy meta))
+                      (not (:settlement-released? meta))
+                      (nil? (:settlement-claim meta)))
+         (throw (ex-info "Deferred discard authority is no longer current"
+                         {:type ::stale-deferred-settlement
+                          :fork/id (:id fork)
+                          :run/id (:run-id meta)})))
+       (when-not (claim!)
+         (throw (ex-info "Deferred discard lost its settlement race"
+                         {:type ::deferred-settlement-aborted
+                          :fork/id (:id fork)})))
+       (swap! (:meta fork) assoc :settlement-claim :discard)
+       (try
+         (binding [*deferred-settlement-authority* (:id fork)]
+           (discard fork))
+         (catch Throwable error
+           ;; Abort while the same affine lock is still held. If its durable
+           ;; compensation fails, retain a closed recovery claim rather than
+           ;; opening a race or holding this lock through an unbounded retry.
+           (let [abort-error (try (abort!) nil
+                                  (catch Throwable abort-error abort-error))]
+             (if abort-error
+               (swap! (:meta fork) assoc :settlement-claim :discard-recovery)
+               (swap! (:meta fork) dissoc :settlement-claim))
+             (throw (if abort-error
+                      (ex-info "Deferred discard requires durable abort recovery"
+                               {:type ::deferred-discard-recovery-required
+                                :fork/id (:id fork)
+                                :abort-error (ex-message abort-error)}
+                               error)
+                      error)))))))
+   fork))
+
 (defn merge-room
   "Merge fork into parent.
 
@@ -1909,6 +2040,7 @@
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
   ([parent fork {:keys [merge-opts]}]
+   (assert-settlement-released! fork :merge)
    (let [callbacks (drain-room-listeners! fork :merge)
          work-fence-token* (volatile! nil)]
      (try

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -683,7 +683,7 @@
       (install-room-listener! room f))))
 
 (defn- recover-room-quiescence!
-  [room callbacks error]
+  [room callbacks work-fence error]
   (let [handle (fork-handle room)
         token (get-in @(:meta room) [fork-transfer-state-key :token])]
     (if (or (nil? handle) (ygg/open-fork? handle))
@@ -707,8 +707,10 @@
                  room
                  (fn []
                    (locking (:meta room)
-                     (when (= token (get-in @(:meta room)
-                                            [fork-transfer-state-key :token]))
+                     (when (and (= token (get-in @(:meta room)
+                                                 [fork-transfer-state-key :token]))
+                                (or (nil? work-fence)
+                                    (sandbox-work/recover-room-work! room work-fence)))
                        (swap! (:meta room) dissoc fork-transfer-state-key)
                        true))))]
             (if recovered?
@@ -1346,6 +1348,7 @@
               receipt* (volatile! nil)
               listeners* (volatile! [])
               fence-token* (volatile! nil)
+              work-fence-token* (volatile! nil)
               {:keys [adopted receipt descriptor]}
               (try
                 ;; No worker may retain a capability into a substrate once
@@ -1354,7 +1357,11 @@
                 (vreset! listeners* (drain-room-listeners! fork :transfer))
                 (vreset! fence-token*
                          (get-in @(:meta fork) [fork-transfer-state-key :token]))
-                (sandbox-work/close-room-work! fork)
+                (try
+                  (vreset! work-fence-token* (sandbox-work/close-room-work! fork))
+                  (catch Throwable error
+                    (vreset! work-fence-token* (:fence (ex-data error)))
+                    (throw error)))
                 (drain-room-runs! fork)
                 ;; Once every admitted Run has physically stopped, retire its
                 ;; causal-post allowance before durable preparation or authority
@@ -1439,9 +1446,12 @@
                                  fork
                                  (fn []
                                    (locking (:meta fork)
-                                     (when (= @fence-token*
-                                              (get-in @(:meta fork)
-                                                      [fork-transfer-state-key :token]))
+                                     (when (and (= @fence-token*
+                                                   (get-in @(:meta fork)
+                                                           [fork-transfer-state-key :token]))
+                                                (or (nil? @work-fence-token*)
+                                                    (sandbox-work/recover-room-work!
+                                                     fork @work-fence-token*)))
                                        (swap! (:meta fork) dissoc fork-transfer-state-key)
                                        true))))]
                             (if recovered?
@@ -1851,9 +1861,14 @@
   ;; Idempotence: once unregistered, the fork is a zombie — re-discarding would
   ;; double-delete the yggdrasil branch (which errors). Guard on registry.
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
-    (let [callbacks (drain-room-listeners! fork :discard)]
+    (let [callbacks (drain-room-listeners! fork :discard)
+          work-fence-token* (volatile! nil)]
       (try
-        (sandbox-work/close-room-work! fork)
+        (try
+          (vreset! work-fence-token* (sandbox-work/close-room-work! fork))
+          (catch Throwable error
+            (vreset! work-fence-token* (:fence (ex-data error)))
+            (throw error)))
         (drain-room-runs! fork)                ; stop work before removing its substrate
         (seal-room-quiescence! fork :discard)
         (when-let [handle (fork-handle fork)]
@@ -1871,7 +1886,7 @@
           (peer-bus/post! {:type :dvergr/fork-discarded
                            :dvergr/origin (:id fork)}))
         (catch Throwable error
-          (recover-room-quiescence! fork callbacks error)))))
+          (recover-room-quiescence! fork callbacks @work-fence-token* error)))))
   fork)
 
 (defn merge-room
@@ -1891,9 +1906,14 @@
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
   ([parent fork {:keys [merge-opts]}]
-   (let [callbacks (drain-room-listeners! fork :merge)]
+   (let [callbacks (drain-room-listeners! fork :merge)
+         work-fence-token* (volatile! nil)]
      (try
-       (sandbox-work/close-room-work! fork)
+       (try
+         (vreset! work-fence-token* (sandbox-work/close-room-work! fork))
+         (catch Throwable error
+           (vreset! work-fence-token* (:fence (ex-data error)))
+           (throw error)))
        (drain-room-runs! fork)                 ; stop work before merging its substrate
        (seal-room-quiescence! fork :merge)
    ;; (1) SUBSTRATE merge — branched yggdrasil systems (CRDTs, datahike, git) fold
@@ -1947,7 +1967,7 @@
                           :dvergr/parent   (:id parent)}))
        parent
        (catch Throwable error
-         (recover-room-quiescence! fork callbacks error))))))
+         (recover-room-quiescence! fork callbacks @work-fence-token* error))))))
 
 ;; ============================================================================
 ;; PR-style merge review

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -38,6 +38,7 @@
             [dvergr.substrate.geschichte :as geschichte]
             [dvergr.runtime.peer-bus :as peer-bus]
             [dvergr.agent.run :as agent-run]
+            [dvergr.sandbox.work :as sandbox-work]
             [dvergr.room.store :as rstore]
             [dvergr.room.store.datahike :as store-dh]
             [dvergr.room.registry :as rreg]
@@ -994,6 +995,7 @@
         (drain-room-listeners! room :close)
         (vreset! fence-token*
                  (get-in @(:meta room) [fork-transfer-state-key :token]))
+        (sandbox-work/close-room-work! room)
         (drain-room-runs! room)
         (seal-room-quiescence! room :close)
         (leave-all! room)
@@ -1352,6 +1354,7 @@
                 (vreset! listeners* (drain-room-listeners! fork :transfer))
                 (vreset! fence-token*
                          (get-in @(:meta fork) [fork-transfer-state-key :token]))
+                (sandbox-work/close-room-work! fork)
                 (drain-room-runs! fork)
                 ;; Once every admitted Run has physically stopped, retire its
                 ;; causal-post allowance before durable preparation or authority
@@ -1850,6 +1853,7 @@
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
     (let [callbacks (drain-room-listeners! fork :discard)]
       (try
+        (sandbox-work/close-room-work! fork)
         (drain-room-runs! fork)                ; stop work before removing its substrate
         (seal-room-quiescence! fork :discard)
         (when-let [handle (fork-handle fork)]
@@ -1889,6 +1893,7 @@
   ([parent fork {:keys [merge-opts]}]
    (let [callbacks (drain-room-listeners! fork :merge)]
      (try
+       (sandbox-work/close-room-work! fork)
        (drain-room-runs! fork)                 ; stop work before merging its substrate
        (seal-room-quiescence! fork :merge)
    ;; (1) SUBSTRATE merge — branched yggdrasil systems (CRDTs, datahike, git) fold

--- a/src/dvergr/discourse/attention.clj
+++ b/src/dvergr/discourse/attention.clj
@@ -166,3 +166,39 @@
                      {:type ::invalid-boundary :boundary type :data data})))
    (cond-> {:attention.boundary/type type}
      data (assoc :attention.boundary/data data))))
+
+(defn execution-plan
+  "Negotiate a validated decision against one interpreter's honest
+   capabilities.
+
+   Capabilities are sets under `:memory`, `:activation`, `:control`, and
+   `:boundaries`; `:priority?` declares whether non-zero priorities are honored.
+   An optional `:accept?` predicate may return nil or one explanatory map for a
+   cross-axis combination the adapter cannot implement.
+   The result preserves the complete decision. Unsupported axes produce a
+   deferred plan instead of silently degrading semantics or inventing provider
+   behavior. This is capability negotiation, not a second scheduler."
+  [x capabilities]
+  (let [d (normalize x)
+        checks [[:memory (:memory d) (:memory capabilities)]
+                [:activation (:activation d) (:activation capabilities)]
+                [:control (:control d) (:control capabilities)]
+                [:at (:at d) (:boundaries capabilities)]]
+        constraint (when-let [accept? (:accept? capabilities)]
+                     (accept? d))
+        unsupported
+        (cond->
+         (into []
+               (keep (fn [[axis value supported]]
+                       (when-not (contains? (or supported #{}) value)
+                         {:axis axis :value value})))
+               checks)
+          (and (not (:priority? capabilities))
+               (not (zero? (:priority d))))
+          (conj {:axis :priority :value (:priority d)})
+
+          constraint
+          (conj constraint))]
+    {:status (if (seq unsupported) :deferred :ready)
+     :decision d
+     :unsupported unsupported}))

--- a/src/dvergr/discourse/commands.clj
+++ b/src/dvergr/discourse/commands.clj
@@ -440,6 +440,8 @@
              (nil? aid)  (say "Usage: /sandbox <agent> — e.g. /sandbox var")
              :else
              (if-let [cc (lookup (:id room) aid)]
-               (say (format-sandbox-report aid (status (:sci-ctx cc))))
+               (let [resolve-sci (resolve 'dvergr.chat.context/sci-context-in)]
+                 (say (format-sandbox-report
+                       aid (status (resolve-sci cc (:ctx room))))))
                (say (str "@" (name aid) " has no active sandbox yet "
                          "— message it once so its session spins up."))))))})

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -148,6 +148,101 @@
     (attention/restart :conversation/same-thread)
     (attention/enqueue :conversation/different-thread)))
 
+(def llm-attention-capabilities
+  "Provider-neutral attention subset implemented by the native LLM arbiter.
+   Richer products remain durable/queued until an adapter advertises the needed
+   integration boundary; they are never silently projected to a weaker action."
+  {:memory attention/memory-modes
+   ;; This interpreter can retain later work. It cannot wake a suspended
+   ;; continuation because LLM calls currently have no durable continuation.
+   :activation #{:none :enqueue}
+   :control #{:continue :restart :suspend :cancel}
+   :boundaries #{:now :next-safe-boundary :quiescent}
+   :priority? false
+   :accept? (fn [{:keys [memory activation control at]}]
+              (cond
+                (and (#{:restart :suspend :cancel} control)
+                     (not (#{:now :next-safe-boundary} at)))
+                {:axes [:control :at]
+                 :values [control at]}
+
+                (and (= :enqueue activation) (not= :continue control))
+                {:axes [:activation :control]
+                 :values [activation control]}
+
+                ;; The current adapter has one disposition per decision. Do not
+                ;; claim atomic replay for "include now and enqueue later" until
+                ;; partial-axis acknowledgements exist.
+                (and (= :enqueue activation) (= :include memory))
+                {:axes [:memory :activation]
+                 :values [memory activation]}))})
+
+(defn- record-attention!
+  "Persist one participant's decision over `incoming` as typed Room activity.
+
+   The activity is deliberately not conversational input and does not claim a
+   thread. It is the durable projection used to rebuild participant-specific
+   provider context and to explain deferred decisions after restart."
+  [room participant-id incoming plan run-id]
+  (let [room-store (:store room)
+        room-id (some-> room d/conversation-id)
+        decision (:decision plan)
+        decision-id (rstore/attention-id room-id participant-id (:id incoming)
+                                         run-id :decision)
+        fact
+        (cond-> {:attention/id decision-id
+                 :attention/participant participant-id
+                 :attention/message-id (:id incoming)
+                 :attention/status (:status plan)
+                 :attention/created-at (java.util.Date.)}
+          run-id (assoc :attention/run-id run-id)
+          (:memory decision) (assoc :attention/memory (:memory decision))
+          (:activation decision) (assoc :attention/activation (:activation decision))
+          (:control decision) (assoc :attention/control (:control decision))
+          (:at decision) (assoc :attention/at (:at decision))
+          (some? (:priority decision))
+          (assoc :attention/priority (:priority decision))
+          (:reason decision) (assoc :attention/reason (:reason decision))
+          (:metadata decision) (assoc :attention/metadata (:metadata decision)))]
+    (when room
+      (when room-store
+        (when-not (satisfies? rstore/PAttentionStore room-store)
+          (throw (ex-info "Configured Room store lacks durable attention support"
+                          {:type ::attention-store-unsupported
+                           :room (:id room)})))
+        (rstore/-store-attention! room-store (d/conversation-id room) fact)))
+    decision-id))
+
+(defn- record-attention-applied!
+  "Append the disposition proving that every supported axis was applied."
+  ([room participant-id incoming plan run-id decision-id]
+   (record-attention-applied! room participant-id incoming plan run-id
+                              decision-id nil))
+  ([room participant-id incoming plan run-id decision-id result-run-id]
+   (when (and room (:store room))
+     (let [room-id (d/conversation-id room)
+           decision (:decision plan)
+           fact
+           (cond-> {:attention/id
+                    (rstore/attention-id room-id participant-id (:id incoming)
+                                         run-id :applied)
+                    :attention/decision-id decision-id
+                    :attention/participant participant-id
+                    :attention/message-id (:id incoming)
+                    :attention/status :applied
+                    :attention/created-at (java.util.Date.)}
+             run-id (assoc :attention/run-id run-id)
+             result-run-id (assoc :attention/result-run-id result-run-id)
+             (:memory decision) (assoc :attention/memory (:memory decision))
+             (:activation decision) (assoc :attention/activation (:activation decision))
+             (:control decision) (assoc :attention/control (:control decision))
+             (:at decision) (assoc :attention/at (:at decision))
+             (some? (:priority decision))
+             (assoc :attention/priority (:priority decision))
+             (:reason decision) (assoc :attention/reason (:reason decision))
+             (:metadata decision) (assoc :attention/metadata (:metadata decision)))]
+       (rstore/-store-attention! (:store room) room-id fact)))))
+
 (defn llm-agent
   "Construct a discourse Participant backed by an LLM.
 
@@ -204,22 +299,23 @@
   (let [ctx       (or ctx ec/*execution-context*)
         ;; Room-less FALLBACK working ctx (sidecar / tests). When the
         ;; agent is joined to a ROOM, the per-[room,agent] room-context ctx is
-        ;; used instead — seeded from the room store, kept current by a bus fold,
+        ;; used instead — seeded from the room store and admitted by attention,
         ;; stable id (budget + persistence across restart/fork) — resolved per
         ;; turn in on-message. Priority: :participant-context > :chat-ctx > fresh.
         ;; :with-sci? true so a room-less agent's clojure_eval has a sandbox.
         fallback-chat-ctx
-        (or (when participant-context
-              (pctx/->chat-context participant-context))
-            chat-ctx
-            (let [c (turn/new-working-ctx
-                     {:execution-ctx  ctx
-                      :title          (str "agent " (name id))
-                      :budget-dollars (:dollars budget 1.0)
-                      :db-conn        db-conn})]
-              (when-let [sp (:system-prompt spec)]
-                (cc/add-message! c {:role :system :content sp}))
-              c))
+        (delay
+          (or (when participant-context
+                (pctx/->chat-context participant-context))
+              chat-ctx
+              (let [c (turn/new-working-ctx
+                       {:execution-ctx  ctx
+                        :title          (str "agent " (name id))
+                        :budget-dollars (:dollars budget 1.0)
+                        :db-conn        db-conn})]
+                (when-let [sp (:system-prompt spec)]
+                  (cc/add-message! c {:role :system :content sp}))
+                c)))
         ;; Grace window for the manager to extend the budget after exhaustion.
         compaction-strategy (:strategy compaction :sync-before-turn)
         ;; In race mode, disable run-turn-fn's internal sync compaction — we
@@ -242,14 +338,14 @@
                (let [room     (:room p)        ; the Room this participant is joined to
                      turn-ctx (if room (:ctx room) ctx)  ; run the turn in the ROOM's ctx
                    ;; Per-[room,agent] working chat-ctx (design D): seeded from the
-                   ;; room store, kept current by a bus fold, stable id (budget +
+                   ;; room store, updated by explicit attention admission, stable id (budget +
                    ;; persistence across restart/fork). Room-less → the fallback ctx.
                    ;; Directives AND the turn loop share this resolved chat-ctx.
                      chat-ctx (if room
                                 (room-context/ensure-ctx! room id
                                                           {:system-prompt  (:system-prompt spec)
                                                            :budget-dollars (:dollars budget 1.0)})
-                                fallback-chat-ctx)]
+                                @fallback-chat-ctx)]
                  (case (:type msg)
 
                ;; --- directive: extend the dollar budget ---
@@ -290,12 +386,14 @@
                          ;; inbox after this execution. The Room log is already the
                          ;; durable source; these are only live coordination handles.
                          queued-other-threads (atom [])
+                         pending-safe-inclusions (atom [])
+                         pending-quiescent-inclusions (atom [])
                          seen-inflight-ids    (atom (cond-> #{} (:id msg) (conj (:id msg))))
                      ;; SCI sandbox: the chat-ctx's own, set up ONCE by
                      ;; turn/new-working-ctx (room fold AND room-less fallback alike)
                      ;; with the agent namespaces injected — so clojure_eval has
                      ;; dh/room/intake without a per-turn re-fork.
-                         sci-ctx  (:sci-ctx chat-ctx)
+                         sci-ctx  (cc/sci-context chat-ctx)
                      ;; Normalize once: name→tool-def map (also the execute-side
                      ;; authoritative allowlist below).
                          tool-map (tools/normalize-tools tools)
@@ -377,29 +475,59 @@
                                 ;; system notes for unresolvable ones.
                                     :on-reply         on-reply}
                          errored           (atom nil)
-                         waiting?          (atom false)
+                         wait-reason       (atom nil)
+                         policy-cancelled? (atom false)
                          finish-after-reply? (atom false)
                      ;; #38: the last assistant message BEFORE this invocation
                      ;; runs (the store-seeded prior reply, or nil) — the exit
                      ;; path uses it to tell a genuinely NEW reply from stale
                      ;; seeded history.
                          pre-turn-last-asst (last-assistant-message chat-ctx)
-                     ;; Inbound fold: ROOM path append-inbound! (deduped
-                     ;; against the bus fold by msg id, decorated with author
+                     ;; Inbound admission: ROOM path append-inbound! (deduped
+                     ;; against the durable seed by msg id, decorated with author
                      ;; + time); room-less adds directly to the fallback ctx.
                      ;; Used for the triggering message AND for steer folds.
                          fold-inbound!
                          (fn [m]
                            (if room
-                             (room-context/append-inbound! (:id room) id (:id m)
+                             (room-context/append-inbound! room id (:id m)
                                                            :user (:content m)
                                                            (room-context/display-name room (:from m))
                                                            (:ts m))
-                             (cc/add-message! chat-ctx {:role :user :content (:content m)})))]
+                             (cc/add-message! chat-ctx {:role :user :content (:content m)})))
+                         drain-inclusions!
+                         (fn [pending]
+                           (let [[included _]
+                                 (swap-vals! pending (constantly []))]
+                             (doseq [{:keys [message plan decision-id]} included]
+                               (fold-inbound! message)
+                               (record-attention-applied!
+                                room id message plan run-id decision-id))))]
                  ;; The just-arrived user message (and any message that STEERS a
                  ;; running turn, below) folds in via fold-inbound! from the let.
                      (try
-                       (fold-inbound! msg)
+                       ;; A quiescent enqueue is only durably applied once its
+                       ;; successor Run exists. Until this handler starts, the
+                       ;; participant FIFO is process-local and the ready fact
+                       ;; intentionally remains visible to recovery.
+                       (when-let [{prior-plan :plan
+                                   prior-decision-id :decision-id
+                                   prior-run-id :run-id}
+                                  (::deferred-attention msg)]
+                         (record-attention-applied!
+                          room id msg prior-plan prior-run-id prior-decision-id run-id))
+                       ;; The trigger is the first attention admission for this
+                       ;; Run. Persist it before provider input changes.
+                       (let [trigger-plan
+                             {:status :ready
+                              :decision (attention/decision
+                                         {:memory :include
+                                          :reason :run/trigger})}
+                             trigger-decision-id
+                             (record-attention! room id msg trigger-plan run-id)]
+                         (fold-inbound! msg)
+                         (record-attention-applied!
+                          room id msg trigger-plan run-id trigger-decision-id))
                  ;; ONE CONTROL PLANE (steerable turn). Every influence on a
                  ;; running turn arrives as a message on the participant's own
                  ;; inbox — INCLUDING the LLM call's completion, which a bridge
@@ -532,10 +660,11 @@
                                                            :incoming-message m
                                                            :participant p
                                                            :room room})
-                                                         action
+                                                         plan
                                                          (try
-                                                           (attention/legacy-action
-                                                            attention-decision)
+                                                           (attention/execution-plan
+                                                            attention-decision
+                                                            llm-attention-capabilities)
                                                            (catch Throwable error
                                                              (tel/log!
                                                               {:level :warn
@@ -543,26 +672,92 @@
                                                                :data {:agent id
                                                                       :decision attention-decision
                                                                       :error (.getMessage error)}}
-                                                              "Invalid attention decision; queued conservatively")
-                                                             ::invalid-attention-decision))]
-                                                     (case action
-                                                       :steer {:tag :steer :msg m}
-                                                       :observe (recur)
-                                                       :queue (do
-                                                                (swap! queued-other-threads conj m)
-                                                                (recur))
-                                                       ::invalid-attention-decision
+                                                              "Invalid attention decision retained for diagnosis")
+                                                             {:status :invalid}))]
+                                                     (if (= :ready (:status plan))
+                                                       (let [{:keys [memory activation control at]
+                                                              :as decision} (:decision plan)
+                                                             decision-id
+                                                             (rstore/attention-id
+                                                              (some-> room d/conversation-id)
+                                                              id (:id m) run-id :decision)
+                                                             entry {:message m
+                                                                    :plan plan
+                                                                    :decision-id decision-id}
+                                                             ;; Stage boundary/queue state
+                                                             ;; before publishing a ready
+                                                             ;; decision. The applied fact is
+                                                             ;; written only after every axis
+                                                             ;; actually takes effect.
+                                                             _ (cond
+                                                                 (= :enqueue activation)
+                                                                 nil
+
+                                                                 (and (= :continue control)
+                                                                      (= :include memory)
+                                                                      (= :next-safe-boundary at))
+                                                                 (swap! pending-safe-inclusions
+                                                                        conj entry)
+
+                                                                 (and (= :continue control)
+                                                                      (= :include memory)
+                                                                      (= :quiescent at))
+                                                                 (swap! pending-quiescent-inclusions
+                                                                        conj entry))]
+                                                         (record-attention! room id m plan run-id)
+                                                         (when (and (#{:restart :suspend :cancel} control)
+                                                                    (= :include memory)
+                                                                    (= :now at))
+                                                           (fold-inbound! m))
+                                                         (case control
+                                                           :restart {:tag :attention
+                                                                     :control :restart
+                                                                     :msg m
+                                                                     :decision decision
+                                                                     :plan plan
+                                                                     :decision-id decision-id}
+                                                           :suspend {:tag :attention
+                                                                     :control :suspend
+                                                                     :msg m
+                                                                     :decision decision
+                                                                     :plan plan
+                                                                     :decision-id decision-id}
+                                                           :cancel {:tag :attention
+                                                                    :control :cancel
+                                                                    :msg m
+                                                                    :decision decision
+                                                                    :plan plan
+                                                                    :decision-id decision-id}
+                                                           :continue
+                                                           (cond
+                                                             (= :enqueue activation)
+                                                             (do (swap! queued-other-threads conj entry)
+                                                                 (recur))
+
+                                                             (and (= :include memory)
+                                                                  (= :now at))
+                                                             (do (fold-inbound! m)
+                                                                 (record-attention-applied!
+                                                                  room id m plan run-id decision-id)
+                                                                 (recur))
+
+                                                             (= :include memory)
+                                                             (recur)
+
+                                                             :else
+                                                             (do (record-attention-applied!
+                                                                  room id m plan run-id decision-id)
+                                                                 (recur)))))
                                                        (do
-                                                         (swap! queued-other-threads conj m)
-                                                         (recur))
-                                                       (do
-                                                         (tel/log!
-                                                          {:level :warn
-                                                           :id ::invalid-attention-decision
-                                                           :data {:agent id
-                                                                  :decision attention-decision}}
-                                                          "Unsupported attention decision; queued conservatively")
-                                                         (swap! queued-other-threads conj m)
+                                                         (record-attention! room id m plan run-id)
+                                                         (when (= :deferred (:status plan))
+                                                           (tel/log!
+                                                            {:level :warn
+                                                             :id ::unsupported-attention-decision
+                                                             :data {:agent id
+                                                                    :decision (:decision plan)
+                                                                    :unsupported (:unsupported plan)}}
+                                                            "Unsupported attention decision retained as durable deferred attention"))
                                                          (recur)))))))))))
                                    ;; No inbox (room-less participant that was
                                    ;; never joined): plain await, no steering.
@@ -585,11 +780,34 @@
                                    (cc/set-status! chat-ctx :cancelled)
                                    (sp/await (:done h))
                                    (cc/set-status! chat-ctx :active)
+                                   ;; `:next-safe-boundary` is reached when the
+                                   ;; provider call settles. Admit all earlier
+                                   ;; non-preempting includes before restarting.
+                                   (drain-inclusions! pending-safe-inclusions)
                                    (case (:tag decision)
                                      :cancel (do (reset! cancelled? true) nil)
                                      :switch (recur turn)
-                                     :steer  (do (fold-inbound! (:msg decision))
-                                                 (recur (inc turn)))))
+                                     :attention
+                                     (let [{:keys [control msg plan decision-id]
+                                            attention-decision :decision} decision]
+                                       (when (and (= :include (:memory attention-decision))
+                                                  (not= :now (:at attention-decision)))
+                                         (fold-inbound! msg))
+                                       (case control
+                                         :restart
+                                         (do (record-attention-applied!
+                                              room id msg plan run-id decision-id)
+                                             (recur (inc turn)))
+                                         :suspend
+                                         (do (reset! wait-reason :attention-suspended)
+                                             (record-attention-applied!
+                                              room id msg plan run-id decision-id)
+                                             nil)
+                                         :cancel
+                                         (do (reset! policy-cancelled? true)
+                                             (record-attention-applied!
+                                              room id msg plan run-id decision-id)
+                                             nil)))))
                                  (let [result (:result decision)]
                                    (cond
                                      (or @cancelled? (run/cancel-requested? run-id)) nil
@@ -623,19 +841,34 @@
                                                used  (/ (:used b) (double acct/MICRODOLLARS-PER-DOLLAR))
                                                total (/ (:total b) (double acct/MICRODOLLARS-PER-DOLLAR))]
                                            (turn/post-budget-warning! room id used total run-id msg)))
-                                       (reset! waiting? true)
+                                       (reset! wait-reason :budget-exhausted)
                                        (proc/budget-exhausted! id chat-ctx)
                                        nil)
 
                                ;; Normal :continue, budget OK → next turn.
-                                     :else (recur (inc turn)))))))))
+                                     :else (do
+                                             ;; Provider/tool `:continue` is the
+                                             ;; next safe integration boundary,
+                                             ;; not the end of the whole Run.
+                                             (drain-inclusions! pending-safe-inclusions)
+                                             (recur (inc turn))))))))))
 
+                     ;; Resolve the final safe boundary, then quiescence. Keeping
+                     ;; these queues distinct makes `:quiescent` strictly later
+                     ;; than provider/tool continuation boundaries.
+                       (drain-inclusions! pending-safe-inclusions)
+                       (drain-inclusions! pending-quiescent-inclusions)
                      ;; The outer participant loop can now start queued work. Put
                      ;; consumed messages in the participant-owned priority FIFO,
                      ;; not at the live mailbox tail: a newer arrival during this
                      ;; hand-back window must not overtake older topics.
-                       (doseq [queued @queued-other-threads]
-                         (d/defer-inbox! p queued))
+                       (doseq [{:keys [message plan decision-id]}
+                               @queued-other-threads]
+                         (d/defer-inbox!
+                          p (assoc message ::deferred-attention
+                                   {:plan plan
+                                    :decision-id decision-id
+                                    :run-id run-id})))
                      ;; A FAILED turn produced no new reply — surface it as a NON-triggering
                      ;; :_activity row and DON'T fall through to re-post the STALE last reply
                      ;; (which the room's other agents answer, looping — the "repeating" bug).
@@ -647,6 +880,8 @@
                      ;; posting it is the repeating bug. Surface it instead.
                      ;; A deliberate cancel stays quiet.
                        (when (and (not @errored) (not @cancelled?)
+                                  (not @policy-cancelled?)
+                                  (not @wait-reason)
                                   (not (run/cancel-requested? run-id))
                                   (not= :cancelled (cc/get-status chat-ctx))
                                   (= pre-turn-last-asst (last-assistant-message chat-ctx)))
@@ -702,26 +937,26 @@
                        (finally
                          (when (and run-id (not @finish-after-reply?))
                            (let [cancelled-run? (or @cancelled?
+                                                    @policy-cancelled?
                                                     (run/cancel-requested? run-id)
                                                     (= :cancelled (cc/get-status chat-ctx)))
                                  status (cond
                                           cancelled-run? :cancelled
                                           @errored :failed
-                                          @waiting? :waiting
+                                          @wait-reason :waiting
                                           :else :completed)]
                              (run/finish! run-id status
                                           (cond-> {}
                                             cancelled-run? (assoc :reason :cancel-requested)
-                                            @waiting? (assoc :reason :budget-exhausted)
+                                            @wait-reason (assoc :reason @wait-reason)
                                             @errored (assoc :reason :error :error @errored))))))))))))
 
             :factory
             (fn [new-ctx]
-         ;; Fork-room semantics for an LLM agent: re-create fresh in the
-         ;; new context. The fork's agent has no prior conversation,
-         ;; matching the §6.5 ToM-probe semantics ("what would they say,
-         ;; given only the priming I set up?"). Future enhancement: pass
-         ;; an :init-snapshot to carry conversation forward.
+         ;; `fork-room :ctx` installs the inherited room working context before
+         ;; invoking this factory, so the clone selects forked signals and SCI
+         ;; through the stable component ref. `:none` remains a lightweight
+         ;; message-only clone. The room-less fallback stays lazy in both cases.
               (llm-agent {:id          id
                           :spec        spec
                           :tools       tools

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -405,32 +405,36 @@
 
    Stored under `[:dvergr/bash-session WORKSPACE-ID]`."
   [chat-ctx]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (let [ws (default-workspace)
-          key (if (map? ws) (:id ws) ws)
-          path (session-path key)]
-      (or (ec/get-state path)
+  (let [world ((requiring-resolve
+                'dvergr.chat.context/selected-execution-context) chat-ctx)]
+    (binding [ec/*execution-context* world]
+      (let [ws (default-workspace)
+            key (if (map? ws) (:id ws) ws)
+            path (session-path key)]
+        (or (ec/get-state path)
           ;; cwd is the SANDBOX root "/" (= the worktree via make-host's
           ;; :mount-at "/"); `ws` (the real path) stays only as the cache key.
-          (let [s (ms/spindel-session-using (:spindel-ctx chat-ctx)
-                                            (make-sandboxed-env {:cwd "/"}))]
-            (ec/swap-state! path (fn [existing] (or existing s)))
-            (ec/get-state path))))))
+            (let [s (ms/spindel-session-using world
+                                              (make-sandboxed-env {:cwd "/"}))]
+              (ec/swap-state! path (fn [existing] (or existing s)))
+              (ec/get-state path)))))))
 
 (defn get-or-create-host!
   "Return the chat-ctx's BuiltinHost for the current workspace,
    creating it on first use. See `get-or-create-session!` for why
    this is keyed by workspace path."
   [chat-ctx]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (let [ws (default-workspace)
-          key (if (map? ws) (:id ws) ws)
-          path (host-path key)]
-      (or (ec/get-state path)
-          (let [h (make-host {:workspace ws
-                              :mounts (resolve-mounts chat-ctx)})]
-            (ec/swap-state! path (fn [existing] (or existing h)))
-            (ec/get-state path))))))
+  (let [world ((requiring-resolve
+                'dvergr.chat.context/selected-execution-context) chat-ctx)]
+    (binding [ec/*execution-context* world]
+      (let [ws (default-workspace)
+            key (if (map? ws) (:id ws) ws)
+            path (host-path key)]
+        (or (ec/get-state path)
+            (let [h (make-host {:workspace ws
+                                :mounts (resolve-mounts chat-ctx)})]
+              (ec/swap-state! path (fn [existing] (or existing h)))
+              (ec/get-state path)))))))
 
 ;; ============================================================================
 ;; Public API
@@ -560,7 +564,9 @@
           ;; time (make-sandboxed-env), so the snapshot is already
           ;; secret-free. Pass it as the explicit starting env so
           ;; one-shot library use stays well-defined.
-          env0 (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+          env0 (binding [ec/*execution-context*
+                         ((requiring-resolve
+                           'dvergr.chat.context/selected-execution-context) chat-ctx)]
                  (msession/-env sess))
           interrupt-fn (mbudget/combine (process-abort-interrupt-fn process))
           {:keys [stdout stderr exit env permit trace]}

--- a/src/dvergr/mcp/server.clj
+++ b/src/dvergr/mcp/server.clj
@@ -18,6 +18,7 @@
             [dvergr.mcp.json-rpc :as json-rpc]
             [dvergr.ops :as ops]
             [dvergr.discourse :as d]
+            [dvergr.chat.context :as chat-context]
             [org.replikativ.spindel.engine.core :as ec]
             [jsonista.core :as json])
   (:import (java.net ServerSocket Socket)
@@ -92,9 +93,11 @@
     (if room
       (binding [ec/*execution-context* (:ctx room)]
         (let [cctx (ensure-ctx! room :mcp {})]
-          (execute tname input (make-context {:sci-ctx  (:sci-ctx cctx)
+          (execute tname input (make-context {:sci-ctx  (chat-context/sci-context-in
+                                                         cctx (:ctx room))
                                               :db-conn  (:db-conn cctx)
-                                              :chat-ctx cctx}))))
+                                              :chat-ctx cctx
+                                              :execution-ctx (:ctx room)}))))
       (execute tname input (make-context {})))))
 
 (defn- coding-tool [tname tdef]

--- a/src/dvergr/participant/context.clj
+++ b/src/dvergr/participant/context.clj
@@ -29,7 +29,7 @@
                             (often yggdrasil-managed so substrate-fork
                             branches it automatically).
      - `:role-data`       — map of role-specific extensions. LLM puts
-                            `:sci-ctx` and `:tool-ctx` here; human can
+                            `:sci-component` and `:tool-ctx` here; human can
                             stash UI prefs, presence signal, etc. Stays
                             out of the common record so role-specific
                             additions don't churn the API.
@@ -113,7 +113,7 @@
      :from-chat-ctx  — an existing dvergr.chat.context/ChatContext
      :chat-ctx-opts  — opts map passed to cc/create-chat-context
 
-   Role-data carries the chat-ctx-only fields (`:chat-ctx`, `:sci-ctx`)
+   Role-data carries the chat-ctx-only fields (`:chat-ctx`, `:sci-component`)
    so existing dvergr.chat.context callers can still reach them via
    `(:role-data pctx)`."
   [{:keys [participant-id from-chat-ctx chat-ctx-opts role-data]}]
@@ -128,7 +128,7 @@
                           (:status-signal chat-ctx)
                           (:db-conn chat-ctx)
                           (merge {:chat-ctx chat-ctx
-                                  :sci-ctx (:sci-ctx chat-ctx)}
+                                  :sci-component (:sci-component chat-ctx)}
                                  role-data))))
 
 ;; ===========================================================================

--- a/src/dvergr/resource.clj
+++ b/src/dvergr/resource.clj
@@ -5,7 +5,8 @@
    create or discard speculative application state, but they never copy or
    settle this authority: a child receives resources only through one governed
    Kontor transfer from its parent wallet."
-  (:require [dvergr.room.store :as store]
+  (:require [dvergr.agent.attempt.governance :as attempt-governance]
+            [dvergr.room.store :as store]
             [kontor.resource :as kontor])
   (:import [java.nio.charset StandardCharsets]
            [java.util Date UUID]))
@@ -50,6 +51,10 @@
    already exist so its lookup ref can own the wallet."
   [conn room-id chat-id]
   (kontor/install! conn)
+  ;; Kontor currently owns Datahike's single tx-predicate registration slot.
+  ;; Recompose the Attempt governor after every (idempotent) installation so
+  ;; neither invariant family can replace the other by boot order.
+  (attempt-governance/govern! conn)
   (kontor/install-unit! conn {:symbol microdollars
                               :name "Micro US dollars"
                               :precision 0})

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -25,6 +25,18 @@
 ;; fork discard) funnels through `unregister!`, so one hook covers them all.
 (defonce ^:private unregister-hooks (atom {}))
 
+;; Hooks that must complete BEFORE registry removal. Unlike observation-only
+;; unregister hooks, failures propagate and keep the Room registered so teardown
+;; can be retried safely.
+(defonce ^:private pre-unregister-hooks (atom {}))
+
+(defn add-pre-unregister-hook!
+  "Register a Room teardown fence. `f` receives the live Room before removal;
+   failures abort unregister and remain visible to the caller."
+  [id f]
+  (swap! pre-unregister-hooks assoc id f)
+  nil)
+
 (defn add-unregister-hook!
   "Register `f` (1-arg, takes room-id) to run after any room is unregistered.
    Keyed by `id` so re-registration (ns reload) replaces rather than dupes."
@@ -59,6 +71,9 @@
 (defn unregister!
   "Remove a Room from the registry by id, then run unregister hooks."
   [room-id]
+  (when-let [room (get (rctx/shared-get-state registry-path) room-id)]
+    (doseq [f (vals @pre-unregister-hooks)]
+      (f room)))
   (rctx/shared-swap-state! registry-path (fn [m] (dissoc (or m {}) room-id)))
   (doseq [f (vals @unregister-hooks)]
     (try (f room-id) (catch Throwable _ nil)))

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -30,6 +30,19 @@
 ;; can be retried safely.
 (defonce ^:private pre-unregister-hooks (atom {}))
 
+;; Registration fences run before replacing the registry entry. They are for
+;; lifecycle owners whose identity must not be reset by an add-or-replace
+;; refresh. Unlike observational register hooks, failures propagate and leave
+;; the existing registry entry untouched.
+(defonce ^:private pre-register-hooks (atom {}))
+
+(defn add-pre-register-hook!
+  "Register a Room admission fence. `f` receives the prospective Room before
+   registry replacement; failures abort registration."
+  [id f]
+  (swap! pre-register-hooks assoc id f)
+  nil)
+
 (defn add-pre-unregister-hook!
   "Register a Room teardown fence. `f` receives the live Room before removal;
    failures abort unregister and remain visible to the caller."
@@ -63,6 +76,8 @@
   "Add or replace a Room in the registry, then run register hooks. Returns the
    Room."
   [room]
+  (doseq [f (vals @pre-register-hooks)]
+    (f room))
   (rctx/shared-swap-state! registry-path (fn [m] (assoc (or m {}) (:id room) room)))
   (doseq [f (vals @register-hooks)]
     (try (f room) (catch Throwable _ nil)))

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -19,6 +19,27 @@
 (def ^:private registry-path [:dvergr/rooms])
 (def ^:private fork-topology-path [:dvergr/fork-topology])
 (defonce ^:private lifecycle-lock (Object.))
+(defonce ^:private transitions (atom {}))
+
+(defn- transition-key [room-id]
+  [(:fork-id (rctx/current-root)) room-id])
+
+(defn- reserve-transition! [room-id operation]
+  (let [key (transition-key room-id)
+        token (random-uuid)]
+    (when (contains? @transitions key)
+      (throw (ex-info "Room registry lifecycle is already in progress"
+                      {:type ::lifecycle-in-progress
+                       :room-id room-id
+                       :operation operation})))
+    (swap! transitions assoc key {:token token :operation operation})
+    [key token]))
+
+(defn- release-transition! [key token]
+  (locking lifecycle-lock
+    (when (= token (get-in @transitions [key :token]))
+      (swap! transitions dissoc key)))
+  nil)
 
 ;; Callbacks run (with the room-id) AFTER a room is unregistered. Lets
 ;; dependents (e.g. dvergr.agent.room-context) tear down per-room resources
@@ -77,24 +98,56 @@
   "Add or replace a Room in the registry, then run register hooks. Returns the
    Room."
   [room]
-  (locking lifecycle-lock
-    (doseq [f (vals @pre-register-hooks)]
-      (f room))
-    (rctx/shared-swap-state! registry-path (fn [m] (assoc (or m {}) (:id room) room)))
-    (doseq [f (vals @register-hooks)]
-      (try (f room) (catch Throwable _ nil))))
-  room)
+  (let [[key token] (locking lifecycle-lock
+                      (reserve-transition! (:id room) :register))]
+    (try
+      ;; Lifecycle owners reserve/check outside the global monitor. The token
+      ;; prevents unregister/replacement from interleaving while hooks run.
+      (doseq [f (vals @pre-register-hooks)]
+        (f room))
+      (locking lifecycle-lock
+        (when-not (= token (get-in @transitions [key :token]))
+          (throw (ex-info "Room registration reservation was lost"
+                          {:type ::lifecycle-reservation-lost
+                           :room-id (:id room)})))
+        (rctx/shared-swap-state! registry-path
+                                 (fn [m] (assoc (or m {}) (:id room) room))))
+      (doseq [f (vals @register-hooks)]
+        (try (f room) (catch Throwable _ nil)))
+      room
+      (finally
+        (release-transition! key token)))))
 
 (defn unregister!
   "Remove a Room from the registry by id, then run unregister hooks."
   [room-id]
-  (locking lifecycle-lock
-    (when-let [room (get (rctx/shared-get-state registry-path) room-id)]
-      (doseq [f (vals @pre-unregister-hooks)]
-        (f room)))
-    (rctx/shared-swap-state! registry-path (fn [m] (dissoc (or m {}) room-id)))
-    (doseq [f (vals @unregister-hooks)]
-      (try (f room-id) (catch Throwable _ nil))))
+  (let [{:keys [room key token]}
+        (locking lifecycle-lock
+          (when-let [room (get (rctx/shared-get-state registry-path) room-id)]
+            (let [[key token] (reserve-transition! room-id :unregister)]
+              {:room room :key key :token token})))]
+    (when room
+      (try
+        ;; Draining user/runtime work must never hold the daemon-global monitor.
+        ;; Same-Room lifecycle contenders fail on the reservation; unrelated
+        ;; registries continue normally.
+        (doseq [f (vals @pre-unregister-hooks)]
+          (f room))
+        (locking lifecycle-lock
+          (when-not (and (= token (get-in @transitions [key :token]))
+                         (= (:incarnation room)
+                            (:incarnation (get (rctx/shared-get-state registry-path)
+                                               room-id))))
+            (throw (ex-info "Room unregister reservation no longer owns the incarnation"
+                            {:type ::lifecycle-reservation-lost
+                             :room-id room-id})))
+          (rctx/shared-swap-state! registry-path (fn [m] (dissoc (or m {}) room-id))))
+        ;; Keep the reservation through cleanup so a new incarnation cannot be
+        ;; registered before old process-local handles have been forgotten.
+        (doseq [f (vals @unregister-hooks)]
+          (try (f room-id) (catch Throwable _ nil)))
+        (finally
+          (release-transition! key token)))))
   nil)
 
 (defn lookup

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -118,6 +118,42 @@
       (finally
         (release-transition! key token)))))
 
+(defn register-fork!
+  "Atomically publish an isolated child Room and its structural topology edge.
+
+   Readers can never observe a globally reachable child without the settlement
+  identity needed to govern it. Register hooks run only after both projections
+   are visible."
+  [room parent-id ygg-fork-id]
+  (let [child-id (:id room)
+        [key token] (locking lifecycle-lock
+                      (reserve-transition! child-id :register-fork))]
+    (try
+      ;; A fork is still a Room incarnation. Run the same admission fences as
+      ;; ordinary registration before making either global projection visible.
+      (doseq [f (vals @pre-register-hooks)]
+        (f room))
+      (locking lifecycle-lock
+        (when-not (= token (get-in @transitions [key :token]))
+          (throw (ex-info "Fork registration reservation was lost"
+                          {:type ::lifecycle-reservation-lost
+                           :room-id child-id})))
+        (rctx/shared-swap-root!
+         (fn [state]
+           (-> (or state {})
+               (update-in registry-path #(assoc (or % {}) child-id room))
+               (update-in fork-topology-path
+                          #(assoc (or % {}) child-id
+                                  {:fork/id child-id
+                                   :fork/parent-id parent-id
+                                   :fork/ygg-id ygg-fork-id
+                                   :fork/state :local}))))))
+      (doseq [f (vals @register-hooks)]
+        (try (f room) (catch Throwable _ nil)))
+      room
+      (finally
+        (release-transition! key token)))))
+
 (defn unregister!
   "Remove a Room from the registry by id, then run unregister hooks."
   [room-id]
@@ -158,6 +194,21 @@
       (keyword? id-or-slug) (get m id-or-slug)
       (string? id-or-slug)  (some (fn [[_ r]] (when (= (:slug r) id-or-slug) r)) m)
       :else                 nil)))
+
+(defn admitted-incarnation?
+  "True when `room` is the currently published incarnation and no lifecycle
+   transition owns its registry slot.
+
+   Callers that allocate process-local Room resources use this while holding
+   the Room's own lifecycle fence. An unregister reservation therefore closes
+   admission before pre-unregister cleanup starts, and a failed unregister
+   automatically reopens admission when its reservation is released."
+  [room]
+  (locking lifecycle-lock
+    (let [room-id (:id room)
+          current (get (rctx/shared-get-state registry-path) room-id)]
+      (and (= (:incarnation room) (:incarnation current))
+           (not (contains? @transitions (transition-key room-id)))))))
 
 (defn list-rooms
   "All rooms in the registry. Optional :where filter as a predicate.

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -18,6 +18,7 @@
 
 (def ^:private registry-path [:dvergr/rooms])
 (def ^:private fork-topology-path [:dvergr/fork-topology])
+(defonce ^:private lifecycle-lock (Object.))
 
 ;; Callbacks run (with the room-id) AFTER a room is unregistered. Lets
 ;; dependents (e.g. dvergr.agent.room-context) tear down per-room resources
@@ -76,22 +77,24 @@
   "Add or replace a Room in the registry, then run register hooks. Returns the
    Room."
   [room]
-  (doseq [f (vals @pre-register-hooks)]
-    (f room))
-  (rctx/shared-swap-state! registry-path (fn [m] (assoc (or m {}) (:id room) room)))
-  (doseq [f (vals @register-hooks)]
-    (try (f room) (catch Throwable _ nil)))
+  (locking lifecycle-lock
+    (doseq [f (vals @pre-register-hooks)]
+      (f room))
+    (rctx/shared-swap-state! registry-path (fn [m] (assoc (or m {}) (:id room) room)))
+    (doseq [f (vals @register-hooks)]
+      (try (f room) (catch Throwable _ nil))))
   room)
 
 (defn unregister!
   "Remove a Room from the registry by id, then run unregister hooks."
   [room-id]
-  (when-let [room (get (rctx/shared-get-state registry-path) room-id)]
-    (doseq [f (vals @pre-unregister-hooks)]
-      (f room)))
-  (rctx/shared-swap-state! registry-path (fn [m] (dissoc (or m {}) room-id)))
-  (doseq [f (vals @unregister-hooks)]
-    (try (f room-id) (catch Throwable _ nil)))
+  (locking lifecycle-lock
+    (when-let [room (get (rctx/shared-get-state registry-path) room-id)]
+      (doseq [f (vals @pre-unregister-hooks)]
+        (f room)))
+    (rctx/shared-swap-state! registry-path (fn [m] (dissoc (or m {}) room-id)))
+    (doseq [f (vals @unregister-hooks)]
+      (try (f room-id) (catch Throwable _ nil))))
   nil)
 
 (defn lookup

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -19,7 +19,8 @@
                                        `:chat/*` / `:message/*` /
                                        `:room/*` schema, same data
                                        as today's `dvergr.rooms`."
-  (:require [clojure.string :as str]))
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]))
 
 (defprotocol PRoomStore
   "Pluggable durability surface for Rooms. Implementations decide
@@ -109,6 +110,40 @@
   (-resource-receipt [this transfer-id]
     "Return the durable transfer receipt, or nil."))
 
+(defprotocol PAttentionStore
+  "Participant-specific attention projections over immutable Room messages.
+
+   Attention is control/memory state, not speech, so it deliberately does not
+   travel through PRoomStore's message log. Implementations colocate it with the
+   Room authority and make first-write identity durable."
+
+  (-store-attention! [this room-id fact]
+    "Persist one validated attention fact. Returns the stored fact.")
+
+  (-list-attention [this room-id opts]
+    "List attention facts, optionally restricted by exact :id, :participant,
+     and :limit. Exact identity lookup is never subject to the history limit."))
+
+(defprotocol PAttemptStore
+  "Durable query projection for trusted, verified evaluation Attempts.
+
+   The Attempt is owned by the same Room store as its terminal Run. Exact
+   open-ended values may live in an immutable artifact store, but certification
+   is not durable until this typed index and all artifact references commit."
+
+  (-store-attempt! [this room-id attempt]
+    "Persist one immutable certified Attempt. The root Run must be terminal in
+     this Room. Repeating identical content is idempotent; reusing the Run
+     identity for different content is an error.")
+
+  (-load-attempt [this room-id attempt-id]
+    "Return one exact certified Attempt by UUID in `room-id`, else nil.")
+
+  (-list-attempts [this room-id opts]
+    "Return recent certified Attempts newest first. Optional exact filters are
+     :environment-id, :environment-content-id, :provider, :model, and :status;
+     :limit is applied after filtering."))
+
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
@@ -120,8 +155,163 @@
 
 (def terminal-run-statuses #{:completed :failed :cancelled})
 
+(def durable-attention-keys
+  #{:attention/id :attention/participant :attention/message-id
+    :attention/decision-id :attention/run-id :attention/memory :attention/activation
+    :attention/control :attention/at :attention/priority
+    :attention/status :attention/reason :attention/metadata
+    :attention/result-run-id :attention/created-at})
+
+(defn attention-id
+  "Deterministic identity for one decision or disposition over a message."
+  [room-id participant message-id run-id phase]
+  (java.util.UUID/nameUUIDFromBytes
+   (.getBytes (pr-str [:dvergr/attention room-id participant message-id run-id phase])
+              java.nio.charset.StandardCharsets/UTF_8)))
+
+(def attention-semantic-keys
+  [:attention/participant :attention/message-id :attention/run-id
+   :attention/memory :attention/activation :attention/control :attention/at
+   :attention/priority :attention/reason :attention/metadata])
+
+(defn validate-attention-disposition!
+  "Require an applied fact to match one existing ready decision exactly."
+  [decision applied]
+  (when-not decision
+    (throw (ex-info "Applied attention references a missing decision"
+                    {:type :room-store/orphan-attention-disposition
+                     :applied applied})))
+  (when-not (= :ready (:attention/status decision))
+    (throw (ex-info "Only a ready attention decision can be applied"
+                    {:type :room-store/invalid-attention-disposition
+                     :decision decision :applied applied})))
+  (when-not (= (:attention/id decision) (:attention/decision-id applied))
+    (throw (ex-info "Applied attention references the wrong decision"
+                    {:type :room-store/invalid-attention-disposition
+                     :decision decision :applied applied})))
+  (when-not (= (select-keys decision attention-semantic-keys)
+               (select-keys applied attention-semantic-keys))
+    (throw (ex-info "Applied attention axes differ from its decision"
+                    {:type :room-store/attention-disposition-mismatch
+                     :decision decision :applied applied})))
+  (if (= :enqueue (:attention/activation applied))
+    (when-not (uuid? (:attention/result-run-id applied))
+      (throw (ex-info "Applied enqueue attention requires a successor Run"
+                      {:type :room-store/missing-attention-result-run
+                       :decision decision :applied applied})))
+    (when (:attention/result-run-id applied)
+      (throw (ex-info "Only applied enqueue attention may reference a successor Run"
+                      {:type :room-store/unexpected-attention-result-run
+                       :decision decision :applied applied}))))
+  applied)
+
+(defn validate-attention-result-run!
+  "Require enqueue acknowledgement to name the exact successor execution."
+  [applied result-run]
+  (when (= :enqueue (:attention/activation applied))
+    (when-not result-run
+      (throw (ex-info "Applied enqueue attention references a missing successor Run"
+                      {:type :room-store/missing-attention-result-run
+                       :applied applied})))
+    (when-not (and (= (:attention/participant applied) (:run/actor result-run))
+                   (= (:attention/message-id applied) (:run/trigger result-run)))
+      (throw (ex-info "Applied enqueue attention references an unrelated successor Run"
+                      {:type :room-store/invalid-attention-result-run
+                       :applied applied :result-run result-run}))))
+  applied)
+
+(defn validate-attention!
+  "Validate one durable participant attention projection and return it."
+  [fact]
+  (when-let [unknown (seq (remove durable-attention-keys (keys fact)))]
+    (throw (ex-info "Unknown durable attention keys"
+                    {:type :room-store/unknown-attention-keys
+                     :unknown (set unknown)})))
+  (doseq [k [:attention/id :attention/message-id]
+          :let [v (get fact k)]]
+    (when-not (uuid? v)
+      (throw (ex-info (str k " must be a UUID")
+                      {:type :room-store/invalid-attention :key k :fact fact}))))
+  (when-not (keyword? (:attention/participant fact))
+    (throw (ex-info ":attention/participant must be a keyword"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when (and (:attention/run-id fact) (not (uuid? (:attention/run-id fact))))
+    (throw (ex-info ":attention/run-id must be a UUID"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when (and (:attention/result-run-id fact)
+             (not (uuid? (:attention/result-run-id fact))))
+    (throw (ex-info ":attention/result-run-id must be a UUID"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when (and (:attention/decision-id fact)
+             (not (uuid? (:attention/decision-id fact))))
+    (throw (ex-info ":attention/decision-id must be a UUID"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when (and (= :applied (:attention/status fact))
+             (not (uuid? (:attention/decision-id fact))))
+    (throw (ex-info "Applied attention requires :attention/decision-id"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (doseq [[k allowed] [[:attention/memory #{:ignore :remember :include}]
+                       [:attention/activation #{:none :enqueue :wake}]
+                       [:attention/control #{:continue :integrate :restart :suspend :cancel}]
+                       [:attention/at #{:now :next-safe-boundary :before-model :token
+                                        :before-tool :after-tool :after-model :quiescent}]
+                       [:attention/status #{:ready :deferred :invalid :applied
+                                            :baseline-complete}]]
+          :let [v (get fact k)]
+          :when (and (some? v) (not (contains? allowed v)))]
+    (throw (ex-info (str "Invalid durable " k)
+                    {:type :room-store/invalid-attention :key k :value v})))
+  (when (and (some? (:attention/priority fact))
+             (not (number? (:attention/priority fact))))
+    (throw (ex-info ":attention/priority must be numeric"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when (and (:attention/reason fact)
+             (not (keyword? (:attention/reason fact))))
+    (throw (ex-info ":attention/reason must be a keyword"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when (and (:attention/metadata fact)
+             (not (map? (:attention/metadata fact))))
+    (throw (ex-info ":attention/metadata must be a map"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (when-let [metadata (:attention/metadata fact)]
+    (let [round-trip
+          (try
+            (edn/read-string (pr-str metadata))
+            (catch Throwable error
+              (throw (ex-info ":attention/metadata must be round-trippable EDN"
+                              {:type :room-store/invalid-attention-metadata
+                               :metadata metadata}
+                              error))))]
+      (when-not (= metadata round-trip)
+        (throw (ex-info ":attention/metadata must round-trip without type loss"
+                        {:type :room-store/invalid-attention-metadata
+                         :metadata metadata :round-trip round-trip})))))
+  (when-not (instance? java.util.Date (:attention/created-at fact))
+    (throw (ex-info ":attention/created-at must be an instant"
+                    {:type :room-store/invalid-attention :fact fact})))
+  (cond-> fact
+    (some? (:attention/priority fact))
+    (update :attention/priority double)))
+
+(defn unapplied-attention
+  "Return ready decisions that have no append-only applied disposition.
+
+   This is recovery/audit input, not an instruction to replay blindly: the
+   owning interpreter must reconcile the durable Run and effect boundary before
+   deciding whether retry is safe."
+  [facts]
+  (let [applied (into #{}
+                      (keep #(when (= :applied (:attention/status %))
+                               (:attention/decision-id %)))
+                      facts)]
+    (->> facts
+         (filter #(= :ready (:attention/status %)))
+         (remove #(contains? applied (:attention/id %)))
+         vec)))
+
 (def durable-run-keys
   #{:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+    :run/caused-by
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error
     :run/world :run/isolation :run/settlement-policy
@@ -164,6 +354,17 @@
   (when (and (:run/parent run) (not (uuid? (:run/parent run))))
     (throw (ex-info ":run/parent must be a UUID"
                     {:type :room-store/invalid-run :key :run/parent :run run})))
+  (when-not (and (set? (or (:run/caused-by run) #{}))
+                 (every? uuid? (:run/caused-by run)))
+    (throw (ex-info ":run/caused-by must be a set of Run UUIDs"
+                    {:type :room-store/invalid-run
+                     :key :run/caused-by
+                     :run run})))
+  (when (contains? (:run/caused-by run) (:run/id run))
+    (throw (ex-info "A Run cannot causally depend on itself"
+                    {:type :room-store/invalid-run
+                     :key :run/caused-by
+                     :run run})))
   (when (and (:run/roster run) (not (keyword? (:run/roster run))))
     (throw (ex-info ":run/roster must be a keyword"
                     {:type :room-store/invalid-run :key :run/roster :run run})))
@@ -195,10 +396,14 @@
              (not (instance? java.util.Date (:run/ended-at run))))
     (throw (ex-info "A terminal run requires :run/ended-at"
                     {:type :room-store/invalid-run :key :run/ended-at :run run})))
+  (when (and (not (contains? terminal-run-statuses (:run/status run)))
+             (some? (:run/ended-at run)))
+    (throw (ex-info "A nonterminal run cannot have :run/ended-at"
+                    {:type :room-store/invalid-run :key :run/ended-at :run run})))
   run)
 
 (defn validate-run-update!
-  "Reject an update that changes the causal identity of an existing Run."
+  "Reject an update that changes identity or removes durable causal evidence."
   [existing run]
   (when (and existing
              (not= (select-keys existing immutable-run-keys)
@@ -208,6 +413,48 @@
                      :run-id (:run/id run)
                      :existing (select-keys existing immutable-run-keys)
                      :update (select-keys run immutable-run-keys)})))
+  (when (and existing
+             (not (every? (or (:run/caused-by run) #{})
+                          (or (:run/caused-by existing) #{}))))
+    (throw (ex-info "Durable Run causal inputs are append-only"
+                    {:type :room-store/causes-not-append-only
+                     :run-id (:run/id run)
+                     :existing (:run/caused-by existing)
+                     :update (:run/caused-by run)})))
+  (when (and existing
+             (contains? terminal-run-statuses (:run/status existing))
+             (or (not= (:run/status existing) (:run/status run))
+                 (not= (:run/ended-at existing) (:run/ended-at run))))
+    (throw (ex-info "A terminal Run lifecycle is immutable"
+                    {:type :room-store/terminal-run-update
+                     :run-id (:run/id run)
+                     :existing-status (:run/status existing)
+                     :update-status (:run/status run)
+                     :existing-ended-at (:run/ended-at existing)
+                     :update-ended-at (:run/ended-at run)})))
+  run)
+
+(defn validate-run-causes!
+  "Validate newly asserted causal edges through `load-cause`.
+
+   The loader is scoped to the same durable Room namespace by each store. A
+   causal input must already exist there and be terminal. Existing edges are
+   not rechecked on replay, but `validate-run-update!` prevents their removal."
+  [existing load-cause run]
+  (doseq [cause-id (remove (or (:run/caused-by existing) #{})
+                           (or (:run/caused-by run) #{}))]
+    (let [cause (load-cause cause-id)]
+      (when-not cause
+        (throw (ex-info "Causal input Run is not durable in the same Room"
+                        {:type :room-store/cause-not-durable
+                         :run-id (:run/id run)
+                         :cause-run/id cause-id})))
+      (when-not (contains? terminal-run-statuses (:run/status cause))
+        (throw (ex-info "Causal input Run has not resolved"
+                        {:type :room-store/cause-not-resolved
+                         :run-id (:run/id run)
+                         :cause-run/id cause-id
+                         :cause-run/status (:run/status cause)})))))
   run)
 
 (def durable-message-metadata-keys
@@ -217,13 +464,17 @@
   #{:role :source-user :source-username :source-user-id
     :audience :mentions :attachment :provenance
     :object
-    :tool-uses :reasoning :kind :from :source :schedule-id
+    :tool-uses :activities :reasoning :kind :from :source :schedule-id
     :notification/type :notification/agent :notification/task
     :notification/elapsed :run-id})
 
 (def ^:private attachment-metadata-keys #{:blob-id :node-id :mime :name :size})
 (def ^:private provenance-metadata-keys #{:mode :source})
 (def ^:private object-metadata-keys #{:kind :id})
+(def ^:private activity-metadata-keys
+  #{:activity/id :activity/run-id :activity/kind :activity/verb
+    :activity/status :activity/tool-name :activity/tool-use-id
+    :activity/outcome :activity/critical? :activity/at})
 
 (defn- reject-unknown-metadata! [kind allowed value]
   (let [unknown (seq (remove allowed (keys (or value {}))))]
@@ -233,6 +484,34 @@
                        :kind kind
                        :unknown (set unknown)
                        :allowed allowed})))))
+
+(defn- validate-activity! [activity]
+  (when-not (map? activity)
+    (throw (ex-info "Message activity must be a map"
+                    {:type :room-store/invalid-message-metadata
+                     :activity activity})))
+  (reject-unknown-metadata! :activity activity-metadata-keys activity)
+  (doseq [[key pred label] [[:activity/id uuid? "UUID"]
+                            [:activity/kind keyword? "keyword"]
+                            [:activity/verb keyword? "keyword"]
+                            [:activity/run-id uuid? "UUID"]
+                            [:activity/status keyword? "keyword"]
+                            [:activity/tool-name string? "string"]
+                            [:activity/tool-use-id string? "string"]
+                            [:activity/outcome string? "string"]
+                            [:activity/critical? boolean? "boolean"]
+                            [:activity/at #(instance? java.util.Date %) "instant"]]]
+    (when (and (contains? activity key) (not (pred (get activity key))))
+      (throw (ex-info (str "Message " key " must be a " label)
+                      {:type :room-store/invalid-message-metadata
+                       :key key :activity activity}))))
+  (when-not (and (uuid? (:activity/id activity))
+                 (keyword? (:activity/kind activity))
+                 (keyword? (:activity/verb activity)))
+    (throw (ex-info "Message activity requires UUID :activity/id and keyword kind/verb"
+                    {:type :room-store/invalid-message-metadata
+                     :activity activity})))
+  activity)
 
 (defn validate-message-metadata!
   "Validate the typed durable message metadata vocabulary and return `metadata`.
@@ -257,6 +536,25 @@
                         {:type :room-store/invalid-message-metadata
                          :provenance provenance})))
       (reject-unknown-metadata! :provenance provenance-metadata-keys provenance))
+    (when (contains? metadata :activities)
+      (when-not (sequential? (:activities metadata))
+        (throw (ex-info "Message :activities must be sequential"
+                        {:type :room-store/invalid-message-metadata
+                         :activities (:activities metadata)})))
+      (run! validate-activity! (:activities metadata)))
+    (when-let [message-run-id (:run-id metadata)]
+      (doseq [activity (:activities metadata)]
+        (when (and (:activity/run-id activity)
+                   (not= message-run-id (:activity/run-id activity)))
+          (throw (ex-info "Message activity Run must match its enclosing message"
+                          {:type :room-store/invalid-message-metadata
+                           :message-run-id message-run-id
+                           :activity activity})))))
+    (when (and (nil? (:run-id metadata))
+               (some :activity/run-id (:activities metadata)))
+      (throw (ex-info "Run-correlated activity requires an enclosing message Run"
+                      {:type :room-store/invalid-message-metadata
+                       :activities (:activities metadata)})))
     (when (contains? metadata :object)
       (let [object (:object metadata)]
         (when-not (map? object)

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -7,12 +7,17 @@
    The store maps a Room's keyword id ↔ a Datahike :chat/id UUID via
    the :room/slug attribute (`slug->room-id`/`room-id->slug` in
    `dvergr.room.store`)."
-  (:require [datahike.api :as dh]
+  (:require [clojure.edn :as edn]
+            [datahike.api :as dh]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.attempt.governance :as attempt-governance]
+            [dvergr.artifact :as artifact]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.persist :as persist]
             [dvergr.room.store :as store]
             [kontor.gate :as kontor-gate]
             [kontor.resource :as resource]
+            [hasch.core :as hasch]
             [taoensso.telemere :as tel]))
 
 ;; =============================================================================
@@ -138,6 +143,7 @@
       ;; gap where the room-store path used to drop tool-uses the chat-ctx
       ;; path kept.
       (seq (:tool-uses metadata)) (assoc :message/tool-uses (vec (:tool-uses metadata)))
+      (seq (:activities metadata)) (assoc :message/activities (vec (:activities metadata)))
       ;; Interleaved-thinking trace from a reasoning-model reply, so it survives
       ;; rehydration and is fed back to the model (see room-context seeding).
       (seq (:reasoning metadata))  (assoc :message/reasoning (:reasoning metadata)))))
@@ -152,7 +158,135 @@
   [db entity room-touch]
   (if (dh/entity db [:message/id (:message/id entity)])
     []
-    [entity room-touch]))
+    (do
+      (when (some :activity/run-id (:message/activities entity))
+        (let [message-run-id (:message/run-id entity)
+              run            (and message-run-id
+                                  (dh/entity db [:run/id message-run-id]))
+              chat-id        (second (:message/chat entity))]
+          (when-not run
+            (throw (ex-info "Run-correlated activity references a missing Run"
+                            {:type :room-store/orphan-message-activity
+                             :message-id (:message/id entity)
+                             :run-id message-run-id})))
+          (when-not (= chat-id (:chat/id (:run/chat run)))
+            (throw (ex-info "Run-correlated activity crosses Room stores"
+                            {:type :room-store/activity-room-mismatch
+                             :message-id (:message/id entity)
+                             :run-id message-run-id
+                             :message-chat chat-id
+                             :run-chat (:chat/id (:run/chat run))})))))
+      [entity room-touch])))
+
+(defn- store-attention-if-absent
+  "Transaction function preserving immutable attention identity under races."
+  [db entity]
+  (if (dh/entity db [:attention/id (:attention/id entity)])
+    []
+    (do
+      (when (= :applied (:attention/status entity))
+        (let [decision (dh/entity db [:attention/id (:attention/decision-id entity)])
+              semantic-attrs [:attention/participant :attention/message-id
+                              :attention/run-id :attention/memory
+                              :attention/activation :attention/control
+                              :attention/at :attention/priority
+                              :attention/reason :attention/metadata-edn]]
+          (when-not decision
+            (throw (ex-info "Applied attention references a missing decision"
+                            {:type :room-store/orphan-attention-disposition
+                             :entity entity})))
+          (when-not (= :ready (:attention/status decision))
+            (throw (ex-info "Only ready attention can be applied"
+                            {:type :room-store/invalid-attention-disposition
+                             :entity entity})))
+          (when-not (= (second (:attention/chat entity))
+                       (:chat/id (:attention/chat decision)))
+            (throw (ex-info "Attention disposition crosses Room stores"
+                            {:type :room-store/attention-room-mismatch
+                             :entity entity})))
+          (when-not (every? #(= (get decision %) (get entity %)) semantic-attrs)
+            (throw (ex-info "Applied attention axes differ from its decision"
+                            {:type :room-store/attention-disposition-mismatch
+                             :entity entity})))
+          (if (= :enqueue (:attention/activation entity))
+            (let [result-run-id (:attention/result-run-id entity)
+                  result-run (and result-run-id
+                                  (dh/entity db [:run/id result-run-id]))]
+              (when-not result-run-id
+                (throw (ex-info "Applied enqueue attention requires a successor Run"
+                                {:type :room-store/missing-attention-result-run
+                                 :entity entity})))
+              (when-not result-run
+                (throw (ex-info "Applied enqueue attention references a missing successor Run"
+                                {:type :room-store/missing-attention-result-run
+                                 :entity entity})))
+              (when-not (and (= (second (:attention/chat entity))
+                                (:chat/id (:run/chat result-run)))
+                             (= (:attention/participant entity) (:run/actor result-run))
+                             (= (:attention/message-id entity) (:run/trigger result-run)))
+                (throw (ex-info "Applied enqueue attention references an unrelated successor Run"
+                                {:type :room-store/invalid-attention-result-run
+                                 :entity entity}))))
+            (when (:attention/result-run-id entity)
+              (throw (ex-info "Only applied enqueue attention may reference a successor Run"
+                              {:type :room-store/unexpected-attention-result-run
+                               :entity entity}))))))
+      [entity])))
+
+(defn- store-attempt-if-absent
+  "Transaction function for immutable first-write-wins Attempt certification."
+  [db entity]
+  (if (dh/entity db [:attempt/id (:attempt/id entity)])
+    []
+    (let [chat-id (second (:attempt/chat entity))
+          run-id (second (:attempt/run entity))
+          run (dh/entity db [:run/id run-id])
+          terminal? #{:completed :failed :cancelled}]
+      (when-not run
+        (throw (ex-info "Attempt references a missing Run"
+                        {:type :room-store/invalid-attempt-run
+                         :attempt/id (:attempt/id entity) :run/id run-id})))
+      (when-not (= chat-id (:chat/id (:run/chat run)))
+        (throw (ex-info "Attempt Run crosses Room stores"
+                        {:type :room-store/attempt-room-mismatch
+                         :attempt/id (:attempt/id entity) :run/id run-id})))
+      (when-not (contains? terminal? (:run/status run))
+        (throw (ex-info "Attempt Run is not terminal"
+                        {:type :room-store/non-terminal-attempt-run
+                         :attempt/id (:attempt/id entity)
+                         :run/status (:run/status run)})))
+      (when-not (= (:run/status run) (:attempt/status entity))
+        (throw (ex-info "Attempt status differs from its Run"
+                        {:type :room-store/attempt-run-status-mismatch
+                         :run/status (:run/status run)
+                         :attempt/status (:attempt/status entity)})))
+      (doseq [[attempt-key run-key]
+              [[:attempt/agent-def-hash :run/agent-def-hash]
+               [:attempt/program-kind :run/program-kind]
+               [:attempt/interpreter-version :run/interpreter-version]]]
+        (when-not (= (get entity attempt-key) (get run run-key))
+          (throw (ex-info "Attempt provenance differs from its Run"
+                          {:type :room-store/attempt-run-provenance-mismatch
+                           :attempt/key attempt-key
+                           :attempt/value (get entity attempt-key)
+                           :run/value (get run run-key)}))))
+      (doseq [ref (:attempt/evidence-runs entity)]
+        (let [evidence-run (dh/entity db ref)]
+          (when-not (and evidence-run
+                         (= chat-id (:chat/id (:run/chat evidence-run))))
+            (throw (ex-info "Attempt evidence Run is missing or cross-Room"
+                            {:type :room-store/invalid-attempt-evidence-run
+                             :attempt/id (:attempt/id entity)
+                             :run/ref ref})))))
+      (doseq [ref (:attempt/evidence-messages entity)]
+        (let [message (dh/entity db ref)]
+          (when-not (and message
+                         (= chat-id (:chat/id (:message/chat message))))
+            (throw (ex-info "Attempt evidence message is missing or cross-Room"
+                            {:type :room-store/invalid-attempt-evidence-message
+                             :attempt/id (:attempt/id entity)
+                             :message/ref ref})))))
+      [entity])))
 
 (def ^:private message-pull-pattern
   '[:message/id :message/role :message/content
@@ -179,16 +313,45 @@
     :message/notification-elapsed
     {:message/tool-uses
      [:tool-use/id :tool-use/name
-      {:tool-use/input [*]}]}])
+      {:tool-use/input [*]}]}
+    {:message/activities
+     [:activity/id :activity/run-id :activity/kind :activity/verb
+      :activity/status :activity/tool-name :activity/tool-use-id
+      :activity/outcome :activity/critical? :activity/at]}])
 
 (def ^:private run-pull-pattern
-  '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+  '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent :run/caused-by
     :run/roster :run/agent-version :run/program-kind :run/interpreter-version
     :run/agent-def-hash :run/chat-id
     :run/world :run/isolation :run/settlement-policy
     :run/settlement-status :run/settlement-reason
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error])
+
+(def ^:private attempt-pull-pattern
+  '[:attempt/id :attempt/content-id :attempt/payload-blob
+    :attempt/payload-codec :attempt/environment-id
+    :attempt/environment-version :attempt/environment-content-id
+    :attempt/verifier-id :attempt/verifier-version
+    :attempt/provider :attempt/model :attempt/status
+    :attempt/started-at :attempt/elapsed-ms :attempt/certified-at
+    :attempt/reward :attempt/agent-def-hash :attempt/program-kind
+    :attempt/interpreter-version :attempt/prompt-id
+    :attempt/model-resolution :attempt/model-steps
+    :attempt/evidence-content-id :attempt/settlement-intent
+    {:attempt/run [:run/id]}
+    {:attempt/evidence-runs [:run/id]}
+    {:attempt/evidence-messages [:message/id]}
+    {:attempt/checks [:attempt.check/id :attempt.check/key
+                      :attempt.check/passed?]}])
+
+(def ^:private attention-pull-pattern
+  '[:attention/id :attention/participant :attention/message-id
+    :attention/decision-id :attention/run-id :attention/result-run-id
+    :attention/memory :attention/activation
+    :attention/control :attention/at :attention/priority
+    :attention/status :attention/reason :attention/metadata-edn
+    :attention/created-at])
 
 (defn- run->entity [chat-id run]
   (cond-> {:run/id         (:run/id run)
@@ -202,6 +365,7 @@
            :run/started-at (:run/started-at run)
            :run/updated-at (:run/updated-at run)}
     (:run/parent run)   (assoc :run/parent (:run/parent run))
+    (seq (:run/caused-by run)) (assoc :run/caused-by (:run/caused-by run))
     (:run/roster run) (assoc :run/roster (:run/roster run))
     (:run/agent-version run) (assoc :run/agent-version (:run/agent-version run))
     (:run/program-kind run) (assoc :run/program-kind (:run/program-kind run))
@@ -221,11 +385,147 @@
     (:run/reason run)   (assoc :run/reason (:run/reason run))
     (:run/error run)    (assoc :run/error (str (:run/error run)))))
 
+(defn- entity->run [entity]
+  (cond-> entity
+    (:run/caused-by entity) (update :run/caused-by set)))
+
+(defn- check-id [attempt-id check-key]
+  (hasch/uuid [:dvergr/attempt-check attempt-id check-key]))
+
+(defn- attempt->entity [chat-id value payload-ref]
+  (let [receipt (:attempt/receipt value)
+        definition (:attempt/environment value)
+        verifier (:environment/verifier definition)
+        metrics (:attempt/metrics receipt)]
+    (cond-> {:attempt/id (:attempt/id value)
+             :attempt/chat [:chat/id chat-id]
+             :attempt/run [:run/id (:attempt/run-id value)]
+             :attempt/content-id (:attempt/content-id value)
+             :attempt/payload-blob payload-ref
+             :attempt/payload-codec :edn-v1
+             :attempt/environment-id (:environment/id definition)
+             :attempt/environment-version (:environment/version definition)
+             :attempt/environment-content-id (:environment/content-id definition)
+             :attempt/verifier-id (:verifier/id verifier)
+             :attempt/verifier-version (:verifier/version verifier)
+             :attempt/provider (:attempt/provider receipt)
+             :attempt/model (:attempt/model receipt)
+             :attempt/status (:attempt/status receipt)
+             :attempt/started-at (java.util.Date. ^long (:attempt/started-at receipt))
+             :attempt/elapsed-ms (long (:attempt/elapsed-ms receipt))
+             :attempt/certified-at (java.util.Date. ^long (:attempt/certified-at value))
+             :attempt/reward (double (:attempt/reward receipt))
+             :attempt/agent-def-hash (:attempt/agent-def-hash value)
+             :attempt/program-kind (:program-kind metrics)
+             :attempt/interpreter-version (long (:interpreter-version metrics))
+             :attempt/evidence-content-id (:attempt/evidence-content-id value)
+             :attempt/evidence-runs
+             (mapv (fn [id] [:run/id id]) (:attempt/evidence-run-ids value))
+             :attempt/settlement-intent (:attempt/settlement-intent value)
+             :attempt/checks
+             (mapv (fn [[k passed?]]
+                     {:attempt.check/id (check-id (:attempt/id value) k)
+                      :attempt.check/key k
+                      :attempt.check/passed? passed?})
+                   (:attempt/checks receipt))}
+      (:prompt-id metrics) (assoc :attempt/prompt-id (:prompt-id metrics))
+      (:model-resolution metrics)
+      (assoc :attempt/model-resolution (:model-resolution metrics))
+      (:model-steps metrics) (assoc :attempt/model-steps (long (:model-steps metrics)))
+      (seq (:attempt/evidence-message-ids value))
+      (assoc :attempt/evidence-messages
+             (mapv (fn [id] [:message/id id])
+                   (:attempt/evidence-message-ids value))))))
+
+(defn- entity->attempt [entity artifacts]
+  (when entity
+    (when-not (= :edn-v1 (:attempt/payload-codec entity))
+      (throw (ex-info "Unsupported Attempt payload codec"
+                      {:type :room-store/unsupported-attempt-payload
+                       :codec (:attempt/payload-codec entity)})))
+    (let [value (artifact/get-value artifacts (:attempt/payload-blob entity))]
+      (when-not value
+        (throw (ex-info "Attempt payload artifact is unavailable"
+                        {:type :room-store/missing-attempt-payload
+                         :attempt/id (:attempt/id entity)
+                         :artifact/ref (:attempt/payload-blob entity)})))
+      (attempt/validate-attempt value)
+      (let [receipt (:attempt/receipt value)
+            definition (:attempt/environment value)
+            verifier (:environment/verifier definition)
+            metrics (:attempt/metrics receipt)
+            checks (into {}
+                         (map (juxt :attempt.check/key
+                                    :attempt.check/passed?))
+                         (:attempt/checks entity))
+            projected {:attempt/id (:attempt/id value)
+                       :attempt/content-id (:attempt/content-id value)
+                       :attempt/environment-id (:environment/id definition)
+                       :attempt/environment-version (:environment/version definition)
+                       :attempt/environment-content-id
+                       (:environment/content-id definition)
+                       :attempt/verifier-id (:verifier/id verifier)
+                       :attempt/verifier-version (:verifier/version verifier)
+                       :attempt/provider (:attempt/provider receipt)
+                       :attempt/model (:attempt/model receipt)
+                       :attempt/status (:attempt/status receipt)
+                       :attempt/started-at
+                       (java.util.Date. ^long (:attempt/started-at receipt))
+                       :attempt/elapsed-ms (:attempt/elapsed-ms receipt)
+                       :attempt/certified-at
+                       (java.util.Date. ^long (:attempt/certified-at value))
+                       :attempt/reward (double (:attempt/reward receipt))
+                       :attempt/agent-def-hash (:attempt/agent-def-hash value)
+                       :attempt/program-kind (:program-kind metrics)
+                       :attempt/interpreter-version (:interpreter-version metrics)
+                       :attempt/prompt-id (:prompt-id metrics)
+                       :attempt/model-resolution (:model-resolution metrics)
+                       :attempt/model-steps (:model-steps metrics)
+                       :attempt/evidence-content-id
+                       (:attempt/evidence-content-id value)
+                       :attempt/settlement-intent
+                       (:attempt/settlement-intent value)
+                       :attempt/check-map (:attempt/checks receipt)
+                       :attempt/evidence-run-ids
+                       (:attempt/evidence-run-ids value)
+                       :attempt/evidence-message-ids
+                       (or (:attempt/evidence-message-ids value) #{})}
+            actual (assoc entity
+                          :attempt/check-map checks
+                          :attempt/evidence-run-ids
+                          (into #{} (map :run/id)
+                                (:attempt/evidence-runs entity))
+                          :attempt/evidence-message-ids
+                          (into #{} (map :message/id)
+                                (:attempt/evidence-messages entity)))]
+        (doseq [[k expected] projected]
+          (when-not (= expected (get actual k))
+            (throw (ex-info "Attempt typed projection differs from exact payload"
+                            {:type :room-store/corrupt-attempt-projection
+                             :attempt/id (:attempt/id value)
+                             :key k :expected expected :actual (get actual k)}))))
+        value))))
+
+(defn- attention->entity [chat-id fact]
+  (cond-> (-> fact
+              (dissoc :attention/metadata)
+              (assoc :attention/chat [:chat/id chat-id]))
+    (:attention/metadata fact)
+    (assoc :attention/metadata-edn (pr-str (:attention/metadata fact)))
+
+    (some? (:attention/priority fact))
+    (update :attention/priority double)))
+
+(defn- entity->attention [entity]
+  (cond-> (dissoc entity :attention/metadata-edn)
+    (:attention/metadata-edn entity)
+    (assoc :attention/metadata (edn/read-string (:attention/metadata-edn entity)))))
+
 ;; =============================================================================
 ;; Store impl
 ;; =============================================================================
 
-(defrecord DatahikeStore [conn]
+(defrecord DatahikeStore [conn artifacts]
   store/PRoomStore
 
   (-store-room! [_ room-id metadata]
@@ -263,9 +563,29 @@
                               [?c :chat/id ?cid]
                               [?r :run/chat ?c]
                               [?r :run/id ?rid]]
-                            @conn chat-id)]
-          (dh/transact conn (-> (mapv (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids)
+                            @conn chat-id)
+              attempt-ids (dh/q '[:find [?aid ...]
+                                  :in $ ?cid
+                                  :where
+                                  [?c :chat/id ?cid]
+                                  [?a :attempt/chat ?c]
+                                  [?a :attempt/id ?aid]]
+                                @conn chat-id)
+              attention-ids (dh/q '[:find [?aid ...]
+                                    :in $ ?cid
+                                    :where
+                                    [?c :chat/id ?cid]
+                                    [?a :attention/chat ?c]
+                                    [?a :attention/id ?aid]]
+                                  @conn chat-id)]
+          (dh/transact conn (-> (mapv (fn [aid]
+                                        [:db/retractEntity [:attempt/id aid]])
+                                      attempt-ids)
+                                (into (map (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids))
                                 (into (map (fn [rid] [:db/retractEntity [:run/id rid]]) run-ids))
+                                (into (map (fn [aid]
+                                             [:db/retractEntity [:attention/id aid]])
+                                           attention-ids))
                                 (conj [:db/retractEntity [:chat/id chat-id]])))))))
 
   (-list-rooms [_]
@@ -427,6 +747,8 @@
                                           (:message/notification-elapsed m))
                                    (seq (:message/tool-uses m))
                                    (assoc :tool-uses (:message/tool-uses m))
+                                   (seq (:message/activities m))
+                                   (assoc :activities (:message/activities m))
                                    (seq (:message/reasoning m))
                                    (assoc :reasoning (:message/reasoning m)))]
                     (store/normalize-message-thread
@@ -457,28 +779,36 @@
   (-store-run! [this room-id run]
     (let [slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
-        (let [run (->> run
-                       store/validate-run!
-                       (store/validate-run-update!
-                        (store/-load-run this room-id (:run/id run))))]
-          (when (persist/persist-tx!
-                 conn
-                 [(run->entity (:chat/id ent) run)
-                  {:db/id [:chat/id (:chat/id ent)]
-                   :chat/updated-at (java.util.Date.)}]
-                 {:op :store-run :room-id room-id :run-id (:run/id run)})
-            run)))))
+        ;; Serialize validation and assertion on the connection. Terminal cause
+        ;; Runs cannot be retracted through this store, and append-only checking
+        ;; prevents concurrent/stale writers from losing an accepted edge.
+        (locking conn
+          (let [run (store/validate-run! run)
+                existing (store/-load-run this room-id (:run/id run))
+                run (->> run
+                         (store/validate-run-update! existing)
+                         (store/validate-run-causes!
+                          existing
+                          #(store/-load-run this room-id %)))]
+            (when (persist/persist-tx!
+                   conn
+                   [(run->entity (:chat/id ent) run)
+                    {:db/id [:chat/id (:chat/id ent)]
+                     :chat/updated-at (java.util.Date.)}]
+                   {:op :store-run :room-id room-id :run-id (:run/id run)})
+              run))))))
 
   (-load-run [_ room-id run-id]
     (let [slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
-        (dh/q '[:find (pull ?r pattern) .
-                :in $ ?chat-id ?run-id pattern
-                :where
-                [?c :chat/id ?chat-id]
-                [?r :run/chat ?c]
-                [?r :run/id ?run-id]]
-              @conn (:chat/id ent) run-id run-pull-pattern))))
+        (some-> (dh/q '[:find (pull ?r pattern) .
+                        :in $ ?chat-id ?run-id pattern
+                        :where
+                        [?c :chat/id ?chat-id]
+                        [?r :run/chat ?c]
+                        [?r :run/id ?run-id]]
+                      @conn (:chat/id ent) run-id run-pull-pattern)
+                entity->run))))
 
   (-list-runs [_ room-id {:keys [limit status actor]}]
     (let [slug (store/room-id->slug room-id)]
@@ -489,6 +819,7 @@
                      [?c :chat/id ?chat-id]
                      [?r :run/chat ?c]]
                    @conn (:chat/id ent) run-pull-pattern)
+             (map entity->run)
              (filter #(if status (= status (:run/status %)) true))
              (filter #(if actor (= actor (:run/actor %)) true))
              (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
@@ -496,6 +827,198 @@
                       #(compare %2 %1))
              (take (or limit 100))
              vec)
+        [])))
+
+  store/PAttemptStore
+
+  (-store-attempt! [this room-id value]
+    (let [value (attempt/validate-attempt value)
+          slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        ;; CAS is immutable: a blob written before a failed Datahike commit is a
+        ;; harmless unreferenced object and can be collected independently.
+        (let [payload-ref (artifact/put-value! artifacts value)
+              entity (attempt->entity (:chat/id ent) value payload-ref)]
+          (locking conn
+            (if-let [existing (store/-load-attempt this room-id
+                                                   (:attempt/id value))]
+              (if (= existing value)
+                existing
+                (throw (ex-info "Attempt identity is immutable"
+                                {:type :room-store/attempt-identity-collision
+                                 :existing existing :attempt value})))
+              (let [report
+                    (attempt-governance/with-authorized-write
+                      conn (:attempt/id value)
+                      (fn [tx-meta]
+                        (persist/persist-tx-result!
+                         conn
+                         [[:db.fn/call store-attempt-if-absent entity]]
+                         {:op :store-attempt :room-id room-id
+                          :attempt-id (:attempt/id value)
+                          :tx-meta tx-meta})))]
+                (when report
+                  ;; A concurrent identical writer may have won. Always compare
+                  ;; the exact payload after the serialized first-write decision.
+                  (let [stored (store/-load-attempt this room-id
+                                                    (:attempt/id value))]
+                    (when-not (= stored value)
+                      (throw (ex-info "Concurrent Attempt identity collision"
+                                      {:type :room-store/attempt-identity-collision
+                                       :stored stored :attempt value})))
+                    stored)))))))))
+
+  (-load-attempt [_ room-id attempt-id]
+    (let [slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        (some-> (dh/q '[:find (pull ?a pattern) .
+                        :in $ ?chat-id ?attempt-id pattern
+                        :where
+                        [?c :chat/id ?chat-id]
+                        [?a :attempt/chat ?c]
+                        [?a :attempt/id ?attempt-id]]
+                      @conn (:chat/id ent) attempt-id attempt-pull-pattern)
+                (entity->attempt artifacts)))))
+
+  (-list-attempts [_ room-id {:keys [limit environment-id
+                                     environment-content-id provider model
+                                     status]}]
+    (let [slug (store/room-id->slug room-id)]
+      (if-let [ent (room-by-slug conn slug)]
+        (let [where (cond-> '[[?c :chat/id ?chat-id]
+                              [?a :attempt/chat ?c]]
+                      environment-id
+                      (conj '[?a :attempt/environment-id ?environment-id])
+                      environment-content-id
+                      (conj '[?a :attempt/environment-content-id
+                              ?environment-content-id])
+                      provider (conj '[?a :attempt/provider ?provider])
+                      model (conj '[?a :attempt/model ?model])
+                      status (conj '[?a :attempt/status ?status]))
+              inputs (cond-> '[$ ?chat-id pattern]
+                       environment-id (conj '?environment-id)
+                       environment-content-id (conj '?environment-content-id)
+                       provider (conj '?provider)
+                       model (conj '?model)
+                       status (conj '?status))
+              args (cond-> [@conn (:chat/id ent) attempt-pull-pattern]
+                     environment-id (conj environment-id)
+                     environment-content-id (conj environment-content-id)
+                     provider (conj provider)
+                     model (conj model)
+                     status (conj status))
+              query {:find '[(pull ?a pattern)]
+                     :in inputs
+                     :where where}]
+          (->> (apply dh/q query args)
+               (map first)
+               (sort-by (juxt #(some-> ^java.util.Date
+                                (:attempt/certified-at %) .getTime)
+                              #(str (:attempt/id %)))
+                        #(compare %2 %1))
+               (take (or limit 100))
+               (mapv #(entity->attempt % artifacts))))
+        [])))
+
+  store/PAttentionStore
+
+  (-store-attention! [_ room-id fact]
+    (let [slug (store/room-id->slug room-id)
+          fact (store/validate-attention! fact)]
+      (if-let [ent (room-by-slug conn slug)]
+        (let [_ (when (= :applied (:attention/status fact))
+                  (let [decision
+                        (some-> (dh/q '[:find (pull ?a pattern) .
+                                        :in $ ?id pattern
+                                        :where [?a :attention/id ?id]]
+                                      @conn (:attention/decision-id fact)
+                                      attention-pull-pattern)
+                                entity->attention)
+                        decision-chat-id
+                        (dh/q '[:find ?chat-id .
+                                :in $ ?id
+                                :where
+                                [?a :attention/id ?id]
+                                [?a :attention/chat ?c]
+                                [?c :chat/id ?chat-id]]
+                              @conn (:attention/decision-id fact))
+                        result-run
+                        (when-let [result-run-id (:attention/result-run-id fact)]
+                          (dh/q '[:find (pull ?r pattern) .
+                                  :in $ ?chat-id ?run-id pattern
+                                  :where
+                                  [?c :chat/id ?chat-id]
+                                  [?r :run/chat ?c]
+                                  [?r :run/id ?run-id]]
+                                @conn (:chat/id ent) result-run-id
+                                run-pull-pattern))]
+                    (when (and decision (not= (:chat/id ent) decision-chat-id))
+                      (throw (ex-info "Attention disposition crosses Room stores"
+                                      {:type :room-store/attention-room-mismatch
+                                       :decision decision :fact fact})))
+                    (-> (store/validate-attention-disposition! decision fact)
+                        (store/validate-attention-result-run! result-run))))
+              report (persist/persist-tx-result!
+                      conn
+                      [[:db.fn/call store-attention-if-absent
+                        (attention->entity (:chat/id ent) fact)]]
+                      {:op :store-attention
+                       :room-id room-id
+                       :attention-id (:attention/id fact)})]
+          (when (false? report)
+            (throw (ex-info "Attention persistence failed"
+                            {:type :room-store/attention-persistence-failed
+                             :room-id room-id :fact fact})))
+          (let [stored (some-> (dh/q '[:find (pull ?a pattern) .
+                                       :in $ ?id pattern
+                                       :where [?a :attention/id ?id]]
+                                     @conn (:attention/id fact) attention-pull-pattern)
+                               entity->attention)
+                stored-chat-id
+                (dh/q '[:find ?chat-id .
+                        :in $ ?id
+                        :where
+                        [?a :attention/id ?id]
+                        [?a :attention/chat ?c]
+                        [?c :chat/id ?chat-id]]
+                      @conn (:attention/id fact))]
+            (when-not (and (= (:chat/id ent) stored-chat-id)
+                           (= fact stored))
+              (throw (ex-info "Attention identity is immutable"
+                              {:type :room-store/attention-identity-collision
+                               :existing stored :existing-chat-id stored-chat-id
+                               :room-chat-id (:chat/id ent) :fact fact})))
+            fact))
+        (throw (ex-info "Cannot persist attention for unknown room"
+                        {:type :room-store/missing-room :room-id room-id})))))
+
+  (-list-attention [_ room-id {:keys [id participant limit]}]
+    (let [slug (store/room-id->slug room-id)]
+      (if-let [ent (room-by-slug conn slug)]
+        (if id
+          (some-> (dh/q '[:find (pull ?a pattern) .
+                          :in $ ?chat-id ?id pattern
+                          :where
+                          [?c :chat/id ?chat-id]
+                          [?a :attention/chat ?c]
+                          [?a :attention/id ?id]]
+                        @conn (:chat/id ent) id attention-pull-pattern)
+                  entity->attention
+                  vector)
+          (->> (dh/q '[:find [(pull ?a pattern) ...]
+                       :in $ ?chat-id pattern
+                       :where
+                       [?c :chat/id ?chat-id]
+                       [?a :attention/chat ?c]]
+                     @conn (:chat/id ent) attention-pull-pattern)
+               (map entity->attention)
+               (filter #(if participant
+                          (= participant (:attention/participant %))
+                          true))
+               (sort-by (juxt #(some-> ^java.util.Date (:attention/created-at %) .getTime)
+                              #(str (:attention/id %))))
+               (take-last (or limit 1000))
+               vec))
         [])))
 
   store/PResourceStore
@@ -535,6 +1058,10 @@
 
 (defn make
   "Create a DatahikeStore. `conn` must be an existing Datahike
-   connection whose db includes the dvergr.chat.schema attributes."
-  [conn]
-  (->DatahikeStore conn))
+   connection whose db includes the dvergr.chat.schema attributes. An optional
+   artifact store can be injected for tests; production uses the blob CAS."
+  ([conn]
+   (make conn (artifact/blob-store)))
+  ([conn artifacts]
+   (attempt-governance/govern! conn)
+   (->DatahikeStore conn artifacts)))

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -2,13 +2,15 @@
   "In-memory PRoomStore — atom-backed. For tests and ephemeral rooms
    (e.g. `:isolation :none` forks where the agent's substrate ctx is
    shared with the parent so persistence would be redundant)."
-  (:require [dvergr.room.store :as store]))
+  (:require [dvergr.agent.attempt :as attempt]
+            [dvergr.room.store :as store]))
 
 (defrecord MemoryStore [state]
   ;; state atom shape:
   ;;   {:rooms     {room-id metadata}
   ;;    :messages  {room-id [msg ...] (chronological)}
-  ;;    :runs      {room-id {run-id run}}}
+  ;;    :runs      {room-id {run-id run}}
+  ;;    :attempts  {room-id {attempt-id attempt}}}
   store/PRoomStore
 
   (-store-room! [_ room-id metadata]
@@ -21,11 +23,17 @@
                 rooms))))
 
   (-delete-room! [_ room-id]
-    (swap! state (fn [s]
-                   (-> s
-                       (update :rooms    dissoc room-id)
-                       (update :messages dissoc room-id)
-                       (update :runs     dissoc room-id)))))
+    (swap! state
+           (fn [s]
+             (let [attention-ids (keys (get-in s [:attention room-id] {}))]
+               (-> s
+                   (update :rooms    dissoc room-id)
+                   (update :messages dissoc room-id)
+                   (update :runs     dissoc room-id)
+                   (update :attempts dissoc room-id)
+                   (update :attention dissoc room-id)
+                   (update :attention-index
+                           #(apply dissoc % attention-ids)))))))
 
   (-list-rooms [_]
     (->> (vals (:rooms @state))
@@ -42,13 +50,25 @@
                         (if (some #(= (:id %) msg-id)
                                   (get-in s [:messages room-id] []))
                           s
-                          (-> s
-                              (update-in [:messages room-id] (fnil conj []) msg)
-                              (update-in [:rooms room-id]
-                                         (fn [m]
-                                           (when m
-                                             (assoc m :updated-at
-                                                    (java.util.Date.)))))))))]
+                          (do
+                            (when-let [activity-run-id
+                                       (some :activity/run-id
+                                             (get-in msg [:metadata :activities]))]
+                              (when-not (get-in s [:runs room-id activity-run-id])
+                                (throw
+                                 (ex-info
+                                  "Run-correlated activity references a missing Run in this Room"
+                                  {:type :room-store/orphan-message-activity
+                                   :room-id room-id
+                                   :message-id msg-id
+                                   :run-id activity-run-id}))))
+                            (-> s
+                                (update-in [:messages room-id] (fnil conj []) msg)
+                                (update-in [:rooms room-id]
+                                           (fn [m]
+                                             (when m
+                                               (assoc m :updated-at
+                                                      (java.util.Date.))))))))))]
       (if (some #(= (:id %) msg-id)
                 (get-in before [:messages room-id] []))
         :duplicate
@@ -72,11 +92,16 @@
       (vec (take-last n filtered))))
 
   (-store-run! [_ room-id run]
-    (let [run (->> run
-                   store/validate-run!
-                   (store/validate-run-update!
-                    (get-in @state [:runs room-id (:run/id run)])))]
-      (swap! state assoc-in [:runs room-id (:run/id run)] run)
+    (let [run (store/validate-run! run)]
+      (swap! state
+             (fn [snapshot]
+               (let [existing (get-in snapshot [:runs room-id (:run/id run)])
+                     run (->> run
+                              (store/validate-run-update! existing)
+                              (store/validate-run-causes!
+                               existing
+                               #(get-in snapshot [:runs room-id %])))]
+                 (assoc-in snapshot [:runs room-id (:run/id run)] run))))
       run))
 
   (-load-run [_ room-id run-id]
@@ -90,9 +115,150 @@
                         #(str (:run/id %)))
                   #(compare %2 %1))
          (take (or limit 100))
-         vec)))
+         vec))
+
+  store/PAttemptStore
+
+  (-store-attempt! [_ room-id value]
+    (let [value (attempt/validate-attempt value)
+          attempt-id (:attempt/id value)]
+      (swap! state
+             (fn [snapshot]
+               (let [run (get-in snapshot [:runs room-id
+                                           (:attempt/run-id value)])
+                     existing (get-in snapshot [:attempts room-id attempt-id])]
+                 (when-not (and run
+                                (contains? store/terminal-run-statuses
+                                           (:run/status run)))
+                   (throw (ex-info "Attempt references a missing or non-terminal Run"
+                                   {:type :room-store/invalid-attempt-run
+                                    :room-id room-id
+                                    :attempt/id attempt-id
+                                    :run/id (:attempt/run-id value)})))
+                 (when-not (= (:run/status run)
+                              (get-in value [:attempt/receipt :attempt/status]))
+                   (throw (ex-info "Attempt receipt status differs from its Run"
+                                   {:type :room-store/attempt-run-status-mismatch
+                                    :run/status (:run/status run)
+                                    :attempt/status
+                                    (get-in value [:attempt/receipt
+                                                   :attempt/status])})))
+                 (doseq [[attempt-key run-key]
+                         [[:attempt/agent-def-hash :run/agent-def-hash]
+                          [:program-kind :run/program-kind]
+                          [:interpreter-version :run/interpreter-version]]]
+                   (let [attempt-value
+                         (if (= :attempt/agent-def-hash attempt-key)
+                           (get value attempt-key)
+                           (get-in value [:attempt/receipt :attempt/metrics
+                                          attempt-key]))]
+                     (when-not (= attempt-value (get run run-key))
+                       (throw
+                        (ex-info "Attempt provenance differs from its Run"
+                                 {:type
+                                  :room-store/attempt-run-provenance-mismatch
+                                  :attempt/key attempt-key
+                                  :attempt/value attempt-value
+                                  :run/value (get run run-key)})))))
+                 (doseq [evidence-run-id (:attempt/evidence-run-ids value)]
+                   (when-not (get-in snapshot [:runs room-id evidence-run-id])
+                     (throw
+                      (ex-info "Attempt evidence Run is missing from this Room"
+                               {:type :room-store/invalid-attempt-evidence-run
+                                :room-id room-id
+                                :attempt/id attempt-id
+                                :run/id evidence-run-id}))))
+                 (doseq [evidence-message-id
+                         (:attempt/evidence-message-ids value)]
+                   (when-not (some #(= evidence-message-id (:id %))
+                                   (get-in snapshot [:messages room-id] []))
+                     (throw
+                      (ex-info "Attempt evidence message is missing from this Room"
+                               {:type :room-store/invalid-attempt-evidence-message
+                                :room-id room-id
+                                :attempt/id attempt-id
+                                :message/id evidence-message-id}))))
+                 (when (and existing (not= existing value))
+                   (throw (ex-info "Attempt identity is immutable"
+                                   {:type :room-store/attempt-identity-collision
+                                    :existing existing :attempt value})))
+                 (if existing snapshot
+                     (assoc-in snapshot [:attempts room-id attempt-id] value)))))
+      value))
+
+  (-load-attempt [_ room-id attempt-id]
+    (get-in @state [:attempts room-id attempt-id]))
+
+  (-list-attempts [_ room-id {:keys [limit environment-id
+                                     environment-content-id provider model
+                                     status]}]
+    (->> (vals (get-in @state [:attempts room-id] {}))
+         (filter #(if environment-id
+                    (= environment-id
+                       (get-in % [:attempt/environment :environment/id]))
+                    true))
+         (filter #(if environment-content-id
+                    (= environment-content-id
+                       (get-in % [:attempt/environment
+                                  :environment/content-id]))
+                    true))
+         (filter #(if provider
+                    (= provider (get-in % [:attempt/receipt
+                                           :attempt/provider]))
+                    true))
+         (filter #(if model
+                    (= model (get-in % [:attempt/receipt :attempt/model]))
+                    true))
+         (filter #(if status
+                    (= status (get-in % [:attempt/receipt :attempt/status]))
+                    true))
+         (sort-by (juxt :attempt/certified-at #(str (:attempt/id %)))
+                  #(compare %2 %1))
+         (take (or limit 100))
+         vec))
+
+  store/PAttentionStore
+
+  (-store-attention! [_ room-id fact]
+    (let [fact (store/validate-attention! fact)
+          attention-id (:attention/id fact)
+          path [:attention room-id attention-id]
+          [_ after]
+          (swap-vals!
+           state
+           (fn [s]
+             (if (get-in s [:attention-index attention-id])
+               s
+               (do
+                 (when (= :applied (:attention/status fact))
+                   (-> (store/validate-attention-disposition!
+                        (get-in s [:attention-index (:attention/decision-id fact) :fact])
+                        fact)
+                       (store/validate-attention-result-run!
+                        (get-in s [:runs room-id (:attention/result-run-id fact)]))))
+                 (-> s
+                     (assoc-in path fact)
+                     (assoc-in [:attention-index attention-id]
+                               {:room-id room-id :fact fact}))))))
+          stored (get-in after [:attention-index attention-id])]
+      (when-not (= {:room-id room-id :fact fact} stored)
+        (throw (ex-info "Attention identity is immutable"
+                        {:type :room-store/attention-identity-collision
+                         :existing stored :fact fact})))
+      fact))
+
+  (-list-attention [_ room-id {:keys [id participant limit]}]
+    (if id
+      (some-> (get-in @state [:attention room-id id]) vector)
+      (->> (vals (get-in @state [:attention room-id] {}))
+           (filter #(if participant (= participant (:attention/participant %)) true))
+           (sort-by (juxt #(some-> ^java.util.Date (:attention/created-at %) .getTime)
+                          #(str (:attention/id %))))
+           (take-last (or limit 1000))
+           vec))))
 
 (defn make
   "Create a fresh in-memory store."
   []
-  (->MemoryStore (atom {:rooms {} :messages {} :runs {}})))
+  (->MemoryStore (atom {:rooms {} :messages {} :runs {} :attempts {}
+                        :attention {} :attention-index {}})))

--- a/src/dvergr/rooms.clj
+++ b/src/dvergr/rooms.clj
@@ -134,8 +134,8 @@
     (rstore/slug->room-id slug)))
 
 (defn delete-room!
-  "Delete a room: retract its persisted `:chat/*`/`:message/*` entity from the
-   store, then unregister it from the registry. The CRUD counterpart of
+  "Delete a room: quiesce and unregister its live runtime, then retract its
+   persisted `:chat/*`/`:message/*` entity from the store. The CRUD counterpart of
    `create-room!` — the single op both the TUI (`d`) and web (`/delete`) call.
 
    (Distinct from `dvergr.rooms.forks/discard!`, which tears down a FORK's git +
@@ -144,9 +144,11 @@
   [room]
   (try
     (when room
+      ;; The durable store is the last boundary. Participant Runs and SCI work
+      ;; must acknowledge cancellation before conversation state disappears.
+      (d/close-room! room)
       (when-let [store (:store room)]
-        (rstore/-delete-room! store (:id room)))
-      (rreg/unregister! (:id room)))
+        (rstore/-delete-room! store (:id room))))
     {:ok? true}
     (catch Throwable t {:ok? false :error (.getMessage t)})))
 

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -19,6 +19,107 @@
 
 (declare fork-diff)
 
+(defn deferred?
+  "True when a Run world is retained behind its host-owned settlement gate."
+  [fork]
+  (let [meta (some-> fork :meta deref)]
+    (and (= :deferred (:settlement-policy meta))
+         (not (:settlement-released? meta)))))
+
+(defn release-deferred!
+  "Release an existing deferred Run world for ordinary review/settlement.
+
+   Durable projection is updated before the process-local gate opens, so a
+   reviewer can never merge a world whose certification state is still
+   `:deferred`. This does not merge, copy, or create another fork."
+  ([fork reason]
+   (release-deferred! fork reason (constantly true)))
+  ([fork reason claim!]
+   (locking (:meta fork)
+     (let [parent (rreg/lookup (:parent-id fork))
+           live (rreg/lookup (:id fork))
+           meta @(:meta fork)
+           run-id (:run-id meta)]
+       (when-not (and (= fork live)
+                      (= :deferred (:settlement-policy meta))
+                      (not (:settlement-released? meta))
+                      (nil? (:settlement-claim meta)))
+         (throw (ex-info "Fork is not awaiting deferred settlement"
+                         {:type ::not-deferred :fork/id (:id fork)})))
+       (when-not (and parent run-id)
+         (throw (ex-info "Deferred Run world has no live settlement owner"
+                         {:type ::missing-settlement-owner
+                          :fork/id (:id fork)
+                          :run/id run-id})))
+       (when-not (claim!)
+         (throw (ex-info "Deferred release lost its settlement race"
+                         {:type ::deferred-settlement-aborted
+                          :fork/id (:id fork)})))
+       (agent-run/update-durable-settlement! parent run-id :review reason)
+       (swap! (:meta fork) assoc :settlement-released? true
+              :settlement-claim :release)
+       {:ok? true :status :review :run/id run-id :fork/id (:id fork)}))))
+
+(defn discard-deferred!
+  "Durability-first consumption of a deferred Run world's discard capability.
+
+   The terminal projection is written by the claim callback while the fork's
+   affine settlement lock is held, before substrate destruction. A projection
+   failure therefore leaves the world live. If physical discard fails after
+   preparation, compensate the still-live world back to `:deferred`."
+  ([fork reason]
+   (discard-deferred! fork reason (constantly true)))
+  ([fork reason claim!]
+   (let [parent (rreg/lookup (:parent-id fork))
+         run-id (some-> fork :meta deref :run-id)
+         prepared? (atom false)
+         durable-claim!
+         (fn []
+           (when (claim!)
+             (when (and parent run-id)
+               (agent-run/update-durable-settlement! parent run-id :discarded
+                                                     reason))
+             (reset! prepared? true)
+             true))
+         durable-abort!
+         (fn []
+           (when (and @prepared? parent run-id)
+             (agent-run/update-durable-settlement!
+              parent run-id :deferred :discard-failed)))]
+     (try
+       (d/discard-deferred fork durable-claim! durable-abort!)
+       {:ok? true}
+       (catch Throwable error
+         {:ok? false :error (ex-message error)})))))
+
+(defn retry-deferred-discard-abort!
+  "Restore a live world fenced by a failed durable discard compensation."
+  [fork]
+  (locking (:meta fork)
+    (let [meta @(:meta fork)
+          parent (rreg/lookup (:parent-id fork))
+          live (rreg/lookup (:id fork))
+          run-id (:run-id meta)]
+      (when-not (and (= fork live)
+                     (= :deferred (:settlement-policy meta))
+                     (= :discard-recovery (:settlement-claim meta))
+                     parent run-id)
+        (throw (ex-info "Fork has no current deferred discard recovery"
+                        {:type ::no-discard-recovery
+                         :fork/id (:id fork)})))
+      (agent-run/update-durable-settlement! parent run-id :deferred
+                                            :discard-failed)
+      (swap! (:meta fork) dissoc :settlement-claim)
+      {:ok? true :status :deferred :run/id run-id :fork/id (:id fork)})))
+
+(defn- require-settleable! [fork operation]
+  (when (deferred? fork)
+    (throw (ex-info "Deferred Run world must be released before settlement"
+                    {:type ::settlement-deferred
+                     :operation operation
+                     :fork/id (:id fork)
+                     :run/id (some-> fork :meta deref :run-id)}))))
+
 (defn fork?
   "Is this Room a fork? The canonical marker is `:forked-from` in the room's
    meta — set by `fork-room` — the SAME thing `dvergr.rooms.tree` keys its
@@ -82,7 +183,8 @@
        :files       (vec (:files gdiff))
        :db-changes  db-changes
        :msgs-since  (max 0 (- total flen))
-       :mergeable?  (boolean parent)})))
+       :mergeable?  (boolean (and parent (not (deferred? fork))))
+       :settlement-deferred? (deferred? fork)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Unified diff + tier classification — the substrate the agent merge-reviewer
@@ -151,6 +253,7 @@
    {:ok? true :parent-slug ...} or {:ok? false :error ...}."
   [fork]
   (try
+    (require-settleable! fork :merge)
     (if-let [parent (rreg/lookup (:parent-id fork))]
       (let [run-id (some-> fork :meta deref :run-id)]
         (d/merge-room parent fork)
@@ -326,17 +429,20 @@
 
 (defn discard!
   "Discard a fork (`discourse/discard`) — deletes its branches. Returns
-   {:ok? true} or {:ok? false :error ...}."
-  [fork]
-  (try
-    (let [parent (rreg/lookup (:parent-id fork))
-          run-id (some-> fork :meta deref :run-id)]
-      (d/discard fork)
-      (when (and parent run-id)
-        (agent-run/update-durable-settlement! parent run-id :discarded
-                                              :review-rejected))
-      {:ok? true})
-    (catch Throwable t {:ok? false :error (.getMessage t)})))
+   {:ok? true} or {:ok? false :error ...}. An explicit reason lets trusted
+   policies distinguish rejection, evaluation policy, and failed certification."
+  ([fork]
+   (discard! fork :review-rejected))
+  ([fork reason]
+   (try
+     (require-settleable! fork :discard)
+     (let [parent (rreg/lookup (:parent-id fork))
+           run-id (some-> fork :meta deref :run-id)]
+       (d/discard fork)
+       (when (and parent run-id)
+         (agent-run/update-durable-settlement! parent run-id :discarded reason))
+       {:ok? true})
+     (catch Throwable t {:ok? false :error (.getMessage t)}))))
 
 (defn adopt!
   "Promote a retained isolated fork into an external durable owner.
@@ -352,6 +458,7 @@
    must never settle descriptor systems by bypassing those handles."
   [fork new-owner opts]
   (try
+    (require-settleable! fork :adopt)
     (let [parent (rreg/lookup (:parent-id fork))
           run-id (some-> fork :meta deref :run-id)
           transfer (d/transfer-fork! fork new-owner opts)

--- a/src/dvergr/rooms/messages.clj
+++ b/src/dvergr/rooms/messages.clj
@@ -12,7 +12,8 @@
    Same consistency story as everything else here: the bus is the per-room
    totally-ordered log; the store (disk) and this signal (memory) are two folds
    of it, consistent by construction, deduped by message id."
-  (:require [dvergr.discourse :as d]
+  (:require [dvergr.activity :as activity]
+            [dvergr.discourse :as d]
             [dvergr.runtime.bus :as bus]
             [dvergr.runtime.ctx :as rctx]
             [dvergr.room.registry :as rreg]
@@ -64,6 +65,8 @@
    :in-reply-to (:in-reply-to m)
    :thread-root-id (d/thread-root-id m)
    :role      (store/infer-role m)
+   :run-id    (activity/message-run-id m)
+   :activities (activity/message-activities m)
    :tool-uses (or (:tool-uses m) (:tool-uses (:metadata m)))
    :reasoning (or (:reasoning m) (:reasoning (:metadata m)) (:message/reasoning m))})
 

--- a/src/dvergr/rooms/scheduler.clj
+++ b/src/dvergr/rooms/scheduler.clj
@@ -21,6 +21,7 @@
    A negligible lingering no-op per deleted/discarded room until restart."
   (:require [datahike.api :as dh]
             [dvergr.agent.room-context :as room-context]
+            [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as disc]
             [dvergr.runtime.clock :as clock]
             [dvergr.runtime.ctx :as rctx]
@@ -73,8 +74,9 @@
             (let [cctx (room-context/ensure-ctx! room aid {})
                   {:keys [success value error]}
                   (sandbox/eval-code
-                   (:sci-ctx cctx) (:schedule/code s)
-                   :timeout-ms (* 5 60 1000) :realize? true)]
+                   (chat-context/sci-context-in cctx (:ctx room)) (:schedule/code s)
+                   :timeout-ms (* 5 60 1000) :realize? true
+                   :execution-context (:ctx room))]
               (if success
                 (str "⏱ " (or (:schedule/description s) "code task") " → "
                      (subs value 0 (min 500 (count value))))

--- a/src/dvergr/runtime/ctx.clj
+++ b/src/dvergr/runtime/ctx.clj
@@ -32,6 +32,74 @@
   [ctx]
   (if-let [p (:parent-ctx ctx)] (recur p) ctx))
 
+(defn descendant-context?
+  "True when `candidate` is `ancestor` or belongs to its fork lineage.
+
+   A dynamically bound context must not override an object's owning world when
+   it is the owner's parent or an unrelated sibling. That would make an async
+   coordinator accidentally read the parent projection of child-owned state."
+  [candidate ancestor]
+  (boolean
+   (when (and candidate ancestor)
+     (loop [ctx candidate]
+       (cond
+         (or (identical? ctx ancestor)
+             (= (:fork-id ctx) (:fork-id ancestor))) true
+         (:parent-ctx ctx) (recur (:parent-ctx ctx))
+         :else false)))))
+
+(defn selected-context
+  "Select a bound descendant of `owner`, otherwise retain `owner`.
+
+   This is the ambient-world rule for stable handles: child execution may
+   refine an owner into its fork, while parent/sibling execution cannot pull a
+   child-owned value out of its world."
+  [owner]
+  (let [bound (when (ec/execution-context-bound?)
+                (ec/current-execution-context))]
+    (if (descendant-context? bound owner) bound owner)))
+
+(def ^:private sandbox-bindings-path
+  "Fork-local bindings used by stable SCI host capabilities.  The binding key
+   is stable for the lifetime of one interpreter component; Yggdrasil copies
+   the map into a child and the child projection replaces only its data."
+  [:dvergr/sandbox-bindings])
+
+(defn install-sandbox-binding!
+  "Install serializable world data for `binding-id` in `ctx`.
+
+   Host functions injected into SCI must capture only `owner` + `binding-id`,
+   never a Room, connection, filesystem or workspace.  That makes functions
+   defined before a SCI fork select the child binding when invoked there."
+  [ctx binding-id data]
+  (binding [ec/*execution-context* ctx]
+    (ec/swap-state! (conj sandbox-bindings-path binding-id)
+                    #(merge (or % {}) data)))
+  data)
+
+(defn update-sandbox-binding!
+  "Update a capability binding in the ambient descendant world of `owner`."
+  [owner binding-id f & args]
+  (let [ctx (selected-context owner)]
+    (binding [ec/*execution-context* ctx]
+      (ec/swap-state! (conj sandbox-bindings-path binding-id)
+                      #(apply f (or % {}) args)))))
+
+(defn sandbox-binding
+  "Read `binding-id` in the ambient descendant world of `owner`."
+  [owner binding-id]
+  (let [ctx (selected-context owner)]
+    (binding [ec/*execution-context* ctx]
+      (ec/get-state (conj sandbox-bindings-path binding-id)))))
+
+(defn sandbox-binding-resolver
+  "Return a stable zero-argument resolver suitable for an SCI host closure."
+  [owner binding-id]
+  #(or (sandbox-binding owner binding-id)
+       (throw (ex-info "SCI capability has no world binding"
+                       {:binding-id binding-id
+                        :owner-fork-id (:fork-id owner)}))))
+
 (defn current-root
   "The root of the currently-bound execution context."
   []
@@ -43,6 +111,14 @@
    registry, tree/message signals, peer-bus — anything the UI reactively reads."
   [path f]
   (rtp/swap-state! (current-root) path f))
+
+(defn shared-swap-root!
+  "Atomically update the complete Tier-1 root state.
+
+   Use this sparingly for invariants spanning multiple Tier-1 paths, such as
+   publishing a Room together with its structural fork edge."
+  [f]
+  (rtp/swap-state! (current-root) [] f))
 
 (defn shared-get-state
   "Tier-1 read from the ROOT ctx (the authoritative copy)."

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -667,6 +667,8 @@
                       "(dvergr.tasks/list)   (dvergr.tasks/complete! id)"]
    "dvergr.agent"    ["program specialized agents as immutable rosters; exact programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm ...}; hire! starts a durable Run with an explicit result Spin"
                       "join with result-spin; for a first-result race that really cancels losing Runs: (let [team (-> (dvergr.agent/roster) (dvergr.agent/make-agent {:id :fast :program {:kind :scripted :delay-ms 10 :reply :fast}}) (dvergr.agent/make-agent {:id :slow :program {:kind :scripted :delay-ms 5000 :reply :slow}})) a (dvergr.agent/hire! team :fast {:task :solve}) b (dvergr.agent/hire! team :slow {:task :solve})] @(spin (-> (await (spindel.comb/race (dvergr.agent/owned-result-spin a) (dvergr.agent/owned-result-spin b))) :run/value)))"]
+   "spindel.work"    ["structured higher-order FRP admission: latest, serial, busy, and bounded parallel; each accepted value becomes owned work"
+                      "(let [c (spindel.work/latest (fn [x] (spindel.work/task x)))] (spindel.work/submit! c :first) (spindel.work/submit! c :newest) (spindel.work/close! c) @(spin (await (spindel.work/completion c))))"]
    "dvergr.agents"   ["directory of agents (read-only): who exists / is online"
                       "(dvergr.agents/list)   (dvergr.agents/online? :var)"]
    "dvergr.actors"   ["durable participant identities — register/retire agents or humans and assign skills"
@@ -679,7 +681,7 @@
 (def ^:private guide-order
   ["babashka.fs" "babashka.http-client" "babashka.process" "cheshire.core" "clojure.data.xml"
    "datahike.api" "dvergr.room" "dvergr.mail" "dvergr.intake" "dvergr.codec" "git" "env" "llm"
-   "dvergr.scheduler" "dvergr.tasks" "dvergr.agent" "dvergr.agents" "dvergr.actors" "dvergr.skills"
+   "dvergr.scheduler" "dvergr.tasks" "dvergr.agent" "spindel.work" "dvergr.agents" "dvergr.actors" "dvergr.skills"
    "clojure.test"])
 
 (defn ns-overview-data
@@ -810,7 +812,10 @@
        "`agent/roster`, `agent/make-agent`, and `agent/revise-agent` return new "
        "values; only `agent/hire!` starts an effect. Compose `(agent/result-spin "
        "handle)` with `await`, parallel Spins, or `race`; inspect exact signatures "
-       "with `(sandbox/doc 'dvergr.agent)`.\n\n"
+       "with `(sandbox/doc 'dvergr.agent)`. For ongoing event sources, use "
+       "`spindel.work/latest`, `serial`, `busy`, or bounded `parallel`; their "
+       "`task` bodies use the same `await` algebra. Inspect `(sandbox/doc "
+       "'spindel.work)`.\n\n"
        "**Your databases.** Your room owns its data — NOT a shared global DB. "
        "`dvergr.room/*kb*` is your knowledge base, `dvergr.room/*room*` your room's "
        "own datahike (messages/state); query them with ordinary datahike, e.g. "
@@ -978,7 +983,10 @@
     ;; value, and live execution state belongs to the Room's Spindel context.
     (ns-agent/add-programming-ns! sci-ctx (or room-runtime-id room-id) spindel-ctx
                                   agent-program-ceiling)
-    (ns-data/add-spindel-extras-ns! sci-ctx spindel-ctx)
+    (ns-data/add-spindel-extras-ns!
+     sci-ctx spindel-ctx
+     {:room-id (or room-runtime-id room-id)
+      :ceiling (:work-admission agent-program-ceiling)})
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)
     (ns-io/add-fs-ns!   sci-ctx :base-path cwd :filesystem filesystem

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -970,7 +970,9 @@
         ;; via `dvergr.room/*kb*` + `kb-find`/`kb-search` + `d` — no separate `entity`
         ;; namespace (dropped as redundant; a global entity CRM can return later).
         (ns-room/add-room-ns! sci-ctx room-conn kb-conn room-id spindel-ctx
-                              agent-program-ceiling)
+                              agent-program-ceiling
+                              {:id (or room-runtime-id room-id)
+                               :incarnation room-incarnation})
         ;; dvergr.mail/*inbox* — the room's attached mailbox conn (fork-aware),
         ;; nil when no mailbox attached. Read helpers are seed source (dvergr/mail/).
         (ns-mail/add-mail-ns! sci-ctx)

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -936,7 +936,7 @@
    Returns the audit-log atom — a vector of IO events ({:op :t :data}) accumulated
    during the agent's execution.  Attach to the agent result for post-hoc analysis."
   [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id
-                                 room-runtime-id agent-program-ceiling]
+                                 room-runtime-id room-incarnation agent-program-ceiling]
                           :or   {proc-allow #{}}}]
   (let [audit-log  (make-audit-log)
         workspace  (binding [rtc/*execution-context* spindel-ctx]
@@ -986,6 +986,7 @@
     (ns-data/add-spindel-extras-ns!
      sci-ctx spindel-ctx
      {:room-id (or room-runtime-id room-id)
+      :room-incarnation room-incarnation
       :ceiling (:work-admission agent-program-ceiling)})
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -12,6 +12,8 @@
             [clojure.string :as str]
             [datahike.api :as dh]
             [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.sci.world :as sci-world]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [org.replikativ.spindel.core :as sync]
             [dvergr.sci.clojure-test :as sci-test]
@@ -27,6 +29,7 @@
             [dvergr.sandbox.workspace :as workspace]
             [dvergr.sandbox.ns.agent :as ns-agent]
             [dvergr.sandbox.ns.io :as ns-io]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.system.db :as sdb])
   (:import [java.io StringWriter]
            [java.lang.management ManagementFactory]))
@@ -38,16 +41,19 @@
 ;; A consumer (e.g. an accounting kernel) registers an injector fn here at
 ;; startup; the sandbox setup runs every registered injector so its surface is
 ;; available in `clojure_eval`, WITHOUT dvergr knowing what it is. Each injector
-;; is `(fn [sci-ctx opts])`, opts = {:room-id :room-conn :kb-conn}.
+;; is `(fn [sci-ctx opts])`; opts also carries a fork-safe `:world-binding`
+;; resolver for host closures that can survive an interpreter fork.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private ns-injectors* (atom []))
 
 (defn register-ns-injector!
   "Register an SCI namespace-injector `f` — `(fn [sci-ctx opts])`, opts =
-   {:room-id :room-conn :kb-conn} — run for every agent sandbox after the
+   {:room-id :room-conn :kb-conn :world-binding} — run for every agent sandbox after the
    built-in surface. Lets a consumer expose extra namespaces (a domain kernel)
-   in `clojure_eval` without dvergr depending on it. Idempotent per identical fn.
+   in `clojure_eval` without dvergr depending on it. A host closure which may
+   survive a fork MUST call the zero-argument `:world-binding` resolver rather
+   than capture a room id or raw resource. Idempotent per identical fn.
    Returns `f`."
   [f]
   (swap! ns-injectors* (fn [v] (if (some #{f} v) v (conj v f))))
@@ -337,6 +343,48 @@
                 ;; :sci-opts and merges it into sci/init.)
                 :sci-opts     {:load-fn workspace/load-fn}})))
 
+(defn create-spindel-sci-world!
+  "Create a fork-selected SCI interpreter component in `spindel-ctx`.
+
+   Returns a stable Spindel ComponentRef rather than the interpreter itself.
+   Resolve it with `sci-context-in`; a descendant execution context selects its
+   own SCI fork while the reference remains unchanged."
+  [spindel-ctx]
+  (let [ref (sci-world/create!
+             spindel-ctx
+             {:interrupt-fn (make-resource-limits)
+              :sci-opts {:load-fn workspace/load-fn}})
+        interpreter (sci-world/context-in spindel-ctx ref)]
+    ;; The world constructor starts from Spindel's SCI environment, not
+    ;; dvergr's plain base context. Restore the same safe classes/core shims and
+    ;; bind clojure.test to this interpreter before any descendant forks it.
+    (sci/merge-opts interpreter
+                    {:classes base-classes
+                     :namespaces {'clojure.core core-extras}})
+    (sci/merge-opts interpreter
+                    {:namespaces
+                     {'clojure.test
+                      (sci-test/ctx-aware-test-namespace interpreter)}})
+    ref))
+
+(defn sci-context-in
+  "Resolve stable SCI world `ref` in `spindel-ctx`."
+  [spindel-ctx ref]
+  (when ref
+    (sci-world/context-in spindel-ctx ref)))
+
+(defn release-spindel-sci-world!
+  "Remove stable SCI world `ref` from `spindel-ctx`.
+
+   This releases only the selected process-local interpreter realization. It is
+   deliberately separate from closing durable room resources: a forked room
+   may share a ChatContext identity while selecting an independent SCI heap."
+  [spindel-ctx ref]
+  (when ref
+    (binding [rtc/*execution-context* spindel-ctx]
+      (component/unregister! ref)))
+  nil)
+
 ;; ---------------------------------------------------------------------------
 ;; Session Context Management
 ;; ---------------------------------------------------------------------------
@@ -371,7 +419,7 @@
 ;; Evaluation
 ;; ---------------------------------------------------------------------------
 
-(defn eval-code
+(defn- eval-code*
   "Evaluate Clojure code in the session's SCI context.
 
    Returns map with:
@@ -567,6 +615,20 @@
            :stderr (str stderr)
            :success false})))))
 
+(defn eval-code
+  "Evaluate code in an SCI interpreter, selecting `:execution-context` for
+   ambient Spindel/Yggdrasil capabilities when supplied.
+
+   The interpreter selects the SCI world; the Spindel context selects the
+   matching substrate world. Other options are `:timeout-ms`, `:cancel?`, and
+   `:realize?`, as documented by the evaluator above."
+  [sci-ctx code & {:keys [execution-context] :as opts}]
+  (let [args (mapcat identity (dissoc opts :execution-context))]
+    (if execution-context
+      (binding [rtc/*execution-context* execution-context]
+        (apply eval-code* sci-ctx code args))
+      (apply eval-code* sci-ctx code args))))
+
 (defn eval-forms
   "Evaluate multiple forms sequentially in the same context.
    Returns vector of results (one per form)."
@@ -665,7 +727,7 @@
                        "(dvergr.scheduler/create {:agent-id :var :schedule {:every :hour :n 4} :code \"(require 'my.ns)(my.ns/run!)\" :description \"…\"})  (dvergr.scheduler/list)  (dvergr.scheduler/cancel id)"]
    "dvergr.tasks"    ["the shared task ledger — list/accept/complete work items"
                       "(dvergr.tasks/list)   (dvergr.tasks/complete! id)"]
-   "dvergr.agent"    ["program specialized agents as immutable rosters; exact programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm ...}; hire! starts a durable Run with an explicit result Spin"
+   "dvergr.agent"    ["program specialized agents as immutable rosters; define content-addressed verified environments as portable data; exact programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm ...}; hire! starts a durable Run with an explicit result Spin"
                       "join with result-spin; for a first-result race that really cancels losing Runs: (let [team (-> (dvergr.agent/roster) (dvergr.agent/make-agent {:id :fast :program {:kind :scripted :delay-ms 10 :reply :fast}}) (dvergr.agent/make-agent {:id :slow :program {:kind :scripted :delay-ms 5000 :reply :slow}})) a (dvergr.agent/hire! team :fast {:task :solve}) b (dvergr.agent/hire! team :slow {:task :solve})] @(spin (-> (await (spindel.comb/race (dvergr.agent/owned-result-spin a) (dvergr.agent/owned-result-spin b))) :run/value)))"]
    "spindel.work"    ["structured higher-order FRP admission: latest, serial, busy, and bounded parallel; each accepted value becomes owned work"
                       "(let [c (spindel.work/latest (fn [x] (spindel.work/task x)))] (spindel.work/submit! c :first) (spindel.work/submit! c :newest) (spindel.work/close! c) @(spin (await (spindel.work/completion c))))"]
@@ -805,7 +867,8 @@
        "this room, write `app/index.html` (+ assets under `app/`) in your "
        "workspace — served at `/apps/<room-slug>/`.\n\n"
        "**Reactive agent programs.** `dvergr.agent` provides immutable rosters "
-       "and Run-backed execution. Use the exact Spindel namespaces: "
+       "and Run-backed execution; `agent/environment` creates a content-addressed "
+       "task/verifier/policy definition without starting an attempt. Use the exact Spindel namespaces: "
        "`(require '[dvergr.agent :as agent] "
        "'[org.replikativ.spindel.spin.cps :refer [spin]] "
        "'[org.replikativ.spindel.effects.await :refer [await]])`. "
@@ -936,9 +999,21 @@
    Returns the audit-log atom — a vector of IO events ({:op :t :data}) accumulated
    during the agent's execution.  Attach to the agent result for post-hoc analysis."
   [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id
-                                 room-runtime-id room-incarnation agent-program-ceiling]
+                                 room-runtime-id room-incarnation capability-id
+                                 agent-program-ceiling]
                           :or   {proc-allow #{}}}]
   (let [audit-log  (make-audit-log)
+        binding-resolver (when capability-id
+                           (runtime-ctx/sandbox-binding-resolver spindel-ctx capability-id))
+        binding-swap! (when capability-id
+                        (fn [f & args]
+                          (apply runtime-ctx/update-sandbox-binding!
+                                 spindel-ctx capability-id f args)))
+        workspace-resolver
+        (fn []
+          (binding [rtc/*execution-context* (runtime-ctx/selected-context spindel-ctx)]
+            (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
+                 (catch Throwable _ nil))))
         workspace  (binding [rtc/*execution-context* spindel-ctx]
                      (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
                           (catch Throwable _ nil)))
@@ -964,15 +1039,21 @@
       ;; falls back to sys-conn so it still has a queryable db (flagged: give them a
       ;; scratch db so even room-less never writes the registry).
       (let [sys-conn (sdb/get-conn)]
-        (ns-datahike/add-datahike-ns! sci-ctx room-id spindel-ctx) ; the ONE datahike surface: faithful `d`/`datahike.api`
+        (when binding-swap!
+          (binding-swap! #(if (contains? % :ephemeral-databases)
+                            %
+                            (assoc % :ephemeral-databases {}))))
+        (ns-datahike/add-datahike-ns! sci-ctx room-id spindel-ctx
+                                      binding-resolver binding-swap!) ; the ONE datahike surface: faithful `d`/`datahike.api`
         ;; ONE `dvergr.room` (+ legacy `room` alias): the Room ops MERGED with the
         ;; room's DB surface (*room*/*kb*/databases/db + queries). The KB is reached
         ;; via `dvergr.room/*kb*` + `kb-find`/`kb-search` + `d` — no separate `entity`
         ;; namespace (dropped as redundant; a global entity CRM can return later).
         (ns-room/add-room-ns! sci-ctx room-conn kb-conn room-id spindel-ctx
                               agent-program-ceiling
-                              {:id (or room-runtime-id room-id)
-                               :incarnation room-incarnation})
+                              {:binding-resolver binding-resolver
+                               :source-room {:id (or room-runtime-id room-id)
+                                             :incarnation room-incarnation}})
         ;; dvergr.mail/*inbox* — the room's attached mailbox conn (fork-aware),
         ;; nil when no mailbox attached. Read helpers are seed source (dvergr/mail/).
         (ns-mail/add-mail-ns! sci-ctx)
@@ -984,18 +1065,26 @@
     ;; effect. No roster is kept in a host atom: callers thread the immutable
     ;; value, and live execution state belongs to the Room's Spindel context.
     (ns-agent/add-programming-ns! sci-ctx (or room-runtime-id room-id) spindel-ctx
-                                  agent-program-ceiling)
+                                  agent-program-ceiling binding-resolver)
     (ns-data/add-spindel-extras-ns!
      sci-ctx spindel-ctx
      {:room-id (or room-runtime-id room-id)
       :room-incarnation room-incarnation
-      :ceiling (:work-admission agent-program-ceiling)})
+      :ceiling (:work-admission agent-program-ceiling)
+      :world-binding binding-resolver})
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)
     (ns-io/add-fs-ns!   sci-ctx :base-path cwd :filesystem filesystem
+                        :filesystem-resolver
+                        (when workspace
+                          #(when-let [workspace (workspace-resolver)]
+                             ((requiring-resolve
+                               'dvergr.substrate.geschichte/filesystem)
+                              workspace)))
                         :audit-log audit-log)
     ;; (proc folded into the muschel-backed babashka.process — add-bash-ns! in turn.clj)
     (ns-io/add-git-ns!  sci-ctx :base-path cwd :workspace workspace
+                        :workspace-resolver (when workspace workspace-resolver)
                         :audit-log audit-log)
     (ns-kb/add-llm-ns!  sci-ctx agent-program-ceiling)
     ;; Boundary secret injection (doc/boundary-secret-injection.md): build the
@@ -1008,9 +1097,23 @@
           sandbox-env  (try ((requiring-resolve 'dvergr.substrate.config/sandbox-env))
                             (catch Throwable _ nil))
           secrets      (ns-io/build-secret-registry secret-specs)]
+      (when binding-swap!
+        (binding-swap! #(if (contains? % :sandbox-env)
+                          %
+                          (assoc % :sandbox-env (or sandbox-env {})))))
       ;; :user-config = non-secret config values returned verbatim (identifiers,
       ;; site URLs); :secrets = sensitive values returned as placeholders.
-      (ns-io/add-env-ns!  sci-ctx :user-config (atom (or sandbox-env {})) :secrets secrets)
+      (ns-io/add-env-ns! sci-ctx
+                         :user-config (atom (or sandbox-env {}))
+                         :config-resolver (when binding-resolver
+                                            #(or (:sandbox-env (binding-resolver)) {}))
+                         :config-swap! (when binding-swap!
+                                         (fn [f & args]
+                                           (binding-swap!
+                                            #(update % :sandbox-env
+                                                     (fn [m]
+                                                       (apply f (or m {}) args))))))
+                         :secrets secrets)
       (ns-io/add-http-ns! sci-ctx :audit-log audit-log :allowed-domains allowed-http-domains
                           :secrets secrets))
     (ns-agent/add-scheduler-ns! sci-ctx)
@@ -1024,7 +1127,8 @@
     ;; expose their surface here without dvergr depending on them. Run before
     ;; reflection so overview sees them; a failing injector never breaks setup.
     (doseq [f (registered-ns-injectors)]
-      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn})
+      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn
+                       :world-binding binding-resolver})
            (catch Throwable e
              (binding [*out* *err*] (println "ns-injector failed:" (.getMessage e))))))
     ;; Self-reflection LAST, so (sandbox/overview) sees every ns injected above.
@@ -1032,6 +1136,19 @@
     ;; SECURITY, last of all: lock JVM interop to the class allowlist.
     (lock-interop! sci-ctx)
     audit-log))
+
+(defn release-agent-resources!
+  "Release disposable host resources owned by one SCI capability in `ctx`.
+   Durable/mergeable world state is deliberately untouched."
+  [ctx capability-id]
+  (when capability-id
+    (try
+      (let [resolver (runtime-ctx/sandbox-binding-resolver ctx capability-id)
+            swap! (fn [f & args]
+                    (apply runtime-ctx/update-sandbox-binding!
+                           ctx capability-id f args))]
+        (ns-datahike/dispose-ephemeral-databases! resolver swap!))
+      (catch clojure.lang.ExceptionInfo _ nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; clojure.test Integration (from Babashka)

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -8,6 +8,7 @@
    `(find-doc …)` answer nothing for them inside the sandbox. See
    `dvergr.sandbox.ns.doc`."
   (:require [sci.core :as sci]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox.ns.doc :as doc]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -49,7 +50,7 @@
           (-> (await (comb/race (agent/owned-result-spin a)
                                 (agent/owned-result-spin b)))
               :run/value)))"
-  [sci-ctx room-id spindel-ctx agent-program-ceiling]
+  [sci-ctx room-id spindel-ctx agent-program-ceiling & [binding-resolver]]
   (let [make-roster*   (requiring-resolve 'dvergr.agent.roster/make-roster)
         make-agent*    (requiring-resolve 'dvergr.agent.roster/make-agent)
         revise-agent*  (requiring-resolve 'dvergr.agent.roster/revise-agent)
@@ -57,6 +58,8 @@
         agent-ref*     (requiring-resolve 'dvergr.agent.roster/agent-ref)
         agents*        (requiring-resolve 'dvergr.agent.roster/agents)
         select-agents* (requiring-resolve 'dvergr.agent.roster/select-agents)
+        make-environment* (requiring-resolve 'dvergr.agent.environment/make-environment)
+        environment-ref* (requiring-resolve 'dvergr.agent.environment/environment-ref)
         hire-in*       (requiring-resolve 'dvergr.agent.program/hire-in!)
         observe*       (requiring-resolve 'dvergr.agent.program/observe)
         cancel*        (requiring-resolve 'dvergr.agent.program/cancel!)
@@ -66,9 +69,13 @@
         room-balance*  (requiring-resolve 'dvergr.resource/balance)
         run-balance*   (requiring-resolve 'dvergr.resource/run-balance)
         room-lookup*   (requiring-resolve 'dvergr.room.registry/lookup)
+        selected-ctx   #(runtime-ctx/selected-context spindel-ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-runtime-id (binding-resolver)))
+                             room-id)
         current-room   (fn []
-                         (when room-id
-                           (binding [ec/*execution-context* spindel-ctx]
+                         (when-let [room-id (current-room-id)]
+                           (binding [ec/*execution-context* (selected-ctx)]
                              (room-lookup* room-id))))
         room!          (fn []
                          (or (current-room)
@@ -94,6 +101,10 @@
                                kind (get-in definition [:agent/program :kind])
                                allowed-kinds (:program-kinds agent-program-ceiling)
                                ambient-parent (:parent-run agent-program-ceiling)]
+                           (when (= :deferred (:settlement opts))
+                             (throw (ex-info
+                                     "Deferred settlement is reserved for trusted host policies"
+                                     {:type ::deferred-settlement-forbidden})))
                            (when (and allowed-kinds
                                       (not (contains? allowed-kinds kind)))
                              (throw (ex-info
@@ -133,6 +144,15 @@
                                control-room (control-room! work-room)]
                            (binding [ec/*execution-context* (:ctx work-room)]
                              (cancel* control-room handle-or-id))))
+        result-spin-fn (fn [handle]
+                         (if-let [run-id (:parent-run agent-program-ceiling)]
+                           (result-spin* run-id handle)
+                           (result-spin* handle)))
+        owned-result-spin-fn
+        (fn [handle]
+          (if-let [run-id (:parent-run agent-program-ceiling)]
+            (owned-result-spin* run-id handle)
+            (owned-result-spin* handle)))
         balance-fn     (fn []
                          (let [work-room (room!)
                                control-room (control-room! work-room)]
@@ -149,13 +169,16 @@
         'ref          agent-ref*
         'list         agents*
         'select       select-agents*
+        'environment  make-environment*
+        'environment-ref environment-ref*
+        'room-id      (fn [] (:id (room!)))
         'hire!        hire-fn
         'observe      observe-fn
         'cancel!      cancel-fn
         'balance      balance-fn
         'run-id       run-id*
-        'result-spin  result-spin*
-        'owned-result-spin owned-result-spin*}
+        'result-spin  result-spin-fn
+        'owned-result-spin owned-result-spin-fn}
        '{roster       [([] [opts]) "Create an immutable Roster value. Options may include portable :id, :defaults, :scope, and :metadata data."]
          make-agent   [([roster spec]) "Return a NEW Roster containing `spec`. Programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm :max-model-steps n :budget-dollars n} plus :model-policy and :tools. Pure: input unchanged."]
          revise-agent [([roster id patch]) "Return a NEW Roster with AgentDef `id` revised and its version incremented."]
@@ -163,13 +186,16 @@
          ref          [([agent-def]) "Return the stable {:agent/id :agent/version} reference for an AgentDef."]
          list         [([roster]) "All AgentDefs in a Roster, deterministically ordered by id."]
          select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
+         environment  [([spec]) "Create a portable, content-addressed EnvironmentDef. Requires :id, :task, and trusted verifier ref {:id keyword :version n}; optional :limits/:world/:metadata stay data, never live functions or handles."]
+         environment-ref [([environment]) "Return the stable logical/version/content reference for one exact EnvironmentDef. Individual execution Run IDs remain unique."]
+         room-id      [([]) "Return the live identity of the current Room/world. In an isolated fork this is the child Room, not its parent."]
          hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
          cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]
          balance      [([]) "Return the conserved resource vector available to the current Run, or the Room root at top level."]
          run-id       [([handle]) "Return the durable Run UUID represented by a RunHandle."]
-         result-spin  [([handle]) "Return a passive Spindel observer Spin for a RunHandle. Multiple observers may await it; cancelling an observer does not cancel the Run."]
-         owned-result-spin [([handle]) "Return an ownership-coupled result Spin. Cancelling this observer also cancels the underlying Run; use only when the observer owns that child execution."]}))))
+         result-spin  [([handle]) "Return a passive Spindel observer Spin for a RunHandle. On resolution the current Run durably records the child as a causal input. Multiple observers may await it; cancelling an observer does not cancel the Run."]
+         owned-result-spin [([handle]) "Return an ownership-coupled result Spin. On resolution the current Run durably records the child as a causal input. Cancelling this observer also cancels the underlying Run; use only when the observer owns that child execution."]}))))
 
 (defn add-agents-ns!
   "Expose the agent registry as 'agents namespace in SCI.

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -4,10 +4,77 @@
   (:require [sci.core :as sci]
             [is.simm.partial-cps.sequence :as aseq]
             [datahike.api :as dh]
+            [dvergr.agent.roster :as roster]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox.ns.doc :as doc]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.effects.await :as sp-await]
+            [org.replikativ.spindel.spin.cps :as sp]
             [org.replikativ.spindel.core :as sync]))
+
+(defn- portable-posterior
+  "Project a native Spindel measure before it crosses into SCI. Execution
+   contexts and their process-local executors deliberately do not survive."
+  [measure]
+  (let [measure-ns  (find-ns 'org.replikativ.spindel.inference.measure)
+        contexts    (@(ns-resolve measure-ns 'get-contexts) measure)
+        value-of    @(ns-resolve measure-ns 'get-value)
+        log-weights (vec (@(ns-resolve measure-ns 'get-log-weights) measure))
+        values      (mapv value-of contexts)
+        worlds      (->> contexts
+                         (keep #(rtp/get-state % [:inference :world-descriptor]))
+                         vec)
+        posterior   {:posterior/values values
+                     :posterior/log-weights log-weights
+                     :posterior/weights
+                     (@(ns-resolve measure-ns 'normalize-log-weights) log-weights)
+                     :posterior/ess
+                     (@(ns-resolve measure-ns 'effective-sample-size) measure)
+                     :posterior/log-marginal
+                     (@(ns-resolve measure-ns 'log-marginal) measure)
+                     :posterior/worlds worlds}]
+    (when-not (roster/data-value? posterior)
+      (throw (ex-info "Inference result is not portable data"
+                      {:type ::non-portable-posterior})))
+    posterior))
+
+(defn- posterior-spin [native-spin]
+  (sp/spin
+   (portable-posterior (sp-await/await native-spin))))
+
+(defn- posterior-query [posterior query-fn]
+  (let [values  (mapv query-fn (:posterior/values posterior))
+        weights (:posterior/weights posterior)]
+    (when-not (every? number? values)
+      (throw (ex-info "infer/query requires numeric projected values"
+                      {:type ::non-numeric-query})))
+    (let [mean      (reduce + (map * weights values))
+          variance (reduce + (map (fn [weight value]
+                                    (* weight (Math/pow (- value mean) 2)))
+                                  weights values))
+          sorted    (vec (sort values))
+          n         (count sorted)
+          quantile  (fn [p]
+                      (nth sorted (min (dec n)
+                                       (long (Math/floor (* p n))))))]
+      {:mean mean
+       :variance variance
+       :std-dev (Math/sqrt variance)
+       :samples values
+       :weights weights
+       :quantiles {:p50 (quantile 0.5)
+                   :p025 (quantile 0.025)
+                   :p975 (quantile 0.975)}
+       :type :empirical})))
+
+(defn- posterior-predict [posterior pred-fn samples]
+  (let [measure-ns (find-ns 'org.replikativ.spindel.inference.measure)
+        indices    (@(ns-resolve measure-ns 'systematic-resample)
+                    (:posterior/weights posterior) samples)
+        values     (:posterior/values posterior)]
+    (mapv #(pred-fn (nth values %)) indices)))
 
 (defn add-spindel-extras-ns!
   "Expose spindel combinators, sync primitives, and signals to SCI.
@@ -21,11 +88,18 @@
    These are safe: they only coordinate within the SCI context."
   ([sci-ctx spindel-ctx]
    (add-spindel-extras-ns! sci-ctx spindel-ctx {}))
-  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling]}]
+  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling world-binding]}]
    (require 'org.replikativ.spindel.spin.combinators)
    (require 'org.replikativ.spindel.signal)
    (let [comb-ns (find-ns 'org.replikativ.spindel.spin.combinators)
-         sig-ns  (find-ns 'org.replikativ.spindel.signal)]
+         sig-ns  (find-ns 'org.replikativ.spindel.signal)
+         create-work (fn [strategy opts work-fn]
+                       (let [binding (when world-binding (world-binding))]
+                         (sandbox-work/create!
+                          (or (:room-runtime-id binding) room-id)
+                          (or (:room-incarnation binding) room-incarnation)
+                          (runtime-ctx/selected-context spindel-ctx)
+                          ceiling strategy opts work-fn)))]
      (binding [rtc/*execution-context* spindel-ctx]
        ;; Sync primitives (same as before but unified here)
        (sci/add-namespace! sci-ctx 'sync
@@ -51,32 +125,31 @@
                            (doc/with-docs
                              {'latest       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest {} work-fn))
+                                               (create-work :latest {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest opts work-fn)))
+                                               (create-work :latest opts work-fn)))
                               'serial       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
+                                               (create-work :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial opts work-fn)))
+                                               (create-work :serial opts work-fn)))
                               'busy         (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy {} work-fn))
+                                               (create-work :busy {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy opts work-fn)))
+                                               (create-work :busy opts work-fn)))
                               'parallel     (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel {} work-fn))
+                                               (create-work :parallel {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel opts work-fn)))
+                                               (create-work :parallel opts work-fn)))
                               'controller   (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
+                                               (create-work :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling
-                                                                     (:strategy opts :serial)
-                                                                     (dissoc opts :strategy)
-                                                                     work-fn)))
+                                               (create-work (:strategy opts :serial)
+                                                            (dissoc opts :strategy)
+                                                            work-fn)))
                               'submit!      sandbox-work/submit!
                               'events       sandbox-work/events!
                               'next-event   aseq/anext
@@ -207,7 +280,13 @@
 
      (spin
        (let [measure (await (infer/smc-infer (my-model) 100))]
-         (infer/query measure identity)))
+         (infer/values measure)))
+
+   Dvergr defaults SMC, importance sampling, and the generic kernel runner to
+   `:world-policy :fork`. Each particle therefore executes in a frozen
+   canonical Yggdrasil world and only its immutable result projection survives;
+   particle worlds are discarded before the inference Spin completes. Callers
+   may explicitly request `:fresh` for a proven-pure model.
 
    Namespaces added:
    - dist/   — Anglican distributions: normal, beta, gamma, uniform, flip, …
@@ -315,12 +394,54 @@
                          'chi-squared        @(ns-resolve ar 'chi-squared)
                          'student-t          (fn [nu] (@(ns-resolve ar 'student-t) nu))}))
 
-  ;; Inference runners — these take/return spins, compose with await in spin bodies
-  (sci/add-namespace! sci-ctx 'infer
-                      {'smc-infer          @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
-                       'importance-sampling @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
-                       'kernel-infer       @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
-                       'query              @(resolve 'org.replikativ.spindel.inference.inference/query)
-                       'predict            @(resolve 'org.replikativ.spindel.inference.inference/predict)
-                       'pimh-infer         @(resolve 'org.replikativ.spindel.inference.inference/pimh-infer)
-                       'pgibbs-infer       @(resolve 'org.replikativ.spindel.inference.inference/pgibbs-infer)}))
+  ;; Inference runners — these take/return Spins and compose with await in Spin
+  ;; bodies. Room-capable sandboxes default to canonical particle worlds: a
+  ;; model that happens to touch a registered Yggdrasil system must not alias
+  ;; the ambient room merely because its author omitted an expert-only option.
+  ;; `:fresh` remains an explicit fast path for known-pure models.
+  (let [smc*        @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
+        importance* @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
+        kernel*     @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
+        world-opts  (fn [opts]
+                      (merge {:world-policy :fork} (or opts {})))]
+    (sci/add-namespace!
+     sci-ctx 'infer
+     (doc/with-docs
+       {'smc-infer (fn
+                     ([model particles]
+                      (posterior-spin
+                       (smc* model particles (world-opts nil))))
+                     ([model particles opts]
+                      (posterior-spin
+                       (smc* model particles (world-opts opts)))))
+        'importance-sampling
+        (fn
+          ([model particles]
+           (posterior-spin
+            (importance* model particles (world-opts nil))))
+          ([model particles opts]
+           (posterior-spin
+            (importance* model particles (world-opts opts)))))
+        'kernel-infer
+        (fn
+          ([model kernel particles]
+           (posterior-spin
+            (kernel* model kernel particles (world-opts nil))))
+          ([model kernel particles opts]
+           (posterior-spin
+            (kernel* model kernel particles (world-opts opts)))))
+        'query       posterior-query
+        'predict     posterior-predict
+        'values      :posterior/values
+        'log-weights :posterior/log-weights
+        'ess         :posterior/ess
+        'worlds      :posterior/worlds}
+       '{smc-infer [([model particles] [model particles opts]) "Run SMC. Dvergr defaults opts :world-policy to :fork; pass :fresh only for a proven-pure model."]
+         importance-sampling [([model particles] [model particles opts]) "Run importance sampling with canonical particle worlds by default."]
+         kernel-infer [([model kernel particles] [model kernel particles opts]) "Run a Spindel inference kernel with canonical particle worlds by default."]
+         query [([posterior query-fn]) "Compute numeric posterior statistics from portable program results."]
+         predict [([posterior pred-fn samples]) "Resample portable posterior values and apply pred-fn; execution contexts never enter SCI."]
+         values [([posterior]) "Return each particle's portable program result in posterior order."]
+         log-weights [([measure]) "Return posterior particle log weights."]
+         ess [([measure]) "Return effective sample size."]
+         worlds [([measure]) "Return portable canonical world descriptors retained in posterior projections; never live settlement handles."]}))))

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -2,8 +2,10 @@
   "SCI injectors — datahike read/write/diff, spindel sync/combinators/signals,
    and probabilistic inference. Split out of dvergr.sandbox (Phase 4)."
   (:require [sci.core :as sci]
+            [is.simm.partial-cps.sequence :as aseq]
             [datahike.api :as dh]
             [dvergr.sandbox.ns.doc :as doc]
+            [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.engine.core :as rtc]
             [org.replikativ.spindel.core :as sync]))
 
@@ -14,44 +16,108 @@
    - spindel.comb — parallel, race, timeout, sleep
    - sync         — deferred, deliver!, mailbox, post!
    - spindel.sig  — signal (for external world boundary)
+   - spindel.work — structured latest/serial/busy/parallel admission
 
    These are safe: they only coordinate within the SCI context."
-  [sci-ctx spindel-ctx]
-  (require 'org.replikativ.spindel.spin.combinators)
-  (require 'org.replikativ.spindel.signal)
-  (let [comb-ns (find-ns 'org.replikativ.spindel.spin.combinators)
-        sig-ns  (find-ns 'org.replikativ.spindel.signal)]
-    (binding [rtc/*execution-context* spindel-ctx]
-      ;; Sync primitives (same as before but unified here)
-      (sci/add-namespace! sci-ctx 'sync
-                          {'deferred  (fn [] (sync/deferred))
-                           'deliver!  (fn [d v] (sync/deliver! d v))
-                           'mailbox   (fn [] (sync/mailbox))
-                           'post!     (fn [mb v] (mb v))})
+  ([sci-ctx spindel-ctx]
+   (add-spindel-extras-ns! sci-ctx spindel-ctx {}))
+  ([sci-ctx spindel-ctx {:keys [room-id ceiling]}]
+   (require 'org.replikativ.spindel.spin.combinators)
+   (require 'org.replikativ.spindel.signal)
+   (let [comb-ns (find-ns 'org.replikativ.spindel.spin.combinators)
+         sig-ns  (find-ns 'org.replikativ.spindel.signal)]
+     (binding [rtc/*execution-context* spindel-ctx]
+       ;; Sync primitives (same as before but unified here)
+       (sci/add-namespace! sci-ctx 'sync
+                           {'deferred  (fn [] (sync/deferred))
+                            'deliver!  (fn [d v] (sync/deliver! d v))
+                            'mailbox   (fn [] (sync/mailbox))
+                            'post!     (fn [mb v] (mb v))})
       ;; Combinators
-      (sci/add-namespace! sci-ctx 'spindel.comb
-                          (doc/with-docs
-                            {'parallel @(ns-resolve comb-ns 'parallel)
-                             'race     @(ns-resolve comb-ns 'race)
-                             'timeout  @(ns-resolve comb-ns 'timeout)
-                             'sleep    @(ns-resolve comb-ns 'sleep)}
-                            '{parallel [([& spins]) "Run Spins concurrently and produce their values in input order. Cancelling the composition cancels its branches."]
-                              race     [([& spins]) "Produce the first Spin value and cancel losing branches. For hired Runs, pass dvergr.agent/owned-result-spin when branch cancellation must cancel the Run; passive result-spin deliberately leaves shared work alive."]
-                              timeout  [([spin timeout-ms] [spin timeout-ms timeout-value]) "Race a Spin against a timer and cancel the timed-out branch."]
-                              sleep    [([milliseconds]) "Return a Spin that completes after the given duration without blocking the engine thread."]}))
+       (sci/add-namespace! sci-ctx 'spindel.comb
+                           (doc/with-docs
+                             {'parallel @(ns-resolve comb-ns 'parallel)
+                              'race     @(ns-resolve comb-ns 'race)
+                              'timeout  @(ns-resolve comb-ns 'timeout)
+                              'sleep    @(ns-resolve comb-ns 'sleep)}
+                             '{parallel [([& spins]) "Run Spins concurrently and produce their values in input order. Cancelling the composition cancels its branches."]
+                               race     [([& spins]) "Produce the first Spin value and cancel losing branches. For hired Runs, pass dvergr.agent/owned-result-spin when branch cancellation must cancel the Run; passive result-spin deliberately leaves shared work alive."]
+                               timeout  [([spin timeout-ms] [spin timeout-ms timeout-value]) "Race a Spin against a timer and cancel the timed-out branch."]
+                               sleep    [([milliseconds]) "Return a Spin that completes after the given duration without blocking the engine thread."]}))
+      ;; Structured work admission. `task` is defined below inside SCI because
+      ;; it must run partial-cps expansion in the sandbox's own symbol table;
+      ;; copying the host macro would resolve sandbox vars against the host.
+       (sci/add-namespace! sci-ctx 'spindel.work
+                           (doc/with-docs
+                             {'latest       (fn
+                                              ([work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :latest {} work-fn))
+                                              ([opts work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :latest opts work-fn)))
+                              'serial       (fn
+                                              ([work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :serial {} work-fn))
+                                              ([opts work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :serial opts work-fn)))
+                              'busy         (fn
+                                              ([work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :busy {} work-fn))
+                                              ([opts work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :busy opts work-fn)))
+                              'parallel     (fn
+                                              ([work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :parallel {} work-fn))
+                                              ([opts work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :parallel opts work-fn)))
+                              'controller   (fn
+                                              ([work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling :serial {} work-fn))
+                                              ([opts work-fn]
+                                               (sandbox-work/create! room-id spindel-ctx ceiling
+                                                                     (:strategy opts :serial)
+                                                                     (dissoc opts :strategy)
+                                                                     work-fn)))
+                              'submit!      sandbox-work/submit!
+                              'events       sandbox-work/events!
+                              'next-event   aseq/anext
+                              'untap!       sandbox-work/untap!
+                              'snapshot     sandbox-work/snapshot
+                              'completion   sandbox-work/completion
+                              'close!       sandbox-work/close!
+                              'cancel!      sandbox-work/cancel!}
+                             '{latest      [([work-fn] [opts work-fn]) "Create switch-to-latest admission. A replacement starts only after superseded work has quiesced."]
+                               serial      [([work-fn] [opts work-fn]) "Create FIFO admission with bounded waiting capacity."]
+                               busy        [([work-fn] [opts work-fn]) "Create exhaust/busy admission: suppress input while work is active."]
+                               parallel    [([work-fn] [opts work-fn]) "Create bounded parallel admission; set :concurrency in opts."]
+                               controller  [([work-fn] [opts work-fn]) "Create admission with explicit :strategy (:latest, :serial, :busy, or :parallel)."]
+                               submit!     [([controller value] [controller id value]) "Submit a value without blocking; returns its correlation id or nil when ingress is closed/full."]
+                               events      [([controller]) "Open an independent hot event stream for later admission and completion events."]
+                               next-event  [([event-source]) "Return an awaitable for the next [event remaining-source] pair."]
+                               untap!      [([controller event-source]) "Detach an abandoned event stream."]
+                               snapshot    [([controller]) "Return fork-local active, queued, and lifecycle state without live handles."]
+                               completion  [([controller]) "Return a passive awaitable that joins controller quiescence after close!/cancel!."]
+                               close!      [([controller]) "Stop admission, drain accepted work, and close."]
+                               cancel!     [([controller]) "Stop admission and cooperatively cancel queued and active owned work."]}))
+       (sci/eval-string*
+        sci-ctx
+        "(ns spindel.work (:require [is.simm.partial-cps.async :as pcps-async]))
+        (defmacro task
+          \"Create reusable one-shot CPS work. The controller gives every submission fresh Spin identity and ownership.\"
+          [& body]
+          `(pcps-async/async ~@body))")
       ;; Signals — signal is a macro; wrap as a function using the underlying record
-      (let [signal-ref-ctor (ns-resolve sig-ns '->SignalRef)
-            addr-ns (do (require 'org.replikativ.spindel.engine.addressing)
-                        (find-ns 'org.replikativ.spindel.engine.addressing))
-            next-addr! @(ns-resolve addr-ns 'next-address!)
-            deltaable-ns (do (require 'org.replikativ.spindel.incremental.deltaable)
-                             (find-ns 'org.replikativ.spindel.incremental.deltaable))
-            clear-deltas @(ns-resolve deltaable-ns 'clear-deltas)]
-        (sci/add-namespace! sci-ctx 'spindel.sig
-                            {'signal (fn [initial-value]
-                                       (let [ctx (rtc/current-execution-context)
-                                             id  (next-addr! ctx "signal" {:file "sci" :line 0 :column 0})]
-                                         (signal-ref-ctor id (clear-deltas initial-value))))})))))
+       (let [signal-ref-ctor (ns-resolve sig-ns '->SignalRef)
+             addr-ns (do (require 'org.replikativ.spindel.engine.addressing)
+                         (find-ns 'org.replikativ.spindel.engine.addressing))
+             next-addr! @(ns-resolve addr-ns 'next-address!)
+             deltaable-ns (do (require 'org.replikativ.spindel.incremental.deltaable)
+                              (find-ns 'org.replikativ.spindel.incremental.deltaable))
+             clear-deltas @(ns-resolve deltaable-ns 'clear-deltas)]
+         (sci/add-namespace! sci-ctx 'spindel.sig
+                             {'signal (fn [initial-value]
+                                        (let [ctx (rtc/current-execution-context)
+                                              id  (next-addr! ctx "signal" {:file "sci" :line 0 :column 0})]
+                                          (signal-ref-ctor id (clear-deltas initial-value))))}))))))
 
 (defn add-datahike-query-ns!
   "Add datahike query namespace to SCI context.

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -21,7 +21,7 @@
    These are safe: they only coordinate within the SCI context."
   ([sci-ctx spindel-ctx]
    (add-spindel-extras-ns! sci-ctx spindel-ctx {}))
-  ([sci-ctx spindel-ctx {:keys [room-id ceiling]}]
+  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling]}]
    (require 'org.replikativ.spindel.spin.combinators)
    (require 'org.replikativ.spindel.signal)
    (let [comb-ns (find-ns 'org.replikativ.spindel.spin.combinators)
@@ -51,29 +51,29 @@
                            (doc/with-docs
                              {'latest       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :latest {} work-fn))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :latest opts work-fn)))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest opts work-fn)))
                               'serial       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :serial {} work-fn))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :serial opts work-fn)))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial opts work-fn)))
                               'busy         (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :busy {} work-fn))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :busy opts work-fn)))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy opts work-fn)))
                               'parallel     (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :parallel {} work-fn))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :parallel opts work-fn)))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel opts work-fn)))
                               'controller   (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling :serial {} work-fn))
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id spindel-ctx ceiling
+                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling
                                                                      (:strategy opts :serial)
                                                                      (dissoc opts :strategy)
                                                                      work-fn)))

--- a/src/dvergr/sandbox/ns/datahike.clj
+++ b/src/dvergr/sandbox/ns/datahike.clj
@@ -24,52 +24,212 @@
    created data DBs — is dvergr-specific and lives in `dvergr.room`, not here.)"
   (:require [datahike.api :as d]
             [dvergr.system.rooms :as srooms]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
+            [sci.fork :as sci-fork]
             [sci.core :as sci]))
+
+(deftype WorldConnection [resolver]
+  clojure.lang.IDeref
+  (deref [_]
+    @(resolver))
+
+  sci-fork/Forkable
+  (fork-value [this]
+    ;; The handle is immutable. Its resolver consults the dynamically selected
+    ;; Spindel world, so sharing the handle selects a different Ygg connection
+    ;; after a world fork rather than sharing the connection itself.
+    this))
+
+(defn world-connection
+  "Create an ambient Datahike connection handle. Deref returns the selected
+   connection's DB; mirrored Datahike functions unwrap it to the connection."
+  [resolve-conn]
+  (WorldConnection. resolve-conn))
+
+(defn resolve-connection
+  "Resolve a WorldConnection, otherwise return `value` unchanged."
+  [value]
+  (if (instance? WorldConnection value)
+    (or ((.-resolver ^WorldConnection value))
+        (throw (ex-info "Ambient Datahike connection is unavailable in this world"
+                        {:type ::connection-unavailable})))
+    value))
 
 ;; The safe DATA surface of datahike.api — resolved from the real namespace so the
 ;; mirror never drifts. Lifecycle (connect/create/delete/exists?) is GUARDED below.
 (def ^:private data-ops
   '[q pull pull-many entity entity-db datoms seek-datoms
     schema reverse-schema metrics db history as-of since filter
-    transact transact! load-entities with])
+    transact transact! with])
+
+(defn- attempt-attr? [x]
+  (and (keyword? x)
+       (contains? #{"attempt" "attempt.check"} (namespace x))))
+
+(defn- attempt-entity? [conn eid]
+  (try
+    (let [entity (d/entity @conn eid)]
+      (boolean (or (:attempt/id entity) (:attempt.check/id entity))))
+    (catch Throwable _ false)))
+
+(defn- assert-no-attempt-write! [conn tx-data]
+  (doseq [form tx-data]
+    (let [protected?
+          (cond
+            (map? form)
+            (or (some attempt-attr? (keys form))
+                (attempt-entity? conn (:db/id form)))
+
+            (vector? form)
+            (let [[op eid attr] form]
+              (or (= :db.fn/call op)
+                  (attempt-attr? attr)
+                  (and (vector? eid) (attempt-attr? (first eid)))
+                  (and (#{:db/retractEntity :db.fn/retractEntity} op)
+                       (attempt-entity? conn eid))))
+
+            :else false)]
+      (when protected?
+        (throw (ex-info "Verified Attempt projections are host-certified and read-only in SCI"
+                        {:type ::protected-attempt-write :tx-form form})))))
+  tx-data)
 
 (defn- cfg-name
   "The logical database name from a datahike config: `:store :id`, else the
    basename of `:store :path`. We own placement, so this is the only handle."
   [cfg]
-  (or (some-> (get-in cfg [:store :id]) name not-empty)
+  (or (some-> (get-in cfg [:store :id]) str (str/replace #"^:" "") not-empty)
       (some-> (get-in cfg [:store :path]) str (str/split #"/") last not-empty)
       (throw (ex-info "datahike config needs a :store :id (the database name)" {:cfg cfg}))))
 
 (defn- mem? [cfg] (boolean (#{:mem :memory} (get-in cfg [:store :backend]))))
 
+(defn- entry-conn [entry]
+  (if (map? entry) (:connection entry) entry))
+
+(defn- world-memory-config
+  "Translate an agent-visible logical memory config into a process-global
+   Datahike config namespaced by the selected interpreter world."
+  [cfg binding-resolver]
+  (let [binding (when binding-resolver (binding-resolver))
+        logical-name (cfg-name cfg)
+        world-key (str (:capability-id binding) "|"
+                       (:room-runtime-id binding) "|"
+                       (:room-incarnation binding) "|"
+                       logical-name)
+        physical-id (if binding-resolver
+                      (java.util.UUID/nameUUIDFromBytes
+                       (.getBytes world-key java.nio.charset.StandardCharsets/UTF_8))
+                      (random-uuid))]
+    (-> cfg
+        (assoc-in [:store :backend] :memory)
+        (assoc-in [:store :id] physical-id))))
+
+(defn dispose-ephemeral-databases!
+  "Release and delete every process-global scratch database owned by the
+   currently selected interpreter world. Returns cleanup errors, if any."
+  [binding-resolver binding-swap!]
+  (when (and binding-resolver binding-swap!)
+    (let [entries (or (:ephemeral-databases (binding-resolver)) {})
+          errors (reduce-kv
+                  (fn [errors name entry]
+                    (let [conn (entry-conn entry)
+                          cfg (:config entry)]
+                      (try
+                        (when conn (d/release conn))
+                        (when (and cfg (d/database-exists? cfg))
+                          (d/delete-database cfg))
+                        errors
+                        (catch Throwable error
+                          (conj errors {:name name :error error})))))
+                  [] entries)]
+      (binding-swap! assoc :ephemeral-databases {})
+      errors)))
+
 (defn add-datahike-ns!
   "Mount the faithful datahike API under `datahike.api` and `d`, with lifecycle fns
    guarded to room `room-id` (resolved fork-aware under `ctx`)."
-  [sci-ctx room-id ctx]
+  [sci-ctx room-id ctx & [binding-resolver binding-swap!]]
   (let [data      (into {} (keep (fn [sym]
-                                   (when-let [v (ns-resolve 'datahike.api sym)] [sym @v]))
+                                   (when-let [v (ns-resolve 'datahike.api sym)]
+                                     (let [f @v]
+                                       [sym (fn [& args]
+                                              (let [resolved (mapv resolve-connection args)]
+                                                (try
+                                                  (apply f resolved)
+                                                  (catch Throwable error
+                                                    (throw
+                                                     (ex-info
+                                                      "Sandbox Datahike operation failed"
+                                                      {:operation sym
+                                                       :argument-types
+                                                       (mapv #(some-> % class str) resolved)}
+                                                      error))))))])))
                                  data-ops))
+        data      (assoc data
+                         'transact
+                         (fn [conn tx-data]
+                           (let [conn (resolve-connection conn)]
+                             (d/transact conn
+                                         (assert-no-attempt-write! conn tx-data))))
+                         'transact!
+                         (fn [conn tx-data]
+                           (let [conn (resolve-connection conn)]
+                             (d/transact! conn
+                                          (assert-no-attempt-write! conn tx-data)))))
         ;; per-sandbox ephemeral (:mem) databases, keyed by logical name
         ephemeral (atom {})
-        in-ctx    (fn [f] (binding [ec/*execution-context* ctx] (f)))
+        ephemeral-map #(if binding-resolver
+                         (or (:ephemeral-databases (binding-resolver)) {})
+                         @ephemeral)
+        swap-ephemeral! (fn [f & args]
+                          (if binding-swap!
+                            (binding-swap!
+                             #(update % :ephemeral-databases
+                                      (fn [m]
+                                        (apply f (or m {}) args))))
+                            (apply swap! ephemeral f args)))
+        selected-ctx #(runtime-ctx/selected-context ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-id (binding-resolver)))
+                             room-id)
+        in-ctx    (fn [f]
+                    (binding [ec/*execution-context* (selected-ctx)] (f)))
+        managed-connection
+        (fn [nm]
+          (world-connection
+           #(binding [ec/*execution-context* (selected-ctx)]
+              (or (srooms/room-conn-by-name (current-room-id) nm)
+                  (throw (ex-info (str "No database named " (pr-str nm)
+                                       " in this room")
+                                  {:name nm}))))))
         no-room   (fn [op] (throw (ex-info (str op " needs a room — this sandbox isn't attached to one "
                                                 "(only :mem databases are available here).") {})))
         guard
         {'create-database
          (fn [cfg]
            (in-ctx
-            (fn [] (let [nm (cfg-name cfg)]
+            (fn [] (let [nm (cfg-name cfg)
+                         room-id (current-room-id)]
                      (cond
-                       (mem? cfg) (let [c (assoc-in cfg [:store :id] nm)]
-                                    (when-not (d/database-exists? c) (d/create-database c))
-                                    (swap! ephemeral assoc nm (d/connect c)) cfg)
+                       (mem? cfg) (if (contains? (ephemeral-map) nm)
+                                    cfg
+                                    (let [c (world-memory-config cfg binding-resolver)]
+                                      (when (d/database-exists? c)
+                                        (throw (ex-info
+                                                "Scratch database exists without a live world owner"
+                                                {:name nm :physical-config c})))
+                                      (d/create-database c)
+                                      (swap-ephemeral! assoc nm
+                                                       {:connection (d/connect c)
+                                                        :config c})
+                                      cfg))
                        room-id    (do (srooms/create-room-db! room-id nm
-                                                               ;; honour datahike's own default (:write) — don't
-                                                               ;; silently downgrade to :read. Explicit :read in cfg
-                                                               ;; still wins (schema-free append-only scratch).
+                                                             ;; honour datahike's own default (:write) — don't
+                                                             ;; silently downgrade to :read. Explicit :read in cfg
+                                                             ;; still wins (schema-free append-only scratch).
                                                               :schema-flexibility (get cfg :schema-flexibility :write))
                                       cfg)
                        :else      (no-room "create-database"))))))
@@ -77,8 +237,8 @@
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (or (get @ephemeral nm)
-                         (when room-id (srooms/room-conn-by-name room-id nm))
+                     (or (some-> (get (ephemeral-map) nm) entry-conn)
+                         (when (current-room-id) (managed-connection nm))
                          (throw (ex-info (str "No database named " (pr-str nm)
                                               " in this room — create it with create-database, or see "
                                               "(dvergr.room/databases).")
@@ -87,15 +247,24 @@
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (boolean (or (get @ephemeral nm)
-                                  (when room-id (srooms/room-conn-by-name room-id nm))))))))
+                     (boolean (or (get (ephemeral-map) nm)
+                                  (when-let [room-id (current-room-id)]
+                                    (srooms/room-conn-by-name room-id nm))))))))
          'delete-database
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (if (contains? @ephemeral nm)
-                       (do (swap! ephemeral dissoc nm) true)
-                       (boolean (when room-id (srooms/delete-room-db! room-id nm))))))))}
+                     (if (contains? (ephemeral-map) nm)
+                       (let [{:keys [connection config] :as entry}
+                             (get (ephemeral-map) nm)]
+                         (when-let [conn (entry-conn entry)]
+                           (d/release conn))
+                         (when (and config (d/database-exists? config))
+                           (d/delete-database config))
+                         (swap-ephemeral! dissoc nm)
+                         true)
+                       (boolean (when-let [room-id (current-room-id)]
+                                  (srooms/delete-room-db! room-id nm))))))))}
         m (merge data guard)]
     ;; The real datahike.api name (the model aliases it `:as d` itself, as everyone does).
     (sci/add-namespace! sci-ctx 'datahike.api m)))

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -344,6 +344,36 @@
       (throw (ex-info "Virtual filesystem sink does not accept binary content"
                       {:path path})))))
 
+(defn- world-filesystem
+  "A stable Muschel handle whose every operation resolves the ambient world.
+
+   SCI code may retain this value across an interpreter fork.  Delegating at
+   the protocol boundary prevents such saved functions from retaining the
+   parent's Geschichte workspace."
+  [resolver]
+  (letfn [(fs! [] (or (resolver)
+                      (throw (ex-info "Current world has no filesystem" {}))))]
+    (reify mfs/FS
+      (-resolve [_ path] (mfs/-resolve (fs!) path))
+      (-cwd [_] (mfs/-cwd (fs!)))
+      (-cd! [_ path] (mfs/-cd! (fs!) path))
+      (-exists? [_ path] (mfs/-exists? (fs!) path))
+      (-stat [_ path] (mfs/-stat (fs!) path))
+      (-list-dir [_ path] (mfs/-list-dir (fs!) path))
+      (-read-file [_ path] (mfs/-read-file (fs!) path))
+      (-read-bytes [_ path] (mfs/-read-bytes (fs!) path))
+      (-open-source [_ path] (mfs/-open-source (fs!) path))
+      (-open-sink [_ path append?] (mfs/-open-sink (fs!) path append?))
+      (-mkdir [_ path] (mfs/-mkdir (fs!) path))
+      (-delete [_ path] (mfs/-delete (fs!) path))
+      (-rename [_ from to] (mfs/-rename (fs!) from to))
+      (-touch [_ path] (mfs/-touch (fs!) path))
+      (-chmod [_ path mode] (mfs/-chmod (fs!) path mode))
+      (-symlink [_ target link-path] (mfs/-symlink (fs!) target link-path))
+      (-chown [_ path owner group] (mfs/-chown (fs!) path owner group))
+      (-sandbox-relativize [_ path] (mfs/-sandbox-relativize (fs!) path))
+      (-physical-path [_ path] (mfs/-physical-path (fs!) path)))))
+
 (defn- glob-regex [pattern]
   (-> pattern
       (str/replace "." "\\.")
@@ -449,9 +479,13 @@
 (defn add-fs-ns!
   "Expose a filesystem namespace backed by Muschel when `:filesystem` is
   supplied; otherwise retain the transitional physical adapter."
-  [sci-ctx & {:keys [filesystem] :as options}]
-  (if filesystem
-    (add-virtual-fs-ns! sci-ctx filesystem (:audit-log options))
+  [sci-ctx & {:keys [filesystem filesystem-resolver] :as options}]
+  (if (or filesystem filesystem-resolver)
+    (add-virtual-fs-ns! sci-ctx
+                        (if filesystem-resolver
+                          (world-filesystem filesystem-resolver)
+                          filesystem)
+                        (:audit-log options))
     (apply add-physical-fs-ns! sci-ctx (mapcat identity options))))
 
 (defn add-git-ns!
@@ -481,11 +515,14 @@
 
      (git/commit \"Add feature\")
      ;; => \"[main abc1234] Add feature\""
-  [sci-ctx & {:keys [base-path audit-log workspace]
+  [sci-ctx & {:keys [base-path audit-log workspace workspace-resolver]
               :or   {base-path ((requiring-resolve 'dvergr.substrate.git/safe-workspace-root))}}]
-  (let [run!      (if workspace
+  (let [run!      (if (or workspace workspace-resolver)
                     (fn [& args]
-                      (let [result ((requiring-resolve
+                      (let [workspace (if workspace-resolver
+                                        (workspace-resolver)
+                                        workspace)
+                            result ((requiring-resolve
                                      'dvergr.substrate.geschichte/execute-git)
                                     workspace (vec args))]
                         (if (zero? (:exit result))
@@ -549,8 +586,9 @@
      (env/get \"API_KEY\" \"default\")   ;; with fallback
      (env/keys)                        ;; list granted keys (no values)
      (env/set \"KEY\" \"value\")         ;; store in user config (session-local)"
-  [sci-ctx & {:keys [user-config secrets]}]
+  [sci-ctx & {:keys [user-config config-resolver config-swap! secrets]}]
   (let [config-atom (or user-config (atom {}))
+        config      #(if config-resolver (config-resolver) @config-atom)
         ;; A configured boundary-injection SECRET resolves to its opaque
         ;; PLACEHOLDER (never the real value) — the HTTP egress substitutes the
         ;; real value at the destination. Non-secret granted keys still return
@@ -559,12 +597,16 @@
                  (let [k (str key)]
                    (if-let [s (get secrets k)]
                      (:placeholder s)
-                     (or (get @config-atom k) (get @config-atom (keyword key))))))
+                     (or (get (config) k) (get (config) (keyword key))))))
         get-fn (fn
                  ([key]         (get-1 key))
                  ([key default] (or (get-1 key) default)))
-        set-fn (fn [key value] (swap! config-atom assoc (str key) value) :ok)
-        keys-fn (fn [] (vec (distinct (concat (map str (keys @config-atom))
+        set-fn (fn [key value]
+                 (if config-swap!
+                   (config-swap! assoc (str key) value)
+                   (swap! config-atom assoc (str key) value))
+                 :ok)
+        keys-fn (fn [] (vec (distinct (concat (map str (keys (config)))
                                               (keys (or secrets {}))))))]
     (sci/add-namespace! sci-ctx 'env
                         (doc/with-docs

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -69,12 +69,12 @@
         join-agent!*    @(ns-resolve 'dvergr.rooms 'join-agent!)
         leave-agent!*   @(ns-resolve 'dvergr.rooms 'leave-agent!)
         set-parent!*    @(ns-resolve 'dvergr.rooms 'set-parent!)
+        delete-room!*   @(ns-resolve 'dvergr.rooms 'delete-room!)
         get-by-slug*    @(ns-resolve 'dvergr.rooms 'get-room-by-slug)
         slug->id*       @(ns-resolve 'dvergr.room.store 'slug->room-id)
         rreg-lookup*    @(ns-resolve 'dvergr.room.registry 'lookup)
         rreg-list*      @(ns-resolve 'dvergr.room.registry 'list-rooms)
         rreg-children*  @(ns-resolve 'dvergr.room.registry 'children)
-        delete!*        @(ns-resolve 'dvergr.room.store '-delete-room!)
         registry*       (find-ns 'dvergr.room.registry)
         rstore-ns*      (find-ns 'dvergr.room.store)
         ;; Helpers
@@ -142,10 +142,21 @@
         delete-fn   (fn [ref]
                       (binding [rtc/*execution-context* spindel-ctx]
                         (if-let [room (resolve-room ref)]
-                          (let [store (:store room)]
-                            (when store (delete!* store (:id room)))
-                            ((ns-resolve 'dvergr.room.registry 'unregister!) (:id room))
-                            {:deleted (:id room)})
+                          (do
+                            ;; An SCI evaluation cannot synchronously join its
+                            ;; own controller/context teardown. Self-deletion is
+                            ;; a supervisor effect; subordinate Rooms are safe.
+                            (when (identical? spindel-ctx (:ctx room))
+                              (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
+                                              {:type ::self-delete
+                                               :room-id (:id room)})))
+                            (let [result (delete-room!* room)]
+                              (if (:ok? result)
+                                {:deleted (:id room)}
+                                (throw (ex-info "Room deletion failed"
+                                                {:type ::room-delete-failed
+                                                 :room-id (:id room)
+                                                 :error (:error result)})))))
                           {:error (str "Room not found: " ref)})))
         fork-fn     (fn fork-fn
                       ([ref] (fork-fn ref {}))

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -5,6 +5,7 @@
    datahike + spindel directly."
   (:require [sci.core :as sci]
             [datahike.api :as dh]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [org.replikativ.spindel.engine.core :as rtc]
             [dvergr.sandbox.ns.doc :as doc]))
 
@@ -54,7 +55,8 @@
   (require 'dvergr.room.registry)
   (require 'dvergr.room.store)
   (require 'dvergr.rooms.forks)
-  (let [fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
+  (let [selected-ctx    #(runtime-ctx/selected-context spindel-ctx)
+        fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
         fork-review*    @(ns-resolve 'dvergr.rooms.forks 'review)
         fork-classify*  @(ns-resolve 'dvergr.rooms.forks 'classify)
         post*           @(ns-resolve 'dvergr.discourse 'post!)
@@ -77,9 +79,13 @@
         rreg-children*  @(ns-resolve 'dvergr.room.registry 'children)
         registry*       (find-ns 'dvergr.room.registry)
         rstore-ns*      (find-ns 'dvergr.room.store)
+        current-source-room (fn []
+                              (if (fn? source-room)
+                                (source-room)
+                                source-room))
         ;; Helpers
         resolve-room    (fn [ref]
-                          (binding [rtc/*execution-context* spindel-ctx]
+                          (binding [rtc/*execution-context* (selected-ctx)]
                             (cond
                               (and (map? ref) (:id ref))
                               (rreg-lookup* (:id ref))            ; canonical Room only
@@ -90,20 +96,21 @@
         create-fn   (fn [{:keys [title slug type telegram-chat-id agents
                                  agent-ids parent-id]
                           :as _opts}]
-                      (binding [rtc/*execution-context* spindel-ctx]
-                        (let [aset (set (or agents agent-ids))]
-                          (create-room!*
-                           (cond-> {:title title
-                                    :slug  slug
-                                    :type  (or type :internal)
-                                    :ctx   spindel-ctx}
-                             telegram-chat-id (assoc :telegram-chat-id telegram-chat-id)
-                             (seq aset)       (assoc :agent-ids aset)
-                             parent-id        (assoc :parent-id parent-id)))
-                          {:slug slug :title (or title slug) :agents aset
-                           :room (rreg-lookup* (slug->id* slug))})))
+                      (let [world (selected-ctx)]
+                        (binding [rtc/*execution-context* world]
+                          (let [aset (set (or agents agent-ids))]
+                            (create-room!*
+                             (cond-> {:title title
+                                      :slug  slug
+                                      :type  (or type :internal)
+                                      :ctx   world}
+                               telegram-chat-id (assoc :telegram-chat-id telegram-chat-id)
+                               (seq aset)       (assoc :agent-ids aset)
+                               parent-id        (assoc :parent-id parent-id)))
+                            {:slug slug :title (or title slug) :agents aset
+                             :room (rreg-lookup* (slug->id* slug))}))))
         list-fn     (fn [& {:keys [where]}]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (if where (rreg-list* :where where) (rreg-list*))))
         get-fn      resolve-room
         post-fn     (fn [ref {:keys [content from source-user source-username source-user-id]}]
@@ -121,7 +128,7 @@
                         (messages* room (cond-> {} limit (assoc :limit limit)
                                                 since (assoc :since since)))))
         children-fn (fn [ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (when-let [room (resolve-room ref)]
                           (rreg-children* (:id room)))))
         set-parent-fn (fn [child-ref parent-ref]
@@ -140,18 +147,19 @@
                         (leave-agent!* room agent-id)
                         {:left agent-id :room (:id room)}))
         delete-fn   (fn [ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (if-let [room (resolve-room ref)]
                           (do
                             ;; An SCI evaluation cannot synchronously join its
                             ;; own controller/context teardown. Self-deletion is
                             ;; a supervisor effect; subordinate Rooms are safe.
-                            (when (and (= (:id source-room) (:id room))
-                                       (= (:incarnation source-room)
-                                          (:incarnation room)))
-                              (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
-                                              {:type ::self-delete
-                                               :room-id (:id room)})))
+                            (let [source-room (current-source-room)]
+                              (when (and (= (:id source-room) (:id room))
+                                         (= (:incarnation source-room)
+                                            (:incarnation room)))
+                                (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
+                                                {:type ::self-delete
+                                                 :room-id (:id room)}))))
                             (let [result (delete-room!* room)]
                               (if (:ok? result)
                                 {:deleted (:id room)}
@@ -163,7 +171,7 @@
         fork-fn     (fn fork-fn
                       ([ref] (fork-fn ref {}))
                       ([ref opts]
-                       (binding [rtc/*execution-context* spindel-ctx]
+                       (binding [rtc/*execution-context* (selected-ctx)]
                          (when-let [room (resolve-room ref)]
                            (binding [rtc/*execution-context* (:ctx room)]
                              (fork-room* room opts))))))
@@ -175,18 +183,18 @@
                         (discard* fork)))
         ;; Merge review — the per-system diff + tier the agent reads to decide.
         diff-fn     (fn [fork-ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (some-> (resolve-room fork-ref) fork-diff*)))
         review-fn   (fn [fork-ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (some-> (resolve-room fork-ref) fork-review*)))
         forks-fn    (fn []
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (rreg-list* :where #(some? (:forked-from @(:meta %))))))
         participants-fn (fn [room]
                           (when room (vec (keys @(:participants room)))))
         root-fn     (fn []
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (or (rreg-lookup* :daemon)
                             (rtc/get-state [:dvergr/discourse-root]))))]
     (doc/with-docs

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -48,7 +48,7 @@
    `review`/`classify`/`forks`/`participants`/`root` — for the `dvergr.room` SCI
    namespace (mounted, merged with the DB surface, by `dvergr.sandbox.ns.room`).
    Persistent rooms + forks are behind one surface — same for agents, TUI, web."
-  [spindel-ctx & [agent-program-ceiling]]
+  [spindel-ctx & [agent-program-ceiling source-room]]
   (require 'dvergr.discourse)
   (require 'dvergr.rooms)
   (require 'dvergr.room.registry)
@@ -81,8 +81,8 @@
         resolve-room    (fn [ref]
                           (binding [rtc/*execution-context* spindel-ctx]
                             (cond
-                              (and (map? ref) (:bus ref) (:participants ref))
-                              ref                                ; already a Room
+                              (and (map? ref) (:id ref))
+                              (rreg-lookup* (:id ref))            ; canonical Room only
                               (keyword? ref) (rreg-lookup* ref)
                               (string? ref)  (or (rreg-lookup* ref)
                                                  (rreg-lookup* (slug->id* ref))))))
@@ -146,7 +146,9 @@
                             ;; An SCI evaluation cannot synchronously join its
                             ;; own controller/context teardown. Self-deletion is
                             ;; a supervisor effect; subordinate Rooms are safe.
-                            (when (identical? spindel-ctx (:ctx room))
+                            (when (and (= (:id source-room) (:id room))
+                                       (= (:incarnation source-room)
+                                          (:incarnation room)))
                               (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
                                               {:type ::self-delete
                                                :room-id (:id room)})))

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -34,7 +34,7 @@
    may be nil (room-less ctx) — the helpers degrade gracefully.
    `agent-program-ceiling` is forwarded to the room-bound SCI setup; bounded
    delegation itself lives only in the `dvergr.agent` namespace."
-  [sci-ctx room-conn kb-conn room-id ctx & [agent-program-ceiling]]
+  [sci-ctx room-conn kb-conn room-id ctx & [agent-program-ceiling source-room]]
   (let [;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
         ;; its own KB plus whatever is granted to it, and the two are written
         ;; through different bindings of the same katzen schema — dvergr's
@@ -127,7 +127,7 @@
                                     ws)))))
         kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
                                 (srooms/room-kb-conn room-id slug))))
-        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling) ; create!/fork!/merge!/post!/messages/…
+        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling source-room) ; create!/fork!/merge!/post!/messages/…
                         ;; Docs live HERE rather than only in these trailing
                         ;; comments: the comments never reached the sandbox, so
                         ;; `(clojure.repl/doc dvergr.room/kb-search)` answered

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -16,6 +16,8 @@
   (:require [datahike.api :as d]
             [dvergr.system.rooms :as srooms]
             [dvergr.sandbox.ns.kb :as ns-kb]
+            [dvergr.sandbox.ns.datahike :as ns-datahike]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
@@ -34,8 +36,30 @@
    may be nil (room-less ctx) — the helpers degrade gracefully.
    `agent-program-ceiling` is forwarded to the room-bound SCI setup; bounded
    delegation itself lives only in the `dvergr.agent` namespace."
-  [sci-ctx room-conn kb-conn room-id ctx & [agent-program-ceiling source-room]]
-  (let [;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
+  [sci-ctx room-conn kb-conn room-id ctx
+   & [agent-program-ceiling {:keys [binding-resolver source-room]}]]
+  (let [selected-ctx   #(runtime-ctx/selected-context ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-id (binding-resolver)))
+                             room-id)
+        current-source-room #(if binding-resolver
+                               (let [binding (binding-resolver)]
+                                 {:id (:room-runtime-id binding)
+                                  :incarnation (:room-incarnation binding)})
+                               source-room)
+        room-view      (when (or room-id room-conn)
+                         (ns-datahike/world-connection
+                          #(if-let [room-id (current-room-id)]
+                             (binding [ec/*execution-context* (selected-ctx)]
+                               (srooms/room-msgs-conn room-id))
+                             room-conn)))
+        kb-view        (when (or room-id kb-conn)
+                         (ns-datahike/world-connection
+                          #(if-let [room-id (current-room-id)]
+                             (binding [ec/*execution-context* (selected-ctx)]
+                               (srooms/room-kb-conn room-id))
+                             kb-conn)))
+        ;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
         ;; its own KB plus whatever is granted to it, and the two are written
         ;; through different bindings of the same katzen schema — dvergr's
         ;; `:entity/title` and a product's `:S.Page/title`. Reading one store
@@ -46,8 +70,8 @@
         ;; address that KB by name (see `kbs` / `kb`).
         title-attrs    [:entity/title :S.Page/title]
         readable       (fn []
-                         (if room-id
-                           (binding [ec/*execution-context* ctx]
+                         (if-let [room-id (current-room-id)]
+                           (binding [ec/*execution-context* (selected-ctx)]
                              (srooms/room-kb-conns room-id))
                            (when kb-conn [{:conn kb-conn :slug "kb"}])))
         titled         (fn [db]
@@ -83,51 +107,59 @@
                                        (take 25) vec))))
         msg-time       (fn [m] (or (some-> ^java.util.Date (:message/created-at m) .getTime) 0))
         recent-msgs    (fn [n]
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (->> (d/q '[:find [(pull ?m [:message/content :message/role :message/created-at]) ...]
-                                              :where [?m :message/content _]] @room-conn)
+                                              :where [?m :message/content _]] @room-view)
                                        (sort-by msg-time >)
                                        (take (or n 20)) vec))))
         search-msgs    (fn [term]
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (let [lc (str/lower-case (str term))]
                                     (->> (d/q '[:find [(pull ?m [:message/content :message/role :message/created-at]) ...]
-                                                :where [?m :message/content _]] @room-conn)
+                                                :where [?m :message/content _]] @room-view)
                                          (filter (fn [m] (str/includes? (str/lower-case (str (:message/content m))) lc)))
                                          (take 50) vec)))))
         schedules      (fn []
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (d/q '[:find [(pull ?s [*]) ...]
-                                         :where [?s :schedule/id _]] @room-conn))))
+                                         :where [?s :schedule/id _]] @room-view))))
         ;; Discovery: WHERE the agent's databases are + by-name access. Resolved
         ;; fork-aware under `ctx` so a fork lists/returns its branched systems.
-        databases      (fn [] (safe #(when room-id
-                                       (binding [ec/*execution-context* ctx]
+        databases      (fn [] (safe #(when-let [room-id (current-room-id)]
+                                       (binding [ec/*execution-context* (selected-ctx)]
                                          (srooms/room-databases room-id)))))
-        db             (fn [db-name] (safe #(when room-id
-                                              (binding [ec/*execution-context* ctx]
-                                                (srooms/room-conn-by-name room-id db-name)))))
+        db             (fn [db-name]
+                         (safe #(when-let [room-id (current-room-id)]
+                                  (ns-datahike/world-connection
+                                   (fn []
+                                     (binding [ec/*execution-context* (selected-ctx)]
+                                       (srooms/room-conn-by-name room-id db-name)))))))
         ;; Reclaim unreachable storage for THIS room/fork's workspace (datahike
         ;; index blobs + git objects). Default keeps all history (orphan garbage
         ;; only); pass {:remove-before <Date>} to collapse old history.
         gc!            (fn gc!
                          ([] (gc! {}))
-                         ([opts] (safe #(binding [ec/*execution-context* ctx] (ygg/gc! opts)))))
+                         ([opts] (safe #(binding [ec/*execution-context* (selected-ctx)]
+                                          (ygg/gc! opts)))))
         ;; Which KBs this room may WRITE, and which one `*kb*` is. A room's own
         ;; KB is the default, but a room whose knowledge lives in an ATTACHED KB
         ;; would otherwise write into its own empty one with nothing saying so —
         ;; the agent could not even name the alternatives. These make the choice
         ;; visible and addressable.
-        kbs (fn [] (safe #(binding [ec/*execution-context* ctx]
-                            (let [ws (srooms/writable-kbs room-id)]
+        kbs (fn [] (safe #(binding [ec/*execution-context* (selected-ctx)]
+                            (let [ws (srooms/writable-kbs (current-room-id))]
                               (into [] (map-indexed
                                         (fn [i {:keys [slug permission]}]
                                           {:name slug :permission permission
                                            :default? (zero? i)}))
                                     ws)))))
-        kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
-                                (srooms/room-kb-conn room-id slug))))
-        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling source-room) ; create!/fork!/merge!/post!/messages/…
+        kb  (fn [slug]
+              (safe #(ns-datahike/world-connection
+                      (fn []
+                        (binding [ec/*execution-context* (selected-ctx)]
+                          (srooms/room-kb-conn (current-room-id) slug))))))
+        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling
+                                            current-source-room) ; create!/fork!/merge!/post!/messages/…
                         ;; Docs live HERE rather than only in these trailing
                         ;; comments: the comments never reached the sandbox, so
                         ;; `(clojure.repl/doc dvergr.room/kb-search)` answered
@@ -136,8 +168,8 @@
                         ;; (or nil) — values with no signature to state — so
                         ;; they carry no entry and are described in ns-guide.
                         (doc/with-docs
-                          {'*room*          room-conn      ; the room's own datahike (messages store)
-                           '*kb*            kb-conn         ; the DEFAULT writable KB (see kbs)
+                          {'*room*          room-view      ; ambient messages-store handle
+                           '*kb*            kb-view       ; ambient default-KB handle
                            'kbs             kbs             ; [{:name :permission :default?}] — writable KBs
                            'kb              kb              ; fork-aware conn to a writable KB by name
                            'databases       databases       ; [{:name :type :permission}] — your DBs

--- a/src/dvergr/sandbox/work.clj
+++ b/src/dvergr/sandbox/work.clj
@@ -1,0 +1,218 @@
+(ns dvergr.sandbox.work
+  "Room-owned capability boundary for SCI work-admission controllers.
+
+   Native Spindel controllers intentionally remain process-local. This namespace
+   gives them an opaque SCI handle, bounds their resource fan-out, and ties them
+   to the Room lifecycle so a discarded fork cannot leave work running on the
+   root executor. The registry contains handles only; semantic state and public
+   projections remain in Spindel."
+  (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.work :as work]
+            [dvergr.room.registry :as room-registry]))
+
+(def default-ceiling
+  {:controllers 16
+   :concurrency 8
+   :capacity 1024
+   :ingress-capacity 1024
+   :event-taps 8})
+
+(deftype Controller [native room-id owner-context taps ceiling])
+
+(defonce ^:private lifecycle-lock (Object.))
+(defonce ^:private rooms* (atom {}))
+
+(defn- positive-limit! [ceiling k]
+  (let [value (get ceiling k)]
+    (when-not (and (integer? value) (pos? value))
+      (throw (ex-info "SCI work-admission ceiling must be a positive integer"
+                      {:type ::invalid-ceiling :limit k :value value})))
+    value))
+
+(defn normalize-ceiling
+  "Validate an optional attenuation of the host's SCI work-admission limits."
+  [ceiling]
+  (let [unknown (seq (remove (set (keys default-ceiling)) (keys ceiling)))
+        effective (merge default-ceiling ceiling)]
+    (when unknown
+      (throw (ex-info "Unknown SCI work-admission ceiling keys"
+                      {:type ::invalid-ceiling :unknown-keys (vec unknown)})))
+    (doseq [k (keys default-ceiling)]
+      (positive-limit! effective k)
+      (when (> (get effective k) (get default-ceiling k))
+        (throw (ex-info "SCI work-admission ceiling cannot exceed the host maximum"
+                        {:type ::invalid-ceiling
+                         :limit k
+                         :requested (get effective k)
+                         :maximum (get default-ceiling k)}))))
+    effective))
+
+(defn- native-controller [controller]
+  (if (instance? Controller controller)
+    (.-native ^Controller controller)
+    (throw (ex-info "Expected a spindel.work controller"
+                    {:type ::invalid-controller}))))
+
+(defn- ensure-room! [room-id]
+  (when-not room-id
+    (throw (ex-info "Structured work admission requires a room-scoped SCI session"
+                    {:type ::room-required}))))
+
+(defn- bounded-opts [strategy ceiling opts]
+  (let [allowed #{:concurrency :capacity :ingress-capacity}
+        unknown (seq (remove allowed (keys opts)))
+        defaults {:concurrency (if (= strategy :parallel)
+                                 (min 4 (:concurrency ceiling))
+                                 1)
+                  :capacity (min 1024 (:capacity ceiling))
+                  :ingress-capacity (min 1024 (:ingress-capacity ceiling))}
+        effective (merge defaults opts)]
+    (when unknown
+      (throw (ex-info "Unknown SCI work-admission options"
+                      {:type ::invalid-options :unknown-keys (vec unknown)})))
+    (doseq [[option limit] [[:concurrency :concurrency]
+                            [:capacity :capacity]
+                            [:ingress-capacity :ingress-capacity]]]
+      (let [value (get effective option)]
+        (when-not (and (integer? value)
+                       (if (= option :capacity) (not (neg? value)) (pos? value)))
+          (throw (ex-info "SCI work-admission option is outside its numeric domain"
+                          {:type ::invalid-options :option option :value value})))
+        (when (> value (get ceiling limit))
+          (throw (ex-info "SCI work-admission option exceeds this sandbox's ceiling"
+                          {:type ::ceiling-exceeded
+                           :option option
+                           :requested value
+                           :ceiling (get ceiling limit)})))))
+    effective))
+
+(defn- forget-controller! [^Controller controller]
+  (locking lifecycle-lock
+    (swap! rooms* update-in [(.-room-id controller) :controllers]
+           (fn [controllers] (disj (or controllers #{}) controller))))
+  nil)
+
+(defn create!
+  "Create and register an opaque, room-owned controller."
+  [room-id owner-context ceiling strategy opts work-fn]
+  (ensure-room! room-id)
+  (let [ceiling (normalize-ceiling ceiling)
+        opts (bounded-opts strategy ceiling opts)]
+    (locking lifecycle-lock
+      (let [{:keys [state controllers]
+             :or {state :open controllers #{}}} (get @rooms* room-id)]
+        (when-not (= :open state)
+          (throw (ex-info "Room work admission is closed for teardown"
+                          {:type ::admission-closed :room-id room-id})))
+        (when (>= (count controllers) (:controllers ceiling))
+          (throw (ex-info "SCI work-admission controller limit reached"
+                          {:type ::ceiling-exceeded
+                           :limit :controllers
+                           :ceiling (:controllers ceiling)})))
+        (let [native (binding [ec/*execution-context* owner-context]
+                       (work/work-admission (assoc opts :strategy strategy) work-fn))
+              controller (Controller. native room-id owner-context (atom #{}) ceiling)]
+          (swap! rooms* assoc room-id
+                 {:state :open :controllers (conj controllers controller)})
+          ;; A passive completion observer releases the allocation slot. It does
+          ;; not own/cancel the controller and cannot be abandoned by SCI.
+          (binding [ec/*execution-context* owner-context]
+            ((work/completion native)
+             (fn [_] (forget-controller! controller))
+             (fn [_] (forget-controller! controller))))
+          controller)))))
+
+(defn submit!
+  ([controller value]
+   (work/submit! (native-controller controller) value))
+  ([controller id value]
+   (work/submit! (native-controller controller) id value)))
+
+(defn snapshot [controller]
+  (work/snapshot (native-controller controller)))
+
+(defn completion [controller]
+  (work/completion (native-controller controller)))
+
+(defn close! [controller]
+  (work/close! (native-controller controller)))
+
+(defn cancel! [controller]
+  (work/cancel! (native-controller controller)))
+
+(defn events! [^Controller controller]
+  (when-not (instance? Controller controller)
+    (native-controller controller))
+  (let [taps (.-taps controller)
+        ceiling (get (.-ceiling controller) :event-taps)]
+    (locking taps
+      (when (>= (count @taps) ceiling)
+        (throw (ex-info "SCI work-admission event-tap limit reached"
+                        {:type ::ceiling-exceeded
+                         :limit :event-taps
+                         :ceiling ceiling})))
+      (let [tap (work/events (.-native controller))]
+        (swap! taps conj tap)
+        tap))))
+
+(defn untap! [^Controller controller event-source]
+  (when-not (instance? Controller controller)
+    (native-controller controller))
+  (let [taps (.-taps controller)]
+    (locking taps
+      (when-not (contains? @taps event-source)
+        (throw (ex-info "Event source does not belong to this controller"
+                        {:type ::foreign-event-source})))
+      (work/untap-events! (.-native controller) event-source)
+      (swap! taps disj event-source)))
+  nil)
+
+(defn- await-controller! [^Controller controller deadline-ms]
+  (let [settled (promise)
+        ctx (.-owner-context controller)]
+    (binding [ec/*execution-context* ctx]
+      (work/cancel! (.-native controller))
+      ((work/completion (.-native controller))
+       #(deliver settled [:ok %])
+       #(deliver settled [:error %])))
+    (let [remaining (max 0 (- deadline-ms (System/currentTimeMillis)))
+          result (deref settled remaining ::timeout)]
+      (if (= ::timeout result)
+        (throw (ex-info "Room teardown timed out waiting for SCI work"
+                        {:type ::teardown-timeout
+                         :room-id (.-room-id controller)
+                         :snapshot (binding [ec/*execution-context*
+                                             (.-owner-context controller)]
+                                     (work/snapshot (.-native controller)))}))
+        (case (first result)
+          :ok nil
+          :error (throw (ex-info "SCI work controller failed during Room teardown"
+                                 {:type ::teardown-failed
+                                  :room-id (.-room-id controller)}
+                                 (second result))))))))
+
+(defn close-room-work!
+  "Fence, cancel, and join every SCI controller owned by `room`. Idempotent."
+  [room]
+  (when room
+    (let [room-id (:id room)
+          controllers
+          (locking lifecycle-lock
+            (let [controllers (get-in @rooms* [room-id :controllers] #{})]
+              (swap! rooms* assoc room-id
+                     {:state :closing :controllers controllers})
+              controllers))
+          deadline (+ (System/currentTimeMillis) 5000)]
+      (doseq [controller controllers]
+        (await-controller! controller deadline))))
+  nil)
+
+(defn- reopen-room! [room]
+  (locking lifecycle-lock
+    (swap! rooms* assoc (:id room) {:state :open :controllers #{}}))
+  nil)
+
+;; Registration reopens a reused durable room id. Pre-unregister is the common
+;; settlement boundary for close, fork discard, and merge cleanup.
+(room-registry/add-register-hook! ::work-admission reopen-room!)
+(room-registry/add-pre-unregister-hook! ::work-admission close-room-work!)

--- a/src/dvergr/sandbox/work.clj
+++ b/src/dvergr/sandbox/work.clj
@@ -8,7 +8,8 @@
    projections remain in Spindel."
   (:require [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.work :as work]
-            [dvergr.room.registry :as room-registry]))
+            [dvergr.room.registry :as room-registry]
+            [dvergr.runtime.ctx :as runtime-ctx]))
 
 (def default-ceiling
   {:controllers 16
@@ -17,7 +18,7 @@
    :ingress-capacity 1024
    :event-taps 8})
 
-(deftype Controller [native room-id generation owner-context taps ceiling])
+(deftype Controller [native room-id lifecycle-key generation owner-context taps ceiling])
 
 (defonce ^:private lifecycle-lock (Object.))
 (defonce ^:private rooms* (atom {}))
@@ -58,6 +59,12 @@
     (throw (ex-info "Structured work admission requires a room-scoped SCI session"
                     {:type ::room-required}))))
 
+(defn- root-key [ctx]
+  (:fork-id (runtime-ctx/root-ctx ctx)))
+
+(defn- lifecycle-key [ctx room-id]
+  [(root-key ctx) room-id])
+
 (defn- bounded-opts [strategy ceiling opts]
   (let [allowed #{:concurrency :capacity :ingress-capacity}
         unknown (seq (remove allowed (keys opts)))
@@ -89,28 +96,33 @@
 (defn- forget-controller! [^Controller controller]
   (locking lifecycle-lock
     (let [room-id (.-room-id controller)
+          key (.-lifecycle-key controller)
           generation (.-generation controller)]
       (swap! rooms*
              (fn [rooms]
-               (if (= generation (get-in rooms [room-id :generation]))
-                 (update-in rooms [room-id :controllers]
+               (if (= generation (get-in rooms [key :generation]))
+                 (update-in rooms [key :controllers]
                             (fn [controllers] (disj (or controllers #{}) controller)))
                  rooms)))))
   nil)
 
 (defn create!
   "Create and register an opaque, room-owned controller."
-  [room-id owner-context ceiling strategy opts work-fn]
+  [room-id incarnation owner-context ceiling strategy opts work-fn]
   (ensure-room! room-id)
-  (let [ceiling (normalize-ceiling ceiling)
+  (let [key (lifecycle-key owner-context room-id)
+        ceiling (normalize-ceiling ceiling)
         opts (bounded-opts strategy ceiling opts)]
     (locking lifecycle-lock
       (let [{:keys [state controllers generation]
              lifecycle-owner :owner-context
-             :as lifecycle} (get @rooms* room-id)]
+             :as lifecycle} (get @rooms* key)]
         (when-not lifecycle
           (throw (ex-info "Room work admission has no live lifecycle owner"
                           {:type ::room-not-registered :room-id room-id})))
+        (when-not (= incarnation generation)
+          (throw (ex-info "SCI session belongs to a stale Room incarnation"
+                          {:type ::stale-room-incarnation :room-id room-id})))
         (when-not (identical? lifecycle-owner owner-context)
           (throw (ex-info "SCI session does not own this Room incarnation"
                           {:type ::stale-room-incarnation :room-id room-id})))
@@ -124,9 +136,9 @@
                            :ceiling (:controllers ceiling)})))
         (let [native (binding [ec/*execution-context* owner-context]
                        (work/work-admission (assoc opts :strategy strategy) work-fn))
-              controller (Controller. native room-id generation owner-context
+              controller (Controller. native room-id key generation owner-context
                                       (atom #{}) ceiling)]
-          (swap! rooms* update-in [room-id :controllers] conj controller)
+          (swap! rooms* update-in [key :controllers] conj controller)
           ;; A passive completion observer releases the allocation slot. It does
           ;; not own/cancel the controller and cannot be abandoned by SCI.
           (binding [ec/*execution-context* owner-context]
@@ -213,15 +225,17 @@
   [room]
   (when room
     (let [room-id (:id room)
+          key (lifecycle-key (:ctx room) room-id)
           {:keys [controllers fence]}
           (locking lifecycle-lock
-            (when-let [lifecycle (get @rooms* room-id)]
-              (when-not (identical? (:owner-context lifecycle) (:ctx room))
+            (when-let [lifecycle (get @rooms* key)]
+              (when-not (and (= (:incarnation room) (:generation lifecycle))
+                             (identical? (:owner-context lifecycle) (:ctx room)))
                 (throw (ex-info "Room instance does not own its work lifecycle"
                                 {:type ::stale-room-incarnation :room-id room-id})))
               (let [fence (or (:fence lifecycle) (random-uuid))
                     lifecycle (assoc lifecycle :state :closing :fence fence)]
-                (swap! rooms* assoc room-id lifecycle)
+                (swap! rooms* assoc key lifecycle)
                 {:controllers (:controllers lifecycle) :fence fence})))
           deadline (+ (System/currentTimeMillis) 5000)
           failures (transient [])]
@@ -256,20 +270,33 @@
   (when (and room fence)
     (locking lifecycle-lock
       (let [room-id (:id room)
-            lifecycle (get @rooms* room-id)]
+            key (lifecycle-key (:ctx room) room-id)
+            lifecycle (get @rooms* key)]
         (when (and (= fence (:fence lifecycle))
                    (= :closing (:state lifecycle))
+                   (= (:incarnation room) (:generation lifecycle))
                    (identical? (:owner-context lifecycle) (:ctx room)))
-          (swap! rooms* assoc room-id
+          (swap! rooms* assoc key
                  (-> lifecycle (assoc :state :open) (dissoc :fence)))
           true)))))
 
 (defn- register-room! [room]
   (let [room-id (:id room)
-        owner-context (:ctx room)]
+        owner-context (:ctx room)
+        registry-root (runtime-ctx/current-root)
+        owner-root (runtime-ctx/root-ctx owner-context)
+        _ (when-not (= (root-key registry-root) (root-key owner-root))
+            (throw (ex-info "Room must register in its execution tree's root registry"
+                            {:type ::registry-root-mismatch :room-id room-id})))
+        key (lifecycle-key registry-root room-id)
+        incarnation (:incarnation room)]
     (locking lifecycle-lock
-      (if-let [lifecycle (get @rooms* room-id)]
+      (if-let [lifecycle (get @rooms* key)]
         (cond
+          (not= incarnation (:generation lifecycle))
+          (throw (ex-info "Room id is still owned by another live incarnation"
+                          {:type ::room-incarnation-conflict :room-id room-id}))
+
           (not (identical? owner-context (:owner-context lifecycle)))
           (throw (ex-info "Room id is still owned by another live incarnation"
                           {:type ::room-incarnation-conflict :room-id room-id}))
@@ -282,9 +309,9 @@
           ;; Idempotent refresh of the same Room context preserves controllers,
           ;; ceilings, and the lifecycle generation.
           nil)
-        (swap! rooms* assoc room-id
+        (swap! rooms* assoc key
                {:state :open
-                :generation (random-uuid)
+                :generation incarnation
                 :owner-context owner-context
                 :controllers #{}}))))
   nil)
@@ -294,7 +321,7 @@
   ;; makes stale SCI sessions fail closed instead of attaching to a later Room
   ;; that happens to reuse the durable id.
   (locking lifecycle-lock
-    (swap! rooms* dissoc room-id))
+    (swap! rooms* dissoc (lifecycle-key (runtime-ctx/current-root) room-id)))
   nil)
 
 ;; The safety hook runs before add-or-replace registration and may reject a

--- a/src/dvergr/sandbox/work.clj
+++ b/src/dvergr/sandbox/work.clj
@@ -17,7 +17,7 @@
    :ingress-capacity 1024
    :event-taps 8})
 
-(deftype Controller [native room-id owner-context taps ceiling])
+(deftype Controller [native room-id generation owner-context taps ceiling])
 
 (defonce ^:private lifecycle-lock (Object.))
 (defonce ^:private rooms* (atom {}))
@@ -88,8 +88,14 @@
 
 (defn- forget-controller! [^Controller controller]
   (locking lifecycle-lock
-    (swap! rooms* update-in [(.-room-id controller) :controllers]
-           (fn [controllers] (disj (or controllers #{}) controller))))
+    (let [room-id (.-room-id controller)
+          generation (.-generation controller)]
+      (swap! rooms*
+             (fn [rooms]
+               (if (= generation (get-in rooms [room-id :generation]))
+                 (update-in rooms [room-id :controllers]
+                            (fn [controllers] (disj (or controllers #{}) controller)))
+                 rooms)))))
   nil)
 
 (defn create!
@@ -99,8 +105,15 @@
   (let [ceiling (normalize-ceiling ceiling)
         opts (bounded-opts strategy ceiling opts)]
     (locking lifecycle-lock
-      (let [{:keys [state controllers]
-             :or {state :open controllers #{}}} (get @rooms* room-id)]
+      (let [{:keys [state controllers generation]
+             lifecycle-owner :owner-context
+             :as lifecycle} (get @rooms* room-id)]
+        (when-not lifecycle
+          (throw (ex-info "Room work admission has no live lifecycle owner"
+                          {:type ::room-not-registered :room-id room-id})))
+        (when-not (identical? lifecycle-owner owner-context)
+          (throw (ex-info "SCI session does not own this Room incarnation"
+                          {:type ::stale-room-incarnation :room-id room-id})))
         (when-not (= :open state)
           (throw (ex-info "Room work admission is closed for teardown"
                           {:type ::admission-closed :room-id room-id})))
@@ -111,9 +124,9 @@
                            :ceiling (:controllers ceiling)})))
         (let [native (binding [ec/*execution-context* owner-context]
                        (work/work-admission (assoc opts :strategy strategy) work-fn))
-              controller (Controller. native room-id owner-context (atom #{}) ceiling)]
-          (swap! rooms* assoc room-id
-                 {:state :open :controllers (conj controllers controller)})
+              controller (Controller. native room-id generation owner-context
+                                      (atom #{}) ceiling)]
+          (swap! rooms* update-in [room-id :controllers] conj controller)
           ;; A passive completion observer releases the allocation slot. It does
           ;; not own/cancel the controller and cannot be abandoned by SCI.
           (binding [ec/*execution-context* owner-context]
@@ -167,11 +180,14 @@
       (swap! taps disj event-source)))
   nil)
 
+(defn- cancel-controller! [^Controller controller]
+  (binding [ec/*execution-context* (.-owner-context controller)]
+    (work/cancel! (.-native controller))))
+
 (defn- await-controller! [^Controller controller deadline-ms]
   (let [settled (promise)
         ctx (.-owner-context controller)]
     (binding [ec/*execution-context* ctx]
-      (work/cancel! (.-native controller))
       ((work/completion (.-native controller))
        #(deliver settled [:ok %])
        #(deliver settled [:error %])))
@@ -192,27 +208,98 @@
                                  (second result))))))))
 
 (defn close-room-work!
-  "Fence, cancel, and join every SCI controller owned by `room`. Idempotent."
+  "Fence, broadcast cancellation to, and join every SCI controller owned by
+   `room`. Returns the fence generation. Repeated calls join the same fence."
   [room]
   (when room
     (let [room-id (:id room)
-          controllers
+          {:keys [controllers fence]}
           (locking lifecycle-lock
-            (let [controllers (get-in @rooms* [room-id :controllers] #{})]
-              (swap! rooms* assoc room-id
-                     {:state :closing :controllers controllers})
-              controllers))
-          deadline (+ (System/currentTimeMillis) 5000)]
+            (when-let [lifecycle (get @rooms* room-id)]
+              (when-not (identical? (:owner-context lifecycle) (:ctx room))
+                (throw (ex-info "Room instance does not own its work lifecycle"
+                                {:type ::stale-room-incarnation :room-id room-id})))
+              (let [fence (or (:fence lifecycle) (random-uuid))
+                    lifecycle (assoc lifecycle :state :closing :fence fence)]
+                (swap! rooms* assoc room-id lifecycle)
+                {:controllers (:controllers lifecycle) :fence fence})))
+          deadline (+ (System/currentTimeMillis) 5000)
+          failures (transient [])]
+      ;; Cancellation is a broadcast. A broken controller must not prevent its
+      ;; siblings from receiving the teardown signal.
       (doseq [controller controllers]
-        (await-controller! controller deadline))))
+        (try
+          (cancel-controller! controller)
+          (catch Throwable error
+            (conj! failures {:phase :cancel :controller controller :error error}))))
+      ;; Then join every controller against one common deadline, aggregating all
+      ;; failures so callers can retry or enter explicit recovery.
+      (doseq [controller controllers]
+        (try
+          (await-controller! controller deadline)
+          (catch Throwable error
+            (conj! failures {:phase :join :controller controller :error error}))))
+      (let [failures (persistent! failures)]
+        (when (seq failures)
+          (throw (ex-info "Room teardown failed waiting for SCI work"
+                          {:type ::room-work-teardown-failed
+                           :room-id room-id
+                           :fence fence
+                           :failures (mapv #(select-keys % [:phase]) failures)}
+                          (:error (first failures)))))
+        fence))))
+
+(defn recover-room-work!
+  "Reopen exactly the fenced Room incarnation identified by `fence`. Returns
+   true when recovery won, false for a stale/missing fence."
+  [room fence]
+  (when (and room fence)
+    (locking lifecycle-lock
+      (let [room-id (:id room)
+            lifecycle (get @rooms* room-id)]
+        (when (and (= fence (:fence lifecycle))
+                   (= :closing (:state lifecycle))
+                   (identical? (:owner-context lifecycle) (:ctx room)))
+          (swap! rooms* assoc room-id
+                 (-> lifecycle (assoc :state :open) (dissoc :fence)))
+          true)))))
+
+(defn- register-room! [room]
+  (let [room-id (:id room)
+        owner-context (:ctx room)]
+    (locking lifecycle-lock
+      (if-let [lifecycle (get @rooms* room-id)]
+        (cond
+          (not (identical? owner-context (:owner-context lifecycle)))
+          (throw (ex-info "Room id is still owned by another live incarnation"
+                          {:type ::room-incarnation-conflict :room-id room-id}))
+
+          (not= :open (:state lifecycle))
+          (throw (ex-info "Room work lifecycle is fenced"
+                          {:type ::admission-closed :room-id room-id}))
+
+          :else
+          ;; Idempotent refresh of the same Room context preserves controllers,
+          ;; ceilings, and the lifecycle generation.
+          nil)
+        (swap! rooms* assoc room-id
+               {:state :open
+                :generation (random-uuid)
+                :owner-context owner-context
+                :controllers #{}}))))
   nil)
 
-(defn- reopen-room! [room]
+(defn- unregister-room! [room-id]
+  ;; The pre-unregister fence leaves this incarnation :closing. Removing it
+  ;; makes stale SCI sessions fail closed instead of attaching to a later Room
+  ;; that happens to reuse the durable id.
   (locking lifecycle-lock
-    (swap! rooms* assoc (:id room) {:state :open :controllers #{}}))
+    (swap! rooms* dissoc room-id))
   nil)
 
-;; Registration reopens a reused durable room id. Pre-unregister is the common
-;; settlement boundary for close, fork discard, and merge cleanup.
-(room-registry/add-register-hook! ::work-admission reopen-room!)
+;; The safety hook runs before add-or-replace registration and may reject a
+;; stale incarnation. Pre-unregister is the common settlement boundary for
+;; close, fork discard, and merge cleanup.
+(room-registry/add-pre-register-hook! ::work-admission register-room!)
 (room-registry/add-pre-unregister-hook! ::work-admission close-room-work!)
+(room-registry/add-unregister-hook! ::work-admission unregister-room!)

--- a/src/dvergr/sci/clojure_test.clj
+++ b/src/dvergr/sci/clojure_test.clj
@@ -4,7 +4,8 @@
    We've vendored babashka's clojure.test (EPL licensed) and adapted it
    to work without babashka's infrastructure."
   (:require [dvergr.sci.impl.clojure-test :as t]
-            [sci.core :as sci]))
+            [sci.core :as sci]
+            [sci.ctx-store :as sci-ctx-store]))
 
 ;; Create the test namespace object
 (def tns t/tns)
@@ -12,6 +13,16 @@
 ;; Helper to create SCI vars
 (defn new-var [var-sym f]
   (sci/new-var var-sym f {:ns tns}))
+
+(defn- shared-host-capability
+  "Declare a vendored clojure.test implementation object as an ambient
+   capability. Its mutable state is not agent memory: SCI code receives the
+   callable/output Var but Dvergr installs the implementation once at boot.
+   Marking the individual Var keeps SCI's fail-closed policy for every other
+   host value while allowing world forks to retain this implementation table."
+  [v]
+  (alter-meta! v assoc :sci.impl/fork-fn identity)
+  v)
 
 ;; Base namespace map — everything except the high-level runners that need ctx.
 ;; Combine with ctx-aware-test-namespace (below) for full functionality.
@@ -28,13 +39,13 @@
    '*initial-report-counters* t/initial-report-counters
    '*testing-vars*           t/testing-vars
    '*testing-contexts*       t/testing-contexts
-   '*test-out*               t/test-out
+   '*test-out*               (shared-host-capability t/test-out)
 
    ;; Utilities
    'testing-vars-str    (sci/copy-var t/testing-vars-str tns)
    'testing-contexts-str (sci/copy-var t/testing-contexts-str tns)
    'inc-report-counter  (sci/copy-var t/inc-report-counter tns)
-   'report              t/report
+   'report              (shared-host-capability t/report)
    'do-report           (sci/copy-var t/do-report tns)
 
    ;; Assertion utilities
@@ -43,7 +54,8 @@
    'assert-any          (sci/copy-var t/assert-any tns)
 
    ;; Assertion methods
-   'assert-expr         (sci/copy-var t/assert-expr tns)
+   'assert-expr         (shared-host-capability
+                         (sci/copy-var t/assert-expr tns))
    'try-expr            (sci/copy-var t/try-expr tns)
 
    ;; Assertion macros
@@ -58,7 +70,8 @@
    'set-test            (sci/copy-var t/set-test tns)
 
    ;; Fixtures
-   'use-fixtures        (sci/copy-var t/use-fixtures tns)
+   'use-fixtures        (shared-host-capability
+                         (sci/copy-var t/use-fixtures tns))
    'compose-fixtures    (sci/copy-var t/compose-fixtures tns)
    'join-fixtures       (sci/copy-var t/join-fixtures tns)
 
@@ -71,23 +84,30 @@
    'with-test-out       (sci/copy-var t/with-test-out tns)})
 
 (defn ctx-aware-test-namespace
-  "Build a clojure.test namespace map that closes over the real SCI ctx.
+  "Build a clojure.test namespace map that resolves the active SCI ctx.
 
    The high-level runners (run-tests, test-ns, test-all-vars, run-all-tests) need
-   the real SCI context to enumerate vars via sci-ns-interns*. Passing a dummy ctx
-   causes them to find 0 tests. Call this after (sci/init ...) with the real ctx.
+   the selected SCI context to enumerate vars via sci-ns-interns*. They resolve
+   it from sci.ctx-store at invocation, so a copied runner enumerates the child
+   world after a fork rather than retaining its parent. Call this after
+   (sci/init ...) with the initial ctx.
 
    Usage:
      (sci/merge-opts ctx {:namespaces {'clojure.test (ctx-aware-test-namespace ctx)}})"
-  [ctx]
+  [_ctx]
   (merge clojure-test-namespace
          {'test-all-vars (new-var 'test-all-vars
-                                  (fn [ns-obj] (t/test-all-vars ctx ns-obj)))
+                                  (fn [ns-obj]
+                                    (t/test-all-vars (sci-ctx-store/get-ctx) ns-obj)))
           'test-ns       (new-var 'test-ns
-                                  (fn [ns-sym] (t/test-ns ctx ns-sym)))
+                                  (fn [ns-sym]
+                                    (t/test-ns (sci-ctx-store/get-ctx) ns-sym)))
           'run-tests     (new-var 'run-tests
-                                  (fn [& namespaces] (apply t/run-tests ctx namespaces)))
+                                  (fn [& namespaces]
+                                    (apply t/run-tests
+                                           (sci-ctx-store/get-ctx) namespaces)))
           'run-all-tests (new-var 'run-all-tests
                                   (fn
-                                    ([] (t/run-all-tests ctx))
-                                    ([re] (t/run-all-tests ctx re))))}))
+                                    ([] (t/run-all-tests (sci-ctx-store/get-ctx)))
+                                    ([re] (t/run-all-tests
+                                           (sci-ctx-store/get-ctx) re))))}))

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -595,7 +595,8 @@
                :properties {:code {:type "string"
                                    :description "Clojure code to evaluate"}}
                :required ["code"]}
-  :execute (fn [{:keys [code]} {:keys [sci-ctx isolation eval-ns chat-ctx cancel?]}]
+  :execute (fn [{:keys [code]} {:keys [sci-ctx isolation eval-ns chat-ctx cancel?
+                                       execution-ctx]}]
               ;; Native mode: use real Clojure eval
              (cond
                (= :native isolation)
@@ -631,7 +632,8 @@
                                                  (catch Throwable _ false))))]
                                      (sandbox/eval-code sci-ctx code
                                                         :timeout-ms @eval-timeout-ms
-                                                        :cancel? proc-aborted?))))
+                                                        :cancel? proc-aborted?
+                                                        :execution-context execution-ctx))))
                   ;; Block on process completion / abort.
                  (let [{:keys [ok aborted]} @result-p]
                    (cond
@@ -674,7 +676,8 @@
                sci-ctx
                (let [result (sandbox/eval-code sci-ctx code
                                                :timeout-ms @eval-timeout-ms
-                                               :cancel? cancel?)]
+                                               :cancel? cancel?
+                                               :execution-context execution-ctx)]
                  (if (:success result)
                    {:type :success
                     :content (str "=> " (pr-str (:value result))
@@ -1487,7 +1490,7 @@ Note: changes take effect on the next agent restart or reload."
   ;; The sandbox already has a ctx-aware clojure.test (run-tests / run-all-tests
   ;; enumerate vars in THIS context), so running there is both correct and
   ;; actually isolated. `:sci-ctx` is the same handle clojure_eval receives.
-  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx]}]
+  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx execution-ctx]}]
              (if-not sci-ctx
                {:type :error
                 :error "No sandbox context available to run tests in."}
@@ -1496,7 +1499,8 @@ Note: changes take effect on the next agent restart or reload."
                             pattern (str "(clojure.test/run-all-tests #\""
                                          (str/replace pattern "\"" "\\\"") "\")")
                             :else   "(clojure.test/run-all-tests)")
-                     r    (sandbox/eval-code sci-ctx form)]
+                     r    (sandbox/eval-code sci-ctx form
+                                             :execution-context execution-ctx)]
                  (if-not (:success r)
                    {:type :error
                     :error (str "Test run failed: " (get-in r [:error :message]))}

--- a/src/dvergr/web/dashboard.clj
+++ b/src/dvergr/web/dashboard.clj
@@ -12,6 +12,7 @@
             [org.replikativ.spindel.engine.core :as ec]
             [nextjournal.markdown :as md]
             [nextjournal.markdown.transform :as mdt]
+            [dvergr.activity :as activity]
             [dvergr.rooms.tree :as rooms-tree]
             [dvergr.rooms.stats :as rstats]))
 
@@ -415,7 +416,10 @@
             cs     (rstats/room-agent-contexts room)
             lookup (requiring-resolve 'dvergr.agent.room-context/lookup)
             sbstat (requiring-resolve 'dvergr.sandbox/sandbox-status)
-            sb-of  (fn [aid] (try (sbstat (:sci-ctx (lookup rid aid))) (catch Throwable _ nil)))]
+            sci-in (requiring-resolve 'dvergr.chat.context/sci-context-in)
+            sb-of  (fn [aid]
+                     (try (sbstat (sci-in (lookup rid aid) (:ctx room)))
+                          (catch Throwable _ nil)))]
         (str (h/html
               (if (seq cs)
                 (into [:div.ctx-agents] (map #(agent-context-row % (sb-of (:agent %))) cs))
@@ -515,8 +519,21 @@
            [:span.tool-name (str (or (:tool-use/name tu) (:name tu)))]
            [:pre.msg-extra-body (pr-str (or (:tool-use/input tu) (:input tu)))]])]))))
 
+(defn- activity-hiccup
+  "Compact semantic facts; raw arguments remain in the existing trace details."
+  [message]
+  (when-let [facts (seq (activity/message-activities message))]
+    (let [run-id (or (activity/message-run-id message)
+                     (:activity/run-id (first facts)))]
+      [:div.msg-activities
+       (for [fact facts]
+         [:span.msg-activity
+          (activity/summary fact)
+          (when-let [id (activity/short-id (or (:activity/run-id fact) run-id))]
+            [:span.msg-run "run " id])])])))
+
 (defn- message-hiccup
-  [{:keys [id from content role ts reasoning tool-uses]}]
+  [{:keys [id from content role ts reasoning tool-uses] :as message}]
   (let [name-str (or (some-> from name) "—")
         ;; Per-speaker colour from the SHARED role→colour table — same hues the
         ;; TUI uses (dvergr.rooms.theme); was hardcoded green for every post.
@@ -530,6 +547,7 @@
       (when-let [t (fmt-ts ts)]
         [:span {:style "margin-left:auto;color:#666;font-weight:400;font-size:0.85em;"} t])]
      [:div.msg-body (md->hiccup content)]
+     (activity-hiccup message)
      (think-tool-details id reasoning tool-uses)]))
 
 (defn room-page
@@ -548,6 +566,10 @@
           .msg-body { color:#ddd; word-break:break-word; line-height:1.5; }
           .msg-body > :first-child { margin-top:0; }
           .msg-body > :last-child { margin-bottom:0; }
+          .msg-activities { display:flex;flex-wrap:wrap;gap:5px;margin-top:5px; }
+          .msg-activity { color:#c9a227;background:#25200f;border:1px solid #514519;
+                          border-radius:999px;padding:1px 7px;font-size:0.78em; }
+          .msg-run { color:#888;margin-left:7px;font-family:monospace; }
           .msg-body p { margin:0.4em 0; }
           .msg-body h1,.msg-body h2,.msg-body h3 { color:#e0e0e0; margin:0.6em 0 0.3em; line-height:1.2; }
           .msg-body h1 { font-size:1.25em; } .msg-body h2 { font-size:1.15em; } .msg-body h3 { font-size:1.05em; }

--- a/test/dvergr/activity_test.clj
+++ b/test/dvergr/activity_test.clj
@@ -1,0 +1,68 @@
+(ns dvergr.activity-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.activity :as activity]
+            [dvergr.agent.environment :as environment]))
+
+(deftest tool-activity-identity-is-canonical-and-stable
+  (testing "the same typed source identity hashes to the same activity UUID"
+    (let [run-id (random-uuid)
+          source-id (random-uuid)
+          uses [{:tool-use/id "call-1" :tool-use/name "clojure_eval"}]
+          first-id (:activity/id (first (activity/tool-activities
+                                         run-id source-id uses)))
+          replay-id (:activity/id (first (activity/tool-activities
+                                          run-id source-id uses)))
+          other-id (:activity/id (first (activity/tool-activities
+                                         run-id source-id
+                                         [{:tool-use/id "call-2"
+                                           :tool-use/name "clojure_eval"}])))]
+      (is (uuid? first-id))
+      (is (= first-id replay-id))
+      (is (not= first-id other-id)))))
+
+(deftest tool-traces-preserve-correlation-across-interleaved-runs
+  (let [run-a (random-uuid)
+        run-b (random-uuid)
+        message-a (random-uuid)
+        message-b (random-uuid)
+        use-a {:tool-use/id "call-a"
+               :tool-use/name "search"
+               :tool-use/input {:query "alpha"}}
+        use-b {:tool-use/id "call-b"
+               :tool-use/name "search"
+               :tool-use/input {:query "beta"}}
+        messages
+        [{:id message-a
+          :metadata {:run-id run-a
+                     :tool-uses [use-a]
+                     :activities (activity/tool-activities
+                                  run-a message-a [use-a])}}
+         {:id message-b
+          :metadata {:run-id run-b
+                     :tool-uses [use-b]
+                     :activities (activity/tool-activities
+                                  run-b message-b [use-b])}}]
+        trace (mapv activity/tool-trace-entry messages)]
+    (is (= [[message-a run-a "call-a" run-a]
+            [message-b run-b "call-b" run-b]]
+           (mapv (fn [entry]
+                   [(:message/id entry)
+                    (:run/id entry)
+                    (get-in entry [:tool-uses 0 :tool-use/id])
+                    (get-in entry [:activities 0 :activity/run-id])])
+                 trace)))
+    (is (= [{:query "alpha"} {:query "beta"}]
+           (mapv #(get-in % [:tool-uses 0 :tool-use/input]) trace)))
+    (is (every? integer? (map #(get-in % [:activities 0 :activity/at]) trace)))
+    (let [definition
+          (environment/make-environment
+           {:id :test/tool-trace
+            :task "trace"
+            :verifier {:id :test/trace :version 1}})
+          receipt
+          (environment/make-attempt-receipt
+           definition
+           {:run-id run-a :provider :test :model "stub" :status :completed
+            :started-at 0 :elapsed-ms 1 :metrics {} :checks {:trace? true}
+            :reward 1.0 :trace trace})]
+      (is (= receipt (environment/validate-attempt-receipt receipt))))))

--- a/test/dvergr/agent/attempt_test.clj
+++ b/test/dvergr/agent/attempt_test.clj
@@ -1,0 +1,128 @@
+(ns dvergr.agent.attempt-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.episode :as episode]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [hasch.core :as hasch]))
+
+(defn- fixture []
+  (let [run-id (random-uuid)
+        agent (-> (roster/make-roster)
+                  (roster/make-agent {:id :candidate
+                                      :program {:kind :echo}})
+                  (roster/agent :candidate))
+        definition
+        (environment/make-environment
+         {:id :bench/exact
+          :task {:answer 42}
+          :verifier {:id :bench/exact :version 2 :basis "git:abc"}
+          :limits {:timeout-ms 1000}
+          :world {:isolation :ctx :settlement :review}})
+        receipt
+        (environment/make-attempt-receipt
+         definition
+         {:run-id run-id :provider :dvergr :model "echo"
+          :status :completed :started-at 1000 :elapsed-ms 25
+          :metrics {:program-kind :echo :model-resolution :not-applicable
+                    :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                    :interpreter-version 5}
+          :checks {:exact? true} :reward 1.0
+          :result {:answer 42}
+          :trace {:runs [{:run/id run-id :run/status :completed}]}})
+        certified (attempt/make-attempt definition agent receipt
+                                        {:result {:answer 42}
+                                         :trace {:runs [{:run/id run-id
+                                                         :run/status :completed}]}}
+                                        :review)]
+    {:run-id run-id :agent agent :definition definition
+     :receipt receipt :attempt certified}))
+
+(defn- terminal-run [run-id room-id agent]
+  (let [now (java.util.Date. 1000)]
+    {:run/id run-id :run/kind :agent-task :run/room room-id
+     :run/actor (:agent/id agent) :run/trigger (random-uuid)
+     :run/status :completed :run/created-at now :run/started-at now
+     :run/updated-at now :run/ended-at (java.util.Date. 1025)
+     :run/agent-version (:agent/version agent) :run/program-kind :echo
+     :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)}))
+
+(defn- attempt-with-trace [run-id agent definition trace]
+  (let [receipt
+        (environment/make-attempt-receipt
+         definition
+         {:run-id run-id :provider :dvergr :model "echo"
+          :status :completed :started-at 1000 :elapsed-ms 25
+          :metrics {:program-kind :echo :model-resolution :not-applicable
+                    :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                    :interpreter-version 5}
+          :checks {:exact? true} :reward 1.0 :trace trace})]
+    (attempt/make-attempt definition agent receipt {:trace trace} :review)))
+
+(deftest certified-attempt-is-canonical-portable-data
+  (let [{:keys [attempt run-id]} (fixture)]
+    (is (= attempt (attempt/validate-attempt attempt)))
+    (is (= run-id (:attempt/id attempt)))
+    (is (= #{run-id} (:attempt/evidence-run-ids attempt)))
+    (is (= (get-in attempt [:attempt/receipt :attempt/content-id])
+           (:attempt/content-id attempt)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (attempt/validate-attempt
+                  (assoc attempt :attempt/certified-at 9999))))))
+
+(deftest memory-attempt-store-is-immutable-and-run-backed
+  (let [{:keys [attempt run-id agent]} (fixture)
+        room-id :attempt-memory
+        st (memory/make)]
+    (store/-store-room! st room-id {:slug (name room-id)})
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing or non-terminal"
+                          (store/-store-attempt! st room-id attempt)))
+    (store/-store-run! st room-id (terminal-run run-id room-id agent))
+    (let [missing-run (random-uuid)
+          missing-message (random-uuid)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"evidence Run is missing"
+           (store/-store-attempt!
+            st room-id
+            (attempt-with-trace
+             run-id agent (:attempt/environment attempt)
+             {:runs [{:run/id run-id} {:run/id missing-run}]}))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"evidence message is missing"
+           (store/-store-attempt!
+            st room-id
+            (attempt-with-trace
+             run-id agent (:attempt/environment attempt)
+             {:runs [{:run/id run-id}]
+              :messages [{:message/id missing-message}]})))))
+    (is (= attempt (store/-store-attempt! st room-id attempt)))
+    (is (= attempt (store/-store-attempt! st room-id attempt))
+        "identical certification replay is idempotent")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"identity is immutable"
+                          (store/-store-attempt!
+                           st room-id
+                           (assoc attempt :attempt/settlement-intent :discard))))
+    (is (= [attempt]
+           (store/-list-attempts st room-id
+                                 {:environment-id :bench/exact
+                                  :provider :dvergr :status :completed})))
+    (is (empty? (store/-list-attempts st room-id {:model "other"})))))
+
+(deftest episode-is-a-read-join-not-a-second-lifecycle
+  (let [{:keys [attempt run-id agent]} (fixture)
+        room-id :episode-read
+        st (memory/make)
+        room {:id room-id :store st}]
+    (store/-store-room! st room-id {:slug (name room-id)})
+    (store/-store-run! st room-id (terminal-run run-id room-id agent))
+    (store/-store-attempt! st room-id attempt)
+    (let [exported (episode/export room run-id)]
+      (is (= attempt (:episode/attempt exported)))
+      (is (= :completed (get-in exported [:episode/run :run/status])))
+      (is (integer? (get-in exported [:episode/run :run/started-at])))
+      (is (= [run-id] (mapv :run/id (:episode/evidence-runs exported)))))
+    (swap! (:state st) update-in [:runs room-id] dissoc run-id)
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing Run"
+                          (episode/export room run-id)))))

--- a/test/dvergr/agent/environment_test.clj
+++ b/test/dvergr/agent/environment_test.clj
@@ -1,0 +1,119 @@
+(ns dvergr.agent.environment-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.environment :as environment]
+            [hasch.core :as hasch]))
+
+(def base-spec
+  {:id :programming/join
+   :version 1
+   :task "Build and execute a two-agent join."
+   :verifier {:id :programming/join-checks :version 1
+              :basis "git:abc123"}
+   :limits {:timeout-ms 120000 :max-model-steps 8}
+   :world {:isolation :ctx}})
+
+(deftest definitions-have-stable-content-identity
+  (let [a (environment/make-environment base-spec)
+        b (environment/make-environment
+           (into (array-map) (reverse (seq base-spec))))]
+    (is (= a b))
+    (is (= {:environment/id :programming/join
+            :environment/version 1
+            :environment/content-id (:environment/content-id a)}
+           (environment/environment-ref a)))
+    (doseq [changed [(assoc base-spec :task "Different task")
+                     (assoc-in base-spec [:verifier :version] 2)
+                     (assoc-in base-spec [:limits :max-model-steps] 9)]]
+      (is (not= (:environment/content-id a)
+                (:environment/content-id
+                 (environment/make-environment changed)))))))
+
+(deftest definitions-reject-live-or-ambiguous-state
+  (testing "a trusted verifier is a versioned reference, never an embedded function"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"reference map"
+                          (environment/make-environment
+                           (assoc base-spec :verifier identity)))))
+  (testing "policy fields remain portable forkable data"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"portable data"
+                          (environment/make-environment
+                           (assoc base-spec :metadata {:state (atom 0)})))))
+  (testing "unknown keys fail rather than silently changing hash semantics"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"unknown keys"
+                          (environment/make-environment
+                           (assoc base-spec :verify identity))))))
+
+(deftest references-reject-stale-or-fabricated-content-identities
+  (let [definition (environment/make-environment base-spec)]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match"
+                          (environment/environment-ref
+                           (assoc definition :environment/task "mutated"))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"missing canonical"
+                          (environment/environment-ref
+                           (environment/environment-ref definition))))
+    (is (= definition (environment/validate-environment definition)))))
+
+(deftest trusted-attempt-receipts-bind-run-environment-evidence-and-reward
+  (let [definition (environment/make-environment base-spec)
+        run-id (random-uuid)
+        opts {:run-id run-id
+              :provider :codex-subscription
+              :model "codex-subscription-sol"
+              :status :failed
+              :started-at 1000
+              :elapsed-ms 42
+              :metrics {:prompt-id (random-uuid)
+                        :model-steps 8
+                        :usage {:by-type {:input-tokens 100}}}
+              :checks {:exact-result? false :quiescent? true}
+              :reward 0.0
+              :result nil
+              :trace {:runs [{:run/id run-id :run/status :failed}]}}
+        a (environment/make-attempt-receipt definition opts)
+        b (environment/make-attempt-receipt definition
+                                            (into (array-map) (reverse (seq opts))))
+        rehash (fn [changes]
+                 (let [changed (merge (dissoc a :attempt/content-id) changes)]
+                   (assoc changed :attempt/content-id
+                          (hasch/uuid [:dvergr/environment-attempt changed]))))]
+    (is (= a b))
+    (is (= run-id (:attempt/id a) (:attempt/run-id a)))
+    (is (= (environment/environment-ref definition)
+           (:attempt/environment a)))
+    (is (= a (environment/validate-attempt-receipt a)))
+    (is (uuid? (:attempt/content-id a)))
+    (is (not= (:attempt/content-id a)
+              (:attempt/content-id
+               (environment/make-attempt-receipt
+                definition (assoc opts :reward 1.0)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match"
+                          (environment/validate-attempt-receipt
+                           (assoc a :attempt/reward 1.0))))
+    (doseq [[message changes]
+            [[#"UUID" {:attempt/id "run" :attempt/run-id "run"}]
+             [#"EnvironmentRef" {:attempt/environment :garbage}]
+             [#"non-negative" {:attempt/elapsed-ms -1}]
+             [#"keywords to booleans" {:attempt/checks {:truth :unknown}}]
+             [#"finite" {:attempt/reward ##NaN}]]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo message
+                            (environment/validate-attempt-receipt
+                             (rehash changes)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"keywords to booleans"
+                          (environment/make-attempt-receipt
+                           (environment/make-environment base-spec)
+                           {:run-id (random-uuid) :provider :stub :model "stub"
+                            :status :completed :started-at 0 :elapsed-ms 0
+                            :checks {:truth :unknown} :reward 0.0}))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"finite"
+                        (environment/make-attempt-receipt
+                         (environment/make-environment base-spec)
+                         {:run-id (random-uuid) :provider :stub :model "stub"
+                          :status :completed :started-at 0 :elapsed-ms 0
+                          :checks {} :reward ##Inf}))))

--- a/test/dvergr/agent/evaluation_test.clj
+++ b/test/dvergr/agent/evaluation_test.clj
@@ -1,0 +1,557 @@
+(ns dvergr.agent.evaluation-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.episode :as episode]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [dvergr.rooms.forks :as forks]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.yggdrasil :as ygg]))
+
+(defn- test-room [id]
+  (d/make-room {:id id :store (memory/make)}))
+
+(defrecord RejectingAttemptStore [delegate]
+  store/PRoomStore
+  (-store-room! [_ room-id metadata]
+    (store/-store-room! delegate room-id metadata))
+  (-load-room [_ id] (store/-load-room delegate id))
+  (-delete-room! [_ room-id] (store/-delete-room! delegate room-id))
+  (-list-rooms [_] (store/-list-rooms delegate))
+  (-store-message! [_ room-id message]
+    (store/-store-message! delegate room-id message))
+  (-message-thread-root [_ room-id message-id]
+    (store/-message-thread-root delegate room-id message-id))
+  (-list-messages [_ room-id opts]
+    (store/-list-messages delegate room-id opts))
+  (-store-run! [_ room-id value]
+    (store/-store-run! delegate room-id value))
+  (-load-run [_ room-id run-id]
+    (store/-load-run delegate room-id run-id))
+  (-list-runs [_ room-id opts]
+    (store/-list-runs delegate room-id opts))
+
+  store/PAttemptStore
+  (-store-attempt! [_ _room-id _value] nil)
+  (-load-attempt [_ room-id attempt-id]
+    (store/-load-attempt delegate room-id attempt-id))
+  (-list-attempts [_ room-id opts]
+    (store/-list-attempts delegate room-id opts)))
+
+(defn- wait-until [pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (pred) true
+        (< (System/currentTimeMillis) deadline)
+        (do (Thread/sleep 5) (recur))
+        :else false))))
+
+(defn- definition [id opts]
+  (environment/make-environment
+   (merge {:id id
+           :task {:claim 42}
+           :verifier {:id :test/exact :version 1 :basis "test:v1"}
+           :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+           :world {:isolation :ctx :settlement :review}}
+          opts)))
+
+(def exact-evaluator
+  (evaluation/make-evaluator
+   {:id :test/exact
+    :version 1
+    :basis "test:v1"
+    :observe (fn [{:keys [default]}] default)
+    :verify (fn [environment evidence]
+              (let [exact? (= (:environment/task environment)
+                              (:result evidence))]
+                {:checks {:exact? exact?}
+                 :reward (if exact? 1.0 0.0)}))}))
+
+(defn- discard-retained! [result]
+  (when-let [fork (some-> result :run/result :run/world registry/lookup)]
+    (d/discard fork)))
+
+(deftest evaluation-is-a-lazy-composable-spin-over-ordinary-run-worlds
+  (let [room (test-room :evaluation-parallel)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :candidate
+               :program {:kind :echo}})
+        env (definition :test/parallel {})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [a (evaluation/evaluate room team :candidate env exact-evaluator)
+              b (evaluation/evaluate room team :candidate env exact-evaluator)]
+          (is (empty? (run/active-runs (:id room)))
+              "constructing evaluation Spins has no execution effect")
+          (let [results @(apply comb/parallel [a b])]
+            (try
+              (is (= 2 (count results)))
+              (is (= 2 (count (set (map :run/id results)))))
+              (is (every? #(= 1.0 (get-in % [:attempt-receipt :attempt/reward]))
+                          results))
+              (is (every? #(= {:exact? true}
+                              (get-in % [:attempt-receipt :attempt/checks]))
+                          results))
+              (is (every? #(= :review
+                              (get-in % [:run/result :run/settlement-status]))
+                          results))
+              (is (every? #(= [:dvergr "echo" :echo false]
+                              [(get-in % [:attempt-receipt :attempt/provider])
+                               (get-in % [:attempt-receipt :attempt/model])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :program-kind])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :timed-out?])])
+                          results))
+              (is (every? #(= [:not-applicable 1 5]
+                              [(get-in % [:attempt-receipt :attempt/metrics
+                                          :model-resolution])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :agent-version])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :interpreter-version])])
+                          results))
+              (is (every? uuid?
+                          (map #(get-in % [:attempt-receipt :attempt/metrics
+                                           :agent-def-hash])
+                               results)))
+              (is (every? #(= (:attempt %)
+                              (store/-load-attempt (:store room) (:id room)
+                                                   (:run/id %)))
+                          results)
+                  "certification is durable before a retained world is exposed")
+              (is (every? #(= (:attempt %)
+                              (:episode/attempt
+                               (episode/export room (:run/id %))))
+                          results))
+              (finally
+                (doseq [result results] (discard-retained! result)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-fails-closed-when-attempt-certification-is-not-durable
+  (let [delegate (memory/make)
+        room (d/make-room {:id :evaluation-attempt-durability
+                           :store (->RejectingAttemptStore delegate)})
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/attempt-durability {})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error (try
+                      @(evaluation/evaluate room team :candidate env
+                                            exact-evaluator)
+                      nil
+                      (catch Throwable error error))
+              run-id (:run/id (ex-data error))]
+          (is error)
+          (is (= ::evaluation/certification-failed
+                 (:type (ex-data error))))
+          (is (uuid? run-id))
+          (is (nil? (store/-load-attempt delegate (:id room) run-id)))
+          (is (= :discarded
+                 (:run/settlement-status
+                  (store/-load-run delegate (:id room) run-id))))
+          (is (nil? (registry/lookup
+                     (:run/world (store/-load-run delegate (:id room) run-id)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-rejects-a-mismatched-host-capability-before-admission
+  (let [room (test-room :evaluation-mismatch)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/mismatch {})
+        wrong (evaluation/make-evaluator
+               {:id :test/other :observe (constantly {})
+                :verify (fn [_ _] {:checks {} :reward 0.0})})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not match"
+                            (evaluation/evaluate room team :candidate env wrong)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-refuses-to-merge-before-trusted-scoring
+  (let [room (test-room :evaluation-unsafe-settlement)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/unsafe
+              {:world {:isolation :ctx :settlement :automatic}})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"retain successful worlds"
+                            (evaluation/evaluate
+                             room team :candidate env exact-evaluator)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-requires-portable-evidence
+  (let [room (test-room :evaluation-evidence)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/evidence {:world {:settlement :discard}})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [_] {:live (atom 1)})
+          :verify (fn [_ _] {:checks {} :reward 0.0})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error (try
+                      @(evaluation/evaluate room team :candidate env evaluator)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= :dvergr.agent.evaluation/certification-failed
+                 (:type (ex-data error))))
+          (is (re-find #"portable map" (ex-message (ex-cause error))))
+          (is (nil? (registry/lookup (:run/world (ex-data error)))))))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest deferred-world-cannot-settle-before-scoring
+  (let [room (test-room :evaluation-deferred-gate)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/deferred {})
+        premature (atom nil)
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [result default]}]
+                     (let [fork (registry/lookup (:run/world result))]
+                       (reset! premature {:merge (forks/merge! fork)
+                                          :discard (forks/discard! fork)
+                                          :direct-merge-blocked?
+                                          (try
+                                            (d/merge-room room fork)
+                                            false
+                                            (catch clojure.lang.ExceptionInfo _
+                                              true))
+                                          :direct-discard-blocked?
+                                          (try
+                                            (d/discard fork)
+                                            false
+                                            (catch clojure.lang.ExceptionInfo _
+                                              true))
+                                          :deferred? (forks/deferred? fork)}))
+                     default)
+          :verify (fn [_ _] {:checks {:verified? true} :reward 1.0})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result @(evaluation/evaluate room team :candidate env evaluator)
+              fork (registry/lookup (get-in result [:run/result :run/world]))]
+          (is (false? (get-in @premature [:merge :ok?])))
+          (is (false? (get-in @premature [:discard :ok?])))
+          (is (true? (:direct-merge-blocked? @premature)))
+          (is (true? (:direct-discard-blocked? @premature)))
+          (is (true? (:deferred? @premature)))
+          (is (= :review (get-in result [:run/result :run/settlement-status])))
+          (is (false? (forks/deferred? fork)))
+          (is (= :review (:run/settlement-status
+                          (program/observe room (:run/handle result)))))
+          (d/discard fork)))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-during-host-scoring-cannot-certify-or-release
+  (let [room (test-room :evaluation-cancel-scoring)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/cancel-scoring {})
+        entered (promise)
+        release (promise)
+        observed (atom nil)
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default run-id result]}]
+                     (reset! observed {:run/id run-id
+                                       :run/world (:run/world result)})
+                     (deliver entered true)
+                     @release
+                     default)
+          :verify (fn [_ _] {:checks {:verified? true} :reward 1.0})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [attempt (evaluation/evaluate room team :candidate env evaluator)]
+          (sp/spawn! attempt)
+          (is (= true (deref entered 5000 ::timeout)))
+          (spin-core/cancel-spin! attempt)
+          (deliver release true)
+          (is (wait-until
+               #(let [{:run/keys [id world]} @observed
+                      durable (when id (run/run room id))]
+                  (and (= :discarded (:run/settlement-status durable))
+                       (= :evaluation-cancelled
+                          (:run/settlement-reason durable))
+                       (nil? (registry/lookup world))))
+               5000))
+          (is (not= :review
+                    (:run/settlement-status
+                     (run/run room (:run/id @observed)))))
+          (is (nil? (store/-load-attempt (:store room) (:id room)
+                                         (:run/id @observed)))
+              "cancellation before certification leaves no durable Attempt")))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-at-the-settlement-gate-wins-before-release
+  (let [room (test-room :evaluation-cancel-release)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/cancel-release {})
+        entered (promise)
+        release (promise)
+        observed (atom nil)
+        original-release forks/release-deferred!
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default run-id result]}]
+                     (reset! observed {:run/id run-id
+                                       :run/world (:run/world result)})
+                     default)
+          :verify (fn [_ _] {:checks {:verified? true} :reward 1.0})})]
+    (try
+      (with-redefs [forks/release-deferred!
+                    (fn [fork reason claim!]
+                      (deliver entered true)
+                      @release
+                      (original-release fork reason claim!))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [attempt (evaluation/evaluate room team :candidate env evaluator)]
+            (sp/spawn! attempt)
+            (is (= true (deref entered 5000 ::timeout)))
+            (spin-core/cancel-spin! attempt)
+            (deliver release true)
+            (is (wait-until
+                 #(let [{:run/keys [id world]} @observed
+                        durable (when id (run/run room id))]
+                    (and (= :discarded (:run/settlement-status durable))
+                         (= :evaluation-cancelled
+                            (:run/settlement-reason durable))
+                         (nil? (registry/lookup world))))
+                 5000))
+            (is (nil? (store/-load-attempt (:store room) (:id room)
+                                           (:run/id @observed)))
+                "cancellation at the affine claim gate wins before persistence"))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest unsupported-world-setup-is-rejected-before-admission
+  (let [room (test-room :evaluation-unsupported-setup)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/setup {:world {:isolation :ctx
+                                             :settlement :review
+                                             :setup {:fixture :v1}}})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"trusted resolver"
+                            (evaluation/evaluate room team :candidate env
+                                                 exact-evaluator)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest malformed-verifier-result-discards-uncertified-world
+  (let [room (test-room :evaluation-malformed-score)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/malformed-score {})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default]}] default)
+          :verify (fn [_ _] {:checks {:not :boolean} :reward ##NaN})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error (try
+                      @(evaluation/evaluate room team :candidate env evaluator)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= :dvergr.agent.evaluation/certification-failed
+                 (:type (ex-data error))))
+          (is (uuid? (:run/id (ex-data error))))
+          (is (nil? (registry/lookup (:run/world (ex-data error)))))
+          (is (= :evaluation-certification-failed
+                 (:run/settlement-reason
+                  (run/run room (:run/id (ex-data error))))))
+          (is (nil? (store/-load-attempt (:store room) (:id room)
+                                         (:run/id (ex-data error)))))))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest discard-projection-failure-preserves-the-deferred-world
+  (let [room (test-room :evaluation-discard-durability)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/discard-durability
+              {:world {:isolation :ctx :settlement :discard}})
+        world-id (atom nil)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error
+              (with-redefs [run/update-durable-settlement!
+                            (fn [& _]
+                              (throw (ex-info "store unavailable"
+                                              {:type ::store-unavailable})))]
+                (try
+                  @(evaluation/evaluate room team :candidate env exact-evaluator)
+                  nil
+                  (catch clojure.lang.ExceptionInfo error
+                    (reset! world-id (:run/world (ex-data error)))
+                    error)))
+              durable (run/run room (:run/id (ex-data error)))
+              fork (registry/lookup @world-id)]
+          (is (= :dvergr.agent.evaluation/settlement-recovery-required
+                 (:type (ex-data error))))
+          (is (= :deferred (:run/settlement-status durable)))
+          (is (some? fork))
+          (is (forks/deferred? fork))
+          (is (some? (store/-load-attempt (:store room) (:id room)
+                                          (:run/id (ex-data error))))
+              "certification remains truthful if later settlement projection fails")
+          ;; Restore the real durability boundary before consuming the world.
+          (is (:ok? (forks/discard-deferred!
+                     fork :test-cleanup
+                     (constantly true))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest review-projection-failure-retains-certified-world-for-recovery
+  (let [room (test-room :evaluation-review-durability)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/review-durability {})
+        original-update run/update-durable-settlement!
+        original-observe program/observe
+        calls (atom [])
+        observations (atom 0)
+        world-id (atom nil)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error
+              (with-redefs [run/update-durable-settlement!
+                            (fn [parent id status & [reason]]
+                              (swap! calls conj status)
+                              (if (= :review status)
+                                (throw (ex-info "store unavailable"
+                                                {:type ::store-unavailable}))
+                                (original-update parent id status reason)))
+                            program/observe
+                            (fn [parent handle]
+                              (if (= 1 (swap! observations inc))
+                                (original-observe parent handle)
+                                (throw (ex-info "store remains unavailable"
+                                                {:type ::store-unavailable}))))]
+                (try
+                  @(evaluation/evaluate room team :candidate env exact-evaluator)
+                  nil
+                  (catch clojure.lang.ExceptionInfo error
+                    (reset! world-id (:run/world (ex-data error)))
+                    error)))
+              run-id (:run/id (ex-data error))
+              durable (run/run room run-id)
+              fork (registry/lookup @world-id)]
+          (is (= :dvergr.agent.evaluation/settlement-recovery-required
+                 (:type (ex-data error))))
+          (is (= [:review] @calls)
+              "failed settlement is not followed by destructive cleanup")
+          (is (= 1 @observations)
+              "recovery delivery does not depend on another store read")
+          (is (= :deferred (:run/settlement-status durable)))
+          (is (some? fork))
+          (is (forks/deferred? fork))
+          (is (some? (store/-load-attempt (:store room) (:id room) run-id)))
+          ;; Restore the real durability boundary before consuming the world.
+          (is (:ok? (forks/discard-deferred!
+                     fork :test-cleanup
+                     (constantly true))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest physical-discard-failure-compensates-or-retains-a-recovery-claim
+  (let [room (test-room :evaluation-discard-abort)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        original-update run/update-durable-settlement!]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle (program/hire! room team :candidate
+                                    {:task :work :settlement :deferred})
+              result @handle
+              run-id (program/run-id handle)
+              fork (registry/lookup (:run/world result))]
+          (with-redefs [ygg/discard-fork!
+                        (fn [& _] (throw (ex-info "substrate failed" {})))]
+            (is (false? (:ok? (forks/discard-deferred!
+                               fork :test-discard))))
+            (is (= [:deferred :discard-failed true]
+                   ((juxt :run/settlement-status :run/settlement-reason
+                          (constantly (forks/deferred? fork)))
+                    (run/run room run-id)))))
+          (with-redefs [ygg/discard-fork!
+                        (fn [& _] (throw (ex-info "substrate failed" {})))
+                        run/update-durable-settlement!
+                        (fn [parent id status & [reason]]
+                          (if (= :deferred status)
+                            (throw (ex-info "abort store unavailable" {}))
+                            (original-update parent id status reason)))]
+            (is (false? (:ok? (forks/discard-deferred!
+                               fork :test-discard))))
+            (is (= :discarded
+                   (:run/settlement-status (run/run room run-id))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"not awaiting deferred settlement"
+                                  (forks/release-deferred!
+                                   fork :must-remain-fenced))))
+          (is (:ok? (forks/retry-deferred-discard-abort! fork)))
+          (is (= :deferred
+                 (:run/settlement-status (run/run room run-id))))
+          (is (:ok? (forks/discard-deferred! fork :test-cleanup)))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-timeout-cancels-and-quiesces-before-certification
+  (let [room (test-room :evaluation-timeout)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 1000 :reply :late}})
+        env (definition :test/timeout
+              {:task :late
+               :limits {:timeout-ms 10 :cancel-timeout-ms 2000}})
+        timeout-evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default durable]}]
+                     (assoc default :durable-status (:run/status durable)))
+          :verify (fn [_ evidence]
+                    (let [cancelled? (= :cancelled (:durable-status evidence))]
+                      {:checks {:cancelled? cancelled?}
+                       :reward (if cancelled? 1.0 0.0)}))})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result @(evaluation/evaluate room team :slow env timeout-evaluator)
+              receipt (:attempt-receipt result)]
+          (is (= :cancelled (:attempt/status receipt)))
+          (is (true? (get-in receipt [:attempt/metrics :timed-out?])))
+          (is (= {:cancelled? true} (:attempt/checks receipt)))
+          (is (= :discarded (get-in result [:run/result :run/settlement-status])))
+          (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (d/close-room! room)))))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -479,6 +479,12 @@
               activity (first (filter #(= :_activity (:to %)) messages))]
           (is (= :completed (:run/status result)))
           (is (= "The result is 2." (:run/value result)))
+          (is (uuid? (get-in result [:run/metrics :prompt-id])))
+          (is (= {:provider :codex-subscription
+                  :model "codex-subscription-sol"
+                  :model-steps 2
+                  :usage {:used 0 :by-type {}}}
+                 (dissoc (:run/metrics result) :prompt-id)))
           (is (= :completed (:run/status durable)))
           (is (uuid? (:run/chat-id durable)))
           (is (= 2 (count @calls)))
@@ -494,7 +500,16 @@
                  (program/run-id handle)))
           (is (= ["clojure_eval"]
                  (mapv :tool-use/name
-                       (get-in activity [:metadata :tool-uses]))))))
+                       (get-in activity [:metadata :tool-uses]))))
+          (is (= [{:activity/kind :tool
+                   :activity/verb :invoke
+                   :activity/run-id (program/run-id handle)
+                   :activity/tool-name "clojure_eval"
+                   :activity/tool-use-id "call-1"}]
+                 (mapv #(select-keys % [:activity/kind :activity/verb
+                                        :activity/run-id :activity/tool-name
+                                        :activity/tool-use-id])
+                       (get-in activity [:metadata :activities]))))))
       (finally
         (d/close-room! room)))))
 
@@ -524,6 +539,35 @@
                    (set (map :run/value [@a @b]))))
             (is (= 2 (count (set (map first @seen))))
                 "each particle gets a fresh ChatContext"))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest hire-limits-can-only-restrict-an-llm-agent-policy
+  (let [room (test-room :program-restrictive-limits)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :particle
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 4
+                         :budget-dollars 2.0}})
+        calls (atom 0)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [_ _]
+                      (swap! calls inc)
+                      :continue)]
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire!
+                        room team :particle
+                        {:task :bounded
+                         :limits {:max-model-steps 1
+                                  :budget-dollars 0.01}}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)]
+          (is (= :failed (:run/status result)))
+          (is (= 1 @calls))
+          (is (= {:max-model-steps 1 :budget-dollars 0.01}
+                 (get-in result [:run/metrics :limits])))))
       (finally
         (d/close-room! room)))))
 
@@ -616,7 +660,9 @@
                   :run/reason :budget-exhausted
                   :run/settlement-status :review
                   :run/settlement-reason :execution-waiting}
-                 (dissoc result :run/world)))
+                 (dissoc result :run/world :run/metrics)))
+          (is (= 1 (get-in result [:run/metrics :model-steps])))
+          (is (uuid? (get-in result [:run/metrics :prompt-id])))
           (is (= :waiting (:run/status (program/observe room handle))))
           (is (empty? (filter #(= (program/run-id handle)
                                   (get-in % [:metadata :run-id]))
@@ -649,6 +695,71 @@
             (is (true? (program/cancel! handle)))
             (is (= :cancelled (:run/status (deref handle 2000 ::timeout))))
             (is (= :cancelled (:run/status (program/observe room handle)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest structured-llm-cancellation-retains-collected-metrics
+  (let [room (test-room :program-llm-structured-cancel)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm}})
+        calls (atom 0)
+        entered-second (promise)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [_ {:keys [cancel?]}]
+                      (if (= 1 (swap! calls inc))
+                        :continue
+                        (do
+                          (deliver entered-second true)
+                          (loop []
+                            (if (cancel?)
+                              :cancelled
+                              (do (Thread/sleep 5) (recur)))))))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle (program/hire! room team :worker {:task "stop structurally"})]
+            (is (= true (deref entered-second 10000 ::timeout)))
+            (is (= :winner
+                   @(comb/race (sp/spin :winner)
+                               (program/owned-result-spin handle))))
+            (let [result (deref handle 2000 ::timeout)]
+              (is (= :cancelled (:run/status result)))
+              (is (= {:provider :test
+                      :model "stub"
+                      :usage {:used 0 :by-type {}}}
+                     (dissoc (:run/metrics result)
+                             :prompt-id :model-steps)))
+              (is (<= 1 (get-in result [:run/metrics :model-steps]) 2)
+                  "cancellation may win before or after the worker acknowledges step two")
+              (is (uuid? (get-in result [:run/metrics :prompt-id])))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest llm-cleanup-failure-retains-collected-metrics
+  (let [room (test-room :program-llm-cleanup-failure)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 1}})]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [chat-ctx _]
+                      (chat-context/add-message!
+                       chat-ctx {:role :assistant :content "done"})
+                      :complete)
+                    chat-context/close-chat!
+                    (fn [_] (throw (ex-info "cleanup exploded" {})))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [result @(program/hire! room team :worker {:task "clean up"})]
+            (is (= :failed (:run/status result)))
+            (is (= "cleanup exploded" (:run/error result)))
+            (is (= 1 (get-in result [:run/metrics :model-steps])))
+            (is (uuid? (get-in result [:run/metrics :prompt-id]))))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/agent/room_context_test.clj
+++ b/test/dvergr/agent/room_context_test.clj
@@ -1,15 +1,26 @@
 (ns dvergr.agent.room-context-test
   "Tests for the per-[room,agent] working ChatContext (design D): caching,
-   the bus fold (append others, skip self), id-dedup, and the consistency
-   contract (the in-memory signal matches the durable room store)."
+   explicit attention admission, id-dedup, and durable reconstruction."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [dvergr.agent.room-context :as rc]
+            [dvergr.agent.run :as run]
+            [dvergr.agent.turn :as turn]
             [dvergr.discourse :as d]
             [dvergr.room.store.memory :as mem]
+            [dvergr.room.store :as rstore]
+            [dvergr.room.store.datahike :as store-dh]
+            [dvergr.room.registry :as registry]
+            [dvergr.sandbox :as sandbox]
             [dvergr.chat.context :as cctx]
+            [dvergr.chat.schema :as schema]
+            [datahike.api :as dh]
+            [org.replikativ.spindel.engine.component :as component]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]))
+
+(defn- ledger-count [conn]
+  (or (dh/q '[:find (count ?e) . :where [?e :ledger/id _]] @conn) 0))
 
 (defn- roles+contents [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
@@ -34,24 +45,193 @@
                 "seeded the conversation from the room store")
             (finally (rc/drop-ctx! :rc-seed :var))))))))
 
-(deftest fold-appends-others-skips-self
+(deftest concurrent-first-context-creation-is-singleton
+  (testing "one Room fence covers component allocation and cache publication"
+    (let [c (ctx/create-execution-context)
+          room (d/make-room {:id :rc-concurrent-first :ctx c :store (mem/make)})
+          original turn/new-working-ctx
+          constructor-entered (promise)
+          second-started (promise)
+          release-constructor (promise)
+          calls (atom 0)]
+      (try
+        (with-redefs [turn/new-working-ctx
+                      (fn [opts]
+                        (swap! calls inc)
+                        (deliver constructor-entered true)
+                        @release-constructor
+                        (original opts))]
+          (let [first-result (future (rc/ensure-ctx! room :var
+                                                     {:budget-dollars 1.0}))]
+            (is (true? (deref constructor-entered 3000 ::timeout)))
+            (let [second-result
+                  (future
+                    (deliver second-started true)
+                    (rc/ensure-ctx! room :var {:budget-dollars 1.0}))]
+              (is (true? (deref second-started 3000 ::timeout)))
+              (deliver release-constructor true)
+              (let [first-ctx (deref first-result 10000 ::timeout)
+                    second-ctx (deref second-result 10000 ::timeout)]
+                (is (not= ::timeout first-ctx))
+                (is (identical? first-ctx second-ctx))
+                (is (= 1 @calls))
+                (is (= 1 (count (binding [ec/*execution-context* c]
+                                  (component/registered)))))))))
+        (finally
+          (deliver release-constructor true)
+          (rc/drop-ctx! :rc-concurrent-first :var)
+          (ctx/close-context! c))))))
+
+(deftest failed-hydration-is-unpublished-and-retryable
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-hydration-retry :ctx c :store (mem/make)})
+        original d/messages
+        original-constructor turn/new-working-ctx
+        hydration-calls (atom 0)
+        constructor-calls (atom 0)]
+    (try
+      (with-redefs [d/messages
+                    (fn [& args]
+                      (if (= 1 (swap! hydration-calls inc))
+                        (throw (ex-info "injected hydration failure" {}))
+                        (apply original args)))
+                    turn/new-working-ctx
+                    (fn [opts]
+                      (swap! constructor-calls inc)
+                      (original-constructor opts))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"injected hydration failure"
+                              (rc/ensure-ctx! room :var
+                                              {:budget-dollars 1.0
+                                               :system-prompt "must not leak"})))
+        (is (nil? (rc/lookup (:id room) :var)))
+        (is (empty? (binding [ec/*execution-context* c]
+                      (component/registered))))
+        (is (zero? @constructor-calls)
+            "fallible durable hydration precedes all ChatContext signals")
+        (let [retried (rc/ensure-ctx! room :var
+                                      {:budget-dollars 1.0
+                                       :system-prompt "must not leak"})]
+          (is (some? retried))
+          (is (= 1 @constructor-calls))
+          (is (= 1 (count (binding [ec/*execution-context* c]
+                            (component/registered)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest inbound-admission-waits-for-context-publication
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-admission-during-hydration
+                           :ctx c :store (mem/make)})
+        original d/messages
+        hydration-entered (promise)
+        release-hydration (promise)
+        msg-id (random-uuid)]
+    (try
+      (with-redefs [d/messages
+                    (fn [& args]
+                      (deliver hydration-entered true)
+                      @release-hydration
+                      (apply original args))]
+        (let [ensure-result (future (rc/ensure-ctx! room :var
+                                                    {:budget-dollars 1.0}))]
+          (is (true? (deref hydration-entered 10000 ::timeout)))
+          (let [append-result
+                (future (rc/append-inbound! room :var msg-id :user
+                                            "arrived during hydration"
+                                            "Alice" nil))]
+            (deliver release-hydration true)
+            (let [working (deref ensure-result 10000 ::timeout)]
+              (is (true? (deref append-result 10000 ::timeout)))
+              (is (some #(str/includes? % "arrived during hydration")
+                        (non-system-contents working)))))))
+      (finally
+        (deliver release-hydration true)
+        (d/close-room! room)))))
+
+(deftest working-context-construction-releases-on-rebind-failure
+  (let [c (ctx/create-execution-context)]
+    (try
+      (with-redefs [sandbox/setup-agent-namespaces!
+                    (fn [& _]
+                      (throw (ex-info "injected namespace failure" {})))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"injected namespace failure"
+                              (turn/new-working-ctx
+                               {:execution-ctx c :title "failing"})))
+        (is (empty? (binding [ec/*execution-context* c]
+                      (component/registered)))))
+      (finally
+        (ctx/close-context! c)))))
+
+(deftest unregister-fences-context-creation-and-stale-access
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-unregister-race :ctx c :store (mem/make)})
+        original turn/new-working-ctx
+        constructor-entered (promise)
+        release-constructor (promise)]
+    (try
+      (with-redefs [turn/new-working-ctx
+                    (fn [opts]
+                      (deliver constructor-entered true)
+                      @release-constructor
+                      (original opts))]
+        (let [ensure-result (future (rc/ensure-ctx! room :var
+                                                    {:budget-dollars 1.0}))]
+          (is (true? (deref constructor-entered 3000 ::timeout)))
+          (let [unregister-result
+                (future
+                  (binding [ec/*execution-context* c]
+                    (registry/unregister! (:id room))))]
+            (deliver release-constructor true)
+            (is (not= ::timeout (deref ensure-result 10000 ::timeout)))
+            (is (nil? (deref unregister-result 10000 ::timeout)))
+            (is (nil? (binding [ec/*execution-context* c]
+                        (registry/lookup (:id room)))))
+            (is (nil? (rc/lookup (:id room) :var)))
+            (is (empty? (binding [ec/*execution-context* c]
+                          (component/registered))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"closed Room incarnation"
+                                  (rc/ensure-ctx! room :var
+                                                  {:budget-dollars 1.0}))))))
+      (finally
+        (deliver release-constructor true)
+        (ctx/close-context! c)))))
+
+(deftest resource-cleanup-failure-still-unregisters-component
+  (let [c (ctx/create-execution-context)
+        working (turn/new-working-ctx {:execution-ctx c :title "cleanup"})]
+    (try
+      (is (= 1 (count (binding [ec/*execution-context* c]
+                        (component/registered)))))
+      (with-redefs [sandbox/release-agent-resources!
+                    (fn [& _] (throw (java.io.IOException. "injected cleanup failure")))]
+        (is (thrown-with-msg? java.io.IOException
+                              #"injected cleanup failure"
+                              (cctx/release-sci-in! working c))))
+      (is (empty? (binding [ec/*execution-context* c]
+                    (component/registered))))
+      (finally
+        (cctx/release-sci-in! working c)
+        (ctx/close-context! c)))))
+
+(deftest room-observation-does-not-bypass-attention
   (let [c (ctx/create-execution-context)]
     (binding [ec/*execution-context* c]
-      (let [room (d/make-room {:id :rc-fold :ctx c :store (mem/make)})
+      (let [room (d/make-room {:id :rc-no-eager-fold :ctx c :store (mem/make)})
             cc   (rc/ensure-ctx! room :var {:budget-dollars 1.0})]
         (try
-          (Thread/sleep 50)
           (d/post! room (d/message :alice :var "hi var" nil {:role :user}))
-          (d/post! room (d/message :var :alice "var reply"))   ; self → fold skips
-          (d/post! room (d/message :bob nil "hello room"))      ; other → fold appends
-          (Thread/sleep 350)
           (let [contents (non-system-contents cc)
                 has? (fn [s] (some #(str/includes? % s) contents))]
-            (is (has? "hi var")     "user message folded in (author·time decorated)")
-            (is (has? "hello room") "another agent's message folded in")
-            (is (not (has? "var reply"))
-                "the agent's own message is skipped by the fold (the turn loop adds it)"))
-          (finally (rc/drop-ctx! :rc-fold :var)))))))
+            (is (not (has? "hi var"))
+                "durable Room visibility alone does not admit provider input")
+            (is (true? (rc/append-inbound! :rc-no-eager-fold :var
+                                           (random-uuid) :user "admitted"
+                                           "Alice" nil)))
+            (is (some #(str/includes? % "admitted") (non-system-contents cc))))
+          (finally (rc/drop-ctx! :rc-no-eager-fold :var)))))))
 
 (deftest append-inbound-dedups-by-id
   (let [c (ctx/create-execution-context)]
@@ -67,22 +247,164 @@
               "appended exactly once despite two calls with the same id")
           (finally (rc/drop-ctx! :rc-dedup :var)))))))
 
-(deftest consistency-signal-matches-store
-  (testing "the in-memory fold and the durable room store are two projections
-            of the same bus log — their conversational content matches"
+(deftest forked-working-context-owns-child-persistence
+  (let [parent-ctx (ctx/create-execution-context)
+        child-ctx* (atom nil)
+        parent-conn (schema/create-chat-db!
+                     {:store {:backend :memory :id (random-uuid)}})
+        child-conn (schema/create-chat-db!
+                    {:store {:backend :memory :id (random-uuid)}})
+        parent (d/make-room {:id :rc-db-parent
+                             :ctx parent-ctx
+                             :store (store-dh/make parent-conn)})]
+    (try
+      (let [working (rc/ensure-ctx! parent :var {:budget-dollars 1.0})]
+        (let [child-ctx (ctx/fork-context parent-ctx :mode :frozen)
+              _ (reset! child-ctx* child-ctx)
+              child (d/make-room {:id :rc-db-child
+                                  :ctx child-ctx
+                                  :store (store-dh/make child-conn)})]
+          (dh/transact child-conn
+                       [(schema/create-chat-entity
+                         {:id (:chat-id working) :title (:title working)
+                          :budget 1000000})])
+          (let [projected (rc/fork-ctx! parent child :var)]
+            (is (identical? child-conn (:db-conn projected)))
+            (is (not (identical? parent-conn (:db-conn projected))))
+            (cctx/account-usage! projected :input-tokens 1
+                                 :model "claude-sonnet-4-5")
+            (is (= 0 (ledger-count parent-conn)))
+            (is (= 1 (ledger-count child-conn))))))
+      (finally
+        (rc/drop-ctx! :rc-db-child :var)
+        (rc/drop-ctx! :rc-db-parent :var)
+        (dh/release child-conn)
+        (dh/release parent-conn)
+        (when-let [child-ctx @child-ctx*]
+          (ctx/close-context! child-ctx))
+        (ctx/close-context! parent-ctx)))))
+
+(deftest durable-attention-rebuilds-provider-projection
+  (testing "Run triggers and :include decisions enter provider input while
+            durable :remember facts remain outside it"
     (let [c (ctx/create-execution-context)]
       (binding [ec/*execution-context* c]
         (let [room (d/make-room {:id :rc-cons :ctx c :store (mem/make)})
-              cc   (rc/ensure-ctx! room :var {:budget-dollars 1.0})]
+              trigger (d/message :alice :var "trigger" nil {:role :user})
+              remembered (d/message :bob :var "remember only" nil {:role :user})]
           (try
-            (Thread/sleep 50)
-            (doseq [[from txt] [[:alice "q1"] [:bob "q2"] [:alice "q3"] [:carol "q4"]]]
-              (d/post! room (d/message from :var txt nil {:role :user})))
-            (Thread/sleep 400)
-            (let [signal (set (non-system-contents cc))
-                  store  (set (map :content (d/messages room {:limit 50})))]
-              ;; The signal is the store's content DECORATED with [author · time];
-              ;; every stored message must appear (as a substring) in the signal.
-              (is (every? (fn [s] (some #(str/includes? % s) signal)) store)
-                  "signal (fold) is the author·time-decorated projection of the store"))
+            (d/post! room trigger)
+            (let [cc (rc/ensure-ctx! room :var {:budget-dollars 1.0})
+                  run-ref (run/start! room :var trigger cc)]
+              (run/finish! (:run/id run-ref) :completed)
+              ;; Arrives after the legacy baseline was materialized, as an
+              ;; active-run observation would in production.
+              (d/post! room remembered)
+              (rstore/-store-attention!
+               (:store room) :rc-cons
+               {:attention/id (random-uuid)
+                :attention/participant :var
+                :attention/message-id (:id remembered)
+                :attention/memory :remember
+                :attention/activation :none
+                :attention/control :continue
+                :attention/at :next-safe-boundary
+                :attention/priority 0
+                :attention/status :ready
+                :attention/created-at (java.util.Date.)})
+              (rc/drop-ctx! :rc-cons :var))
+            (let [restored (rc/ensure-ctx! room :var {:budget-dollars 1.0})
+                  contents (non-system-contents restored)]
+              (is (some #(str/includes? % "trigger") contents))
+              (is (not-any? #(str/includes? % "remember only") contents)))
             (finally (rc/drop-ctx! :rc-cons :var))))))))
+
+(deftest legacy-runs-materialize-a-provider-baseline
+  (testing "pre-attention rooms keep non-trigger history even when Runs exist"
+    (let [c (ctx/create-execution-context)]
+      (binding [ec/*execution-context* c]
+        (let [room (d/make-room {:id :rc-legacy-cutover :ctx c :store (mem/make)})
+              trigger (d/message :alice :var "old trigger" nil {:role :user})
+              context (d/message :bob :var "old supporting context" nil {:role :user})
+              run-ctx (turn/new-working-ctx {:execution-ctx c
+                                             :title "legacy run"
+                                             :budget-dollars 1.0})]
+          (try
+            (d/post! room trigger)
+            (d/post! room context)
+            ;; Simulate a room persisted by the Run release before attention
+            ;; projections existed; do not call ensure-ctx! yet.
+            (let [run-ref (run/start! room :var trigger run-ctx)]
+              (run/finish! (:run/id run-ref) :completed))
+            ;; Simulate a crash after the first write of baseline migration.
+            ;; A non-empty projection without the final marker must be retried.
+            (let [decision-id
+                  (rstore/attention-id (:id room) :var (:id trigger) nil
+                                       :legacy-baseline-decision)]
+              (rstore/-store-attention!
+               (:store room) (:id room)
+               {:attention/id decision-id
+                :attention/participant :var
+                :attention/message-id (:id trigger)
+                :attention/memory :include
+                :attention/activation :none
+                :attention/control :continue
+                :attention/at :now
+                :attention/priority 0.0
+                :attention/reason :migration/provider-baseline
+                :attention/status :ready
+                :attention/created-at (java.util.Date. (long (:ts trigger)))}))
+            (let [restored (rc/ensure-ctx! room :var {:budget-dollars 1.0})
+                  contents (non-system-contents restored)
+                  facts (rstore/-list-attention (:store room) (:id room)
+                                                {:participant :var})]
+              (is (some #(str/includes? % "old trigger") contents))
+              (is (some #(str/includes? % "old supporting context") contents))
+              (is (= 2 (count (set (map :attention/message-id
+                                        (filter #(= :applied (:attention/status %))
+                                                facts)))))))
+            (finally (rc/drop-ctx! :rc-legacy-cutover :var))))))))
+
+(deftest baseline-marker-lookup-is-not-history-bounded
+  (testing "an aged migration marker cannot retroactively admit ignored speech"
+    (let [c (ctx/create-execution-context)]
+      (binding [ec/*execution-context* c]
+        (let [room-id :rc-aged-baseline-marker
+              room (d/make-room {:id room-id :ctx c :store (mem/make)})
+              original (d/message :alice :var "legacy baseline" nil {:role :user})
+              ignored (d/message :bob :var "must stay ignored" nil {:role :user})]
+          (try
+            (d/post! room original)
+            (rc/ensure-ctx! room :var {:budget-dollars 1.0})
+            (rc/drop-ctx! room-id :var)
+            (d/post! room ignored)
+            (rstore/-store-attention!
+             (:store room) room-id
+             {:attention/id (random-uuid)
+              :attention/participant :var
+              :attention/message-id (:id ignored)
+              :attention/memory :ignore
+              :attention/activation :none
+              :attention/control :continue
+              :attention/at :now
+              :attention/status :ready
+              :attention/created-at (java.util.Date.)})
+            ;; Age the deterministic marker beyond the ordinary projection window.
+            (dotimes [_ 1001]
+              (rstore/-store-attention!
+               (:store room) room-id
+               {:attention/id (random-uuid)
+                :attention/participant :var
+                :attention/message-id (random-uuid)
+                :attention/memory :remember
+                :attention/status :ready
+                :attention/created-at (java.util.Date.)}))
+            (let [restored (rc/ensure-ctx! room :var {:budget-dollars 1.0})
+                  contents (non-system-contents restored)
+                  retroactive-applied-id
+                  (rstore/attention-id room-id :var (:id ignored) nil
+                                       :legacy-baseline-applied)]
+              (is (not-any? #(str/includes? % "must stay ignored") contents))
+              (is (empty? (rstore/-list-attention
+                           (:store room) room-id {:id retroactive-applied-id}))))
+            (finally (rc/drop-ctx! room-id :var))))))))

--- a/test/dvergr/agent/run_test.clj
+++ b/test/dvergr/agent/run_test.clj
@@ -133,6 +133,46 @@
         (run/finish! (:run/id explicit) :completed)
         (d/close-room! room)))))
 
+(deftest resolved-run-inputs-are-durable-causality-not-structure
+  (let [[room st] (run-room :explicit-causality)
+        parent (run/start! room :orchestrator (random-uuid) (live-ctx))
+        child (run/start! room :specialist (random-uuid) (live-ctx)
+                          {:parent (:run/id parent)})]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"has not resolved"
+           (run/record-cause! (:run/id parent) (:run/id child))))
+      (run/finish! (:run/id child) :completed)
+      (let [updated (run/record-cause! (:run/id parent) (:run/id child))]
+        (is (= #{(:run/id child)} (:run/caused-by updated)))
+        (is (= #{(:run/id child)}
+               (:run/caused-by
+                (store/-load-run st :explicit-causality (:run/id parent)))))
+        (is (= (:run/id parent) (:run/parent child))
+            "containment remains on the child, causality on the consumer"))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"not durable"
+           (run/record-cause! (:run/id parent) (random-uuid))))
+      (finally
+        (run/finish! (:run/id parent) :completed)
+        (d/close-room! room)))))
+
+(deftest storeless-runs-cannot-claim-durable-causality
+  (let [room (d/make-room {:id :storeless-causality})
+        parent (run/start! room :orchestrator (random-uuid) (live-ctx))]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"requires a Room store"
+           (run/record-cause! (:run/id parent) (random-uuid))))
+      (is (nil? (:run/caused-by
+                 (first (run/active-runs :storeless-causality)))))
+      (finally
+        (run/finish! (:run/id parent) :completed)
+        (d/close-room! room)))))
+
 (deftest provenance-cannot-override-core-run-identity
   (let [[room _st] (run-room :provenance-boundary)
         trigger (d/message :alice :agent "work")]

--- a/test/dvergr/chat/agent_test.clj
+++ b/test/dvergr/chat/agent_test.clj
@@ -1,0 +1,102 @@
+(ns dvergr.chat.agent-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [dvergr.chat.agent :as agent]
+            [dvergr.chat.context :as chat-ctx]
+            [dvergr.model.chat :as model-chat]))
+
+(defn- response [content]
+  {:content content
+   :tool-calls []
+   :usage {}
+   :stop-reason :stop})
+
+(deftest empty-response-after-tools-cannot-complete-with-stale-placeholder
+  (testing "one corrective integration step obtains a real final result"
+    (let [ctx (chat-ctx/create-chat-context
+               {:title "empty-response" :with-sci? false})
+          run-id (random-uuid)
+          responses (atom [(response "") (response "verified result")])]
+      (try
+        (chat-ctx/add-message!
+         ctx {:role :assistant
+              :content "Tool calls: [\"clojure_eval\"]"
+              :tool-uses [{:tool-use/id "call-1"
+                           :tool-use/name "clojure_eval"
+                           :tool-use/input {:code "(+ 1 1)"}}]})
+        (chat-ctx/add-message!
+         ctx {:role :tool-result :tool-use-id "call-1" :content "2"})
+        (with-redefs [agent/messages->api-format (fn [messages _ _] messages)
+                      model-chat/chat (fn [& _]
+                                        (let [result (first @responses)]
+                                          (swap! responses subvec 1)
+                                          result))]
+          (is (= :continue
+                 (agent/run-agent-turn!
+                  ctx {:provider :test :model "stub" :tools {}
+                       :auto-compact? false :turn-number 1 :run-id run-id})))
+          (is (.startsWith ^String
+               (-> (chat-ctx/get-messages ctx) last :message/content)
+                           agent/empty-response-nudge))
+          (is (= :complete
+                 (agent/run-agent-turn!
+                  ctx {:provider :test :model "stub" :tools {}
+                       :auto-compact? false :turn-number 2 :run-id run-id})))
+          (is (= "verified result"
+                 (->> (chat-ctx/get-messages ctx)
+                      (filter #(= :assistant (:message/role %)))
+                      last
+                      :message/content))))
+        (finally
+          (chat-ctx/close-chat! ctx))))))
+
+(deftest repeated-empty-response-fails-instead-of-reusing-old-assistant-content
+  (let [ctx (chat-ctx/create-chat-context
+             {:title "repeated-empty" :with-sci? false})
+        run-id (random-uuid)]
+    (try
+      (with-redefs [agent/messages->api-format (fn [messages _ _] messages)
+                    model-chat/chat (fn [& _] (response nil))]
+        (is (= :continue
+               (agent/run-agent-turn!
+                ctx {:provider :test :model "stub" :tools {}
+                     :auto-compact? false :turn-number 0 :run-id run-id})))
+        (is (= :error
+               (agent/run-agent-turn!
+                ctx {:provider :test :model "stub" :tools {}
+                     :auto-compact? false :turn-number 1 :run-id run-id}))))
+      (finally
+        (chat-ctx/close-chat! ctx)))))
+
+(deftest successful-run-does-not-consume-a-later-runs-empty-retry
+  (let [ctx (chat-ctx/create-chat-context
+             {:title "run-scoped-empty" :with-sci? false})
+        first-run (random-uuid)
+        later-run (random-uuid)
+        responses (atom [(response "") (response "first result") (response "")])]
+    (try
+      (with-redefs [agent/messages->api-format (fn [messages _ _] messages)
+                    model-chat/chat (fn [& _]
+                                      (let [result (first @responses)]
+                                        (swap! responses subvec 1)
+                                        result))]
+        (is (= :continue
+               (agent/run-agent-turn!
+                ctx {:provider :test :model "stub" :tools {}
+                     :auto-compact? false :turn-number 0 :run-id first-run})))
+        (is (= :complete
+               (agent/run-agent-turn!
+                ctx {:provider :test :model "stub" :tools {}
+                     :auto-compact? false :turn-number 1 :run-id first-run})))
+        (is (= :continue
+               (agent/run-agent-turn!
+                ctx {:provider :test :model "stub" :tools {}
+                     :auto-compact? false :turn-number 0 :run-id later-run})))
+        (is (= 2
+               (->> (chat-ctx/get-messages ctx)
+                    (filter #(and (= :system (:message/role %))
+                                  (str/starts-with? (:message/content %)
+                                                    agent/empty-response-nudge)))
+                    count))))
+      (finally
+        (chat-ctx/close-chat! ctx)))))

--- a/test/dvergr/chat/context_test.clj
+++ b/test/dvergr/chat/context_test.clj
@@ -2,7 +2,96 @@
   "Integration tests for ChatContext budget tracking."
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.chat.context :as ctx]
-            [dvergr.chat.accounting :as acct]))
+            [dvergr.chat.accounting :as acct]
+            [dvergr.runtime.ctx :as runtime-ctx]
+            [dvergr.sandbox :as sandbox]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as execution-context]))
+
+(deftest ambient-selection-only-refines-into-descendants
+  (let [parent (execution-context/create-execution-context)
+        owner (execution-context/fork-context parent :mode :frozen)
+        sibling (execution-context/fork-context parent :mode :frozen)
+        descendant (execution-context/fork-context owner :mode :frozen)]
+    (try
+      (is (identical? owner (runtime-ctx/selected-context owner)))
+      (binding [ec/*execution-context* parent]
+        (is (identical? owner (runtime-ctx/selected-context owner))))
+      (binding [ec/*execution-context* sibling]
+        (is (identical? owner (runtime-ctx/selected-context owner))))
+      (binding [ec/*execution-context* descendant]
+        (is (identical? descendant (runtime-ctx/selected-context owner))))
+      (finally
+        (execution-context/close-context! descendant)
+        (execution-context/close-context! sibling)
+        (execution-context/close-context! owner)
+        (execution-context/close-context! parent)))))
+
+(deftest sci-interpreter-is-selected-by-world
+  (testing "one stable ChatContext ref resolves independent SCI heaps after fork"
+    (let [parent (execution-context/create-execution-context)
+          chat   (ctx/create-chat-context
+                  {:title "forkable repl"
+                   :execution-context parent})]
+      (try
+        (let [ref (:sci-component chat)
+              parent-sci (ctx/sci-context-in chat parent)
+              eval-in (fn [world interpreter source]
+                        (sandbox/eval-code interpreter source
+                                           :execution-context world))]
+          (is (some? ref))
+          ;; Exercise the interpreter agents actually receive, not only the
+          ;; bare Spindel macro context. Every injected capability must either
+          ;; be world-relative or declare its ambient sharing policy.
+          (sandbox/setup-agent-namespaces! parent-sci parent)
+          (is (= {:value [:parent] :stdout "" :stderr "" :success true}
+                 (eval-in
+                  parent parent-sci
+                  "(def observations (atom [:parent])) @observations")))
+          (let [child (execution-context/fork-context parent :mode :frozen)]
+            (try
+              (let [child-sci (ctx/sci-context-in chat child)]
+                (is (not (identical? parent-sci child-sci)))
+                (is (= [:parent :child]
+                       (:value (eval-in
+                                child child-sci
+                                "(swap! observations conj :child)"))))
+                (is (= [:parent]
+                       (:value (eval-in parent parent-sci "@observations"))))
+                (is (= [:parent :child]
+                       (:value (eval-in child child-sci "@observations"))))
+                (let [result
+                      (eval-in
+                       child child-sci
+                       "(ns child-only-test
+                          (:require [clojure.test :refer [deftest is run-tests]]))
+                        (deftest child-proof (is (= 3 (+ 1 2))))
+                        (run-tests 'child-only-test)")]
+                  (is (:success result))
+                  (is (= {:test 1 :pass 1 :fail 0 :error 0}
+                         (select-keys (:value result)
+                                      [:test :pass :fail :error])))
+                  (is (false?
+                       (:value
+                        (eval-in
+                         parent parent-sci
+                         "(boolean (find-ns 'child-only-test))"))))))
+              (ctx/release-sci-in! chat child)
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"not available"
+                   (ctx/sci-context-in chat child)))
+              (is (contains?
+                   (binding [ec/*execution-context* parent]
+                     (component/registered))
+                   (:id ref))
+                  "releasing a child interpreter preserves its parent")
+              (finally
+                (execution-context/close-context! child)))))
+        (finally
+          (ctx/close-chat! chat)
+          (execution-context/close-context! parent))))))
 
 (deftest create-chat-context-test
   (testing "Create chat with dollar budget"

--- a/test/dvergr/discourse/attention_test.clj
+++ b/test/dvergr/discourse/attention_test.clj
@@ -56,6 +56,40 @@
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown execution boundary"
                         (attention/boundary-event :provider/private-step))))
 
+(deftest execution-plans-negotiate-without-losing-decision-axes
+  (let [capabilities {:memory attention/memory-modes
+                      :activation attention/activation-modes
+                      :control #{:continue :restart :suspend :cancel}
+                      :boundaries #{:now :next-safe-boundary :quiescent}
+                      :priority? false
+                      :accept? (fn [{:keys [control at]}]
+                                 (when (and (= :restart control)
+                                            (= :quiescent at))
+                                   {:axes [:control :at]
+                                    :values [control at]}))}
+        ready (attention/execution-plan
+               {:memory :ignore :activation :wake
+                :control :cancel :at :now}
+               capabilities)
+        unavailable (attention/execution-plan
+                     {:memory :include :activation :enqueue
+                      :control :integrate :at :after-tool :priority 7}
+                     capabilities)
+        cross-axis (attention/execution-plan
+                    {:control :restart :at :quiescent}
+                    capabilities)]
+    (is (= :ready (:status ready)))
+    (is (= {:memory :ignore :activation :wake
+            :control :cancel :at :now :priority 0}
+           (:decision ready)))
+    (is (= :deferred (:status unavailable)))
+    (is (= #{:control :at :priority}
+           (into #{} (map :axis) (:unsupported unavailable))))
+    (is (= :deferred (:status cross-axis)))
+    (is (= [{:axes [:control :at]
+             :values [:restart :quiescent]}]
+           (:unsupported cross-axis)))))
+
 (deftest attention-composes-reactively-with-execution-boundaries
   (testing "continuous observation can defer integration until a safe boundary"
     (let [ctx (context/create-execution-context)]

--- a/test/dvergr/discourse/llm_test.clj
+++ b/test/dvergr/discourse/llm_test.clj
@@ -8,9 +8,14 @@
             [dvergr.discourse.attention :as attention]
             [dvergr.discourse.llm :as llm]
             [dvergr.chat.context :as cc]
+            [dvergr.runtime.ctx :as runtime-ctx]
+            [dvergr.sandbox :as sandbox]
             [dvergr.agent.run :as run]
+            [dvergr.agent.room-context :as room-context]
             [dvergr.room.store :as store]
-            [dvergr.room.store.memory :as memory]))
+            [dvergr.room.store.memory :as memory]
+            [datahike.api :as dh]
+            [org.replikativ.spindel.engine.component :as component]))
 
 ;; ============================================================================
 ;; Mock turn-fn — scripts the LLM responses
@@ -92,11 +97,173 @@
     (-load-run [_ room-id run-id]
       (store/-load-run delegate room-id run-id))
     (-list-runs [_ room-id opts]
-      (store/-list-runs delegate room-id opts))))
+      (store/-list-runs delegate room-id opts))
+    store/PAttentionStore
+    (-store-attention! [_ room-id fact]
+      (store/-store-attention! delegate room-id fact))
+    (-list-attention [_ room-id opts]
+      (store/-list-attention delegate room-id opts))))
 
 ;; ============================================================================
 ;; Tests
 ;; ============================================================================
+
+(deftest isolated-room-fork-reuses-the-forked-working-interpreter
+  (testing "participant cloning selects the inherited SCI world without registering another"
+    (let [parent (d/room :llm-world-parent)
+          parent-db (random-uuid)
+          fork* (atom nil)]
+      (try
+        (binding [ec/*execution-context* (:ctx parent)]
+          (d/join parent
+                  (llm/llm-agent
+                   {:id :researcher
+                    :spec {:provider :mock :model "mock"}
+                    :run-turn-fn (make-mock-turn-fn (atom []))})))
+        (is (empty? (binding [ec/*execution-context* (:ctx parent)]
+                      (component/registered)))
+            "a joined room participant does not eagerly allocate a room-less fallback")
+        (let [working (room-context/ensure-ctx!
+                       parent :researcher {:budget-dollars 1.0})
+              parent-sci (cc/sci-context-in working (:ctx parent))]
+          (is (= 1 (count (binding [ec/*execution-context* (:ctx parent)]
+                            (component/registered)))))
+          (is (= [:parent]
+                 (:value (sandbox/eval-code
+                          parent-sci
+                          (format
+                           "(def evidence (atom [:parent]))
+                            (defn captured-room [] (dvergr.agent/room-id))
+                            (def captured-room-fn dvergr.agent/room-id)
+                            (def captured-env-get env/get)
+                            (def captured-env-set env/set)
+                            (env/set \"WORLD\" \"parent\")
+                            (def captured-db-exists? datahike.api/database-exists?)
+                            (def captured-db-create! datahike.api/create-database)
+                            (def captured-db-connect! datahike.api/connect)
+                            (def captured-work-serial spindel.work/serial)
+                            (def parent-db {:store {:backend :mem :id %s}
+                                            :schema-flexibility :read})
+                            (captured-db-create! parent-db)
+                            (datahike.api/transact (captured-db-connect! parent-db)
+                              [{:marker/id :parent}])
+                            @evidence"
+                           (pr-str parent-db))
+                          :execution-context (:ctx parent)))))
+          (let [fork (d/fork-room parent {:isolation :ctx})]
+            (reset! fork* fork)
+            (let [child-working (room-context/lookup (:id fork) :researcher)
+                  child-sci (cc/sci-context-in child-working (:ctx fork))]
+              (is (not (identical? working child-working)))
+              (is (= (:sci-component working) (:sci-component child-working)))
+              (is (identical? (:ctx fork) (:spindel-ctx child-working)))
+              (is (not (identical? (:db-conn working) (:db-conn child-working)))
+                  "child persistence never retains the raw parent connection")
+              (is (= 1 (count (binding [ec/*execution-context* (:ctx fork)]
+                                (component/registered))))
+                  "the participant factory did not allocate a second interpreter")
+              (is (= (:id parent)
+                     (:value (sandbox/eval-code
+                              parent-sci "(dvergr.agent/room-id)"
+                              :execution-context (:ctx parent)))))
+              (is (= (:id fork)
+                     (:value (sandbox/eval-code
+                              child-sci "(dvergr.agent/room-id)"
+                              :execution-context (:ctx fork))))
+                  "fresh calls resolve the child Room")
+              (is (= [(:id fork) (:id fork)]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(captured-room) (captured-room-fn)]"
+                              :execution-context (:ctx fork))))
+                  "pre-fork helpers and first-class capabilities resolve through the child world")
+              (is (= true
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(let [controller
+                                     (captured-work-serial
+                                      (fn [value] (spindel.work/task value)))]
+                                 (spindel.work/close! controller)
+                                 true)"
+                              :execution-context (:ctx fork))))
+                  "retained FRP constructors allocate against the child Room incarnation")
+              (is (= ["parent" "parent"]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx fork))))
+                  "environment data is inherited through the child world binding")
+              (is (= :ok
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(captured-env-set \"WORLD\" \"child\")"
+                              :execution-context (:ctx fork)))))
+              (is (= ["child" "child"]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx fork)))))
+              (is (= ["parent" "parent"]
+                     (:value (sandbox/eval-code
+                              parent-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx parent))))
+                  "a retained child mutation does not escape into the parent")
+              (is (= [false false]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(datahike.api/database-exists? parent-db)
+                                (captured-db-exists? parent-db)]"
+                              :execution-context (:ctx fork))))
+                  "live ephemeral database handles are disposable across a fork")
+              (is (= true
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(captured-db-create! parent-db)
+                               (datahike.api/transact (captured-db-connect! parent-db)
+                                 [{:marker/id :child}])
+                               (captured-db-exists? parent-db)"
+                              :execution-context (:ctx fork)))))
+              (is (= [:child]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(datahike.api/q
+                                 '[:find [?v ...] :where [_ :marker/id ?v]]
+                                 @(captured-db-connect! parent-db))"
+                              :execution-context (:ctx fork))))
+                  "the inherited logical config maps to child-owned physical storage")
+              (is (= [:parent]
+                     (:value (sandbox/eval-code
+                              parent-sci
+                              "(datahike.api/q
+                                 '[:find [?v ...] :where [_ :marker/id ?v]]
+                                 @(captured-db-connect! parent-db))"
+                              :execution-context (:ctx parent))))
+                  "same-config child writes cannot reach the parent's physical database")
+              (is (= [:parent :child]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(swap! evidence conj :child)"
+                              :execution-context (:ctx fork)))))
+              (is (= [:parent]
+                     (:value (sandbox/eval-code
+                              parent-sci "@evidence"
+                              :execution-context (:ctx parent)))))
+              (let [binding (runtime-ctx/sandbox-binding
+                             (:ctx fork) (:capability-id child-working))
+                    physical-config (-> binding :ephemeral-databases vals first :config)]
+                (is (dh/database-exists? physical-config))
+                (room-context/drop-ctx! (:id fork) :researcher)
+                (is (not (dh/database-exists? physical-config))
+                    "dropping a world deletes its process-global scratch database"))
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"not available"
+                   (cc/sci-context-in child-working (:ctx fork)))))))
+        (finally
+          (when-let [fork @fork*]
+            (d/discard fork))
+          (d/close-room! parent))))))
 
 (deftest single-turn-replies
   (testing "Agent replies after a single :complete turn"
@@ -185,14 +352,17 @@
                                   :run-turn-fn turn-fn})))
       (try
         (d/post! r (d/message :alice :worker "cancel this run"))
-        (is (= true (deref first-started 2000 ::timeout)))
+        ;; Creating the first room-bound interpreter can compile SCI/Spindel
+        ;; namespaces. Leave enough wall-clock headroom for contended CI hosts;
+        ;; the cancellation assertions below still test the semantic deadline.
+        (is (= true (deref first-started 10000 ::timeout)))
         (let [run-id (:run/id (first (run/active-runs :run-cancel-reuse)))]
           (is (uuid? run-id))
           (is (run/cancel-run! run-id))
           (is (await-condition
                #(= :cancelled (:run/status (run/run r run-id)))
-               3000)))
-        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 3000)]
+               10000)))
+        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 10000)]
           (is (= "second completed" (:content reply)))
           (is (= :completed
                  (:run/status (run/run r (get-in reply [:metadata :run-id])))))
@@ -478,7 +648,8 @@
 
 (deftest attention-policy-can-queue-same-thread-peer-chatter
   (testing "thread membership does not permanently imply interruption"
-    (let [r       (d/room :peer-attention-room)
+    (let [st      (memory/make)
+          r       (d/make-room {:id :peer-attention-room :store st})
           entered (promise)
           gate    (promise)
           steps   (atom [(fn [chat-ctx opts]
@@ -509,7 +680,343 @@
           (while (and (< (System/currentTimeMillis) deadline)
                       (< (count @calls) 2))
             (Thread/sleep 10)))
-        (is (= 2 (count @calls)) "peer note became a later execution")))))
+        (is (= 2 (count @calls)) "peer note became a later execution")
+        (let [applied (some #(when (and (= :applied (:attention/status %))
+                                        (= :test/peer-chatter
+                                           (:attention/reason %)))
+                               %)
+                            (store/-list-attention st (:id r)
+                                                   {:participant :policy-worker}))
+              successor (run/run r (:attention/result-run-id applied))]
+          (is (uuid? (:attention/result-run-id applied)))
+          (is (= "peer note"
+                 (:content (some #(when (= (:run/trigger successor) (:id %)) %)
+                                 (d/messages r {:limit 30}))))
+              "applied enqueue names the exact successor Run"))))))
+
+(deftest attention-policy-cancel-is-run-local-and-future-work-recovers
+  (let [r (d/make-room {:id :policy-cancel-room :store (memory/make)})
+        entered (promise)
+        steps (atom [(block-until-cancelled-step entered 8000)
+                     (reply-step "recovered answer")])
+        calls (atom [])
+        policy (fn [_]
+                 (attention/decision {:memory :remember
+                                      :control :cancel
+                                      :at :now
+                                      :reason :test/authorized-cancel}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :policy-cancel-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :budget {:dollars 10.0}
+                                  :attention-policy policy
+                                  :run-turn-fn (make-queued-turn-fn steps calls)})))
+      (let [first-reply
+            (future (await-spin r #(d/ask % :policy-cancel-worker {:content "start"})
+                                2500))]
+        (is (true? (deref entered 3000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :policy-cancel-worker "stop this run" trigger)))
+        (is (= ::timeout @first-reply) "policy cancellation emits no stale reply")
+        (is (await-condition #(empty? (run/active-runs (:id r))) 2000))
+        (is (= :cancelled (:run/status (first (run/runs r)))))
+        (is (= "recovered answer"
+               (:content (await-spin r #(d/ask % :policy-cancel-worker
+                                               {:content "new work"}) 4000)))
+            "attention cancellation does not poison later executions"))
+      (finally
+        (d/close-room! r)))))
+
+(deftest attention-policy-suspend-includes-memory-at-safe-boundary
+  (let [r (d/make-room {:id :policy-suspend-room :store (memory/make)})
+        entered (promise)
+        observed (atom nil)
+        inspect-memory
+        (fn [chat-ctx _]
+          (let [messages (cc/get-messages chat-ctx)
+                _ (reset! observed messages)
+                included? (some #(re-find #"remember before waiting"
+                                          (or (:content %) (:message/content %) ""))
+                                messages)]
+            (cc/add-message! chat-ctx {:role :assistant
+                                       :content (if included? "included" "missing")})
+            :complete))
+        steps (atom [(block-until-cancelled-step entered 8000) inspect-memory])
+        calls (atom [])
+        policy (fn [_]
+                 (attention/decision {:memory :include
+                                      :control :suspend
+                                      :at :next-safe-boundary
+                                      :reason :test/wait}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :policy-suspend-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :budget {:dollars 10.0}
+                                  :attention-policy policy
+                                  :run-turn-fn (make-queued-turn-fn steps calls)})))
+      (let [first-reply
+            (future (await-spin r #(d/ask % :policy-suspend-worker {:content "start"})
+                                2500))]
+        (is (true? (deref entered 3000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :policy-suspend-worker
+                              "remember before waiting" trigger)))
+        (is (= ::timeout @first-reply))
+        (is (await-condition #(empty? (run/active-runs (:id r))) 2000))
+        (is (= :waiting (:run/status (first (run/runs r)))))
+        (is (= :attention-suspended (:run/reason (first (run/runs r)))))
+        (is (= "included"
+               (:content (await-spin r #(d/ask % :policy-suspend-worker
+                                               {:content "resume"}) 4000)))
+            (pr-str @observed)))
+      (finally
+        (d/close-room! r)))))
+
+(deftest non-preempting-include-is-admitted-between-provider-rounds
+  (let [r (d/make-room {:id :policy-include-boundary :store (memory/make)})
+        entered (promise)
+        gate (promise)
+        observed (atom nil)
+        steps (atom [(fn [_chat-ctx _]
+                       (deliver entered true)
+                       @gate
+                       :continue)
+                     (fn [chat-ctx _]
+                       (reset! observed (cc/get-messages chat-ctx))
+                       (cc/add-message! chat-ctx {:role :assistant :content "done"})
+                       :complete)])
+        calls (atom [])
+        policy (fn [_]
+                 (attention/decision {:memory :include
+                                      :control :continue
+                                      :at :next-safe-boundary
+                                      :reason :test/include-next-round}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :include-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :budget {:dollars 10.0}
+                                  :attention-policy policy
+                                  :run-turn-fn (make-queued-turn-fn steps calls)})))
+      (let [reply-f (future (await-spin r #(d/ask % :include-worker {:content "start"})
+                                        5000))]
+        (is (true? (deref entered 3000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :include-worker "use this next" trigger)))
+        (is (await-condition
+             #(some (fn [fact]
+                      (= :test/include-next-round (:attention/reason fact)))
+                    (store/-list-attention (:store r) (:id r)
+                                           {:participant :include-worker}))
+             2000))
+        (deliver gate true)
+        (is (= "done" (:content @reply-f)))
+        (is (some #(re-find #"use this next"
+                            (or (:content %) (:message/content %) ""))
+                  @observed)
+            "include is visible to the very next provider round"))
+      (finally
+        (d/close-room! r)))))
+
+(deftest unsupported-attention-remains-deferred-without-becoming-a-new-run
+  (let [st (memory/make)
+        r (d/make-room {:id :policy-deferred :store st})
+        entered (promise)
+        gate (promise)
+        calls (atom [])
+        steps (atom [(fn [chat-ctx _]
+                       (deliver entered true)
+                       @gate
+                       (cc/add-message! chat-ctx {:role :assistant :content "first"})
+                       :complete)])
+        policy (fn [_]
+                 (attention/decision {:memory :include
+                                      :control :integrate
+                                      :at :after-tool
+                                      :reason :test/provider-boundary}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :deferred-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :attention-policy policy
+                                  :run-turn-fn (make-queued-turn-fn steps calls)})))
+      (let [reply-f (future (await-spin r #(d/ask % :deferred-worker {:content "start"})
+                                        5000))]
+        (is (true? (deref entered 3000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :deferred-worker "after the tool" trigger)))
+        (is (await-condition
+             #(some (fn [fact] (= :deferred (:attention/status fact)))
+                    (store/-list-attention st (:id r)
+                                           {:participant :deferred-worker}))
+             2000))
+        (deliver gate true)
+        (is (= "first" (:content @reply-f)))
+        (Thread/sleep 150)
+        (is (= 1 (count @calls)) "deferred input is not silently degraded to enqueue")
+        (is (= 1 (count (run/runs r))))
+        (is (some #(= :deferred (:attention/status %))
+                  (store/-list-attention st (:id r)
+                                         {:participant :deferred-worker})))
+        (room-context/drop-ctx! (:id r) :deferred-worker)
+        (let [restored (room-context/ensure-ctx!
+                        r :deferred-worker {:budget-dollars 1.0})]
+          (is (not-any? #(re-find #"after the tool"
+                                  (or (:content %) (:message/content %) ""))
+                        (cc/get-messages restored))
+              "a deferred include remains unapplied after reconstruction")))
+      (finally
+        (d/close-room! r)))))
+
+(deftest include-now-updates-working-memory-before-provider-settles
+  (let [st (memory/make)
+        r (d/make-room {:id :policy-include-now :store st})
+        entered (promise)
+        gate (promise)
+        steps (atom [(fn [chat-ctx _]
+                       (deliver entered true)
+                       @gate
+                       (cc/add-message! chat-ctx {:role :assistant :content "done"})
+                       :complete)])
+        calls (atom [])
+        policy (fn [_]
+                 (attention/decision {:memory :include
+                                      :control :continue
+                                      :at :now
+                                      :reason :test/include-now}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :now-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :attention-policy policy
+                                  :run-turn-fn (make-queued-turn-fn steps calls)})))
+      (let [reply-f (future (await-spin r #(d/ask % :now-worker {:content "start"})
+                                        5000))]
+        (is (true? (deref entered 3000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :now-worker "visible immediately" trigger)))
+        (is (await-condition
+             #(some (fn [fact]
+                      (and (= :applied (:attention/status fact))
+                           (= :test/include-now (:attention/reason fact))))
+                    (store/-list-attention st (:id r) {:participant :now-worker}))
+             2000))
+        (is (some #(re-find #"visible immediately"
+                            (or (:content %) (:message/content %) ""))
+                  (cc/get-messages (room-context/lookup (:id r) :now-worker)))
+            "now admission precedes provider settlement")
+        (deliver gate true)
+        (is (= "done" (:content @reply-f))))
+      (finally
+        (d/close-room! r)))))
+
+(deftest preempting-include-now-precedes-cancel-settlement
+  (let [st (memory/make)
+        r (d/make-room {:id :policy-restart-now :store st})
+        entered (promise)
+        cancel-seen (promise)
+        settle (promise)
+        calls (atom 0)
+        turn-fn
+        (fn [chat-ctx {:keys [cancel?]}]
+          (if (= 1 (swap! calls inc))
+            (do
+              (deliver entered true)
+              (loop []
+                (if (and cancel? (cancel?))
+                  (do (deliver cancel-seen true)
+                      @settle
+                      :cancelled)
+                  (do (Thread/sleep 5) (recur)))))
+            (do (cc/add-message! chat-ctx {:role :assistant :content "restarted"})
+                :complete)))
+        policy (fn [_]
+                 (attention/decision {:memory :include
+                                      :control :restart
+                                      :at :now
+                                      :reason :test/restart-now}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :restart-now-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :attention-policy policy
+                                  :run-turn-fn turn-fn})))
+      (let [reply-f (future (await-spin r #(d/ask % :restart-now-worker
+                                                  {:content "start"}) 5000))]
+        (is (true? (deref entered 3000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :restart-now-worker
+                              "admit before settle" trigger)))
+        (is (true? (deref cancel-seen 2000 ::timeout)))
+        (is (some #(re-find #"admit before settle"
+                            (or (:content %) (:message/content %) ""))
+                  (cc/get-messages
+                   (room-context/lookup (:id r) :restart-now-worker))))
+        (deliver settle true)
+        (is (= "restarted" (:content @reply-f))))
+      (finally
+        (deliver settle true)
+        (d/close-room! r)))))
+
+(deftest quiescent-include-waits-until-run-exit
+  (let [st (memory/make)
+        r (d/make-room {:id :policy-include-quiescent :store st})
+        entered (promise)
+        gate (promise)
+        before-quiescence (atom nil)
+        after-quiescence (atom nil)
+        contains-note? (fn [messages]
+                         (some #(re-find #"only at quiescence"
+                                         (or (:content %) (:message/content %) ""))
+                               messages))
+        steps (atom [(fn [_ _]
+                       (deliver entered true)
+                       @gate
+                       :continue)
+                     (fn [chat-ctx _]
+                       (reset! before-quiescence (cc/get-messages chat-ctx))
+                       (cc/add-message! chat-ctx {:role :assistant :content "first done"})
+                       :complete)
+                     (fn [chat-ctx _]
+                       (reset! after-quiescence (cc/get-messages chat-ctx))
+                       (cc/add-message! chat-ctx {:role :assistant :content "second done"})
+                       :complete)])
+        calls (atom [])
+        policy (fn [_]
+                 (attention/decision {:memory :include
+                                      :control :continue
+                                      :at :quiescent
+                                      :reason :test/include-quiescent}))]
+    (try
+      (binding [ec/*execution-context* (:ctx r)]
+        (d/join r (llm/llm-agent {:id :quiescent-worker
+                                  :spec {:provider :mock :model "mock"}
+                                  :attention-policy policy
+                                  :run-turn-fn (make-queued-turn-fn steps calls)})))
+      (let [reply-f (future (await-spin r #(d/ask % :quiescent-worker
+                                                  {:content "start"}) 5000))]
+        (is (true? (deref entered 10000 ::timeout)))
+        (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
+          (d/post! r (d/reply :reviewer :quiescent-worker
+                              "only at quiescence" trigger)))
+        (is (await-condition
+             #(some (fn [fact]
+                      (= :test/include-quiescent (:attention/reason fact)))
+                    (store/-list-attention st (:id r)
+                                           {:participant :quiescent-worker}))
+             2000))
+        (deliver gate true)
+        (is (= "first done" (:content @reply-f)))
+        (is (not (contains-note? @before-quiescence))
+            "provider continuation is earlier than quiescence")
+        (is (= "second done"
+               (:content (await-spin r #(d/ask % :quiescent-worker
+                                               {:content "next run"}) 5000))))
+        (is (contains-note? @after-quiescence)))
+      (finally
+        (d/close-room! r)))))
 
 (deftest cancel-directive-mid-turn
   (testing ":directive/cancel PREEMPTS a running turn (it used to queue behind it)"

--- a/test/dvergr/discourse/personas_test.clj
+++ b/test/dvergr/discourse/personas_test.clj
@@ -14,13 +14,21 @@
             [dvergr.chat.context :as cc]))
 
 (defn- await-spin
-  ([room spin-fn] (await-spin room spin-fn 3000))
+  ;; A first Room turn may need to initialize Datahike and the forkable SCI
+  ;; component before this deliberately trivial mock runs.  Three seconds made
+  ;; this an environment-speed assertion and hid the real failure behind nil
+  ;; map lookups in the callers.
+  ([room spin-fn] (await-spin room spin-fn 10000))
   ([room spin-fn wait-ms]
    (let [p (promise)]
      (binding [ec/*execution-context* (:ctx room)]
        (sp/spawn!
         (sp/spin (deliver p (sp/await (spin-fn room))))))
-     (deref p wait-ms ::timeout))))
+     (let [result (deref p wait-ms ::timeout)]
+       (when (= ::timeout result)
+         (throw (ex-info "Timed out waiting for persona mock turn"
+                         {:wait-ms wait-ms})))
+       result))))
 
 (defn- mock-turn-fn
   "A `run-turn-fn` that writes a single assistant message capturing the

--- a/test/dvergr/repl_meta_harness_test.clj
+++ b/test/dvergr/repl_meta_harness_test.clj
@@ -8,6 +8,8 @@
    registry and durable Datahike row."
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.agent.turn :as turn]
+            [dvergr.chat.context :as chat-context]
+            [dvergr.discourse :as discourse]
             [dvergr.discourse.definitions :as definitions]
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.room.registry :as room-registry]
@@ -63,7 +65,8 @@
            tool-ctx
            (binding [ec/*execution-context* (:ctx parent)]
              (tools/make-context
-              {:sci-ctx       (:sci-ctx chat-ctx)
+              {:sci-ctx       (chat-context/sci-context-in
+                               chat-ctx (:ctx parent))
                :chat-ctx      chat-ctx
                :execution-ctx (:ctx parent)
                :isolation     :sci
@@ -81,33 +84,75 @@
                 ":children (set (map :slug "
                 "(dvergr.room/children " (pr-str parent-slug) ")))}")
            inspect-result (eval! parent tool-ctx inspect-code)
-           create-value (get-in create-result [:metadata :value])
-           inspect-value (get-in inspect-result [:metadata :value])
-           live-child (binding [ec/*execution-context* execution-ctx]
-                        (room-registry/lookup child-id))
-           durable-child (binding [ec/*execution-context* execution-ctx]
-                           (rooms/get-room-by-slug child-slug))
-           checks
-           {:create-tool-succeeded (= :success (:type create-result))
-            :inspect-tool-succeeded (= :success (:type inspect-result))
-            :sandbox-created-child  (= child-slug (get-in create-value [:child :slug]))
-            :repl-state-persisted   (= child-slug (:session-child-slug inspect-value))
-            :sandbox-sees-child     (true? (:visible? inspect-value))
-            :sandbox-sees-nesting   (contains? (:children inspect-value) child-slug)
-            :host-sees-child        (= child-id (:id live-child))
-            :host-sees-nesting      (= (room-store/slug->room-id parent-slug)
-                                       (:parent-id live-child))
-            :datahike-sees-child    (= child-slug (:room/slug durable-child))
-            :datahike-sees-nesting  (= parent-slug (:room/parent-slug durable-child))}]
-       {:passed? (every? true? (vals checks))
-        :checks checks
-        :parent-slug parent-slug
-        :child-slug child-slug
-        :create-result create-result
-        :inspect-result inspect-result
-        :live-room (select-keys live-child [:id :slug :title :parent-id])
-        :durable-room (select-keys durable-child
-                                   [:room/id :room/slug :room/name :room/parent-slug])}))))
+           world-fork (binding [ec/*execution-context* (:ctx parent)]
+                        (discourse/fork-room parent {:isolation :ctx}))]
+       (try
+         (let [fork-tool-ctx
+               (tools/make-context
+                {:sci-ctx       (chat-context/sci-context-in
+                                 chat-ctx (:ctx world-fork))
+                 :chat-ctx      chat-ctx
+                 :execution-ctx (:ctx world-fork)
+                 :isolation     :sci
+                 :tools         {"clojure_eval" (tools/get-tool "clojure_eval")}})
+               probe-id (random-uuid)
+               fork-result
+               (eval!
+                world-fork fork-tool-ctx
+                (str "(require '[datahike.api :as d] '[dvergr.room :as room]) "
+                     "(def fork-local " (pr-str probe-id) ") "
+                     "(d/transact room/*room* [{:message/id " (pr-str probe-id)
+                     " :message/content \"child-world-probe\"}]) "
+                     "{:var fork-local "
+                     " :db (d/q '[:find ?v . :in $ ?id :where "
+                     "[?e :message/id ?id] [?e :message/content ?v]] "
+                     "@room/*room* " (pr-str probe-id) ")}"))
+               parent-after-fork
+               (eval!
+                parent tool-ctx
+                (str "(require '[datahike.api :as d] '[dvergr.room :as room]) "
+                     "{:var-defined? (boolean (resolve 'fork-local)) "
+                     " :db (d/q '[:find ?v . :in $ ?id :where "
+                     "[?e :message/id ?id] [?e :message/content ?v]] "
+                     "@room/*room* " (pr-str probe-id) ")}"))
+               create-value (get-in create-result [:metadata :value])
+               inspect-value (get-in inspect-result [:metadata :value])
+               fork-value (get-in fork-result [:metadata :value])
+               parent-after-fork-value (get-in parent-after-fork [:metadata :value])
+               live-child (binding [ec/*execution-context* execution-ctx]
+                            (room-registry/lookup child-id))
+               durable-child (binding [ec/*execution-context* execution-ctx]
+                               (rooms/get-room-by-slug child-slug))
+               checks
+               {:create-tool-succeeded (= :success (:type create-result))
+                :inspect-tool-succeeded (= :success (:type inspect-result))
+                :sandbox-created-child  (= child-slug (get-in create-value [:child :slug]))
+                :repl-state-persisted   (= child-slug (:session-child-slug inspect-value))
+                :sandbox-sees-child     (true? (:visible? inspect-value))
+                :sandbox-sees-nesting   (contains? (:children inspect-value) child-slug)
+                :host-sees-child        (= child-id (:id live-child))
+                :host-sees-nesting      (= (room-store/slug->room-id parent-slug)
+                                           (:parent-id live-child))
+                :datahike-sees-child    (= child-slug (:room/slug durable-child))
+                :datahike-sees-nesting  (= parent-slug (:room/parent-slug durable-child))
+                :fork-tool-succeeded    (= :success (:type fork-result))
+                :fork-repl-diverged     (= probe-id (:var fork-value))
+                :fork-db-diverged       (= "child-world-probe" (:db fork-value))
+                :parent-var-unchanged   (false? (:var-defined? parent-after-fork-value))
+                :parent-db-unchanged    (nil? (:db parent-after-fork-value))}]
+           {:passed? (every? true? (vals checks))
+            :checks checks
+            :parent-slug parent-slug
+            :child-slug child-slug
+            :create-result create-result
+            :inspect-result inspect-result
+            :fork-result fork-result
+            :parent-after-fork parent-after-fork
+            :live-room (select-keys live-child [:id :slug :title :parent-id])
+            :durable-room (select-keys durable-child
+                                       [:room/id :room/slug :room/name :room/parent-slug])})
+         (finally
+           (discourse/discard world-fork)))))))
 
 (defn run-contract!
   "Run the contract in an isolated, provider-free daemon.
@@ -148,5 +193,6 @@
 (deftest agent-facing-repl-constructs-a-durable-nested-room
   (let [result (run-contract!)]
     (testing "every layer observes the room created from clojure_eval"
-      (is (:passed? result) (pr-str (:checks result)))
+      (is (:passed? result)
+          (pr-str (select-keys result [:checks :fork-result :parent-after-fork])))
       (is (every? true? (vals (:checks result)))))))

--- a/test/dvergr/room/registry_test.clj
+++ b/test/dvergr/room/registry_test.clj
@@ -1,0 +1,42 @@
+(ns dvergr.room.registry-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(deftest fork-registration-runs-admission-fences-before-publication
+  (let [root-ctx (context/create-execution-context)
+        child-ctx (context/fork-context root-ctx :mode :frozen)
+        room-id (keyword (str "rejected-fork-" (random-uuid)))
+        parent-id (keyword (str "parent-" (random-uuid)))
+        room (d/make-room {:id room-id
+                           :ctx child-ctx
+                           :store (memory/make)})
+        hook-id ::reject-this-fork]
+    ;; make-room auto-registers ordinary Rooms; remove that initial projection
+    ;; so this test exercises register-fork!'s publication boundary itself.
+    (binding [ec/*execution-context* root-ctx]
+      (registry/unregister! room-id))
+    (try
+      (binding [ec/*execution-context* root-ctx]
+        (registry/add-pre-register-hook!
+         hook-id
+         (fn [candidate]
+           (when (= room-id (:id candidate))
+             (throw (ex-info "rejected by admission fence" {})))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"rejected by admission fence"
+             (registry/register-fork! room parent-id (random-uuid))))
+        (is (nil? (registry/lookup room-id))
+            "a rejected fork is never globally visible as a Room")
+        (is (empty? (filter #(= room-id (:fork/id %))
+                            (registry/structural-children parent-id)))
+            "a rejected fork publishes no topology edge"))
+      (finally
+        ;; Hooks are process-global and keyed for reload; neutralize this
+        ;; test-specific fence without disturbing production hooks.
+        (registry/add-pre-register-hook! hook-id (constantly nil))
+        (context/close-context! child-ctx)
+        (context/close-context! root-ctx)))))

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -112,3 +112,254 @@
            clojure.lang.ExceptionInfo
            #":run/chat-id must be a UUID"
            (store/-store-run! st room-id (assoc completed :run/chat-id :not-a-uuid)))))))
+
+(defn assert-run-causality!
+  "Exercise terminal/same-room validation and append-only causal updates."
+  [st room-id]
+  (testing "causal inputs are resolved, scoped, append-only Run evidence"
+    (let [other-room-id (keyword (str (name room-id) "-other"))
+          now (java.util.Date. 1787860800000)
+          ended (java.util.Date. 1787860801000)
+          run-map (fn [id actor status]
+                    (cond-> {:run/id id
+                             :run/kind :workflow
+                             :run/room room-id
+                             :run/actor actor
+                             :run/trigger (random-uuid)
+                             :run/status status
+                             :run/created-at now
+                             :run/started-at now
+                             :run/updated-at (if (= :running status) now ended)}
+                      (store/terminal-run-statuses status)
+                      (assoc :run/ended-at ended)))
+          root-id (random-uuid)
+          child-id (random-uuid)
+          foreign-id (random-uuid)
+          root (run-map root-id :root :running)
+          child (run-map child-id :child :running)
+          foreign (assoc (run-map foreign-id :foreign :completed)
+                         :run/room other-room-id)]
+      (store/-store-room! st room-id {:slug (name room-id) :title "causes"})
+      (store/-store-room! st other-room-id
+                          {:slug (name other-room-id) :title "other causes"})
+      (store/-store-run! st room-id root)
+      (store/-store-run! st room-id child)
+      (store/-store-run! st other-room-id foreign)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"has not resolved"
+           (store/-store-run! st room-id
+                              (assoc root :run/caused-by #{child-id}))))
+      (store/-store-run! st room-id
+                         (assoc child :run/status :completed
+                                :run/updated-at ended :run/ended-at ended))
+      (let [caused (assoc root :run/caused-by #{child-id}
+                          :run/updated-at ended)]
+        (is (= caused (store/-store-run! st room-id caused)))
+        (is (= caused (store/-store-run! st room-id caused))
+            "replaying an existing causal set is idempotent")
+        (is (= #{child-id}
+               (:run/caused-by (store/-load-run st room-id root-id))))
+        (is (= #{child-id}
+               (:run/caused-by
+                (first (store/-list-runs st room-id {:actor :root})))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"append-only"
+             (store/-store-run! st room-id (dissoc caused :run/caused-by))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"not durable in the same Room"
+             (store/-store-run! st room-id
+                                (update caused :run/caused-by conj (random-uuid)))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"not durable in the same Room"
+             (store/-store-run! st room-id
+                                (update caused :run/caused-by conj foreign-id))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"terminal Run lifecycle is immutable"
+             (store/-store-run!
+              st room-id
+              (-> (store/-load-run st room-id child-id)
+                  (assoc :run/status :running :run/updated-at ended)
+                  (dissoc :run/ended-at))))
+            "accepted causal evidence cannot later regress to a live Run")))))
+
+(defn assert-attention-projection!
+  "Exercise durable participant-specific attention storage and filtering."
+  [st room-id]
+  (testing "attention is durable control state, separate from speech"
+    (store/-store-room! st room-id {:slug (name room-id) :title "Attention"})
+    (let [created (java.util.Date. 1787860800000)
+          fact {:attention/id (random-uuid)
+                :attention/participant :agent/researcher
+                :attention/message-id (random-uuid)
+                :attention/run-id (random-uuid)
+                :attention/memory :remember
+                :attention/activation :none
+                :attention/control :continue
+                :attention/at :next-safe-boundary
+                :attention/priority 0.0
+                :attention/status :ready
+                :attention/reason :peer/observation
+                :attention/metadata {:classifier :test :confidence 0.75}
+                :attention/created-at created}]
+      (is (= fact (store/-store-attention! st room-id fact)))
+      (is (= [fact]
+             (store/-list-attention st room-id
+                                    {:participant :agent/researcher})))
+      (is (= [fact] (store/unapplied-attention [fact])))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"immutable"
+           (store/-store-attention! st room-id
+                                    (assoc fact :attention/reason :mutated/retry))))
+      (is (empty? (store/-list-messages st room-id {}))
+          "attention facts never contaminate the Room transcript")
+      (is (empty? (store/-list-attention st room-id
+                                         {:participant :agent/other})))
+      (let [applied (-> fact
+                        (assoc :attention/id (random-uuid)
+                               :attention/decision-id (:attention/id fact)
+                               :attention/status :applied
+                               :attention/created-at (java.util.Date. 1787860800001)))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"missing decision"
+             (store/-store-attention!
+              st room-id (assoc applied
+                                :attention/id (random-uuid)
+                                :attention/decision-id (random-uuid)))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"differ"
+             (store/-store-attention!
+              st room-id (assoc applied
+                                :attention/id (random-uuid)
+                                :attention/message-id (random-uuid)))))
+        (store/-store-attention! st room-id applied)
+        (is (empty? (store/unapplied-attention [fact applied])))))))
+
+(defn assert-concurrent-attention-identity!
+  "Conflicting writers must agree on one immutable attention identity."
+  [st room-id]
+  (testing "attention first-write identity is atomic"
+    (store/-store-room! st room-id {:slug (name room-id) :title "Attention race"})
+    (let [attention-id (random-uuid)
+          base {:attention/id attention-id
+                :attention/participant :agent/researcher
+                :attention/message-id (random-uuid)
+                :attention/memory :remember
+                :attention/status :ready
+                :attention/created-at (java.util.Date.)}
+          ready (java.util.concurrent.CountDownLatch. 2)
+          start (promise)
+          writer (fn [reason]
+                   (future
+                     (.countDown ready)
+                     @start
+                     (try
+                       (store/-store-attention! st room-id
+                                                (assoc base :attention/reason reason))
+                       (catch Throwable error error))))
+          a (writer :race/a)
+          b (writer :race/b)]
+      (is (.await ready 5 java.util.concurrent.TimeUnit/SECONDS))
+      (deliver start true)
+      (let [outcomes [@a @b]]
+        (is (= 1 (count (filter map? outcomes))))
+        (is (= 1 (count (filter #(instance? Throwable %) outcomes))))
+        (is (= 1 (count (store/-list-attention st room-id {}))))))))
+
+(defn assert-enqueue-result-run!
+  "An enqueue is applied only by the exact successor execution it caused."
+  [st room-id]
+  (testing "enqueue disposition is correlated to its successor Run"
+    (store/-store-room! st room-id {:slug (name room-id) :title "Enqueue"})
+    (let [participant :agent/researcher
+          message-id (random-uuid)
+          decision {:attention/id (random-uuid)
+                    :attention/participant participant
+                    :attention/message-id message-id
+                    :attention/memory :include
+                    :attention/activation :enqueue
+                    :attention/control :continue
+                    :attention/at :quiescent
+                    :attention/status :ready
+                    :attention/created-at (java.util.Date.)}
+          result-run-id (random-uuid)
+          unrelated-run-id (random-uuid)
+          now (java.util.Date.)
+          result-run {:run/id result-run-id
+                      :run/kind :agent-turn
+                      :run/room room-id
+                      :run/actor participant
+                      :run/trigger message-id
+                      :run/status :running
+                      :run/created-at now
+                      :run/started-at now
+                      :run/updated-at now}
+          applied (assoc decision
+                         :attention/id (random-uuid)
+                         :attention/decision-id (:attention/id decision)
+                         :attention/status :applied
+                         :attention/created-at (java.util.Date.)
+                         :attention/result-run-id result-run-id)]
+      (store/-store-attention! st room-id decision)
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires a successor Run"
+                            (store/-store-attention!
+                             st room-id
+                             (dissoc applied :attention/result-run-id))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing successor Run"
+                            (store/-store-attention!
+                             st room-id
+                             (assoc applied :attention/id (random-uuid)
+                                    :attention/result-run-id (random-uuid)))))
+      (store/-store-run! st room-id
+                         (assoc result-run :run/id unrelated-run-id
+                                :run/actor :agent/other))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unrelated successor Run"
+                            (store/-store-attention!
+                             st room-id
+                             (assoc applied :attention/id (random-uuid)
+                                    :attention/result-run-id unrelated-run-id))))
+      (store/-store-run! st room-id result-run)
+      (is (= applied (store/-store-attention! st room-id applied)))
+      (is (empty? (store/unapplied-attention [decision applied]))))))
+
+(defn assert-cross-room-attention-identity!
+  "One global fact identity cannot be acknowledged under a second Room."
+  [st]
+  (testing "attention identity includes and validates Room ownership"
+    (let [room-a :attention-room-a
+          room-b :attention-room-b
+          fact {:attention/id (random-uuid)
+                :attention/participant :agent/researcher
+                :attention/message-id (random-uuid)
+                :attention/memory :remember
+                :attention/status :ready
+                :attention/created-at (java.util.Date.)}]
+      (store/-store-room! st room-a {:slug (name room-a) :title "A"})
+      (store/-store-room! st room-b {:slug (name room-b) :title "B"})
+      (store/-store-attention! st room-a fact)
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"immutable"
+                            (store/-store-attention! st room-b fact)))
+      (is (empty? (store/-list-attention st room-b {}))))))
+
+(defn assert-attention-metadata-validation!
+  [st room-id]
+  (testing "durable attention metadata must round-trip as EDN"
+    (store/-store-room! st room-id {:slug (name room-id) :title "Metadata"})
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"round-trippable EDN"
+         (store/-store-attention!
+          st room-id
+          {:attention/id (random-uuid)
+           :attention/participant :agent/researcher
+           :attention/message-id (random-uuid)
+           :attention/status :ready
+           :attention/metadata {:callback (fn [])}
+           :attention/created-at (java.util.Date.)})))))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -5,10 +5,17 @@
    chat-ctx path kept)."
   (:require [clojure.test :refer [deftest is testing]]
             [datahike.api :as dh]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.attempt.governance :as attempt-governance]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.artifact :as artifact]
             [dvergr.chat.schema :as schema]
             [dvergr.room.store :as store]
             [dvergr.room.store.contract :as contract]
-            [dvergr.room.store.datahike :as dhs]))
+            [dvergr.room.store.datahike :as dhs]
+            [hasch.core :as hasch]
+            [kontor.resource :as kontor]))
 
 (defn- mem-store []
   (let [cfg {:store {:backend :memory :id (random-uuid)}
@@ -18,6 +25,125 @@
     (let [conn (dh/connect cfg)]
       (schema/ensure-full-schema! conn)
       [conn (dhs/make conn)])))
+
+(defn- store-running-run! [st room-id run-id]
+  (let [now (java.util.Date.)]
+    (store/-store-run!
+     st room-id
+     {:run/id run-id
+      :run/kind :agent-task
+      :run/room room-id
+      :run/actor :agent
+      :run/trigger (random-uuid)
+      :run/status :running
+      :run/created-at now
+      :run/started-at now
+      :run/updated-at now})))
+
+(defn- certified-attempt [run-id agent]
+  (let [definition
+        (environment/make-environment
+         {:id :datahike/exact :task {:answer 42}
+          :verifier {:id :datahike/exact :version 1}
+          :world {:isolation :ctx :settlement :review}})
+        receipt
+        (environment/make-attempt-receipt
+         definition
+         {:run-id run-id :provider :dvergr :model "echo"
+          :status :completed :started-at 1000 :elapsed-ms 10
+          :metrics {:program-kind :echo :model-resolution :not-applicable
+                    :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                    :interpreter-version 5}
+          :checks {:exact? true :portable? true} :reward 1.0
+          :trace {:runs [{:run/id run-id :run/status :completed}]}})]
+    (attempt/make-attempt definition agent receipt
+                          {:trace {:runs [{:run/id run-id
+                                           :run/status :completed}]}}
+                          :review)))
+
+(deftest certified-attempt-round-trips-through-typed-index-and-cas
+  (let [[conn _] (mem-store)
+        artifacts (artifact/memory-store)
+        st (dhs/make conn artifacts)
+        room-id :datahike-attempt
+        run-id (random-uuid)
+        agent (-> (roster/make-roster)
+                  (roster/make-agent {:id :candidate
+                                      :program {:kind :echo}})
+                  (roster/agent :candidate))
+        value (certified-attempt run-id agent)
+        now (java.util.Date. 1000)]
+    (store/-store-room! st room-id {:slug (name room-id)})
+    (store/-store-run!
+     st room-id
+     {:run/id run-id :run/kind :agent-task :run/room room-id
+      :run/actor :candidate :run/trigger (random-uuid)
+      :run/status :completed :run/created-at now :run/started-at now
+      :run/updated-at now :run/ended-at (java.util.Date. 1010)
+      :run/agent-version 1 :run/program-kind :echo
+      :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)})
+    (is (= value (store/-store-attempt! st room-id value)))
+    (is (= value (store/-load-attempt st room-id run-id)))
+    (is (= [value]
+           (store/-list-attempts st room-id
+                                 {:environment-content-id
+                                  (get-in value [:attempt/environment
+                                                 :environment/content-id])
+                                  :model "echo"})))
+    (is (= 2
+           (dh/q '[:find (count ?check) .
+                   :where [?a :attempt/checks ?check]] @conn)))
+    (testing "the mandatory writer predicate guards raw API writes"
+      (is (thrown-with-msg?
+           Throwable #"trusted writer"
+           (dh/transact conn [{:attempt/id (random-uuid)}])))
+      (is (thrown-with-msg?
+           Throwable #"immutable"
+           (dh/transact conn [[:db/add [:attempt/id run-id]
+                               :attempt/reward 0.0]]))))
+    (testing "an arbitrary transaction function is not a trusted writer"
+      (let [rogue-run-id (random-uuid)
+            rogue (certified-attempt rogue-run-id agent)
+            chat-id (dh/q '[:find ?chat-id . :in $ ?slug
+                            :where
+                            [?c :room/slug ?slug]
+                            [?c :chat/id ?chat-id]]
+                          @conn (name room-id))
+            rogue-entity (#'dhs/attempt->entity
+                          chat-id
+                          rogue (artifact/put-value! artifacts rogue))]
+        (store/-store-run!
+         st room-id
+         {:run/id rogue-run-id :run/kind :agent-task :run/room room-id
+          :run/actor :candidate :run/trigger (random-uuid)
+          :run/status :completed :run/created-at now :run/started-at now
+          :run/updated-at now :run/ended-at (java.util.Date. 1010)
+          :run/agent-version 1 :run/program-kind :echo
+          :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)})
+        (is (thrown-with-msg?
+             Throwable #"trusted writer"
+             (dh/transact conn [[:db.fn/call (fn [_] [])] rogue-entity])))
+        (is (nil? (store/-load-attempt st room-id rogue-run-id)))))
+    (testing "installing Kontor preserves both mandatory governors"
+      (kontor/install! conn)
+      (attempt-governance/govern! conn)
+      (is (thrown-with-msg?
+           Throwable #"immutable"
+           (dh/transact conn [[:db/add [:attempt/id run-id]
+                               :attempt/reward 0.25]]))))
+    (testing "the typed row points to the terminal Run rather than copying it"
+      (is (= run-id
+             (dh/q '[:find ?run-id .
+                     :where
+                     [?a :attempt/id _]
+                     [?a :attempt/run ?r]
+                     [?r :run/id ?run-id]] @conn))))
+    (testing "Room deletion removes Attempt components through the same governor"
+      (store/-delete-room! st room-id)
+      (is (nil? (store/-load-attempt st room-id run-id)))
+      (is (zero? (or (dh/q '[:find (count ?check) .
+                             :where [?a :attempt/checks ?check]] @conn)
+                     0))))))
 
 (deftest message-envelope-contract
   (let [[_conn st] (mem-store)]
@@ -68,6 +194,32 @@
 (deftest run-lifecycle-contract
   (let [[_conn st] (mem-store)]
     (contract/assert-run-lifecycle! st :runs-datahike)))
+
+(deftest run-causality-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-run-causality! st :run-causes-datahike)))
+
+(deftest attention-projection-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-attention-projection! st :attention-datahike)))
+
+(deftest concurrent-attention-identity-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-concurrent-attention-identity!
+     st :attention-race-datahike)))
+
+(deftest cross-room-attention-identity-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-cross-room-attention-identity! st)))
+
+(deftest attention-metadata-validation-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-attention-metadata-validation!
+     st :attention-metadata-datahike)))
+
+(deftest enqueue-result-run-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-enqueue-result-run! st :enqueue-result-datahike)))
 
 (deftest thread-filter-bounds-the-datahike-pull
   (testing "the indexed root predicate runs before message bodies are pulled"
@@ -271,3 +423,119 @@
       (let [m (first (store/-list-messages st room-id {}))]
         (is (= "hi" (:content m)))
         (is (not (contains? m :tool-uses)))))))
+
+(deftest semantic-activities-round-trip
+  (testing "typed activities remain attached to their canonical room message"
+    (let [[_conn st] (mem-store)
+          room-id :activity-round-trip
+          activity-id (random-uuid)
+          run-id (random-uuid)
+          activity {:activity/id activity-id
+                    :activity/run-id run-id
+                    :activity/kind :tool
+                    :activity/verb :invoke
+                    :activity/tool-name "clojure_eval"
+                    :activity/tool-use-id "call-1"
+                    :activity/at (java.util.Date.)}]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+      (store-running-run! st room-id run-id)
+      (store/-store-message!
+       st room-id
+       {:id (random-uuid) :from :agent :content "used a tool"
+        :metadata {:role :tool :run-id run-id :activities [activity]}})
+      (let [stored (-> (store/-list-messages st room-id {}) first :metadata :activities first)]
+        (is (= (dissoc activity :activity/at)
+               (dissoc stored :activity/at)))
+        (is (= (.getTime ^java.util.Date (:activity/at activity))
+               (.getTime ^java.util.Date (:activity/at stored))))))))
+
+(deftest semantic-activity-run-cannot-contradict-its-message
+  (let [[_conn st] (mem-store)
+        room-id :activity-run-mismatch]
+    (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"activity Run must match"
+         (store/-store-message!
+          st room-id
+          {:id (random-uuid) :from :agent :content "impossible provenance"
+           :metadata {:role :tool
+                      :run-id (random-uuid)
+                      :activities [{:activity/id (random-uuid)
+                                    :activity/run-id (random-uuid)
+                                    :activity/kind :tool
+                                    :activity/verb :invoke}]}})))))
+
+(deftest semantic-activity-requires-an-enclosing-message-run
+  (let [[_conn st] (mem-store)
+        room-id :activity-missing-message-run]
+    (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"requires an enclosing message Run"
+         (store/-store-message!
+          st room-id
+          {:id (random-uuid) :from :agent :content "orphan"
+           :metadata {:role :tool
+                      :activities [{:activity/id (random-uuid)
+                                    :activity/run-id (random-uuid)
+                                    :activity/kind :tool
+                                    :activity/verb :invoke}]}})))))
+
+(deftest semantic-activity-requires-a-run-in-the-same-room
+  (let [[_conn st] (mem-store)
+        room-a :activity-room-a
+        room-b :activity-room-b
+        run-id (random-uuid)
+        activity {:activity/id (random-uuid)
+                  :activity/run-id run-id
+                  :activity/kind :tool
+                  :activity/verb :invoke}]
+    (doseq [room-id [room-a room-b]]
+      (store/-store-room! st room-id {:slug (name room-id) :title "T"}))
+    (is (= :failed
+           (store/-store-message!
+            st room-a
+            {:id (random-uuid) :from :agent :content "missing"
+             :metadata {:role :tool :run-id run-id :activities [activity]}})))
+    (store-running-run! st room-b run-id)
+    (is (= :failed
+           (store/-store-message!
+            st room-a
+            {:id (random-uuid) :from :agent :content "cross-room"
+             :metadata {:role :tool :run-id run-id :activities [activity]}})))
+    (is (empty? (store/-list-messages st room-a {})))))
+
+(deftest repeated-semantic-id-cannot-mutate-an-earlier-message
+  (let [[conn st] (mem-store)
+        room-id :activity-component-ownership
+        run-id (random-uuid)
+        activity-id (random-uuid)
+        message-ids [(random-uuid) (random-uuid)]]
+    (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+    (store-running-run! st room-id run-id)
+    (doseq [[message-id tool-name] (map vector message-ids ["first" "second"])]
+      (is (= :inserted
+             (store/-store-message!
+              st room-id
+              {:id message-id :from :agent :content tool-name
+               :metadata {:role :tool
+                          :run-id run-id
+                          :activities [{:activity/id activity-id
+                                        :activity/run-id run-id
+                                        :activity/kind :tool
+                                        :activity/verb :invoke
+                                        :activity/tool-name tool-name}]}}))))
+    (is (= ["first" "second"]
+           (mapv #(-> % :metadata :activities first :activity/tool-name)
+                 (store/-list-messages st room-id {}))))
+    (let [component-eids
+          (dh/q '[:find [?a ...]
+                  :in $ ?activity-id
+                  :where [?a :activity/id ?activity-id]]
+                @conn activity-id)]
+      (is (= 2 (count component-eids)))
+      (dh/transact conn [[:db/retractEntity [:message/id (first message-ids)]]])
+      (is (= "second"
+             (-> (store/-list-messages st room-id {}) first
+                 :metadata :activities first :activity/tool-name))))))

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -10,6 +10,32 @@
 (deftest run-lifecycle-contract
   (contract/assert-run-lifecycle! (memory/make) :runs-memory))
 
+(deftest run-causality-contract
+  (contract/assert-run-causality! (memory/make) :run-causes-memory))
+
+(deftest attention-projection-contract
+  (contract/assert-attention-projection! (memory/make) :attention-memory))
+
+(deftest concurrent-attention-identity-contract
+  (contract/assert-concurrent-attention-identity!
+   (memory/make) :attention-race-memory))
+
+(deftest cross-room-attention-identity-contract
+  (contract/assert-cross-room-attention-identity! (memory/make)))
+
+(deftest attention-metadata-validation-contract
+  (contract/assert-attention-metadata-validation!
+   (memory/make) :attention-metadata-memory))
+
+(deftest enqueue-result-run-contract
+  (contract/assert-enqueue-result-run! (memory/make) :enqueue-result-memory))
+
+(deftest attention-id-uses-an-injective-tuple-encoding
+  (let [message-id (random-uuid)]
+    ;; Both tuples rendered as `:a|:b|:c|...` under the old raw separator.
+    (is (not= (store/attention-id :a|:b :c message-id nil :ready)
+              (store/attention-id :a :b|:c message-id nil :ready)))))
+
 (deftest rejects-unmodelled-durable-metadata
   (let [st (memory/make)]
     (store/-store-room! st :strict-memory {:slug "strict-memory"})

--- a/test/dvergr/rooms/messages_test.clj
+++ b/test/dvergr/rooms/messages_test.clj
@@ -4,6 +4,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.rooms.messages :as rmsg]
             [dvergr.discourse :as d]
+            [dvergr.room.store :as store]
             [dvergr.room.store.memory :as mem]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]
@@ -42,6 +43,38 @@
             (is (contains? cs "agent reply") "room signal includes agent replies (unlike per-agent ctx)")
             (is (contains? cs "🔧 grep")     "room signal includes tool-activity rows"))
           (finally (rmsg/drop-room! :rm-fold)))))))
+
+(deftest normalizes-semantic-activity-and-run-correlation
+  (let [c      (ctx/create-execution-context)
+        run-id (random-uuid)
+        fact   {:activity/id (random-uuid)
+                :activity/run-id run-id
+                :activity/kind :tool
+                :activity/verb :invoke
+                :activity/tool-name "clojure_eval"}]
+    (binding [ec/*execution-context* c]
+      (let [st   (mem/make)
+            room (d/make-room {:id :rm-semantic-activity :ctx c :store st})
+            sig  (rmsg/messages-signal room)]
+        (try
+          (let [now (java.util.Date.)]
+            (store/-store-run! st :rm-semantic-activity
+                               {:run/id run-id
+                                :run/kind :agent-turn
+                                :run/room :rm-semantic-activity
+                                :run/actor :var
+                                :run/trigger (random-uuid)
+                                :run/status :running
+                                :run/created-at now
+                                :run/started-at now
+                                :run/updated-at now}))
+          (d/post! room (d/message :var :_activity "tool activity" nil
+                                   {:role :tool :run-id run-id :activities [fact]}))
+          (engine/await-drain-complete! c :timeout-ms 350)
+          (let [view (some #(when (= "tool activity" (:content %)) %) @sig)]
+            (is (= run-id (:run-id view)))
+            (is (= [fact] (:activities view))))
+          (finally (rmsg/drop-room! :rm-semantic-activity)))))))
 
 (deftest dedups-by-id-and-matches-store
   (testing "the room signal and the store are two folds of the same bus —

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -14,6 +14,7 @@
             [dvergr.intake.bash :as b]
             [dvergr.substrate.geschichte :as geschichte]
             [dvergr.room.registry :as registry]
+            [dvergr.system.rooms :as srooms]
             [dvergr.runtime.peer-bus :as peer-bus]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.core :as sp]
@@ -92,6 +93,65 @@
         (is (= (:id fork) (:dvergr/origin (first evts))))
         (is (= :parent (:dvergr/parent (first evts))))
         (is (vector? (:workspace-id (first evts))))))))
+
+(deftest failed-fork-construction-rolls-back-the-world
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :rollback-parent *base-ctx*)
+          bad (assoc (d/echo :bad)
+                     :factory (fn [_]
+                                (throw (ex-info "clone failed" {:type ::clone-failed}))))
+          rooms-before (set (keys (registry/snapshot)))
+          discarded (atom 0)
+          discard! ygg/discard-fork!]
+      (d/join parent bad)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"clone failed"
+           (with-redefs [ygg/discard-fork!
+                         (fn [& args]
+                           (swap! discarded inc)
+                           (apply discard! args))]
+             (d/fork-room parent {:isolation :ctx}))))
+      (is (pos? @discarded) "the unreachable affine fork handle was settled")
+      (is (= rooms-before (set (keys (registry/snapshot))))
+          "no partially constructed Room became reachable")
+      (is (empty? (registry/structural-children (:id parent)))
+          "no stale settlement topology survived rollback"))))
+
+(deftest failed-fork-construction-drops-deferred-grants
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :rollback-grant-parent *base-ctx*)
+          grant {:room-id (random-uuid) :name "scratch" :scope :room}
+          dropped (atom nil)
+          bad (assoc (d/echo :bad-grant)
+                     :factory (fn [_]
+                                (ec/swap-state! [:dvergr/pending-grants]
+                                                (constantly [grant]))
+                                (throw (ex-info "clone failed after grant" {}))))]
+      (d/join parent bad)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"clone failed after grant"
+           (with-redefs [srooms/drop-fork-grants! #(reset! dropped %)]
+             (d/fork-room parent {:isolation :ctx}))))
+      (is (= [grant] @dropped)
+          "rollback releases storage grants provisioned inside the child world"))))
+
+(deftest fork-created-observability-failure-does-not-roll-back-publication
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :event-failure-parent *base-ctx*)
+          discarded (atom 0)
+          fork (with-redefs [peer-bus/post! (fn [_]
+                                              (throw (ex-info "observer unavailable" {})))
+                             ygg/discard-fork! (fn [& _] (swap! discarded inc))]
+                 (d/fork-room parent {:isolation :ctx}))]
+      (try
+        (is (identical? fork (registry/lookup (:id fork)))
+            "the atomically published Room remains authoritative")
+        (is (zero? @discarded)
+            "a failed control-plane notification cannot settle its live handle")
+        (finally
+          ;; The test replaced settlement only during construction; normal
+          ;; cleanup owns and settles the retained fork now.
+          (d/discard fork))))))
 
 (deftest propose-merge!-emits-event-and-tagged-message
   (binding [ec/*execution-context* *base-ctx*]

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -15,6 +15,8 @@
             [dvergr.substrate.geschichte :as geschichte]
             [dvergr.room.registry :as registry]
             [dvergr.runtime.peer-bus :as peer-bus]
+            [dvergr.sandbox.work :as sandbox-work]
+            [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]))
 
@@ -662,6 +664,13 @@
                   (catch clojure.lang.ExceptionInfo error error))]
       (is (= "preflight conflict" (ex-message error)))
       (is (ygg/open-fork? (d/fork-handle fork)))
+      (let [controller (sandbox-work/create!
+                        (:id fork) (:ctx fork) nil :serial {}
+                        (fn [value] (sp/spin value)))]
+        (is (some? controller)
+            "failed settlement reopens the exact SCI work-admission generation")
+        (binding [ec/*execution-context* (:ctx fork)]
+          (sandbox-work/close! controller)))
       (d/post! fork (d/message :human nil "relay after failed merge"))
       (is (= true (deref relayed 2000 ::timeout)))
       (d/discard fork))))

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -665,7 +665,7 @@
       (is (= "preflight conflict" (ex-message error)))
       (is (ygg/open-fork? (d/fork-handle fork)))
       (let [controller (sandbox-work/create!
-                        (:id fork) (:ctx fork) nil :serial {}
+                        (:id fork) (:incarnation fork) (:ctx fork) nil :serial {}
                         (fn [value] (sp/spin value)))]
         (is (some? controller)
             "failed settlement reopens the exact SCI work-admission generation")

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -61,7 +61,8 @@
       ;; that full wiring and catches any omission there.
       (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room) nil)
       (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room)
-                                      {:room-id (:id room)})
+                                      {:room-id (:id room)
+                                       :room-incarnation (:incarnation room)})
       (testing "progressive help contains an executable composition example"
         (let [guide (sandbox/ns-doc-md sci-ctx 'dvergr.agent)]
           (is (re-find #":scripted.*:reply" guide))
@@ -120,7 +121,8 @@
         sci-ctx (sandbox/fork-for-session (:ctx room))]
     (try
       (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room)
-                                      {:room-id (:id room)})
+                                      {:room-id (:id room)
+                                       :room-incarnation (:incarnation room)})
       (let [result
             (binding [ec/*execution-context* (:ctx room)]
               (sandbox/eval-code
@@ -160,7 +162,8 @@
         sci-ctx (sandbox/fork-for-session (:ctx fork))]
     (try
       (data-ns/add-spindel-extras-ns! sci-ctx (:ctx fork)
-                                      {:room-id (:id fork)})
+                                      {:room-id (:id fork)
+                                       :room-incarnation (:incarnation fork)})
       (let [created
             (binding [ec/*execution-context* (:ctx fork)]
               (sandbox/eval-code
@@ -200,6 +203,7 @@
       (data-ns/add-spindel-extras-ns!
        sci-ctx (:ctx room)
        {:room-id (:id room)
+        :room-incarnation (:incarnation room)
         :ceiling {:controllers 1
                   :concurrency 2
                   :capacity 4
@@ -237,30 +241,37 @@
   (let [room (d/make-room {:id :sci-work-incarnation
                            :store (memory/make)})
         other-ctx (context/create-execution-context)
+        other-room (d/make-room {:id :sci-work-incarnation
+                                 :ctx other-ctx
+                                 :store (memory/make)})
         controller (sandbox-work/create!
-                    (:id room) (:ctx room) {:controllers 1}
+                    (:id room) (:incarnation room) (:ctx room) {:controllers 1}
                     :serial {} (fn [value] (sp/spin value)))]
     (try
       (binding [ec/*execution-context* (:ctx room)]
         (room-registry/register! room))
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"controller limit"
-           (sandbox-work/create! (:id room) (:ctx room) {:controllers 1}
+           (sandbox-work/create! (:id room) (:incarnation room) (:ctx room) {:controllers 1}
                                  :serial {} (fn [value] (sp/spin value))))
           "an idempotent registry refresh does not forget live controllers")
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"another live incarnation"
            (binding [ec/*execution-context* (:ctx room)]
-             (room-registry/register! (assoc room :ctx other-ctx)))))
+             (room-registry/register! (assoc room :incarnation (random-uuid))))))
       (is (identical? room
                       (binding [ec/*execution-context* (:ctx room)]
                         (room-registry/lookup (:id room))))
           "a rejected replacement leaves the registered Room untouched")
+      (is (identical? other-room
+                      (binding [ec/*execution-context* other-ctx]
+                        (room-registry/lookup (:id other-room))))
+          "equal Room ids in independent root registries do not share lifecycle state")
       (finally
         (binding [ec/*execution-context* (:ctx room)]
           (sandbox-work/close! controller))
         (d/close-room! room)
-        (context/close-context! other-ctx)))))
+        (d/close-room! other-room)))))
 
 (deftest room-work-teardown-broadcasts-before-joining
   (let [room (d/make-room {:id :sci-work-broadcast
@@ -269,7 +280,7 @@
                      (repeatedly
                       2
                       #(sandbox-work/create!
-                        (:id room) (:ctx room) nil :serial {}
+                        (:id room) (:incarnation room) (:ctx room) nil :serial {}
                         (fn [value] (sp/spin value)))))
         cancellations (atom 0)]
     (try

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -1,7 +1,9 @@
 (ns dvergr.sandbox.agent-programming-test
   "Provider-free acceptance tests for the functional agent surface in room SCI."
   (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.program :as program]
             [dvergr.agent.run :as run]
+            [dvergr.agent.world :as world]
             [dvergr.discourse :as d]
             [dvergr.resource :as resource]
             [dvergr.room.registry :as room-registry]
@@ -69,8 +71,25 @@
           (is (re-find #":delay-ms" guide))
           (is (re-find #"result-spin" guide))
           (is (re-find #"owned-result-spin" guide))
+          (is (re-find #"content-addressed EnvironmentDef" guide))
           (is (re-find #"comb/race" guide))
           (is (re-find #"await" guide)))
+        (let [result
+              (sandbox/eval-code
+               sci-ctx
+               (str "(require '[dvergr.agent :as agent]) "
+                    "(let [a (agent/environment "
+                    "{:id :training/example :task {:input 42} "
+                    ":verifier {:id :checks/example :version 1} "
+                    ":limits {:timeout-ms 1000}}) "
+                    "b (agent/environment "
+                    "{:limits {:timeout-ms 1000} "
+                    ":verifier {:version 1 :id :checks/example} "
+                    ":task {:input 42} :id :training/example})] "
+                    "{:same? (= a b) :ref (agent/environment-ref a)})"))]
+          (is (:success result) (pr-str (:error result)))
+          (is (true? (get-in result [:value :same?])))
+          (is (uuid? (get-in result [:value :ref :environment/content-id]))))
         (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.comb)]
           (is (re-find #"cancel losing branches" guide))
           (is (re-find #"owned-result-spin" guide)))
@@ -113,6 +132,70 @@
           (is (= :completed (get-in result [:value :analyst-status])))
           (is (empty? (run/active-runs (:id room))))))
       (finally
+        (d/close-room! room)))))
+
+(deftest sci-can-author-particles-and-an-independent-verifier
+  (let [room      (d/make-room {:id :sci-self-programming-eval
+                                :store (memory/make)})
+        sci-ctx   (sandbox/fork-for-session (:ctx room))
+        parent-id (:run/id (run/start! room :orchestrator (random-uuid) nil))]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room)
+       {:program-kinds #{:scripted}
+        :parent-run parent-id})
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room))
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                "         '[spindel.comb :as comb]) "
+                "(let [team (-> (agent/roster {:id :particle-eval}) "
+                "               (agent/make-agent {:id :mod-five "
+                "                 :program {:kind :scripted :delay-ms 50 "
+                "                           :reply [8 23 38 53 68 83 98]}}) "
+                "               (agent/make-agent {:id :mod-seven "
+                "                 :program {:kind :scripted :delay-ms 50 "
+                "                           :reply [2 9 16 23 30 37 44 51 58 65 72 79 86 93]}}) "
+                "               (agent/make-agent {:id :verifier "
+                "                 :program {:kind :scripted :delay-ms 50 "
+                "                           :reply {:moduli [[3 2] [5 3] [7 2]] "
+                "                                   :upper-bound 100}}})) "
+                "      a (agent/hire! team :mod-five {:task :candidates}) "
+                "      b (agent/hire! team :mod-seven {:task :candidates}) "
+                "      v (agent/hire! team :verifier {:task :constraints}) "
+                "      [ra rb rv] @(spin (await (comb/parallel "
+                "                                  (agent/result-spin a) "
+                "                                  (agent/result-spin b) "
+                "                                  (agent/result-spin v)))) "
+                "      [xs ys spec] (mapv :run/value [ra rb rv]) "
+                "      candidates (filter (set ys) xs) "
+                "      valid? (fn [n] (and (pos? n) (< n (:upper-bound spec)) "
+                "                            (every? (fn [[m r]] (= r (mod n m))) "
+                "                                    (:moduli spec)))) "
+                "      answers (vec (filter valid? candidates))] "
+                "  {:answer (first answers) :particles 2 :verified (= [23] answers)})")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (= {:answer 23 :particles 2 :verified true} (:value result)))
+        (is (wait-until #(= [parent-id]
+                            (mapv :run/id (run/active-runs (:id room))))
+                        1000))
+        (run/finish! parent-id :completed)
+        (let [root (run/run room parent-id)
+              children (remove #(= parent-id (:run/id %)) (run/runs room))
+              by-actor (into {} (map (juxt :run/actor identity)) children)]
+          (is (= #{:mod-five :mod-seven :verifier} (set (keys by-actor))))
+          (is (every? #(= parent-id (:run/parent %)) children))
+          (is (= (into #{} (map :run/id) children)
+                 (set (:run/caused-by root))))
+          (is (every? #(= :completed (:run/status %)) children))
+          (is (every? #(= :merged (:run/settlement-status %)) children))))
+      (finally
+        (run/finish! parent-id :cancelled)
         (d/close-room! room)))))
 
 (deftest room-sci-programs-serial-work-without-an-llm
@@ -396,7 +479,10 @@
                 "      b (agent/hire! team :slow {:task :solve})] "
                 "  @(spin (-> (await (comb/race (agent/owned-result-spin a) "
                 "                                (agent/owned-result-spin b))) "
-                "             :run/value)))")))]
+                "             :run/value)))")
+               :timeout-ms 15000))]
+        (is (not= "TimeoutException" (get-in result [:error :type]))
+            (pr-str (:error result)))
         (is (:success result) (pr-str (:error result)))
         (is (= :fast (:value result)))
         (is (wait-until #(empty? (run/active-runs (:id room))) 1000))
@@ -405,6 +491,87 @@
           (is (= :cancelled (get-in by-actor [:slow :run/status])))))
       (finally
         (d/close-room! room)))))
+
+(deftest nested-run-sci-race-cancels-and-settles-its-owned-loser
+  (let [room (d/make-room {:id :nested-sci-agent-owned-race
+                           :store (memory/make)})
+        parent-id (random-uuid)
+        trigger (d/message :repl :_runs "coordinate" nil {:role :user})
+        run-world (world/open! room parent-id :discard)
+        work-room (:work run-world)
+        supervisor (binding [ec/*execution-context* (:ctx room)]
+                     @(sp/spin
+                       (#'program/make-supervisor (:ctx room) (:ctx work-room))))
+        ceiling {:program-kinds #{:echo :scripted}
+                 :parent-run parent-id
+                 :own-child! (fn [admit!]
+                               (#'program/with-owned-child! supervisor admit!))}
+        sci-ctx (sandbox/fork-for-session (:ctx work-room))]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (run/start! room :orchestrator trigger nil
+                    {:id parent-id :kind :workflow})
+        (d/post! room trigger))
+      (agent-ns/add-programming-ns! sci-ctx (:id work-room) (:ctx work-room) ceiling)
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx work-room)
+                                      {:room-id (:id work-room)
+                                       :room-incarnation (:incarnation work-room)})
+      (let [result
+            (binding [ec/*execution-context* (:ctx work-room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                "         '[spindel.comb :as comb]) "
+                "(let [team (-> (agent/roster) "
+                "               (agent/make-agent {:id :fast :program {:kind :scripted :delay-ms 10 :reply :fast}}) "
+                "               (agent/make-agent {:id :slow :program {:kind :scripted :delay-ms 5000 :reply :slow}})) "
+                "      a (agent/hire! team :fast {:task :solve}) "
+                "      b (agent/hire! team :slow {:task :solve})] "
+                "  @(spin (-> (await (comb/race (agent/owned-result-spin a) "
+                "                                (agent/owned-result-spin b))) "
+                "             :run/value)))")
+               :timeout-ms 15000))]
+        (is (not= "TimeoutException" (get-in result [:error :type]))
+            (pr-str (:error result)))
+        (is (:success result) (pr-str (:error result)))
+        (is (= :fast (:value result)))
+        (is (wait-until #(= 1 (count (run/active-runs (:id room)))) 1000))
+        (let [children (remove #(= parent-id (:run/id %)) (run/runs room))
+              by-actor (into {} (map (juxt :run/actor identity)) children)]
+          (is (= parent-id (get-in by-actor [:fast :run/parent])))
+          (is (= parent-id (get-in by-actor [:slow :run/parent])))
+          (is (= :completed (get-in by-actor [:fast :run/status])))
+          (is (= :cancelled (get-in by-actor [:slow :run/status])))
+          (is (= :merged (get-in by-actor [:fast :run/settlement-status])))
+          (is (= :discarded (get-in by-actor [:slow :run/settlement-status])))
+          (binding [ec/*execution-context* (:ctx room)]
+            (is (nil? (room-registry/lookup
+                       (get-in by-actor [:fast :run/world]))))
+            (is (nil? (room-registry/lookup
+                       (get-in by-actor [:slow :run/world])))))))
+      (finally
+        (try
+          (binding [ec/*execution-context* (:ctx room)]
+            (#'program/cancel-supervisor! supervisor)
+            (#'program/seal-supervisor! supervisor)
+            (let [waiter (future (#'program/await-supervisor! supervisor))]
+              (when (= ::cleanup-timeout
+                       (deref waiter 15000 ::cleanup-timeout))
+                (future-cancel waiter)
+                (throw (ex-info "Nested agent supervisor did not quiesce"
+                                {:type ::cleanup-timeout})))))
+          (finally
+            (try
+              (binding [ec/*execution-context* (:ctx room)]
+                (when (some #(= parent-id (:run/id %))
+                            (run/active-runs (:id room)))
+                  (run/finish! parent-id :cancelled)))
+              (world/settle! run-world :cancelled)
+              (finally
+                (d/close-room! room)))))))))
 
 (deftest roomless-sci-can-build-rosters-but-cannot-launch-effects
   (let [ctx     (context/create-execution-context)
@@ -471,7 +638,7 @@
   (let [room      (d/make-room {:id :sci-agent-ambient-parent
                                 :store (memory/make)})
         sci-ctx   (sandbox/fork-for-session (:ctx room))
-        parent-id (random-uuid)]
+        parent-id (:run/id (run/start! room :parent (random-uuid) nil))]
     (try
       (agent-ns/add-programming-ns!
        sci-ctx (:id room) (:ctx room)
@@ -491,8 +658,13 @@
                 "  @(spin (await (agent/result-spin child))) "
                 "  (:run/parent (agent/observe child)))")))]
         (is (:success result) (pr-str (:error result)))
-        (is (= parent-id (:value result))))
+        (is (= parent-id (:value result)))
+        (let [child-id (:run/id (first (filter #(= :child (:run/actor %))
+                                               (run/runs room))))]
+          (is (= #{child-id}
+                 (:run/caused-by (run/run room parent-id))))))
       (finally
+        (run/finish! parent-id :completed)
         (d/close-room! room)))))
 
 (deftest sandbox-cannot-redirect-structural-parent-authority

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -8,8 +8,10 @@
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.agent :as agent-ns]
             [dvergr.sandbox.ns.data :as data-ns]
+            [dvergr.sandbox.work :as sandbox-work]
             [dvergr.sandbox.ns.kb :as kb-ns]
             [dvergr.sandbox.ns.room :as room-ns]
+            [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.context :as context]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -30,7 +32,8 @@
       ;; the same injector from setup-agent-namespaces!; doc-coverage exercises
       ;; that full wiring and catches any omission there.
       (agent-ns/add-programming-ns! sci-ctx (:id room) (:ctx room) nil)
-      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room))
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room)
+                                      {:room-id (:id room)})
       (testing "progressive help contains an executable composition example"
         (let [guide (sandbox/ns-doc-md sci-ctx 'dvergr.agent)]
           (is (re-find #":scripted.*:reply" guide))
@@ -41,7 +44,11 @@
           (is (re-find #"await" guide)))
         (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.comb)]
           (is (re-find #"cancel losing branches" guide))
-          (is (re-find #"owned-result-spin" guide))))
+          (is (re-find #"owned-result-spin" guide)))
+        (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.work)]
+          (is (re-find #"switch-to-latest" guide))
+          (is (re-find #"parallel" guide))
+          (is (re-find #"completion" guide))))
       (let [result
             (binding [ec/*execution-context* (:ctx room)]
               (sandbox/eval-code
@@ -76,6 +83,125 @@
           (is (uuid? (get-in result [:value :analyst-run])))
           (is (= :completed (get-in result [:value :analyst-status])))
           (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest room-sci-programs-serial-work-without-an-llm
+  (let [room    (d/make-room {:id :sci-structured-work
+                              :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room)
+                                      {:room-id (:id room)})
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[spindel.work :as work] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                "(let [seen (atom []) "
+                "      c (work/serial "
+                "         (fn [value] "
+                "           (work/task "
+                "             (swap! seen conj value) "
+                "             value)))] "
+                "  @(spin "
+                "     (work/submit! c :first :first) "
+                "     (work/submit! c :second :second) "
+                "     (work/close! c) "
+                "     (await (work/completion c)) "
+                "     {:seen @seen :controller-map? (map? c) "
+                "      :state (work/snapshot c)}))")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (= [:first :second] (get-in result [:value :seen])))
+        (is (false? (get-in result [:value :controller-map?]))
+            "the SCI handle does not expose its owner context or live children as data")
+        (is (= 0 (get-in result [:value :state :work/active])))
+        (is (= 0 (get-in result [:value :state :work/queued])))
+        (is (true? (get-in result [:value :state :terminal?]))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest fork-discard-cancels-and-joins-room-owned-sci-work
+  (let [parent  (d/make-room {:id :sci-work-parent
+                              :store (memory/make)})
+        fork    (binding [ec/*execution-context* (:ctx parent)]
+                  (d/fork-room parent {:isolation :ctx}))
+        sci-ctx (sandbox/fork-for-session (:ctx fork))]
+    (try
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx fork)
+                                      {:room-id (:id fork)})
+      (let [created
+            (binding [ec/*execution-context* (:ctx fork)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[spindel.work :as work] "
+                "         '[sync :as sync] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                "(let [cleanup (atom false) "
+                "      started (sync/deferred) "
+                "      never (sync/deferred) "
+                "      c (work/serial "
+                "         (fn [_] "
+                "           (work/task "
+                "             (try "
+                "               (sync/deliver! started true) "
+                "               (await never) "
+                "               (finally (reset! cleanup true))))))] "
+                "  (work/submit! c :job) "
+                "  {:cleanup cleanup :started started :controller c})")))]
+        (is (:success created) (pr-str (:error created)))
+        (let [{:keys [cleanup started controller]} (:value created)]
+          (binding [ec/*execution-context* (:ctx fork)]
+            (is (true? @(sp/spin (sp/await started)))))
+          (d/discard fork)
+          (is (true? @cleanup) "task finally runs before the fork substrate is discarded")
+          (binding [ec/*execution-context* (:ctx fork)]
+            (is (true? (:terminal? (sandbox-work/snapshot controller)))))))
+      (finally
+        (d/close-room! parent)))))
+
+(deftest room-sci-work-admission-enforces-resource-ceilings
+  (let [room    (d/make-room {:id :sci-work-ceilings
+                              :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      (data-ns/add-spindel-extras-ns!
+       sci-ctx (:ctx room)
+       {:room-id (:id room)
+        :ceiling {:controllers 1
+                  :concurrency 2
+                  :capacity 4
+                  :ingress-capacity 4
+                  :event-taps 1}})
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[spindel.work :as work]) "
+                "(let [too-wide "
+                "      (try (work/parallel {:concurrency 3} (fn [x] (work/task x))) "
+                "           :not-rejected "
+                "           (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))) "
+                "      c (work/serial (fn [x] (work/task x))) "
+                "      tap (work/events c) "
+                "      second-tap "
+                "      (try (work/events c) :not-rejected "
+                "           (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))) "
+                "      second-controller "
+                "      (try (work/serial (fn [x] (work/task x))) :not-rejected "
+                "           (catch clojure.lang.ExceptionInfo e (:type (ex-data e))))] "
+                "  (work/untap! c tap) "
+                "  (work/close! c) "
+                "  {:too-wide too-wide :second-tap second-tap "
+                "   :second-controller second-controller})")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (every? #(= :dvergr.sandbox.work/ceiling-exceeded %)
+                    (vals (:value result)))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -308,20 +308,26 @@
                              :store (memory/make)})
         child (binding [ec/*execution-context* (:ctx parent)]
                 (d/fork-room parent {:isolation :ctx}))
+        shared-child (binding [ec/*execution-context* (:ctx parent)]
+                       (d/fork-room parent {:isolation :none}))
         deleted (atom nil)]
     (try
       (with-redefs [rooms/delete-room!
                     (fn [room]
                       (reset! deleted room)
                       {:ok? true})]
-        (let [ops (kb-ns/room-ops-map (:ctx parent))]
+        (let [ops (kb-ns/room-ops-map (:ctx parent) nil
+                                      (select-keys parent [:id :incarnation]))]
           (is (= {:deleted (:id child)} (('delete! ops) child)))
           (is (identical? child @deleted))
+          (is (= {:deleted (:id shared-child)} (('delete! ops) shared-child))
+              "a subordinate sharing the source context is not mistaken for self")
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo #"cannot delete itself"
-               (('delete! ops) parent)))))
+               (('delete! ops) (assoc parent :ctx (:ctx child)))))))
       (finally
         (d/discard child)
+        (d/discard shared-child)
         (d/close-room! parent)))))
 
 (deftest room-work-teardown-broadcasts-before-joining

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -273,6 +273,57 @@
         (d/close-room! room)
         (d/close-room! other-room)))))
 
+(deftest registry-reservation-does-not-hold-global-lock-while-draining
+  (let [room (d/make-room {:id :registry-drain-target
+                           :store (memory/make)})
+        entered (promise)
+        release (promise)]
+    (room-registry/add-pre-unregister-hook!
+     ::park-target-drain
+     (fn [target]
+       (when (= (:id room) (:id target))
+         (deliver entered true)
+         @release)))
+    (let [unregister (future
+                       (binding [ec/*execution-context* (:ctx room)]
+                         (room-registry/unregister! (:id room))))]
+      (is (= true (deref entered 2000 ::timeout)))
+      (let [other-future
+            (future
+              (d/make-room {:id :registry-unrelated-room
+                            :ctx (:ctx room)
+                            :store (memory/make)}))
+            other (deref other-future 1000 ::timeout)]
+        (try
+          (is (not= ::timeout other)
+              "unrelated registration proceeds while a Room drains outside the monitor")
+          (finally
+            (deliver release true)
+            (is (nil? (deref unregister 2000 ::timeout)))
+            (when-not (= ::timeout other)
+              (d/close-room! other))))))))
+
+(deftest sci-room-deletion-uses-lifecycle-aware-supervisor-path
+  (let [parent (d/make-room {:id :sci-delete-parent
+                             :store (memory/make)})
+        child (binding [ec/*execution-context* (:ctx parent)]
+                (d/fork-room parent {:isolation :ctx}))
+        deleted (atom nil)]
+    (try
+      (with-redefs [rooms/delete-room!
+                    (fn [room]
+                      (reset! deleted room)
+                      {:ok? true})]
+        (let [ops (kb-ns/room-ops-map (:ctx parent))]
+          (is (= {:deleted (:id child)} (('delete! ops) child)))
+          (is (identical? child @deleted))
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"cannot delete itself"
+               (('delete! ops) parent)))))
+      (finally
+        (d/discard child)
+        (d/close-room! parent)))))
+
 (deftest room-work-teardown-broadcasts-before-joining
   (let [room (d/make-room {:id :sci-work-broadcast
                            :store (memory/make)})

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -4,7 +4,10 @@
             [dvergr.agent.run :as run]
             [dvergr.discourse :as d]
             [dvergr.resource :as resource]
+            [dvergr.room.registry :as room-registry]
+            [dvergr.room.store :as room-store]
             [dvergr.room.store.memory :as memory]
+            [dvergr.rooms :as rooms]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.agent :as agent-ns]
             [dvergr.sandbox.ns.data :as data-ns]
@@ -13,7 +16,8 @@
             [dvergr.sandbox.ns.room :as room-ns]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.context :as context]
-            [org.replikativ.spindel.engine.core :as ec]))
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.work :as native-work]))
 
 (defn- wait-until [pred timeout-ms]
   (let [deadline (+ (System/nanoTime) (* timeout-ms 1000000))]
@@ -22,6 +26,30 @@
         (pred) true
         (< (System/nanoTime) deadline) (do (Thread/sleep 5) (recur))
         :else false))))
+
+(defn- ordered-delete-store [delegate order]
+  (reify room-store/PRoomStore
+    (-store-room! [_ room-id metadata]
+      (room-store/-store-room! delegate room-id metadata))
+    (-load-room [_ id-or-slug]
+      (room-store/-load-room delegate id-or-slug))
+    (-delete-room! [_ room-id]
+      (swap! order conj :delete)
+      (room-store/-delete-room! delegate room-id))
+    (-list-rooms [_]
+      (room-store/-list-rooms delegate))
+    (-store-message! [_ room-id message]
+      (room-store/-store-message! delegate room-id message))
+    (-message-thread-root [_ room-id message-id]
+      (room-store/-message-thread-root delegate room-id message-id))
+    (-list-messages [_ room-id opts]
+      (room-store/-list-messages delegate room-id opts))
+    (-store-run! [_ room-id run]
+      (room-store/-store-run! delegate room-id run))
+    (-load-run [_ room-id run-id]
+      (room-store/-load-run delegate room-id run-id))
+    (-list-runs [_ room-id opts]
+      (room-store/-list-runs delegate room-id opts))))
 
 (deftest immutable-rosters-launch-composable-room-runs-from-sci
   (let [room    (d/make-room {:id :sci-agent-programming
@@ -204,6 +232,78 @@
                     (vals (:value result)))))
       (finally
         (d/close-room! room)))))
+
+(deftest room-work-registration-preserves-ownership-and-rejects-stale-incarnations
+  (let [room (d/make-room {:id :sci-work-incarnation
+                           :store (memory/make)})
+        other-ctx (context/create-execution-context)
+        controller (sandbox-work/create!
+                    (:id room) (:ctx room) {:controllers 1}
+                    :serial {} (fn [value] (sp/spin value)))]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (room-registry/register! room))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"controller limit"
+           (sandbox-work/create! (:id room) (:ctx room) {:controllers 1}
+                                 :serial {} (fn [value] (sp/spin value))))
+          "an idempotent registry refresh does not forget live controllers")
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"another live incarnation"
+           (binding [ec/*execution-context* (:ctx room)]
+             (room-registry/register! (assoc room :ctx other-ctx)))))
+      (is (identical? room
+                      (binding [ec/*execution-context* (:ctx room)]
+                        (room-registry/lookup (:id room))))
+          "a rejected replacement leaves the registered Room untouched")
+      (finally
+        (binding [ec/*execution-context* (:ctx room)]
+          (sandbox-work/close! controller))
+        (d/close-room! room)
+        (context/close-context! other-ctx)))))
+
+(deftest room-work-teardown-broadcasts-before-joining
+  (let [room (d/make-room {:id :sci-work-broadcast
+                           :store (memory/make)})
+        controllers (vec
+                     (repeatedly
+                      2
+                      #(sandbox-work/create!
+                        (:id room) (:ctx room) nil :serial {}
+                        (fn [value] (sp/spin value)))))
+        cancellations (atom 0)]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"failed waiting"
+           (with-redefs [native-work/cancel!
+                         (fn [_]
+                           (when (= 1 (swap! cancellations inc))
+                             (throw (ex-info "broken cancel" {}))))
+                         native-work/completion
+                         (fn [_]
+                           (fn [success _failure] (success true)))]
+             (sandbox-work/close-room-work! room))))
+      (is (= 2 @cancellations)
+          "one cancellation failure does not prevent sibling broadcast")
+      (finally
+        ;; Restore the real implementation and make the repeated close settle
+        ;; the already-fenced generation before ordinary Room teardown.
+        (sandbox-work/close-room-work! room)
+        (d/close-room! room)))))
+
+(deftest room-deletion-quiesces-sci-work-before-durable-delete
+  (let [order (atom [])
+        room (d/make-room {:id :sci-work-delete-order
+                           :store (ordered-delete-store (memory/make) order)})
+        close-room! d/close-room!]
+    (with-redefs [d/close-room!
+                  (fn [target]
+                    (swap! order conj :quiesce)
+                    (close-room! target))]
+      (is (:ok? (rooms/delete-room! room))))
+    (is (= :delete (last @order)))
+    (is (some #{:quiesce} (butlast @order))
+        "durable deletion happens only after the runtime quiescence fence")))
 
 (deftest room-sci-race-cancels-and-settles-its-owned-loser
   (let [room (d/make-room {:id :sci-agent-owned-race

--- a/test/dvergr/sandbox/datahike_attempt_guard_test.clj
+++ b/test/dvergr/sandbox/datahike_attempt_guard_test.clj
@@ -1,0 +1,30 @@
+(ns dvergr.sandbox.datahike-attempt-guard-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [dvergr.chat.schema :as schema]
+            [dvergr.sandbox.ns.datahike :as sandbox-datahike]))
+
+(defn- conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? false :schema-flexibility :write}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (schema/ensure-full-schema! conn)
+      conn)))
+
+(deftest sci-datahike-surface-rejects-certified-attempt-writes-and-retractions
+  (let [conn (conn)
+        attempt-id (random-uuid)
+        guard @#'sandbox-datahike/assert-no-attempt-write!]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"host-certified"
+         (guard conn [{:attempt/id attempt-id}])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"host-certified"
+         (guard conn [[:db/add -1 :attempt/reward 1.0]])))
+    ;; Host setup proves numeric retractEntity cannot bypass the namespace check.
+    (d/transact conn [{:attempt/id attempt-id}])
+    (let [eid (:db/id (d/entity @conn [:attempt/id attempt-id]))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"host-certified"
+           (guard conn [[:db/retractEntity eid]]))))))

--- a/test/dvergr/sandbox/escape_corpus_test.clj
+++ b/test/dvergr/sandbox/escape_corpus_test.clj
@@ -103,7 +103,14 @@
       (testing "the agent's own room-facing surface is present"
         (is (= true (:ok (eval-in sci ec "(some? dvergr.room/kb-search)")))))
       (testing "in-jail file access works"
-        (is (= true (:ok (eval-in sci ec "(babashka.fs/exists? \"deps.edn\")")))))
+        (is (= true
+               (:ok (eval-in sci ec
+                             "(let [p (str \".capability-probe-\" (random-uuid))]
+                                (try
+                                  (spit p \"ok\")
+                                  (babashka.fs/exists? p)
+                                  (finally
+                                    (babashka.fs/delete-if-exists p))))")))))
       (testing "but escapes past the jail are refused"
         (is (:err (eval-in sci ec "(babashka.fs/exists? \"/etc/passwd\")")))
         (is (:err (eval-in sci ec "(slurp \"/etc/passwd\")")))))))

--- a/test/dvergr/sandbox/inference_world_test.clj
+++ b/test/dvergr/sandbox/inference_world_test.clj
@@ -1,0 +1,104 @@
+(ns dvergr.sandbox.inference-world-test
+  "Dvergr's SCI inference surface defaults effectful particles to canonical worlds."
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.sandbox.ns.data :as data-ns]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [sci.core :as sci]
+            [yggdrasil.convergent.gset :as g]))
+
+(defn- memory-gset [id]
+  (g/gset id {:store-config {:backend :memory :id (random-uuid)}}
+          {:sync? true}))
+
+(deftest sci-smc-defaults-to-isolated-canonical-worlds
+  (let [root (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [knowledge (ygg/register!
+                         (-> (memory-gset "dvergr-inference-kb")
+                             (g/conj :root {:sync? true})))
+              sci-ctx (sandbox/fork-for-session root)]
+          (data-ns/add-inference-ns! sci-ctx)
+          ;; These are deliberately opaque host capabilities. SCI can request
+          ;; one mutation in its current particle world but cannot obtain a
+          ;; Yggdrasil handle or settlement authority.
+          (sci/add-namespace!
+           sci-ctx 'particle
+           {'id (fn []
+                  (rtp/get-state ec/*execution-context*
+                                 [:inference :particle-id]))
+            'write! (fn [value]
+                      (let [signal (ygg/system-signal "dvergr-inference-kb")]
+                        (reset! signal
+                                (g/conj @signal value {:sync? true})))
+                      value)
+            'values (fn []
+                      (g/elements @(ygg/system-signal "dvergr-inference-kb")
+                                  {:sync? true}))})
+          (let [result
+                (sandbox/eval-code
+                 sci-ctx
+                 (str
+                  "(require '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                  "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                  "         '[org.replikativ.spindel.inference.effects :refer [observe]] "
+                  "         '[dist] '[infer] '[particle]) "
+                  "(let [model (spin "
+                  "              (let [id (particle/id)] "
+                  "                (particle/write! id) "
+                  "                (observe (dist/normal 0.0 1.0) 0.0 :id :evidence) "
+                  "                (particle/values))) "
+                  "      posterior @(spin (await (infer/smc-infer "
+                  "                              model 4 {:resample-threshold 2.0})))] "
+                  "  {:values (infer/values posterior) "
+                  "   :weights (infer/log-weights posterior) "
+                  "   :ess (infer/ess posterior) "
+                  "   :worlds (infer/worlds posterior) "
+                  "   :raw-particles (:particles posterior) "
+                  "   :raw-executor (:executor posterior)})")
+                 ;; Canonical particle worlds fork and settle four complete
+                 ;; execution contexts. Keep the watchdog well above normal
+                 ;; latency so a memory-constrained full-suite worker does not
+                 ;; cancel healthy inference midway through settlement.
+                 :timeout-ms 60000)
+                {:keys [values weights ess worlds raw-particles raw-executor]}
+                (:value result)]
+            (is (:success result) (pr-str (:error result)))
+            (testing "posterior values retain independent selected ancestry"
+              (is (= 4 (count values)))
+              (is (every? #(and (= 2 (count %)) (contains? % :root)) values)))
+            (testing "portable inference projections contain no live authority"
+              (is (= 4 (count weights)))
+              (is (number? ess))
+              (is (= 4 (count worlds)))
+              (is (every? #(and (map? %)
+                                (= :particle (:fork/purpose %)))
+                          worlds))
+              (is (nil? raw-particles))
+              (is (nil? raw-executor)))
+            (testing "particle writes do not contaminate the ambient room world"
+              (is (= #{:root} (g/elements @knowledge {:sync? true})))))
+          (let [pure
+                (sandbox/eval-code
+                 sci-ctx
+                 (str
+                  "(let [posterior @(spin (await (infer/smc-infer "
+                  "                              (spin 7) 2 {:world-policy :fresh})))] "
+                  "  {:values (infer/values posterior) "
+                  "   :worlds (infer/worlds posterior) "
+                  "   :mean (:mean (infer/query posterior identity)) "
+                  "   :predictions (infer/predict posterior inc 3)})")
+                 :timeout-ms 30000)]
+            (testing "a proven-pure model may explicitly choose the cheap path"
+              (is (:success pure) (pr-str (:error pure)))
+              (is (= {:values [7 7]
+                      :worlds []
+                      :mean 7.0
+                      :predictions [8 8 8]}
+                     (:value pure)))))))
+      (finally
+        (context/stop-context! root)))))

--- a/test/dvergr/tui/app_test.clj
+++ b/test/dvergr/tui/app_test.clj
@@ -103,6 +103,19 @@
       (is (str/includes? on "I should compute the product") "reasoning shown in trace")
       (is (str/includes? on "(* 19 23)") "tool input shown in trace"))))
 
+(deftest render-room-message-shows-semantic-activity-correlation
+  (let [run-id (java.util.UUID/fromString "12345678-1234-1234-1234-123456789abc")
+        lines  (render-room-message
+                {:from :var :role :tool :content "used a tool"
+                 :run-id run-id
+                 :activities [{:activity/kind :tool
+                               :activity/verb :invoke
+                               :activity/tool-name "clojure_eval"}]}
+                60 false)
+        text   (strip (str/join "\n" lines))]
+    (is (str/includes? text "invoke · clojure_eval"))
+    (is (str/includes? text "run 12345678"))))
+
 (defn- room-harness [c room-id extra-signals]
   (h/harness
    {:execution-context c

--- a/test/dvergr/web/dashboard_test.clj
+++ b/test/dvergr/web/dashboard_test.clj
@@ -1,0 +1,21 @@
+(ns dvergr.web.dashboard-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [dvergr.web.dashboard :as dashboard]
+            [hiccup2.core :as h]))
+
+(def ^:private message-hiccup #'dashboard/message-hiccup)
+
+(deftest message-renders-semantic-activity-with-run-correlation
+  (let [html (str (h/html
+                   (message-hiccup
+                    {:id (random-uuid)
+                     :from :var
+                     :role :tool
+                     :content "used a tool"
+                     :run-id (java.util.UUID/fromString "12345678-1234-1234-1234-123456789abc")
+                     :activities [{:activity/kind :tool
+                                   :activity/verb :invoke
+                                   :activity/tool-name "clojure_eval"}]})))]
+    (is (str/includes? html "invoke · clojure_eval"))
+    (is (str/includes? html "run 12345678"))))


### PR DESCRIPTION
## Summary
- expose Spindel latest, serial, busy, and bounded-parallel work controllers to SCI programs
- enforce room-scoped controller, concurrency, ingress, capacity, and event-tap ceilings
- make room transfer, discard, merge, and close cancel and join owned controllers before world settlement
- document reusable reactive work admission and add lifecycle, cancellation, isolation, and ceiling tests

## Dependency
Stacked on Spindel PRs #44 and #45 through reviewed git SHA cfc17674. Return to a Clojars coordinate after release.

## Verification
- clojure -M:test --focus dvergr.sandbox.agent-programming-test (12 tests, 59 assertions)
- clojure -M:format