### PR TITLE
Show semantic Run activity in web and TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,17 +279,14 @@ The standalone, runnable scenarios these import live in [`examples/`](examples/)
 | [hato](https://github.com/gnarroway/hato) | HTTP client for provider APIs |
 | [Telemere](https://github.com/taoensso/telemere) | Structured logging + observability |
 
-> **SCI fork note (Clojars library consumers only).** dvergr pins a fork of SCI
-> (`whilo/sci`, branch `resource-check`) for the `:interrupt-fn` cancellation the
-> sandbox relies on, pending an upstream PR. tools.build's `write-pom` emits only
-> Maven coords, so this git dep is **not** in the published pom. The uberjar/CLI
-> and git-dep consumers get it transitively and need nothing extra; a pure-Clojars
-> library consumer must add it themselves:
+> **SCI fork note.** dvergr directly depends on the published replikativ SCI
+> build for resource interruption and forkable interpreter worlds while the
+> corresponding changes are reviewed upstream. Maven and git consumers resolve
+> the same implementation:
 > ```clojure
-> org.babashka/sci {:git/url "https://github.com/whilo/sci"
->                   :git/sha "24762a163ef5b25c692d0e5cd4ea63a5bd6b0a16"}
+> org.replikativ/sci {:mvn/version "0.15.59-replikativ.1"}
 > ```
-> (Goes away once the fork lands upstream or is published to Maven.)
+> This returns to `org.babashka/sci` once the fork lands upstream.
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure       {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure       {:mvn/version "1.12.5"}
 
         ;; HTTP client for provider APIs
         hato/hato                  {:mvn/version "1.0.0"}
@@ -25,12 +25,13 @@
         ;; Async utilities
         org.clojure/core.async     {:mvn/version "1.6.681"}
 
-        ;; SCI — Small Clojure Interpreter for sandboxing.
-        org.babashka/sci           {:mvn/version "0.15.56"}
+        ;; SCI — Small Clojure Interpreter for sandboxing. The replikativ build
+        ;; carries forkable interpreter worlds while sci#1084 is upstreamed.
+        org.replikativ/sci         {:mvn/version "0.15.59-replikativ.1"}
 
-        ;; partial-cps (CPS transform for the SCI spin macro) comes TRANSITIVELY
-        ;; via spindel — not declared here, so spindel is the single source of its
-        ;; version. The `:local` alias's `../spindel` override carries it too.
+        ;; Dvergr uses the async sequence/CPS namespaces directly; keep this a
+        ;; direct dependency instead of relying on Spindel's implementation deps.
+        is.simm/partial-cps        {:mvn/version "0.1.60"}
 
         ;; Spindel — Reactive runtime with CoW forking.
         ;; 0.1.35 (#27 lost-wakeup redesign + follow-ups): continuation
@@ -48,14 +49,9 @@
         ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
         ;; Substrate for the durable-cursor bus pump + supervisor
         ;; restart.
-        ;; 0.1.43 includes structured cancellation and affine partitioned world
-        ;; authority, the substrate used by Run-world adoption and delegation.
-        ;; Structured work admission and its cancellation hand-back fix are
-        ;; currently stacked on spindel#44/#45. Pin the reviewed commit until
-        ;; that release reaches Clojars, then return this to an ordinary version
-        ;; coordinate.
-        org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "286f2013ec68a29ce9e4c61d33b244ee9fafc854"}
+        ;; 0.1.44 includes structured work admission, cancellation hand-back,
+        ;; canonical inference worlds, and forkable SCI world components.
+        org.replikativ/spindel     {:mvn/version "0.1.44"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
@@ -65,53 +61,44 @@
         ;; API this branch's agent workspaces are built on (isolated worktrees,
         ;; checkout semantics delegated to Geschichte, Git served from a virtual
         ;; GeschichteFS base) — so no local root is needed to build it.
-        org.replikativ/muschel     {:mvn/version "0.2.19"}
+        org.replikativ/muschel     {:mvn/version "0.2.19"
+                                    :exclusions  [org.babashka/sci]}
 
         ;; Geschichte — authoritative virtual filesystem + Git compatibility.
-        ;; 0.1.12 is the release where the Yggdrasil adapter MOVED OUT (#8), so
-        ;; there is exactly one GeschichteSystem record on the classpath — the
-        ;; one in yggdrasil.adapters.geschichte. No local root needed.
-        org.replikativ/geschichte  {:mvn/version "0.1.12"}
+        ;; Geschichte remains the authoritative virtual filesystem; its
+        ;; Yggdrasil adapter lives only in Yggdrasil.
+        org.replikativ/geschichte  {:mvn/version "0.1.15"}
 
         ;; rewrite-clj for structural editing
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        ;; 0.8.1861 provides writer-internal operation provenance to mandatory
-        ;; transaction predicates. Kontor uses it to keep purge/history
-        ;; validation internal without extending Datahike's public tx report.
-        org.replikativ/datahike    {:mvn/version "0.8.1861"}
+        ;; Keep the direct dependency current: Dvergr uses Datahike's API and
+        ;; transaction predicates itself, not merely through Geschichte.
+        org.replikativ/datahike    {:mvn/version "0.8.1865"}
         ;; 0.1.37 provides conserved resource vectors, durable receipts, and
         ;; mandatory Datahike invariants for Run resource delegation.
         org.replikativ/kontor      {:mvn/version "0.1.37"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
-        ;; 0.3.38 adopts the Geschichte adapter (yggdrasil.adapters.geschichte,
-        ;; PR #16) and gives it the p/Mergeable it never had, so a room repo can
-        ;; finally produce a FILE diff instead of a datom count over
-        ;; Geschichte's internal schema.
-        org.replikativ/yggdrasil   {:mvn/version "0.3.38"}
+        ;; 0.3.41 includes the Geschichte content-level merge adapter and the
+        ;; current persistent-sorted-set substrate.
+        org.replikativ/yggdrasil   {:mvn/version "0.3.41"
+                                    :exclusions  [org.babashka/sci]}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
-        org.replikativ/scriptum    {:mvn/version "0.1.30"}
+        org.replikativ/scriptum    {:mvn/version "0.1.32"}
 
         ;; Briefkasten (local IMAP mirror) is OPTIONAL — it backs dvergr.intake.mail
         ;; only, and pulls the jakarta-mail tree, so it lives in the
         ;; :dev/:test/:cli/:tui aliases (with clojure-mail), not core.
 
-        ;; Kabel — WebSocket peer-to-peer transport. 0.3.98 pins javac --release 11
-        ;; (0.3.97 shipped Java-25 bytecode → UnsupportedClassVersionError on JDK <25).
-        org.replikativ/kabel       {:mvn/version "0.3.98"}
-        ;; Compatibility alignment: Yggdrasil 0.3.38 still loads
-        ;; hasch.benc.HashRef, which was removed in Hasch 0.4.102. Drop this
-        ;; override when Yggdrasil moves to the new reference representation.
-        org.replikativ/hasch       {:mvn/version "0.4.101"}
+        ;; Dvergr derives stable activity and environment identities directly.
+        ;; Match Datahike's current array-hashing implementation.
+        org.replikativ/hasch       {:mvn/version "0.4.104"}
         ;; Dvergr's drive blob store uses Konserve directly. Keep this aligned
         ;; with Datahike rather than relying on Datahike's transitive API.
-        org.replikativ/konserve    {:mvn/version "0.9.385"}
-
-        ;; Distributed-scope — remote function invocation over Kabel
-        is.simm/distributed-scope  {:mvn/version "0.1.2"}
+        org.replikativ/konserve    {:mvn/version "0.9.391"}
 
         ;; tools.analyzer for code indexing
         org.clojure/tools.analyzer.jvm {:mvn/version "1.3.0"}
@@ -188,7 +175,7 @@
   ;; `:local/root "../datahike"` override uses datahike's DEFAULT :paths (which
   ;; exclude src-secondary), so we add it here for the source-override dev path.
   :local {:extra-paths ["../datahike/src-secondary"]
-          :extra-deps {org.babashka/sci           {:local/root "../sci"}
+          :extra-deps {org.replikativ/sci         {:local/root "../sci"}
                        org.replikativ/datahike    {:local/root "../datahike"}
                        org.replikativ/scriptum    {:local/root "../scriptum"}
                        org.replikativ/yggdrasil   {:local/root "../yggdrasil"}

--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -8,6 +8,8 @@
    language and lifecycle contracts live in ordinary deterministic tests."
   (:require [clojure.edn :as edn]
             [datahike.api :as dh]
+            [dvergr.activity :as activity]
+            [dvergr.agent.environment :as environment]
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
@@ -61,6 +63,30 @@
    :reviewer {:claim 42}
    :returned {resource/microdollars 10000M}})
 
+(def self-programming-task-v1
+  (str "Use clojure_eval to author and execute a recursive Dvergr program. "
+       "Use the exact namespaces `[dvergr.agent :as agent]`, "
+       "`[org.replikativ.spindel.spin.cps :refer [spin]]`, "
+       "`[org.replikativ.spindel.effects.await :refer [await]]`, and "
+       "`[spindel.comb :as comb]`; compose the three result Spins with "
+       "`comb/parallel`. "
+       "Construct an immutable roster with three cheap simulated specialists. "
+       "A :mod-five particle is scripted to return [8 23 38 53 68 83 98]. "
+       "A :mod-seven particle is scripted to return "
+       "[2 9 16 23 30 37 44 51 58 65 72 79 86 93]. "
+       "A :verifier specialist is scripted to return the independent data "
+       "{:moduli [[3 2] [5 3] [7 2]] :upper-bound 100}. Hire all three and "
+       "compositionally await their result Spins in parallel. Intersect the "
+       "particle candidates, interpret the verifier data as executable checks, "
+       "and select the unique positive integer satisfying every remainder and "
+       "the bound. Return only an EDN map shaped like "
+       "{:answer <computed-integer> :particles 2 :verified <boolean>}. Do not "
+       "merely describe the program; create the specialists, await their "
+       "results, and execute it."))
+
+(def expected-self-programming-v1
+  {:answer 23 :particles 2 :verified true})
+
 (defn- parse-edn [value]
   (when (string? value)
     (with-open [reader (PushbackReader. (StringReader. value))]
@@ -98,6 +124,21 @@
       :structural-parentage? (every? #(= root-run-id (:run/parent %)) child-runs)
       :winner-completed? (= :completed (get-in by-actor [:fast :run/status]))
       :loser-cancelled? (= :cancelled (get-in by-actor [:slow :run/status]))})))
+
+(defn- self-programming-checks
+  [{:keys [root-run-id root-causes child-runs] :as observation}]
+  (let [by-actor (into {} (map (juxt :run/actor identity)) child-runs)
+        child-ids (into #{} (map :run/id) child-runs)]
+    (merge
+     (common-checks observation expected-self-programming-v1)
+     {:three-specialists? (= 3 (count child-runs))
+      :expected-specialists? (= #{:mod-five :mod-seven :verifier}
+                                (set (keys by-actor)))
+      :structural-parentage? (every? #(= root-run-id (:run/parent %)) child-runs)
+      :all-results-observed? (= child-ids root-causes)
+      :specialists-completed? (every? #(= :completed (:run/status %)) child-runs)
+      :specialists-merged? (every? #(= :merged (:run/settlement-status %))
+                                   child-runs)})))
 
 (defn- receipt-view [receipt]
   (select-keys receipt [:id :kind :source :destination :resources]))
@@ -147,7 +188,7 @@
       :child-wallets-returned? (every? empty? (vals child-balances))
       :canonical-resource-receipts? (= receipt-contract resource-receipts)})))
 
-(defn- memory-environment [room-id]
+(defn- memory-environment [room-id _definition]
   (let [room (d/make-room {:id room-id :store (memory/make)})]
     {:room room
      :close! #(d/close-room! room)}))
@@ -162,11 +203,13 @@
           (dh/release conn)
           (dh/delete-database cfg))))))
 
-(defn- resource-environment [room-id]
+(defn- resource-environment [room-id definition]
   (let [cfg {:store {:backend :memory :id (random-uuid)}
              :keep-history? true
              :schema-flexibility :write}
-        chat-id (random-uuid)]
+        chat-id (random-uuid)
+        {:keys [room-resources run-resources]}
+        (:environment/limits definition)]
     (dh/create-database cfg)
     (let [conn (try
                  (dh/connect cfg)
@@ -189,9 +232,9 @@
                                  :store (datahike-store/make conn)})]
           (reset! room* room)
           (resource/mint! room {:id (random-uuid)
-                                :resources {resource/microdollars 20000M}})
+                                :resources room-resources})
           {:room room
-           :hire-opts {:resources {resource/microdollars 10000M}}
+           :hire-opts {:resources run-resources}
            :resource-observation
            (fn [root-run-id child-runs]
              (let [by-actor (into {} (map (juxt :run/actor identity)) child-runs)
@@ -223,25 +266,74 @@
               (.addSuppressed error cleanup-error)))
           (throw error))))))
 
+(def ^:private memory-setup-ref
+  {:setup/id :dvergr.environment/memory-room :setup/version 1})
+
+(def ^:private resource-setup-ref
+  {:setup/id :dvergr.environment/resource-room :setup/version 1})
+
+(def ^:private trusted-setups
+  {memory-setup-ref memory-environment
+   resource-setup-ref resource-environment})
+
+(def ^:private trusted-verifiers
+  {#:verifier{:id :programming/join-checks-v1 :version 1} join-checks
+   #:verifier{:id :programming/race-checks-v1 :version 1} race-checks
+   #:verifier{:id :programming/self-programming-checks-v1 :version 1}
+   self-programming-checks
+   #:verifier{:id :programming/resource-delegation-checks-v1 :version 1}
+   resource-checks})
+
+(defn- environment-case
+  [id task verifier-id expected & [{:keys [setup limits world metadata]}]]
+  {:definition
+   (environment/make-environment
+    {:id id
+     :version 1
+     :task task
+     :verifier {:id verifier-id :version 1}
+     :limits (merge {:timeout-ms 120000
+                     :cancel-timeout-ms 10000
+                     ;; Resource/time limits govern normal execution. This is
+                     ;; only a runaway fuse for a malfunctioning provider loop.
+                     :max-model-steps 16
+                     :budget-dollars 1.0}
+                    limits)
+     :world (merge {:isolation :ctx
+                    :settlement :automatic
+                    :setup (or setup memory-setup-ref)}
+                   world)
+     :metadata metadata})
+   :expected expected})
+
 (def ^:private environments
   {:programming/join-v1
-   {:task task-v1
-    :expected expected-v1
-    :max-model-steps 8
-    :verify join-checks}
+   (environment-case :programming/join-v1 task-v1
+                     :programming/join-checks-v1 expected-v1)
 
    :programming/race-v1
-   {:task race-task-v1
-    :expected expected-race-v1
-    :max-model-steps 8
-    :verify race-checks}
+   (environment-case :programming/race-v1 race-task-v1
+                     :programming/race-checks-v1 expected-race-v1)
+
+   :programming/self-programming-v1
+   (environment-case :programming/self-programming-v1 self-programming-task-v1
+                     :programming/self-programming-checks-v1
+                     expected-self-programming-v1
+                     {:metadata {:kind :recursive-agent-program}})
 
    :programming/resource-delegation-v1
-   {:task resource-task-v1
-    :expected expected-resource-v1
-    :max-model-steps 8
-    :setup resource-environment
-    :verify resource-checks}})
+   (environment-case :programming/resource-delegation-v1 resource-task-v1
+                     :programming/resource-delegation-checks-v1
+                     expected-resource-v1
+                     {:setup resource-setup-ref
+                      :limits {:room-resources {resource/microdollars 20000M}
+                               :run-resources {resource/microdollars 10000M}}
+                      :metadata {:kind :conserved-resource-delegation}})})
+
+(defn environment-definition
+  "Return the exact portable definition for a named benchmark environment."
+  [environment-id]
+  (some-> (get environments environment-id) :definition))
 
 (defn run-environment!
   "Run a named programming environment through `provider`/`model`.
@@ -257,14 +349,34 @@
      (run-environment! :programming/race-v1 :claude-code
                        \"claude-code-sonnet\")"
   [environment-id provider model]
-  (let [{:keys [task expected max-model-steps setup verify]}
+  (let [{:keys [definition expected]}
         (or (get environments environment-id)
             (throw (ex-info "Unknown programming environment"
                             {:environment-id environment-id
                              :known (set (keys environments))})))
+        definition (environment/validate-environment definition)
+        task (:environment/task definition)
+        verifier-ref (:environment/verifier definition)
+        verify (or (get trusted-verifiers verifier-ref)
+                   (throw (ex-info "Environment names an untrusted verifier"
+                                   {:environment-id environment-id
+                                    :verifier verifier-ref
+                                    :trusted (set (keys trusted-verifiers))})))
+        {:keys [timeout-ms cancel-timeout-ms max-model-steps budget-dollars]}
+        (:environment/limits definition)
+        {:keys [isolation settlement setup]} (:environment/world definition)
+        _ (when-not (= :ctx isolation)
+            (throw (ex-info "Benchmark runner only supports isolated ctx worlds"
+                            {:environment-id environment-id
+                             :isolation isolation})))
+        setup-environment (or (get trusted-setups setup)
+                              (throw (ex-info "Environment names an untrusted setup"
+                                              {:environment-id environment-id
+                                               :setup setup
+                                               :trusted (set (keys trusted-setups))})))
         room-id (keyword (str "programming-bench-" (random-uuid)))
         {:keys [room hire-opts resource-observation close!]}
-        ((or setup memory-environment) room-id)
+        (setup-environment room-id definition)
         team (roster/make-agent
               (roster/make-roster {:id :benchmark})
               {:id :orchestrator
@@ -274,25 +386,28 @@
                :model-policy {:provider provider :model model}
                :program {:kind :llm
                          :max-model-steps max-model-steps
-                         :budget-dollars 1.0
+                         :budget-dollars budget-dollars
                          :auto-compact? false}})
-        started (System/nanoTime)]
+        started-at (System/currentTimeMillis)
+        started-nanos (System/nanoTime)]
     (try
       (let [handle (binding [ec/*execution-context* (:ctx room)]
                      (program/hire! room team :orchestrator
-                                    (merge {:task task} hire-opts)))
+                                    (merge hire-opts
+                                           {:task task :settlement settlement})))
             initial-result (binding [ec/*execution-context* (:ctx room)]
-                             (deref handle 120000 ::timeout))
+                             (deref handle timeout-ms ::timeout))
             timed-out? (= ::timeout initial-result)
             _ (when timed-out?
                 (binding [ec/*execution-context* (:ctx room)]
                   (program/cancel! handle)))
             result (if timed-out?
                      (binding [ec/*execution-context* (:ctx room)]
-                       (deref handle 10000
+                       (deref handle cancel-timeout-ms
                               {:run/id (program/run-id handle)
                                :run/status :failed
-                               :run/error "Cancellation did not quiesce within 10s"}))
+                               :run/error (str "Cancellation did not quiesce within "
+                                               cancel-timeout-ms "ms")}))
                      initial-result)
             durable (program/observe room handle)
             all-runs (run/runs room {:limit 20})
@@ -304,6 +419,7 @@
             observation {:result result
                          :parsed-value parsed
                          :durable-status (:run/status durable)
+                         :root-causes (set (:run/caused-by durable))
                          :room-id room-id
                          :root-run-id root-run-id
                          :child-runs child-runs
@@ -312,18 +428,51 @@
                                (when resource-observation
                                  (resource-observation root-run-id child-runs)))
             checks (verify observation)
-            passed? (every? true? (vals checks))]
+            passed? (every? true? (vals checks))
+            reward (if passed? 1.0 0.0)
+            elapsed-ms (long (/ (- (System/nanoTime) started-nanos) 1000000))
+            run-trace (mapv #(select-keys % [:run/id :run/parent :run/caused-by
+                                             :run/actor :run/status :run/error
+                                             :run/settlement-status])
+                            all-runs)
+            tool-trace
+            (mapv activity/tool-trace-entry activity)
+            resources (when resource-observation
+                        (select-keys observation
+                                     [:room-balance :root-balance :child-balances
+                                      :resource-receipts]))
+            receipt-opts
+            (cond-> {:run-id root-run-id
+                     :provider provider
+                     :model model
+                     :status (:run/status result)
+                     :started-at started-at
+                     :elapsed-ms elapsed-ms
+                     :metrics (merge (:run/metrics result)
+                                     {:timed-out? timed-out?})
+                     :checks checks
+                     :reward reward
+                     :result parsed
+                     :trace {:runs run-trace :tool-calls tool-trace}}
+              resources (assoc :resources resources))
+            attempt-receipt
+            (environment/make-attempt-receipt definition receipt-opts)]
         (cond->
          {:environment environment-id
+          :environment-ref (environment/environment-ref definition)
+          :environment-definition definition
           :provider provider
           :model model
           :task task
           :expected expected
           :checks checks
-          :reward (if passed? 1.0 0.0)
+          :reward reward
           :passed? passed?
           :timed-out? timed-out?
-          :elapsed-ms (long (/ (- (System/nanoTime) started) 1000000))
+          :elapsed-ms elapsed-ms
+          :attempt-receipt attempt-receipt
+          :prompt-id (get-in result [:run/metrics :prompt-id])
+          :usage (get-in result [:run/metrics :usage])
           ;; Each activity row is a tool-bearing provider exchange. A successful
           ;; exact answer requires one final, non-tool provider exchange as well.
           :model-steps (cond-> (count activity)
@@ -331,21 +480,10 @@
           :result result
           :parsed-value parsed
           :durable-status (:run/status durable)
-          :runs (mapv #(select-keys % [:run/id :run/parent :run/actor
-                                      :run/status :run/error
-                                      :run/settlement-status])
-                      all-runs)
-          :tool-calls
-          (mapv (fn [message]
-                  (mapv #(select-keys % [:tool-use/name :tool-use/input])
-                        (get-in message [:metadata :tool-uses])))
-                activity)
+          :runs run-trace
+          :tool-calls tool-trace
           :active-after (:active-after observation)}
-          resource-observation
-          (assoc :resources
-                 (select-keys observation
-                              [:room-balance :root-balance :child-balances
-                               :resource-receipts]))))
+          resources (assoc :resources resources)))
       (finally
         (close!)))))
 
@@ -363,3 +501,8 @@
   "Run conserved sibling delegation and affine resource-return environment."
   [provider model]
   (run-environment! :programming/resource-delegation-v1 provider model))
+
+(defn run-self-programming-v1!
+  "Run the model-authored particle and verifier environment."
+  [provider model]
+  (run-environment! :programming/self-programming-v1 provider model))

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -261,6 +261,8 @@ what the program did (`:completed`, `:waiting`, `:failed`, or `:cancelled`).
 - `:settlement :automatic` (default): merge completed work;
 - `:settlement :review`: retain completed work in the Room tree;
 - `:settlement :discard`: execute for its result/trace, then drop its effects.
+- `:settlement :deferred`: host-owned two-phase gate; retain the world but
+  reject merge/adoption until the host explicitly releases it.
 
 Failure and cancellation always discard the work plane. Waiting and automatic
 merge conflicts retain it for review. A later merge/discard through
@@ -290,6 +292,106 @@ Run must first receive an eventual Kontor-backed provider allocation.
 
 ## Evaluation ladder
 
+An evaluation environment is an immutable `EnvironmentDef`, separate from any
+attempt to execute it:
+
+```clojure
+(agent/environment
+ {:id :programming/review-v1
+  :task {:artifact "candidate.edn"}
+  :verifier {:id :checks/review-v1 :version 1
+             :basis "git:<verifier-commit>"}
+  :limits {:timeout-ms 120000 :max-model-steps 8}
+  :world {:isolation :ctx :settlement :review}})
+```
+
+The value has a Hasch-derived `:environment/content-id`; map ordering does not
+affect it, while changing the task, verifier reference, limits, or world policy
+does. A verifier is deliberately a versioned reference rather than an embedded
+function: untrusted SCI can author and fork definitions, but only the trusted
+runner resolves exact verifier and world-setup references and computes reward.
+The benchmark interpreter derives its timeout, cancellation grace, restrictive
+model-step and dollar limits, settlement policy, and resource grants from that
+validated definition. It rejects unsupported policy keys instead of silently
+certifying a different scenario. In particular, world `:setup` remains closed
+until the host supplies a versioned trusted setup resolver. Each attempt still
+receives a fresh Run ID, so content identity never collapses distinct
+executions. The current REPL benchmark reports retain both the exact definition
+and its compact reference.
+
+Every opt-in REPL attempt returns a content-addressed `:attempt-receipt`. It binds the
+unique root Run to the exact EnvironmentDef, provider/model, exact assembled
+system-prompt ID, per-resource usage, timing, trusted checks/reward, Run/tool
+trace, and Kontor receipts when present. SCI does not receive the receipt
+constructor or verifier registry, so an evaluated agent can propose an
+environment but cannot certify its own reward.
+
+When the Room has a store, trusted certification persists an immutable Attempt
+before the world can become reviewable or be discarded. The typed Datahike row
+indexes Run, environment, verifier, provider/model, status, timing, reward,
+checks, prompt/program/interpreter provenance, and evidence references. The
+exact EnvironmentDef, AgentDef, receipt, and portable evidence live together in
+Dvergr's immutable blob CAS; the row holds the content reference rather than an
+opaque EDN/JSON column. SCI can query this projection but its Datahike surface
+rejects writes or retractions in the `:attempt/*` and `:attempt.check/*`
+namespaces. A Hasch identity detects content mutation; it does not authenticate
+an external writer, so cross-process imports require a trusted manifest or
+signature before their rewards are admitted.
+
+The reusable host boundary is `dvergr.agent.evaluation/evaluate`. It returns a
+Spin rather than starting a second scheduler: when executed, it admits an
+ordinary Run in an ordinary isolated RunWorld, waits for physical quiescence,
+then invokes a version-matched host `Evaluator` to produce portable evidence,
+checks, reward, and the receipt. Successful evaluation worlds may be retained
+for review or discarded, but first settle as `:deferred`; ordinary merge and
+adoption/discard reject that same world until trusted scoring atomically claims
+release or trusted cleanup. Observer and verifier callbacks run on an external
+worker rather than Spindel's drain path. Cancellation and certification race at
+the settlement claim: a cancelled evaluation can never later make its world
+landable, even if an uncooperative callback returns late. Certification failure
+discards the uncertified world while preserving the Run ID in the structured
+error. The evaluator capability contains functions and therefore remains
+process-local and absent from SCI; SCI can author the portable EnvironmentDef
+it names.
+
+An Episode is a pure export/read projection, not another durable lifecycle:
+
+```text
+Episode = immutable certified Attempt
+        + current durable Run settlement
+        + referenced Runs/messages/activity/resource facts
+```
+
+Review may later merge or discard the Run world. That changes the joined Run
+projection while the historical AttemptReceipt stays content-identical.
+Dataset acceptance, train/eval splits, rankings, particles, and proposal status
+are separate later projections; none mutate certification.
+
+An ensemble is composition, not another primitive:
+
+```clojure
+(let [attempts (mapv #(evaluation/evaluate room team % environment evaluator)
+                     candidate-agent-refs)]
+  @(apply comb/parallel attempts))
+```
+
+Pure policy can rank/select the resulting receipts. Existing room-fork
+merge/discard/adoption remains the only settlement authority. SMC, MCTS,
+Anglican-style inference, and Raster training can consume this same boundary
+without changing Run, Room, or world semantics.
+
+For training, an accepted episode is a projection across the exact
+EnvironmentDef, AgentDef/interpreter identity, Run/tool trajectory, conserved
+resources, checks/reward, and world/memory basis. Raster can consume that
+projection, while a `pretrained-rstr` git-like memory is simply another forked
+system in the episode world. Neither training nor a particular inference
+algorithm changes the execution algebra.
+
+Dollar/token, elapsed-time, and conserved resource limits are the ordinary
+governors. `:max-model-steps` remains only a high emergency fuse for a provider
+loop that keeps returning tool continuations; it is not the conversational or
+FRP unit of progress.
+
 The API and the instructions that teach it are evaluated together at three
 levels:
 
@@ -302,9 +404,10 @@ levels:
    Code, API models, and local models. A trusted host verifier scores the exact
    result plus durable Room/Run facts; model prose is never the reward source.
    Reports retain individual checks, binary reward, generated SCI, leaked
-   Runs/resources, model steps, wall time, task version, and model. Token/cost
-   receipts and a stable hash of the assembled system prompt remain reporting
-   follow-ups.
+   Runs/resources, model steps, token/cost usage, wall time, task version,
+   model, and a stable ID of the exact assembled system prompt. Durable receipt
+   persistence, trusted-writer authorization, and settlement against a retained
+   benchmark world remain follow-ups.
 
 The initial model-facing task set should include pure roster specialization,
 parallel research/review and reduction, race-with-loser-cancellation, explicit
@@ -326,6 +429,7 @@ their reports:
 (bench/run-v1! :codex-subscription "codex-subscription-sol")
 (bench/run-race-v1! :claude-code "claude-code-sonnet")
 (bench/run-resource-v1! :codex-subscription "codex-subscription-sol")
+(bench/run-self-programming-v1! :codex-subscription "codex-subscription-sol")
 
 ;; The generic entry point makes the task/version explicit.
 (bench/run-environment! :programming/race-v1
@@ -359,6 +463,19 @@ parentage and settlement, empty terminal Run wallets, the restored Room balance,
 and global quiescence. In the 2026-08-30 Codex Sol probe it passed all checks in
 three model exchanges. This evaluates affine delegation and return; it does not
 pretend the provider call itself has been debited yet.
+
+The self-programming environment asks the root model to construct two cheap
+simulated particles plus an independent verifier specification, join all three
+through Spindel, and interpret the verifier data as a pure check. Trusted host
+code scores the exact answer, structural parentage, child completion and
+settlement, durable causal observation of every child result, durable root
+completion, and global quiescence. This deliberately
+uses stubbed child effects: it tests whether a model can author recursive
+orchestration before paid recursive LLM delegation is enabled. In the
+2026-08-30 Codex Sol probe, the model discovered the programming API through
+the REPL, authored and executed the three-specialist program, and passed every
+check in six model exchanges and 31.823 seconds. The durable root's causal
+inputs exactly matched the three child Runs.
 
 This is only the seed of a training environment, not yet a reinforcement
 learning system. The intended general contract is: initialize a forked Room and
@@ -399,12 +516,74 @@ A Roster is a value, not a hidden registry. Thread it through functions or carry
 it as a Spin result. Forked computations can therefore use different derived
 rosters without synchronization or leakage.
 
+The evaluation path follows the same placement rule end to end:
+
+| State | Representation |
+|---|---|
+| workflow dependency, awaiting, cancellation | Spin nodes and continuations in the execution context |
+| changing beliefs, populations, queues, or search policy | Spindel signals/runtime atoms in the execution context |
+| Room, Run, message, ledger, and certified Attempt facts | the Datahike Yggdrasil system registered in that context |
+| files and other world substrates | their registered Yggdrasil systems |
+| Roster, AgentDef, EnvironmentDef, evidence, receipt | immutable values flowing through Spins |
+| provider stream, native worker, verifier function, live Run/Fork handle | process-local capability, never semantic or portable state |
+
+Consequently `evaluate` is a lazy Spin rather than another scheduler. It hires
+an ordinary Run in a Yggdrasil-forked world, awaits that Run through Spindel,
+and returns values. Certification writes one immutable Attempt into the
+branch-correct Room store while the affine world-settlement gate is held.
+`episode/export` is only a read projection joining that Attempt to current Run
+facts; it introduces no lifecycle, clock, mutable cell, or settlement authority.
+
+Probabilistic programs use the same placement rule. In SCI, Dvergr defaults
+`infer/smc-infer`, `infer/importance-sampling`, and `infer/kernel-infer` to
+Spindel's `:world-policy :fork`. Each particle and resampling descendant owns a
+canonical Yggdrasil fork. Before a result crosses into SCI, Dvergr removes the
+execution contexts and exposes only portable results, weights, statistics, and
+world descriptors. `infer/predict` likewise receives values rather than native
+contexts. For example:
+
+```clojure
+(spin
+  (let [posterior (await (infer/smc-infer (scenario-model) 64))]
+    {:values  (infer/values posterior)
+     :weights (infer/log-weights posterior)
+     :ess     (infer/ess posterior)
+     :worlds  (infer/worlds posterior)}))
+```
+
+Pass `{:world-policy :fresh}` only when the model is proven not to touch Room,
+Datahike, repository, accounting, or other registered world state. Inference
+does not introduce an `AgentParticle` entity and does not turn every sample into
+a Run. A Run remains the durable identity of an application-level computation;
+particles are its internal execution placements unless the program explicitly
+launches separately audited evaluations.
+
+Particle-independent Metropolis-Hastings and particle Gibbs are not exposed in
+SCI yet. Their repeated-sweep ownership and settlement contract must be made
+canonical before they become part of this surface.
+
+The current canonical fork covers Spindel execution state and every registered
+Yggdrasil system. It does not yet fork mutable cells allocated inside SCI: a
+captured SCI atom or Var is shared by model invocations. Treat SCI closures as
+pure apart from the fork-aware operations above. Full interpreter-state
+isolation depends on the forkable SCI runtime work and will strengthen this
+contract without changing the portable posterior shape.
+
+Small JVM atoms used inside a native-worker supervisor or verifier hand-off are
+short-lived synchronization primitives for non-forkable capabilities. They may
+decide which already-durable transition wins, but their contents are not the
+workflow's recoverable meaning. If a value must survive a continuation, affect
+branch semantics, or be available after restart, it belongs in Spindel state or
+one of the registered Yggdrasil systems instead.
+
 If a workflow needs changing state, allocate it through Spindel's fork-aware
 state vocabulary (signals or reactive atoms) in the relevant execution context.
 Do not place semantic workflow state in a JVM atom, dynamic singleton, or
-process-global registry. SCI Var forkability is a separate runtime project; do
-not rely on a top-level `def` as the portable state boundary until that work is
-complete.
+process-global registry. SCI vars, atoms, bindings, and continuations now fork
+with the interpreter world, so top-level definitions are valid transient
+branch-local program state. They are deliberately discarded rather than merged;
+durable or reviewable meaning still belongs in Room substrates and Run/effect
+records.
 
 A RunHandle is intentionally not durable state and should not be stored inside
 an AgentDef. Its awaitable result/cache belongs to the Spindel execution graph;

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -310,9 +310,19 @@ independent reactive state and an explicit external-system/effect policy.
 Observe evidence, resample descriptors/contexts, and discard unselected
 particles. Only an explicitly selected particle can be promoted or merged.
 
-Needs: the inference coordinator must stop using raw
-`snapshot-context`/`restore-snapshot` for worlds containing Yggdrasil handles;
-that path does not invoke `PForkable` and may alias external state.
+Spindel's inference coordinator now accepts `:world-policy :fork`: initial and
+resampled particles are frozen canonical Yggdrasil forks, and the complete
+speculative tree is discarded after immutable particle results have been
+captured. Dvergr's SCI `infer/smc-infer`, `infer/importance-sampling`, and
+`infer/kernel-infer` wrappers select that policy by default. A caller may pass
+`:world-policy :fresh` only for a model known to be pure. `infer/values`,
+`infer/log-weights`, `infer/ess`, and `infer/worlds` project results and portable
+world descriptors without exposing live settlement handles.
+
+This solves isolation and affine cleanup for one inference population. It does
+not promote a posterior particle automatically: promotion remains an explicit
+Run/proposal operation, and PGAS ancestor scoring is rejected for canonical
+worlds until retained-world ancestry has a sound ownership contract.
 
 ### MCTS
 

--- a/doc/state-model.md
+++ b/doc/state-model.md
@@ -50,7 +50,8 @@ pair (`dvergr.agent.room-context/ensure-ctx!`) — itself a **fold of Tier 1**:
 - `budget-signal` — `{:total :used :by-type}` token accounting
 - `status-signal` — `:active` / `:paused` / `:completed`
 - `db-conn` — the `dvergr-chat-db` connection (in a fork: the *branched* one)
-- `sci-ctx` — the agent's **SCI sandbox** (its `clojure_eval` world)
+- `sci-component` — a stable Spindel component reference selecting the agent's
+  **SCI sandbox** (`clojure_eval` world) in the current execution context
 
 The agent's own ctx is **`:durable? false`** — signal-only. The room store's
 bus→store listener is the *lone* durable writer for the conversation. So the durable
@@ -62,15 +63,30 @@ plus the per-session sandbox.
 `fork-room` calls `spindel.yggdrasil/fork!`, retains its process-local
 `ForkHandle`, and branches every selected registered Yggdrasil system as a unit:
 
-- **Datahike `dvergr-chat-db`** → branched — messages, KB, ledger, proposals, all
-  isolated until merge. *This is the whole chat state, forked through yggdrasil.*
+- **Datahike `dvergr-chat-db`** → branched — messages, Runs, certified Attempt
+  indexes, KB, ledger, proposals, all isolated until merge. Exact Attempt
+  payloads use the immutable global blob CAS; only a branch's typed reference
+  makes one part of that world. *This is the whole semantic chat state, forked
+  through yggdrasil.*
 - **git worktree** → a fresh worktree; the agent's file edits are isolated.
 - **muschel shell session** → its env-atom is CoW-forked alongside, so a worker's
   `cd` / shell state can't leak to the parent.
-- **per-agent SCI sandbox** → on its first turn in the fork, `ensure-ctx!` builds a
-  fresh `ChatContext` whose `sci-ctx` is a `sandbox/fork-for-session` fork —
-  **transient and isolated per fork, never shared** with the parent or siblings
-  (`(def x …)` in one fork is invisible to others).
+- **per-agent SCI sandbox** → the SCI interpreter is a Spindel world component.
+  Forking the execution context forks its heap (vars, atoms, bindings, and
+  continuations) from the effective parent state. The child reuses the stable
+  `ChatContext` identity while resolving an independent interpreter; `(def x …)`
+  in one fork is invisible to its parent and siblings. Discard unregisters the
+  child realization rather than merging transient interpreter state.
+
+Injected host capabilities follow a stricter rule than ordinary SCI values.
+They never close over a Room, Datahike connection, Geschichte workspace, or
+filesystem. Each interpreter component owns a stable capability identity whose
+serializable binding lives in the Spindel execution context. A copied function
+therefore resolves that identity in the currently selected descendant world at
+call time. This is why a helper defined *before* a fork cannot write back into
+its parent even though the helper's SCI function value itself was inherited.
+Namespace refresh after projection exposes new APIs; it is not the isolation
+mechanism.
 
 The fork's conversation is **seeded from the branched store**, so the agent sees
 inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
@@ -78,6 +94,15 @@ inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
 fully **substrate-isolated world** you can review (`diff`) before adopting or
 discarding. The live handle is process-local; `dvergr.discourse/fork-descriptor`
 is the portable projection used by Runs, proposals, UIs, and audit state.
+
+### ChatContext SCI API migration
+
+`ChatContext` no longer exposes a raw `:sci-ctx` field. Embedders must call
+`dvergr.chat.context/sci-context-in` with the intended execution context, or
+`sci-context` while that context is bound. The record now carries
+`:sci-component`, which is an opaque stable reference and must not be passed to
+SCI directly. Tool contexts still use `:sci-ctx`; supply the interpreter returned
+by one of those resolver functions.
 
 ## Personas / agent config — managed, not files
 

--- a/src-clients/dvergr/tui/app.clj
+++ b/src-clients/dvergr/tui/app.clj
@@ -32,6 +32,7 @@
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.effects.track :refer [track]]
             [org.replikativ.spindel.incremental.interval :as iv]
+            [dvergr.activity :as activity]
             [dvergr.audio.record :as rec]
             [dvergr.audio.stt :as stt]
             [dvergr.discourse :as d]
@@ -686,6 +687,21 @@
          (apply str (repeat pad " "))
          (s/render (s/style :fg (s/ansi256 240)) clock))))
 
+(defn- render-activities
+  "Render compact semantic facts. Detailed arguments remain in trace mode."
+  [message inner-w]
+  (let [facts  (activity/message-activities message)
+        run-id (activity/message-run-id message)]
+    (mapcat
+     (fn [fact]
+       (let [run-label (when-let [id (activity/short-id
+                                      (or (:activity/run-id fact) run-id))]
+                         (str " · run " id))
+             label     (str "  ↳ " (activity/summary fact) run-label)]
+         (for [line (wrap-text label inner-w)]
+           (s/render (s/style :fg (s/ansi256 178)) line))))
+     facts)))
+
 (defn- render-room-message
   "Render one room message (unified shape `{:from :content :role :tool-uses}`)
    to styled lines. Three flavors, keyed on `:role`:
@@ -709,7 +725,8 @@
                   trace?               (render-reasoning (:reasoning m) inner-w)
                   (seq (:reasoning m)) [(s/render (s/style :fg (s/ansi256 240))
                                                   "  💭 thinking · ^T to show")]
-                  :else                nil)]
+                  :else                nil)
+        activities (render-activities m inner-w)]
     (cond
       ;; Fork boundary — a centered separator marking where the inherited
       ;; (pre-fork) history ends and the fork's own conversation begins.
@@ -736,6 +753,7 @@
                                        (str speaker " ") "  ")
                                 l)))
                tool-lines)
+              activities
               (when trace? (mapcat #(render-tool-use % inner-w) (:tool-uses m))))))
 
       ;; Agent reply — cyan speaker, markdown body, inline tool calls.
@@ -751,7 +769,8 @@
         ;; wrapped lines (e.g. **bold** whose SGR-open and reset land on
         ;; different lines) can't bleed into the box padding/border.
         (into [(speaker-line speaker (:ts m) (theme/ansi :assistant) inner-w)]
-              (concat reason (map #(str "  " % "\u001b[0m") body-lines) tu-lines)))
+              (concat reason (map #(str "  " % "\u001b[0m") body-lines)
+                      activities tu-lines)))
 
       ;; User / other — green speaker, plain body.
       :else
@@ -759,7 +778,8 @@
             (concat reason
                     (for [raw (str/split-lines content)
                           l   (wrap-text raw (- inner-w 2))]
-                      (s/render (s/style :fg s/white) (str "  " l))))))))
+                      (s/render (s/style :fg s/white) (str "  " l)))
+                    activities)))))
 
 (defn- room-view
   "Render the :room view: header showing the current Room's title +

--- a/src/dvergr/activity.clj
+++ b/src/dvergr/activity.clj
@@ -57,6 +57,28 @@
   (or (:run-id message)
       (get-in message [:metadata :run-id])))
 
+(defn- portable-activity [fact]
+  (cond-> (select-keys fact
+                       [:activity/id :activity/kind :activity/verb :activity/at
+                        :activity/run-id :activity/tool-use-id :activity/tool-name
+                        :activity/status :activity/outcome :activity/critical?])
+    (instance? Date (:activity/at fact))
+    (assoc :activity/at (.getTime ^Date (:activity/at fact)))))
+
+(defn tool-trace-entry
+  "Project one normalized or raw tool-activity message into portable causal
+   evidence. Raw inputs remain available for replay while Run/tool-use IDs and
+   semantic activities preserve correlation under interleaving."
+  [message]
+  {:message/id (or (:id message) (:message/id message))
+   :run/id (message-run-id message)
+   :tool-uses
+   (mapv #(select-keys % [:tool-use/id :tool-use/name :tool-use/input])
+         (or (:tool-uses message)
+             (get-in message [:metadata :tool-uses])
+             []))
+   :activities (mapv portable-activity (message-activities message))})
+
 (defn short-id
   "Compact a UUID-like identity for human-facing correlation labels."
   [id]

--- a/src/dvergr/activity.clj
+++ b/src/dvergr/activity.clj
@@ -4,7 +4,8 @@
    Activities are projections of work that already happened. They are not
    executable effects, lifecycle owners, or a second event log: room messages
    supply discourse identity and Runs supply execution identity."
-  (:require [hasch.core :as hasch])
+  (:require [clojure.string :as str]
+            [hasch.core :as hasch])
   (:import [java.util Date]))
 
 (defn- stable-id
@@ -42,3 +43,33 @@
            :activity/at (Date.)}
     run-id (assoc :activity/run-id run-id)
     outcome (assoc :activity/outcome (str outcome))))
+
+(defn message-activities
+  "Return the semantic activity facts carried by a normalized or raw message."
+  [message]
+  (or (:activities message)
+      (get-in message [:metadata :activities])
+      []))
+
+(defn message-run-id
+  "Return the Run correlated with MESSAGE, accepting normalized and raw shapes."
+  [message]
+  (or (:run-id message)
+      (get-in message [:metadata :run-id])))
+
+(defn short-id
+  "Compact a UUID-like identity for human-facing correlation labels."
+  [id]
+  (when id
+    (let [s (str id)]
+      (subs s 0 (min 8 (count s))))))
+
+(defn summary
+  "Compact, non-authoritative presentation of one semantic activity fact."
+  [fact]
+  (str/join " · "
+            (keep identity
+                  [(some-> (or (:activity/verb fact) (:activity/kind fact)) name)
+                   (:activity/tool-name fact)
+                   (some-> (:activity/status fact) name)
+                   (:activity/outcome fact)])))

--- a/src/dvergr/agent/attempt.clj
+++ b/src/dvergr/agent/attempt.clj
@@ -1,0 +1,146 @@
+(ns dvergr.agent.attempt
+  "Immutable durable records of trusted evaluation certification.
+
+   A certified Attempt is the write model. An Episode is later derived by
+   joining it with the owning Run and immutable Room evidence; it is not a
+   second lifecycle or settlement authority."
+  (:require [dvergr.agent.environment :as environment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.store :as store]
+            [hasch.core :as hasch]))
+
+(def ^:private attempt-keys
+  #{:attempt/id :attempt/run-id :attempt/environment :attempt/agent
+    :attempt/receipt :attempt/evidence :attempt/evidence-run-ids
+    :attempt/evidence-message-ids :attempt/agent-def-hash
+    :attempt/evidence-content-id :attempt/settlement-intent
+    :attempt/certified-at :attempt/content-id})
+
+(def ^:private required-keys
+  (disj attempt-keys :attempt/evidence-message-ids))
+
+(defn- invalid! [message type data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn- trace-ids [evidence k]
+  (->> (get-in evidence [:trace k])
+       (keep #(when (map? %) (get % (case k :runs :run/id :messages :message/id))))
+       (filter uuid?)
+       set))
+
+(defn make-attempt
+  "Construct the exact immutable record for one certified Attempt.
+
+   `settlement-intent` records the requested post-certification policy. Actual
+   settlement remains on the Run projection and is never copied back here."
+  [definition agent receipt evidence settlement-intent]
+  (environment/validate-environment definition)
+  (environment/validate-attempt-receipt receipt)
+  (when-not (roster/data-value? agent)
+    (invalid! "Attempt AgentDef must be portable data"
+              ::invalid-agent {:agent agent}))
+  (when-not (= (environment/environment-ref definition)
+               (:attempt/environment receipt))
+    (invalid! "Attempt receipt names a different EnvironmentDef"
+              ::environment-mismatch
+              {:expected (environment/environment-ref definition)
+               :actual (:attempt/environment receipt)}))
+  (when-not (and (map? evidence) (roster/data-value? evidence))
+    (invalid! "Attempt evidence must be a portable map"
+              ::invalid-evidence {:evidence evidence}))
+  (when-not (contains? #{:review :discard} settlement-intent)
+    (invalid! "Attempt settlement intent must be :review or :discard"
+              ::invalid-settlement-intent
+              {:settlement-intent settlement-intent}))
+  (doseq [k [:result :trace :resources]]
+    (when-not (= [(contains? evidence k) (get evidence k)]
+                 [(contains? receipt (keyword "attempt" (name k)))
+                  (get receipt (keyword "attempt" (name k)))])
+      (invalid! "Attempt evidence differs from its trusted receipt"
+                ::evidence-receipt-mismatch {:key k})))
+  (let [run-id (:attempt/run-id receipt)
+        agent-hash (hasch/uuid agent)
+        metrics (:attempt/metrics receipt)
+        claimed-agent-hash (get-in receipt [:attempt/metrics :agent-def-hash])
+        _ (when-not (= agent-hash claimed-agent-hash)
+            (invalid! "Attempt AgentDef differs from receipt provenance"
+                      ::agent-mismatch
+                      {:expected claimed-agent-hash :actual agent-hash}))
+        _ (doseq [[metric expected]
+                  [[:agent-version (:agent/version agent)]
+                   [:program-kind (get-in agent [:agent/program :kind])]]]
+            (when-not (= expected (get metrics metric))
+              (invalid! "Attempt AgentDef differs from receipt provenance"
+                        ::agent-mismatch
+                        {:metric metric :expected expected
+                         :actual (get metrics metric)})))
+        _ (when-not (and (integer? (:interpreter-version metrics))
+                         (pos? (:interpreter-version metrics)))
+            (invalid! "Attempt receipt requires an interpreter version"
+                      ::missing-interpreter-version {:metrics metrics}))
+        run-ids (conj (trace-ids evidence :runs) run-id)
+        message-ids (trace-ids evidence :messages)]
+    (cond-> {:attempt/id run-id
+             :attempt/run-id run-id
+             :attempt/environment definition
+             :attempt/agent agent
+             :attempt/receipt receipt
+             :attempt/evidence evidence
+             :attempt/evidence-run-ids run-ids
+             :attempt/agent-def-hash agent-hash
+             :attempt/evidence-content-id
+             (hasch/uuid [:dvergr/evaluation-evidence evidence])
+             :attempt/settlement-intent settlement-intent
+             :attempt/certified-at (+ (:attempt/started-at receipt)
+                                      (:attempt/elapsed-ms receipt))
+             ;; The trusted receipt is the immutable certification identity.
+             :attempt/content-id (:attempt/content-id receipt)}
+      (seq message-ids) (assoc :attempt/evidence-message-ids message-ids))))
+
+(defn validate-attempt
+  "Validate exact certified Attempt content and return it unchanged."
+  [value]
+  (when-not (map? value)
+    (invalid! "Certified Attempt must be a map"
+              ::invalid-attempt {:value value}))
+  (when-let [unknown (seq (remove attempt-keys (keys value)))]
+    (invalid! "Certified Attempt contains unknown keys"
+              ::unknown-attempt-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? value %) required-keys))]
+    (invalid! "Certified Attempt is missing required keys"
+              ::missing-attempt-keys {:missing (set missing)}))
+  (when-not (= (:attempt/id value) (:attempt/run-id value))
+    (invalid! "Attempt identity must equal its root Run identity"
+              ::run-mismatch {:attempt value}))
+  (when-not (and (uuid? (:attempt/id value))
+                 (integer? (:attempt/certified-at value))
+                 (not (neg? (:attempt/certified-at value))))
+    (invalid! "Attempt requires UUID identity and epoch-millisecond certification time"
+              ::invalid-identity {:attempt value}))
+  (let [rebuilt (make-attempt (:attempt/environment value)
+                              (:attempt/agent value)
+                              (:attempt/receipt value)
+                              (:attempt/evidence value)
+                              (:attempt/settlement-intent value))]
+    (when-not (= value rebuilt)
+      (invalid! "Certified Attempt is not canonical"
+                ::non-canonical-attempt
+                {:attempt/id (:attempt/id value)})))
+  value)
+
+(defn persist!
+  "Persist `value` through the Room's Attempt store.
+
+   Rooms without a store intentionally produce ephemeral attempts. A configured
+   store must support durable Attempts; silently returning an unaudited reward
+   would violate the trusted evaluation boundary."
+  [room value]
+  (validate-attempt value)
+  (if-let [room-store (:store room)]
+    (if (satisfies? store/PAttemptStore room-store)
+      (or (store/-store-attempt! room-store (:id room) value)
+          (invalid! "Attempt certification was not durable"
+                    ::not-durable {:attempt/id (:attempt/id value)}))
+      (invalid! "Configured Room store does not support durable Attempts"
+                ::unsupported-store {:store (class room-store)}))
+    value))

--- a/src/dvergr/agent/attempt/governance.clj
+++ b/src/dvergr/agent/attempt/governance.clj
@@ -1,0 +1,215 @@
+(ns dvergr.agent.attempt.governance
+  "Mandatory Datahike writer predicate for certified Attempt projections.
+
+   This composes with an existing store predicate (notably Kontor) and validates
+   fully-resolved datoms. It prevents raw transactions, imports, and remote
+   writers from mutating certification after the trusted transaction function
+   creates it."
+  (:require [datahike.api :as d]))
+
+(def ^:private attempt-required
+  #{:attempt/id :attempt/chat :attempt/run :attempt/content-id
+    :attempt/payload-blob :attempt/payload-codec :attempt/environment-id
+    :attempt/environment-version :attempt/environment-content-id
+    :attempt/verifier-id :attempt/verifier-version :attempt/provider
+    :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
+    :attempt/certified-at :attempt/reward :attempt/agent-def-hash
+    :attempt/program-kind :attempt/interpreter-version
+    :attempt/evidence-content-id :attempt/evidence-runs
+    :attempt/settlement-intent :attempt/checks})
+
+(defn- protected-ident? [ident]
+  (and (keyword? ident)
+       (contains? #{"attempt" "attempt.check"} (namespace ident))))
+
+(defn- datom-ident [db datom]
+  (let [attr (nth datom 1)]
+    (if (keyword? attr)
+      attr
+      (:db/ident (d/entity db attr)))))
+
+(defn- touched [report]
+  (let [db (:db-after report)]
+    (filter #(protected-ident? (datom-ident db %)) (:tx-data report))))
+
+(def ^:private entity-pattern
+  '[*
+    {:attempt/chat [:db/id :chat/id]}
+    {:attempt/run [* {:run/chat [:db/id :chat/id]}]}
+    {:attempt/evidence-runs [* {:run/chat [:db/id :chat/id]}]}
+    {:attempt/evidence-messages [* {:message/chat [:db/id :chat/id]}]}
+    {:attempt/checks [*]}])
+
+(defn- entity-map [db eid]
+  (d/pull db entity-pattern eid))
+
+(defn- attempt? [entity] (uuid? (:attempt/id entity)))
+(defn- check? [entity] (uuid? (:attempt.check/id entity)))
+
+(defn- same-chat? [attempt run]
+  (= (:db/id (:attempt/chat attempt)) (:db/id (:run/chat run))))
+
+(defn- validate-new-attempt! [db entity]
+  (let [missing (remove #(contains? entity %) attempt-required)
+        run (:attempt/run entity)]
+    (when (seq missing)
+      (throw (ex-info "Certified Attempt row is incomplete"
+                      {:type ::incomplete-attempt :missing (set missing)})))
+    (when-not (= (:attempt/id entity) (:run/id run))
+      (throw (ex-info "Certified Attempt identity differs from its Run"
+                      {:type ::attempt-run-mismatch
+                       :attempt/id (:attempt/id entity)
+                       :run/id (:run/id run)})))
+    (when-not (and (contains? #{:completed :failed :cancelled}
+                              (:run/status run))
+                   (= (:attempt/status entity) (:run/status run))
+                   (same-chat? entity run))
+      (throw (ex-info "Certified Attempt requires a same-Room terminal Run"
+                      {:type ::invalid-attempt-run
+                       :attempt/id (:attempt/id entity)})))
+    (doseq [[attempt-key run-key]
+            [[:attempt/agent-def-hash :run/agent-def-hash]
+             [:attempt/program-kind :run/program-kind]
+             [:attempt/interpreter-version :run/interpreter-version]]]
+      (when-not (= (get entity attempt-key) (get run run-key))
+        (throw (ex-info "Certified Attempt provenance differs from its Run"
+                        {:type ::attempt-run-provenance-mismatch
+                         :attempt/key attempt-key}))))
+    (doseq [evidence-run (:attempt/evidence-runs entity)]
+      (when-not (and evidence-run (same-chat? entity evidence-run))
+        (throw (ex-info "Certified Attempt has cross-Room Run evidence"
+                        {:type ::invalid-evidence-run
+                         :attempt/id (:attempt/id entity)}))))
+    (doseq [message (:attempt/evidence-messages entity)]
+      (when-not (= (:db/id (:attempt/chat entity))
+                   (:db/id (:message/chat message)))
+        (throw (ex-info "Certified Attempt has cross-Room message evidence"
+                        {:type ::invalid-evidence-message
+                         :attempt/id (:attempt/id entity)}))))
+    (doseq [check (:attempt/checks entity)]
+      (when-not (and (keyword? (:attempt.check/key check))
+                     (boolean? (:attempt.check/passed? check)))
+        (throw (ex-info "Certified Attempt has malformed checks"
+                        {:type ::invalid-check
+                         :attempt/id (:attempt/id entity)}))))
+    db))
+
+(defonce ^:private authorized-writes (atom {}))
+
+(defn- store-id [conn-or-db]
+  (get-in @conn-or-db [:config :store :id]))
+
+(defn with-authorized-write
+  "Invoke `f` with transaction metadata carrying a one-use trusted writer
+   capability for `attempt-id`. The token is meaningful only while this call is
+   active and is never available through the SCI or store API."
+  [conn attempt-id f]
+  (let [token (random-uuid)
+        key [(store-id conn) token]]
+    (swap! authorized-writes assoc key attempt-id)
+    (try
+      (f {:attempt.writer/token token})
+      (finally
+        (swap! authorized-writes dissoc key)))))
+
+(defn- authorized-attempt-id [report]
+  (when-let [token (get-in report [:tx-meta :attempt.writer/token])]
+    (get @authorized-writes
+         [(get-in report [:db-after :config :store :id]) token])))
+
+(defn validate-report
+  "Reject unauthorized creation and every mutation of certified Attempt facts."
+  [{:keys [db-before db-after tx-data] :as report}]
+  (let [changed (vec (touched report))
+        eids (into #{} (map #(nth % 0)) changed)
+        merge? (seq (get-in db-after [:meta :datahike/merge-parents]))
+        authorized-id (authorized-attempt-id report)]
+    (doseq [eid eids]
+      (let [before (entity-map db-before eid)
+            after (entity-map db-after eid)
+            before-attempt? (attempt? before)
+            after-attempt? (attempt? after)
+            before-check? (check? before)
+            after-check? (check? after)
+            entity-datoms (filter #(= eid (nth % 0)) changed)]
+        (cond
+          (and (not before-attempt?) after-attempt?)
+          (do
+            (when-not (or merge? (= authorized-id (:attempt/id after)))
+              (throw (ex-info "Certified Attempts require the trusted writer"
+                              {:type ::unauthorized-attempt-create
+                               :attempt/id (:attempt/id after)})))
+            (validate-new-attempt! db-after after))
+
+          (and before-attempt? after-attempt?)
+          (when (seq entity-datoms)
+            (throw (ex-info "Certified Attempt rows are immutable"
+                            {:type ::attempt-mutation
+                             :attempt/id (:attempt/id before)})))
+
+          (and before-attempt? (not after-attempt?))
+          (when (:chat/id
+                 (d/pull db-after [:chat/id]
+                         (get-in before [:attempt/chat :db/id])))
+            (throw (ex-info "Certified Attempt deletion requires Room deletion"
+                            {:type ::attempt-deletion
+                             :attempt/id (:attempt/id before)})))
+
+          (and (not before-check?) after-check?)
+          (when-not (or merge? authorized-id)
+            (throw (ex-info "Attempt checks require the trusted writer"
+                            {:type ::unauthorized-check-create})))
+
+          (and before-check? after-check?)
+          (when (seq entity-datoms)
+            (throw (ex-info "Attempt checks are immutable"
+                            {:type ::check-mutation
+                             :check/id (:attempt.check/id before)})))
+
+          (and before-check? (not after-check?))
+          (when-let [owner
+                     (d/q '[:find ?a . :in $ ?check
+                            :where [?a :attempt/checks ?check]]
+                          db-before eid)]
+            (when (attempt? (entity-map db-after owner))
+              (throw (ex-info "Attempt check deletion requires Attempt deletion"
+                              {:type ::check-deletion
+                               :check/id (:attempt.check/id before)})))))))
+    ;; A newly-created check must be owned by an Attempt component edge.
+    (doseq [eid eids
+            :let [before (entity-map db-before eid)
+                  after (entity-map db-after eid)]
+            :when (and (not (check? before)) (check? after))]
+      (when-not (d/q '[:find ?a . :in $ ?check
+                       :where [?a :attempt/checks ?check]] db-after eid)
+        (throw (ex-info "Attempt check is not owned by a certified Attempt"
+                        {:type ::orphan-check :check/id (:attempt.check/id after)}))))
+    report))
+
+(defonce ^:private installed (atom {}))
+
+(defn govern!
+  "Compose Attempt validation with the store's current mandatory predicate."
+  [conn]
+  (let [store-id (get-in @conn [:config :store :id])
+        tx-pred-for (requiring-resolve 'datahike.tx-preds/tx-pred-for)
+        register! (requiring-resolve 'datahike.tx-preds/register-tx-pred!)
+        current (tx-pred-for store-id)
+        entry (get @installed store-id)
+        {:keys [base composed]} entry]
+    (cond
+      (and entry (= current composed)) nil
+
+      ;; An idempotent subsystem install may re-register the same base
+      ;; predicate. Restore the existing composite identity rather than nesting
+      ;; or allocating a new closure.
+      (and entry composed (= current base))
+      (register! store-id composed)
+
+      :else
+      (let [composed' (fn [report]
+                        (when current (current report))
+                        (validate-report report))]
+        (swap! installed assoc store-id {:base current :composed composed'})
+        (register! store-id composed')))
+    store-id))

--- a/src/dvergr/agent/environment.clj
+++ b/src/dvergr/agent/environment.clj
@@ -1,0 +1,303 @@
+(ns dvergr.agent.environment
+  "Portable, content-addressed definitions for verified agent environments.
+
+   An EnvironmentDef describes what may be attempted and names trusted verifier
+   code. It never embeds the verifier function, a live world, or a Run handle.
+   The content ID identifies this exact definition; individual attempts retain
+   fresh Run identities."
+  (:require [dvergr.agent.roster :as roster]
+            [hasch.core :as hasch]))
+
+(def ^:private allowed-keys
+  #{:id :version :task :verifier :limits :world :metadata})
+
+(def ^:private definition-keys
+  #{:environment/id :environment/version :environment/task
+    :environment/verifier :environment/limits :environment/world
+    :environment/metadata :environment/content-id})
+
+(def ^:private required-definition-keys
+  #{:environment/id :environment/version :environment/task
+    :environment/verifier :environment/limits :environment/world
+    :environment/content-id})
+
+(defn- invalid! [message type data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn- positive-version! [label version]
+  (when-not (and (integer? version) (pos? version))
+    (invalid! (str label " must be a positive integer")
+              ::invalid-version
+              {:label label :version version}))
+  version)
+
+(defn- verifier-ref! [verifier]
+  (when-not (map? verifier)
+    (invalid! "Environment :verifier must be a reference map"
+              ::invalid-verifier {:verifier verifier}))
+  (when-let [unknown (seq (remove #{:id :version :basis} (keys verifier)))]
+    (invalid! "Environment :verifier contains unknown keys"
+              ::unknown-verifier-keys {:unknown (set unknown)}))
+  (let [{:keys [id version basis]} verifier]
+    (when-not (keyword? id)
+      (invalid! "Verifier :id must be a keyword"
+                ::invalid-verifier-id {:id id}))
+    (positive-version! "Verifier :version" (or version 1))
+    (when-not (roster/data-value? basis)
+      (invalid! "Verifier :basis must contain only portable data"
+                ::non-portable-verifier-basis {:basis basis}))
+    (cond-> {:verifier/id id
+             :verifier/version (or version 1)}
+      basis (assoc :verifier/basis basis))))
+
+(defn make-environment
+  "Construct a portable, content-addressed EnvironmentDef.
+
+   Required options are keyword `:id`, portable `:task`, and `:verifier` as
+   `{:id keyword :version positive-int}`. Optional `:basis` identifies immutable
+   verifier source. `:limits`, `:world`, and `:metadata` are portable policy
+   data interpreted by the runner."
+  [{:keys [id version task verifier limits world metadata]
+    :or {version 1 limits {} world {}}
+    :as opts}]
+  (when-let [unknown (seq (remove allowed-keys (keys opts)))]
+    (invalid! "Environment contains unknown keys"
+              ::unknown-environment-keys
+              {:unknown (set unknown) :allowed allowed-keys}))
+  (when-not (keyword? id)
+    (invalid! "Environment :id must be a keyword"
+              ::invalid-environment-id {:id id}))
+  (positive-version! "Environment :version" version)
+  (when-not (contains? opts :task)
+    (invalid! "Environment requires :task"
+              ::missing-task {:environment/id id}))
+  (doseq [[label value] [[:task task] [:limits limits] [:world world]
+                         [:metadata metadata]]]
+    (when-not (roster/data-value? value)
+      (invalid! (str "Environment " label " must contain only portable data")
+                ::non-portable-data {:label label :value value})))
+  (when-not (map? limits)
+    (invalid! "Environment :limits must be a map"
+              ::invalid-limits {:limits limits}))
+  (when-not (map? world)
+    (invalid! "Environment :world must be a map"
+              ::invalid-world {:world world}))
+  (when (and metadata (not (map? metadata)))
+    (invalid! "Environment :metadata must be a map"
+              ::invalid-metadata {:metadata metadata}))
+  (let [definition (cond-> {:environment/id id
+                            :environment/version version
+                            :environment/task task
+                            :environment/verifier (verifier-ref! verifier)
+                            :environment/limits limits
+                            :environment/world world}
+                     metadata (assoc :environment/metadata metadata))]
+    (assoc definition
+           :environment/content-id
+           (hasch/uuid [:dvergr/environment-definition definition]))))
+
+(defn validate-environment
+  "Validate that `environment` is canonical portable data and that its content
+   ID still names its exact current value. Returns the unchanged definition."
+  [environment]
+  (when-not (map? environment)
+    (invalid! "EnvironmentDef must be a map"
+              ::invalid-definition {:value environment}))
+  (when-let [unknown (seq (remove definition-keys (keys environment)))]
+    (invalid! "EnvironmentDef contains unknown canonical keys"
+              ::unknown-definition-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? environment %)
+                                  required-definition-keys))]
+    (invalid! "EnvironmentDef is missing canonical keys"
+              ::missing-definition-keys {:missing (set missing)}))
+  (when-not (roster/data-value? environment)
+    (invalid! "EnvironmentDef must contain only portable data"
+              ::non-portable-data {:value environment}))
+  (let [claimed (:environment/content-id environment)
+        content (dissoc environment :environment/content-id)
+        actual (hasch/uuid [:dvergr/environment-definition content])]
+    (when-not (= claimed actual)
+      (invalid! "EnvironmentDef content ID does not match its content"
+                ::content-id-mismatch {:claimed claimed :actual actual})))
+  (let [verifier (:environment/verifier environment)
+        spec (cond-> {:id (:environment/id environment)
+                      :version (:environment/version environment)
+                      :task (:environment/task environment)
+                      :verifier (cond-> {:id (:verifier/id verifier)
+                                         :version (:verifier/version verifier)}
+                                  (contains? verifier :verifier/basis)
+                                  (assoc :basis (:verifier/basis verifier)))
+                      :limits (:environment/limits environment)
+                      :world (:environment/world environment)}
+               (contains? environment :environment/metadata)
+               (assoc :metadata (:environment/metadata environment)))]
+    (when-not (= environment (make-environment spec))
+      (invalid! "EnvironmentDef is not in canonical form"
+                ::non-canonical-definition {:value environment})))
+  environment)
+
+(defn environment-ref
+  "Stable reference to one exact EnvironmentDef."
+  [environment]
+  (select-keys (validate-environment environment)
+               [:environment/id :environment/version :environment/content-id]))
+
+(def ^:private attempt-option-keys
+  #{:run-id :provider :model :status :started-at :elapsed-ms :metrics
+    :checks :reward :result :trace :resources})
+
+(def ^:private attempt-receipt-keys
+  #{:attempt/id :attempt/run-id :attempt/environment :attempt/provider
+    :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
+    :attempt/metrics :attempt/checks :attempt/reward :attempt/result
+    :attempt/trace :attempt/resources :attempt/content-id})
+
+(def ^:private required-attempt-receipt-keys
+  #{:attempt/id :attempt/run-id :attempt/environment :attempt/provider
+    :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
+    :attempt/metrics :attempt/checks :attempt/reward :attempt/content-id})
+
+(def ^:private environment-ref-keys
+  #{:environment/id :environment/version :environment/content-id})
+
+(defn- environment-ref! [ref]
+  (when-not (and (map? ref) (= environment-ref-keys (set (keys ref))))
+    (invalid! "Attempt receipt :environment must be an exact EnvironmentRef"
+              ::invalid-attempt-environment {:environment ref}))
+  (when-not (keyword? (:environment/id ref))
+    (invalid! "EnvironmentRef :environment/id must be a keyword"
+              ::invalid-attempt-environment {:environment ref}))
+  (positive-version! "EnvironmentRef :environment/version"
+                     (:environment/version ref))
+  (when-not (uuid? (:environment/content-id ref))
+    (invalid! "EnvironmentRef :environment/content-id must be a UUID"
+              ::invalid-attempt-environment {:environment ref}))
+  ref)
+
+(defn- finite-number? [value]
+  (and (number? value)
+       (try
+         (Double/isFinite (double value))
+         (catch Throwable _ false))))
+
+(defn- attempt-fields!
+  [{:keys [run-id environment provider model status started-at elapsed-ms metrics
+           checks reward result trace resources]}]
+  (when-not (uuid? run-id)
+    (invalid! "Attempt receipt :run-id must be a UUID"
+              ::invalid-attempt-run {:run-id run-id}))
+  (environment-ref! environment)
+  (when-not (keyword? provider)
+    (invalid! "Attempt receipt :provider must be a keyword"
+              ::invalid-attempt-provider {:provider provider}))
+  (when-not (string? model)
+    (invalid! "Attempt receipt :model must be a string"
+              ::invalid-attempt-model {:model model}))
+  (when-not (keyword? status)
+    (invalid! "Attempt receipt :status must be a keyword"
+              ::invalid-attempt-status {:status status}))
+  (when-not (and (integer? started-at) (not (neg? started-at)))
+    (invalid! "Attempt receipt :started-at must be epoch milliseconds"
+              ::invalid-attempt-start {:started-at started-at}))
+  (when-not (and (integer? elapsed-ms) (not (neg? elapsed-ms)))
+    (invalid! "Attempt receipt :elapsed-ms must be a non-negative integer"
+              ::invalid-attempt-elapsed {:elapsed-ms elapsed-ms}))
+  (when-not (map? metrics)
+    (invalid! "Attempt receipt :metrics must be a map"
+              ::invalid-attempt-metrics {:metrics metrics}))
+  (when-not (and (map? checks) (every? keyword? (keys checks))
+                 (every? boolean? (vals checks)))
+    (invalid! "Attempt receipt :checks must map keywords to booleans"
+              ::invalid-attempt-checks {:checks checks}))
+  (when-not (finite-number? reward)
+    (invalid! "Attempt receipt :reward must be a finite number"
+              ::invalid-attempt-reward {:reward reward}))
+  (doseq [[label value] [[:metrics metrics] [:result result] [:trace trace]
+                         [:resources resources]]]
+    (when-not (roster/data-value? value)
+      (invalid! (str "Attempt receipt " label " must contain only portable data")
+                ::non-portable-attempt-data {:label label :value value})))
+  true)
+
+(defn make-attempt-receipt
+  "Create an immutable verified-attempt receipt for one unique root Run.
+
+   This constructor is intentionally host-only: SCI may author EnvironmentDefs,
+   but the trusted runner supplies checks and reward after observing durable
+   effects. `started-at` is epoch milliseconds; metrics/resources/trace remain
+   portable data so the receipt can live in Datahike or Geschichte."
+  [environment {:keys [run-id provider model status started-at elapsed-ms metrics
+                       checks reward result trace resources]
+                :as opts}]
+  (validate-environment environment)
+  (when-let [unknown (seq (remove attempt-option-keys (keys opts)))]
+    (invalid! "Attempt receipt contains unknown keys"
+              ::unknown-attempt-keys {:unknown (set unknown)}))
+  (let [environment-ref (environment-ref environment)
+        metrics (or metrics {})
+        _ (attempt-fields! {:run-id run-id :environment environment-ref
+                            :provider provider :model model :status status
+                            :started-at started-at :elapsed-ms elapsed-ms
+                            :metrics metrics :checks checks :reward reward
+                            :result result :trace trace :resources resources})
+        receipt (cond-> {:attempt/id run-id
+                         :attempt/run-id run-id
+                         :attempt/environment environment-ref
+                         :attempt/provider provider
+                         :attempt/model model
+                         :attempt/status status
+                         :attempt/started-at started-at
+                         :attempt/elapsed-ms elapsed-ms
+                         :attempt/metrics metrics
+                         :attempt/checks checks
+                         :attempt/reward reward}
+                  (contains? opts :result) (assoc :attempt/result result)
+                  (contains? opts :trace) (assoc :attempt/trace trace)
+                  (contains? opts :resources) (assoc :attempt/resources resources))]
+    (assoc receipt :attempt/content-id
+           (hasch/uuid [:dvergr/environment-attempt receipt]))))
+
+(defn validate-attempt-receipt
+  "Reject a malformed or stale attempt receipt before persistence/projection.
+   Content addressing detects mutation; authorization of the writer remains the
+   durable store's responsibility, not a property of an unsigned value."
+  [receipt]
+  (when-not (map? receipt)
+    (invalid! "Attempt receipt must be a map"
+              ::invalid-attempt-receipt {:value receipt}))
+  (when-let [unknown (seq (remove attempt-receipt-keys (keys receipt)))]
+    (invalid! "Attempt receipt contains unknown canonical keys"
+              ::unknown-attempt-receipt-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? receipt %)
+                                  required-attempt-receipt-keys))]
+    (invalid! "Attempt receipt is missing canonical keys"
+              ::missing-attempt-receipt-keys {:missing (set missing)}))
+  (when-not (roster/data-value? receipt)
+    (invalid! "Attempt receipt must contain only portable data"
+              ::non-portable-attempt-data {:value receipt}))
+  (when-not (= (:attempt/id receipt) (:attempt/run-id receipt))
+    (invalid! "Attempt identity must equal its root Run identity"
+              ::attempt-run-mismatch
+              {:attempt/id (:attempt/id receipt)
+               :attempt/run-id (:attempt/run-id receipt)}))
+  (attempt-fields! {:run-id (:attempt/run-id receipt)
+                    :environment (:attempt/environment receipt)
+                    :provider (:attempt/provider receipt)
+                    :model (:attempt/model receipt)
+                    :status (:attempt/status receipt)
+                    :started-at (:attempt/started-at receipt)
+                    :elapsed-ms (:attempt/elapsed-ms receipt)
+                    :metrics (:attempt/metrics receipt)
+                    :checks (:attempt/checks receipt)
+                    :reward (:attempt/reward receipt)
+                    :result (:attempt/result receipt)
+                    :trace (:attempt/trace receipt)
+                    :resources (:attempt/resources receipt)})
+  (let [claimed (:attempt/content-id receipt)
+        actual (hasch/uuid [:dvergr/environment-attempt
+                            (dissoc receipt :attempt/content-id)])]
+    (when-not (= claimed actual)
+      (invalid! "Attempt receipt content ID does not match its content"
+                ::attempt-content-id-mismatch
+                {:claimed claimed :actual actual})))
+  receipt)

--- a/src/dvergr/agent/episode.clj
+++ b/src/dvergr/agent/episode.clj
@@ -1,0 +1,71 @@
+(ns dvergr.agent.episode
+  "Pure read/export projections over certified Attempts and Room facts.
+
+   Episode has no lifecycle, scheduler, or settlement authority. Its current
+   Run projection is joined at read time; the immutable receipt remains exactly
+   as certified even when review later changes world settlement."
+  (:require [dvergr.agent.attempt :as certified]
+            [dvergr.room.store :as store]))
+
+(defn attempt
+  "Load one exact certified Attempt from `room`, or nil."
+  [room attempt-id]
+  (when-let [room-store (:store room)]
+    (when (satisfies? store/PAttemptStore room-store)
+      (store/-load-attempt room-store (:id room) attempt-id))))
+
+(defn attempts
+  "List exact certified Attempts using the store's bounded typed filters."
+  ([room] (attempts room {}))
+  ([room opts]
+   (if-let [room-store (:store room)]
+     (if (satisfies? store/PAttemptStore room-store)
+       (store/-list-attempts room-store (:id room) opts)
+       [])
+     [])))
+
+(def ^:private run-time-keys
+  [:run/created-at :run/started-at :run/updated-at :run/ended-at])
+
+(defn- portable-run [run]
+  (reduce (fn [projection key]
+            (if-let [instant (get projection key)]
+              (assoc projection key (.getTime ^java.util.Date instant))
+              projection))
+          run run-time-keys))
+
+(defn- required-run [room-store room-id attempt-id run-id kind]
+  (if-let [run (store/-load-run room-store room-id run-id)]
+    (portable-run run)
+    (throw (ex-info "Certified Episode references a missing Run"
+                    {:type ::missing-run
+                     :episode/id attempt-id
+                     :run/id run-id
+                     :run/kind kind}))))
+
+(defn export
+  "Assemble one portable Episode from immutable certification plus current facts.
+
+   `:episode/attempt` is historical and byte/content-stable. `:episode/run` and
+   `:episode/evidence-runs` are current durable projections, so settlement may
+   advance without mutating the certified receipt."
+  [room attempt-id]
+  (when-let [certified (attempt room attempt-id)]
+    (certified/validate-attempt certified)
+    (let [room-store (:store room)
+          room-id (:id room)
+          run-ids (sort-by str (:attempt/evidence-run-ids certified))]
+      {:episode/id attempt-id
+       :episode/attempt certified
+       :episode/environment (:attempt/environment certified)
+       :episode/agent (:attempt/agent certified)
+       :episode/receipt (:attempt/receipt certified)
+       :episode/evidence (:attempt/evidence certified)
+       :episode/run (required-run room-store room-id attempt-id
+                                  (:attempt/run-id certified) :root)
+       :episode/evidence-runs
+       (mapv #(required-run room-store room-id attempt-id % :evidence) run-ids)
+       :episode/evidence-message-ids
+       (or (:attempt/evidence-message-ids certified) #{})
+       :episode/resources
+       (get-in certified [:attempt/receipt :attempt/resources])})))

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -1,0 +1,399 @@
+(ns dvergr.agent.evaluation
+  "Algorithm-neutral execution of verified EnvironmentDefs.
+
+   Evaluation does not introduce another scheduler, world, or inference model.
+   It returns a Spin which admits an ordinary isolated Run, observes its durable
+   outcome, invokes a matching host-owned verifier, and produces an attempt
+   receipt. Parallelism, races, quorums, and later inference policies compose
+   these Spins with the existing Spindel combinators."
+  (:require [dvergr.agent.environment :as environment]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.registry :as registry]
+            [dvergr.rooms.forks :as forks]
+            [hasch.core :as hasch]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.sync :as sync]))
+
+(defrecord Evaluator [ref observe verify])
+
+(defn make-evaluator
+  "Create a process-local trusted evaluator capability.
+
+   `id`, `version`, and optional portable `basis` must exactly match an
+   EnvironmentDef verifier reference. `observe` receives durable execution
+   facts and returns portable evidence. `verify` receives the EnvironmentDef
+   plus that evidence and returns `{:checks {keyword boolean} :reward number}`.
+   Evaluators are deliberately not portable and are never exposed to SCI."
+  [{:keys [id version basis observe verify]
+    :or {version 1}}]
+  (when-not (keyword? id)
+    (throw (ex-info "Evaluator :id must be a keyword"
+                    {:type ::invalid-evaluator-id :id id})))
+  (when-not (and (integer? version) (pos? version))
+    (throw (ex-info "Evaluator :version must be a positive integer"
+                    {:type ::invalid-evaluator-version :version version})))
+  (when-not (fn? observe)
+    (throw (ex-info "Evaluator :observe must be a function"
+                    {:type ::invalid-observer})))
+  (when-not (fn? verify)
+    (throw (ex-info "Evaluator :verify must be a function"
+                    {:type ::invalid-verifier})))
+  (when-not (roster/data-value? basis)
+    (throw (ex-info "Evaluator :basis must contain only portable data"
+                    {:type ::invalid-evaluator-basis :basis basis})))
+  (->Evaluator (cond-> {:verifier/id id :verifier/version version}
+                 (some? basis) (assoc :verifier/basis basis))
+               observe verify))
+
+(defn evaluator-ref
+  "Return the portable verifier reference named by an Evaluator capability."
+  [evaluator]
+  (:ref evaluator))
+
+(defn- require-matching-evaluator! [definition evaluator]
+  (when-not (instance? Evaluator evaluator)
+    (throw (ex-info "Evaluation requires a host Evaluator capability"
+                    {:type ::invalid-evaluator})))
+  (let [expected (:environment/verifier definition)
+        actual (evaluator-ref evaluator)]
+    (when-not (= expected actual)
+      (throw (ex-info "Evaluator does not match the EnvironmentDef verifier"
+                      {:type ::evaluator-mismatch
+                       :expected expected
+                       :actual actual}))))
+  evaluator)
+
+(defn- default-evidence [{:keys [result durable]}]
+  {:result (:run/value result)
+   :trace
+   {:runs [(select-keys durable
+                        [:run/id :run/parent :run/caused-by :run/actor
+                         :run/status :run/error :run/settlement-status
+                         :run/roster :run/agent-version :run/agent-def-hash
+                         :run/program-kind :run/interpreter-version])]}})
+
+(defn- execution-identity [agent result durable]
+  (let [metrics (:run/metrics result)
+        kind (or (:run/program-kind durable)
+                 (get-in agent [:agent/program :kind]))
+        model-policy (:agent/model-policy agent)
+        resolved? (and (:provider metrics) (:model metrics))
+        intended? (and (:provider model-policy) (:model model-policy))]
+    {:provider (or (:provider metrics) (:provider model-policy) :dvergr)
+     :model (or (:model metrics) (:model model-policy) (name kind))
+     :metrics
+     (merge {:program-kind kind
+             :model-resolution (cond resolved? :resolved
+                                     intended? :intended
+                                     :else :not-applicable)
+             :agent-version (or (:run/agent-version durable)
+                                (:agent/version agent))
+             :agent-def-hash (or (:run/agent-def-hash durable)
+                                 (hasch/uuid agent))
+             :interpreter-version (or (:run/interpreter-version durable)
+                                      program/interpreter-version)}
+            (when-let [roster-id (:run/roster durable)]
+              {:roster roster-id})
+            metrics)}))
+
+(defn- positive-timeout! [label value]
+  (when-not (and (integer? value) (pos? value))
+    (throw (ex-info (str label " must be a positive integer")
+                    {:type ::invalid-timeout :label label :value value})))
+  value)
+
+(defn- require-supported-policy! [definition agent]
+  (let [limits (:environment/limits definition)
+        world (:environment/world definition)
+        model-limits (select-keys limits [:max-model-steps :budget-dollars])]
+    (when-let [unknown (seq (remove #{:timeout-ms :cancel-timeout-ms
+                                      :max-model-steps :budget-dollars}
+                                    (keys limits)))]
+      (throw (ex-info "Evaluation environment contains unsupported limits"
+                      {:type ::unsupported-evaluation-limits
+                       :unknown (set unknown)})))
+    (when-let [unknown (seq (remove #{:isolation :settlement :resources}
+                                    (keys world)))]
+      (throw (ex-info
+              "Evaluation environment contains unsupported world policy; setup requires a trusted resolver"
+              {:type ::unsupported-evaluation-world
+               :unknown (set unknown)})))
+    (when (and (seq model-limits)
+               (not= :llm (get-in agent [:agent/program :kind])))
+      (throw (ex-info "Environment model limits require an LLM AgentDef"
+                      {:type ::model-limits-require-llm
+                       :agent/id (:agent/id agent)
+                       :limits model-limits})))
+    model-limits))
+
+(defn- settle-certified! [fork requested claim!]
+  (when-not fork
+    (throw (ex-info "Deferred evaluation world is no longer available"
+                    {:type ::missing-evaluation-world})))
+  (case requested
+    :review
+    (forks/release-deferred! fork :evaluation-certified claim!)
+
+    :discard
+    (let [settled (forks/discard-deferred! fork :evaluation-policy claim!)]
+      (when-not (:ok? settled)
+        (throw (ex-info "Certified evaluation world could not be discarded"
+                        {:type ::settlement-failed
+                         :settlement requested
+                         :fork/id (:id fork)
+                         :error (:error settled)})))))
+  requested)
+
+(defn- discard-uncertified! [fork reason]
+  (when fork
+    (forks/discard-deferred! fork reason)))
+
+(defn- spin-cancelled? [error]
+  (loop [error error]
+    (when error
+      (or (= spin-core/spin-cancelled (:type (ex-data error)))
+          (= "Spin cancelled" (ex-message error))
+          (recur (ex-cause error))))))
+
+(defn- certification-candidate
+  [{:keys [room definition evaluator agent run-id result durable
+           started-at started-nanos timeout?]}]
+  (let [evidence ((:observe evaluator)
+                  {:room room
+                   :environment definition
+                   :run-id run-id
+                   :result result
+                   :durable durable
+                   :default (default-evidence {:result result
+                                               :durable durable})})
+        _ (when-not (and (map? evidence) (roster/data-value? evidence))
+            (throw (ex-info "Evaluator evidence must be a portable map"
+                            {:type ::invalid-evidence :evidence evidence})))
+        {:keys [checks reward]} ((:verify evaluator) definition evidence)
+        {:keys [provider model metrics]} (execution-identity agent result durable)
+        elapsed-ms (long (/ (- (System/nanoTime) started-nanos) 1000000))
+        receipt
+        (environment/make-attempt-receipt
+         definition
+         (cond-> {:run-id run-id
+                  :provider provider
+                  :model model
+                  :status (:run/status result)
+                  :started-at started-at
+                  :elapsed-ms elapsed-ms
+                  :metrics (assoc metrics :timed-out? timeout?)
+                  :checks checks
+                  :reward reward}
+           (contains? evidence :result) (assoc :result (:result evidence))
+           (contains? evidence :trace) (assoc :trace (:trace evidence))
+           (contains? evidence :resources) (assoc :resources
+                                                  (:resources evidence))))]
+    {:evidence evidence :receipt receipt}))
+
+(defn evaluate
+  "Return a Spin which evaluates one AgentDef in one EnvironmentDef.
+
+   The Run is the causal execution identity and its ordinary RunWorld is the
+   isolated scenario. Environment `:world` may specify `:settlement` and a
+   conserved `:resources` vector; `:limits` may specify `:timeout-ms` and
+   `:cancel-timeout-ms`. A timeout requests targeted Run cancellation and no
+   receipt is certified until the Run has physically quiesced.
+
+   Options may provide `:from` and structural `:parent-run`. The returned map
+   contains portable evidence/receipt plus the process-local RunHandle; callers
+   settle a retained world through the existing room-fork APIs."
+  ([room team agent-ref definition evaluator]
+   (evaluate room team agent-ref definition evaluator {}))
+  ([room team agent-ref definition evaluator
+    {:keys [from parent-run] :or {from :environment} :as opts}]
+   (environment/validate-environment definition)
+   (require-matching-evaluator! definition evaluator)
+   (let [agent (roster/agent team agent-ref)
+         {:keys [timeout-ms cancel-timeout-ms]
+          :or {timeout-ms 120000 cancel-timeout-ms 10000}}
+         (:environment/limits definition)
+         {:keys [settlement resources]
+          :or {settlement :review}}
+         (:environment/world definition)
+         model-limits (when agent (require-supported-policy! definition agent))]
+     (when-let [unknown (seq (remove #{:from :parent-run} (keys opts)))]
+       (throw (ex-info "Evaluation contains unknown options"
+                       {:type ::unknown-evaluation-options
+                        :unknown (set unknown)})))
+     (when-not agent
+       (throw (ex-info "Evaluation AgentDef does not exist in the Roster"
+                       {:type ::unknown-agent :agent-ref agent-ref})))
+     (positive-timeout! "Environment :timeout-ms" timeout-ms)
+     (positive-timeout! "Environment :cancel-timeout-ms" cancel-timeout-ms)
+     (when-not (contains? #{nil :ctx}
+                          (get-in definition [:environment/world :isolation]))
+       (throw (ex-info "Evaluation environments currently require :ctx isolation"
+                       {:type ::unsupported-evaluation-isolation
+                        :isolation (get-in definition
+                                           [:environment/world :isolation])})))
+     (when-not (#{:review :discard} settlement)
+       (throw (ex-info
+               "Evaluations must retain successful worlds for review or discard them"
+               {:type ::unsafe-evaluation-settlement
+                :settlement settlement
+                :allowed #{:review :discard}})))
+     (sp/spin
+      (let [started-at (System/currentTimeMillis)
+            started-nanos (System/nanoTime)
+            hire-opts (cond-> {:task (:environment/task definition)
+                               :from from
+                               ;; Verification is a two-phase gate over this
+                               ;; same RunWorld. Existing merge/adoption
+                               ;; operations reject it until trusted scoring.
+                               :settlement :deferred}
+                        parent-run (assoc :parent-run parent-run)
+                        (seq resources) (assoc :resources resources)
+                        (seq model-limits) (assoc :limits model-limits))
+            handle (program/hire! room team agent-ref hire-opts)
+            timed-out ::timed-out
+            initial (sp/await
+                     (comb/timeout (program/owned-result-spin handle)
+                                   timeout-ms timed-out))
+            timeout? (= timed-out initial)
+            _ (when timeout? (program/cancel! room handle))
+            result (if timeout?
+                     (sp/await
+                      (comb/timeout (program/result-spin handle)
+                                    cancel-timeout-ms timed-out))
+                     initial)]
+        (when (= timed-out result)
+          (throw (ex-info "Environment Run did not quiesce after cancellation"
+                          {:type ::cancellation-timeout
+                           :run/id (program/run-id handle)
+                           :cancel-timeout-ms cancel-timeout-ms})))
+        (let [run-id (program/run-id handle)
+              durable (program/observe room handle)
+              fork (some-> (:run/world result) registry/lookup)
+              evaluation-spin-id ec/*spin-id*
+              cancelled-externally?
+              #(and evaluation-spin-id
+                    (ec/spin-current-result evaluation-spin-id))
+              state (atom :scoring)
+              persisted-attempt (atom nil)
+              cleanup-result (atom ::pending)
+              cleanup-once!
+              (fn [reason]
+                (locking cleanup-result
+                  (if (= ::pending @cleanup-result)
+                    (let [cleanup (discard-uncertified! fork reason)]
+                      (reset! cleanup-result cleanup)
+                      cleanup)
+                    @cleanup-result)))
+              done (sync/deferred)
+              certification-failure!
+              (fn [error]
+                (if (cancelled-externally?)
+                  (compare-and-set! state :scoring :cancelled)
+                  (compare-and-set! state :scoring :failed))
+                (let [cleanup
+                      (cleanup-once!
+                       (if (= :cancelled @state)
+                         :evaluation-cancelled
+                         :evaluation-certification-failed))]
+                  (sync/deliver!
+                   done
+                   {:error
+                    (ex-info "Evaluation certification failed"
+                             {:type ::certification-failed
+                              :run/id run-id
+                              :run/world (:run/world result)
+                              :cleanup cleanup}
+                             error)})))
+              settlement-failure!
+              (fn [error]
+                (sync/deliver!
+                 done
+                 {:error
+                  (ex-info "Evaluation was certified but world settlement requires recovery"
+                           {:type ::settlement-recovery-required
+                            :run/id run-id
+                            :run/world (:run/world result)
+                            :attempt @persisted-attempt
+                            :run/settlement-status
+                            (:run/settlement-status result)}
+                           error)}))
+              worker
+              (future
+                (binding [ec/*execution-context* (:ctx room)
+                          ec/*spin-id* nil]
+                  (try
+                    (let [{:keys [evidence receipt]}
+                          (certification-candidate
+                           {:room room :definition definition
+                            :evaluator evaluator :agent agent :run-id run-id
+                            :result result :durable durable
+                            :started-at started-at :started-nanos started-nanos
+                            :timeout? timeout?})
+                          certified-attempt
+                          (attempt/make-attempt definition agent receipt evidence
+                                                settlement)]
+                      (let [deferred? (= :deferred
+                                         (:run/settlement-status result))
+                            claim!
+                            #(if (cancelled-externally?)
+                               (do
+                                 (compare-and-set! state :scoring :cancelled)
+                                 false)
+                               (when (compare-and-set! state :scoring
+                                                       :certifying)
+                                 ;; This write occurs inside the fork's affine
+                                 ;; settlement lock. The world cannot become
+                                 ;; reviewable or disappear before its trusted
+                                 ;; certification is durable.
+                                 (reset! persisted-attempt
+                                         (attempt/persist! room
+                                                           certified-attempt))
+                                 true))]
+                        (when (cancelled-externally?)
+                          (compare-and-set! state :scoring :cancelled))
+                        (if (or deferred? (claim!))
+                          (let [final-settlement
+                                (if deferred?
+                                  (settle-certified! fork settlement claim!)
+                                  (:run/settlement-status result))
+                                result (assoc result
+                                              :run/settlement-status
+                                              (case final-settlement
+                                                :discard :discarded
+                                                :review :review
+                                                final-settlement))]
+                            (reset! state :certified)
+                            (sync/deliver!
+                             done
+                             {:ok {:environment definition
+                                   :attempt @persisted-attempt
+                                   :attempt-receipt receipt
+                                   :evidence evidence
+                                   :run/id run-id
+                                   :run/result result
+                                   :run/handle handle}}))
+                          (cleanup-once! :evaluation-cancelled))))
+                    (catch Throwable error
+                      (if @persisted-attempt
+                        (settlement-failure! error)
+                        (certification-failure! error))))))]
+          (try
+            (let [{:keys [ok error]} (sp/await done)]
+              (if error (throw error) ok))
+            (catch Throwable error
+              (when (and (spin-cancelled? error)
+                         (compare-and-set! state :scoring :cancelled))
+                (future-cancel worker)
+                ;; Cancellation remains non-blocking for the Spindel drain
+                ;; path. The gate is already closed by `state`; cleanup runs
+                ;; externally and the interrupted worker can never certify.
+                (future
+                  (binding [ec/*execution-context* (:ctx room)
+                            ec/*spin-id* nil]
+                    (cleanup-once! :evaluation-cancelled))))
+              (throw error)))))))))

--- a/src/dvergr/agent/process.clj
+++ b/src/dvergr/agent/process.clj
@@ -35,7 +35,7 @@
   "Run f with the chat-ctx's spindel-ctx bound. f sees a stable
    *execution-context* for ec/swap-state! and signal derefs."
   [chat-ctx f]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [ec/*execution-context* (chat-ctx/selected-execution-context chat-ctx)]
     (f)))
 
 (defn- registry
@@ -147,7 +147,8 @@
   "Return the latest progress snapshot for a process — a pure read.
    Does not disturb the parked spin."
   [process]
-  (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+  (binding [ec/*execution-context*
+            (chat-ctx/selected-execution-context (:chat-ctx process))]
     (let [now (System/currentTimeMillis)
           term-at (some-> (:terminated-at-ref process) .get)]
       {:id             (:id process)
@@ -195,7 +196,7 @@
   (if-let [process *current-process*]
     (let [chat-ctx  (:chat-ctx process)
           grace-ms  (:grace-ms process 5000)
-          chat-spc  (:spindel-ctx chat-ctx)]
+          chat-spc  (chat-ctx/selected-execution-context chat-ctx)]
       (binding [ec/*execution-context* chat-spc]
         (reset! (:progress-signal process)
                 (cond-> (or state {})
@@ -256,7 +257,7 @@
           ;; sees the latch — flip status directly so work-owners
           ;; polling (aborted? proc) see the abort.
           (when (and (:tracked-only? process) (= :abort (:type canonical)))
-            (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+            (binding [ec/*execution-context* (chat-ctx/selected-execution-context chat-ctx)]
               (reset! (:status-signal process) :aborted))
             (mark-terminated! process))
           :delivered)
@@ -285,13 +286,15 @@
              :or {grace-ms 5000}}]
   {:pre [(string? description)]}
   (let [pid (or id (random-uuid))
+        world (chat-ctx/selected-execution-context chat-ctx)
+        process-chat-ctx (assoc chat-ctx :spindel-ctx world)
         process
-        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [ec/*execution-context* world]
           (let [s (sig/signal :running)
                 p (sig/signal {})]
             (map->Proc
              {:id              pid
-              :chat-ctx        chat-ctx
+              :chat-ctx        process-chat-ctx
               :description     description
               :grace-ms        grace-ms
               :status-signal   s
@@ -301,13 +304,14 @@
               :started-at        (System/currentTimeMillis)
               :terminated-at-ref (AtomicReference. nil)
               :tracked-only?   true})))]
-    (swap-registry! chat-ctx assoc pid process)
+    (swap-registry! process-chat-ctx assoc pid process)
     process))
 
 (defn progress!
   "Update the progress signal on a tracked process."
   [process state]
-  (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+  (binding [ec/*execution-context*
+            (chat-ctx/selected-execution-context (:chat-ctx process))]
     (reset! (:progress-signal process) state))
   state)
 
@@ -317,7 +321,7 @@
    finishes normally."
   [process]
   (let [cctx (:chat-ctx process)]
-    (binding [ec/*execution-context* (:spindel-ctx cctx)]
+    (binding [ec/*execution-context* (chat-ctx/selected-execution-context cctx)]
       (reset! (:status-signal process) :completed))
     (mark-terminated! process)
     ;; Stays in registry briefly so a manager can still snapshot. We
@@ -357,7 +361,7 @@
    summary is wanted it should be an explicit choice — which is what the
    decision protocol makes it (see .internal/decision-protocol-assessment.md)."
   [agent-id chat-ctx]
-  (let [spc           (:spindel-ctx chat-ctx)
+  (let [spc           (chat-ctx/selected-execution-context chat-ctx)
         budget        (binding [ec/*execution-context* spc]
                         @(:budget-signal chat-ctx))
         used-dollars  (/ (:used budget) (double acct/MICRODOLLARS-PER-DOLLAR))
@@ -381,7 +385,8 @@
    at safe points."
   [process]
   (= :aborted
-     (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+     (binding [ec/*execution-context*
+               (chat-ctx/selected-execution-context (:chat-ctx process))]
        @(:status-signal process))))
 
 (defn ->process
@@ -403,13 +408,15 @@
    body-fn]
   {:pre [(string? description)]}
   (let [pid (or id (random-uuid))
+        world (chat-ctx/selected-execution-context chat-ctx)
+        process-chat-ctx (assoc chat-ctx :spindel-ctx world)
         process
-        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [ec/*execution-context* world]
           (let [s (sig/signal :running)
                 p (sig/signal {})]
             (map->Proc
              {:id              pid
-              :chat-ctx        chat-ctx
+              :chat-ctx        process-chat-ctx
               :description     description
               :grace-ms        grace-ms
               :status-signal   s
@@ -418,10 +425,10 @@
               :directive-latch   (CountDownLatch. 1)
               :started-at        (System/currentTimeMillis)
               :terminated-at-ref (AtomicReference. nil)})))]
-    (swap-registry! chat-ctx assoc pid process)
+    (swap-registry! process-chat-ctx assoc pid process)
     (future
       (binding [*current-process*    process
-                ec/*execution-context* (:spindel-ctx chat-ctx)]
+                ec/*execution-context* world]
         (try
           (let [result (body-fn)]
             (reset! (:status-signal process) :completed)

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -36,7 +36,7 @@
    to a Participant is a separate, explicit speech act."
   :_runs)
 
-(def interpreter-version 4)
+(def interpreter-version 5)
 
 (def ^:private default-max-model-steps 32)
 
@@ -80,9 +80,16 @@
                   :cleanup nil
                   :cleanup-phase :pending
                   :cleanup-error nil
+                  :llm-metrics nil
                   :quiesced? false})
     :quiesced (sync/deferred)
     :quiesced-latch (CountDownLatch. 1)}))
+
+(defn- update-llm-metrics!
+  "Update provider evidence under the same lock as cleanup/quiescence state."
+  [supervisor f & args]
+  (locking supervisor
+    (apply swap! (:state supervisor) update :llm-metrics f args)))
 
 (defn- advance-supervisor!
   "Advance cleanup/quiescence after an atomic supervisor transition. Cleanup
@@ -313,32 +320,46 @@
    Deferred; cancelling one observer never cancels the shared execution or a
    peer observer. Use `owned-result-spin` when structured cancellation should
    propagate from a race arm to the hired Run."
-  [^RunHandle handle]
-  (ensure-owner-context! handle)
-  (let [completion (.-completion handle)]
-    (sp/spin (sp/await completion))))
+  ([^RunHandle handle]
+   (ensure-owner-context! handle)
+   (let [completion (.-completion handle)]
+     (sp/spin (sp/await completion))))
+  ([consumer-run-id ^RunHandle handle]
+   (let [observer (result-spin handle)
+         cause-run-id (run-id handle)]
+     (sp/spin
+      (let [result (sp/await observer)]
+        (run/record-cause! consumer-run-id cause-run-id)
+        result)))))
 
 (defn owned-result-spin
   "An owning Spindel observer for a RunHandle. If a combinator cancels this
    observer (for example, as the losing arm of `race`), cancellation propagates
    to the hired Run. Prefer passive `result-spin` for ordinary or shared reads."
-  [^RunHandle handle]
-  (ensure-owner-context! handle)
-  (let [execution (.-worker-execution handle)
-        id (:run/id handle)
-        room-id (:run/room handle)
-        observer (sp/spin
-                  (try
-                    (sp/await (.-completion handle))
-                    (catch Throwable t
-                      (when (= spin-core/spin-cancelled (:type (ex-data t)))
-                        (run/cancel-room-run! room-id id))
-                      (throw t))))]
-    ;; A race can choose another arm before its executor has started this
-    ;; observer, so no await-cont exists yet. Record the same fork-local
-    ;; ownership edge Spindel's fan-out combinators use for that initial window.
-    (spin-core/set-owned-spins! (spin-core/spin-id observer) [execution])
-    observer))
+  ([^RunHandle handle]
+   (ensure-owner-context! handle)
+   (let [execution (.-worker-execution handle)
+         id (:run/id handle)
+         room-id (:run/room handle)
+         observer (sp/spin
+                   (try
+                     (sp/await (.-completion handle))
+                     (catch Throwable t
+                       (when (= spin-core/spin-cancelled (:type (ex-data t)))
+                         (run/cancel-room-run! room-id id))
+                       (throw t))))]
+     ;; A race can choose another arm before its executor has started this
+     ;; observer, so no await-cont exists yet. Record the same fork-local
+     ;; ownership edge Spindel's fan-out combinators use for that initial window.
+     (spin-core/set-owned-spins! (spin-core/spin-id observer) [execution])
+     observer))
+  ([consumer-run-id ^RunHandle handle]
+   (let [observer (owned-result-spin handle)
+         cause-run-id (run-id handle)]
+     (sp/spin
+      (let [result (sp/await observer)]
+        (run/record-cause! consumer-run-id cause-run-id)
+        result)))))
 
 (defn- child-finished! [supervisor lease-id]
   (locking supervisor
@@ -493,7 +514,7 @@
      (-> (tools/make-context
           {:db-conn work-db
            :chat-ctx chat-ctx
-           :sci-ctx (:sci-ctx chat-ctx)
+           :sci-ctx (chat-context/sci-context-in chat-ctx (:ctx room))
            :tools tool-map
            :isolation :sci
            :execution-ctx (:ctx room)
@@ -515,11 +536,18 @@
   "Run a bounded Dvergr-native model/tool loop. Each blocking model round-trip
    runs under a supervised worker; this Spin retains orchestration, activity
    correlation, cleanup, and cancellation in the Room's execution graph."
-  [control-room work-room run-id chat-id agent task trigger supervisor]
+  [control-room work-room run-id chat-id agent task trigger supervisor limits]
   (let [{:keys [max-model-steps budget-dollars auto-compact? compaction-model]
          :or {max-model-steps default-max-model-steps
               budget-dollars 1.0
-              auto-compact? true}} (:agent/program agent)]
+              auto-compact? true}} (:agent/program agent)
+        max-model-steps (min max-model-steps
+                             (or (:max-model-steps limits) max-model-steps))
+        budget-dollars (min (double budget-dollars)
+                            (double (or (:budget-dollars limits)
+                                        budget-dollars)))
+        effective-limits {:max-model-steps max-model-steps
+                          :budget-dollars budget-dollars}]
     (sp/spin
      ;; Context/schema/SCI construction and credential discovery may block.
      ;; Build the whole runtime bundle under the same supervised worker as
@@ -548,6 +576,16 @@
                           (when-let [agent-prompt (:agent/prompt agent)]
                             (str "\n\n" agent-prompt)))
                      {:tools tool-map :isolation :sci :profile :workflow})]
+                (update-llm-metrics!
+                 supervisor
+                 (constantly
+                  (cond->
+                   {:prompt-id (hasch/uuid [:dvergr/llm-system-prompt instructions])
+                    :provider (:provider model-spec)
+                    :model (:model model-spec)
+                    :model-steps 0
+                    :usage {}}
+                    (seq limits) (assoc :limits effective-limits))))
                 (chat-context/add-message!
                  chat-ctx {:role :system :content instructions})
                 (chat-context/add-message!
@@ -592,7 +630,11 @@
                       ;; integration step, not a conversational turn.
                       :turn-number model-step
                       :run-id run-id})))
-                 outcome (sp/await (worker-result-spin call))]
+                 outcome (sp/await (worker-result-spin call))
+                 budget (chat-context/get-budget chat-ctx)]
+             (update-llm-metrics!
+              supervisor merge {:model-steps (inc model-step)
+                                :usage (select-keys budget [:used :by-type])})
              (turn/post-turn-activity! control-room (:agent/id agent) chat-ctx posted
                                        run-id trigger)
              (cond
@@ -645,10 +687,11 @@
   [control-room work-room run-id chat-id agent task trigger supervisor]
   (case (get-in agent [:agent/program :kind])
     :llm (execute-llm-program control-room work-room run-id chat-id agent task
-                              trigger supervisor)
+                              trigger supervisor (::limits agent))
     (execute-deterministic-program run-id agent task)))
 
-(def ^:private hire-option-keys #{:task :from :parent-run :settlement :resources})
+(def ^:private hire-option-keys
+  #{:task :from :parent-run :settlement :resources :limits})
 
 (defn- validate-program!
   [{:keys [kind delay-ms max-model-steps budget-dollars auto-compact? compaction-model]
@@ -683,6 +726,7 @@
                        :max-model-steps max-model-steps})))
     (when (and (= :llm kind)
                (not (and (number? (or budget-dollars 1.0))
+                         (Double/isFinite (double (or budget-dollars 1.0)))
                          (pos? (double (or budget-dollars 1.0))))))
       (throw (ex-info "LLM program :budget-dollars must be positive"
                       {:type ::invalid-budget :budget-dollars budget-dollars})))
@@ -706,7 +750,7 @@
     program))
 
 (defn- validate-hire!
-  [roster agent-ref {:keys [task from parent-run resources] :as opts}]
+  [roster agent-ref {:keys [task from parent-run resources limits] :as opts}]
   (when-let [unknown (seq (remove hire-option-keys (keys opts)))]
     (throw (ex-info "Unknown hire! options"
                     {:type ::unknown-hire-options
@@ -732,6 +776,25 @@
                                resources))))
     (throw (ex-info "hire! :resources must be a non-empty positive resource vector"
                     {:type ::invalid-resources :resources resources})))
+  (when-not (or (nil? limits) (map? limits))
+    (throw (ex-info "hire! :limits must be a map"
+                    {:type ::invalid-limits :limits limits})))
+  (when-let [unknown (seq (remove #{:max-model-steps :budget-dollars}
+                                  (keys limits)))]
+    (throw (ex-info "hire! :limits contains unknown keys"
+                    {:type ::unknown-limit-options
+                     :unknown (set unknown)
+                     :allowed #{:max-model-steps :budget-dollars}})))
+  (when-let [value (:max-model-steps limits)]
+    (when-not (and (integer? value) (<= 1 value 256))
+      (throw (ex-info "hire! limit :max-model-steps must be an integer from 1 to 256"
+                      {:type ::invalid-max-model-steps :max-model-steps value}))))
+  (when-let [value (:budget-dollars limits)]
+    (when-not (and (number? value)
+                   (Double/isFinite (double value))
+                   (pos? (double value)))
+      (throw (ex-info "hire! limit :budget-dollars must be positive"
+                      {:type ::invalid-budget :budget-dollars value}))))
   (when-not (roster/data-value? task)
     (throw (ex-info "Task must be portable data"
                     {:type ::non-portable-task :task task})))
@@ -739,6 +802,11 @@
                   (throw (ex-info "Unknown AgentRef"
                                   {:type ::unknown-agent :agent-ref agent-ref})))]
     (validate-program! (:agent/program agent) agent-ref agent)
+    (when (and (seq limits) (not= :llm (get-in agent [:agent/program :kind])))
+      (throw (ex-info "hire! model limits require an LLM AgentDef"
+                      {:type ::limits-require-llm
+                       :agent-ref agent-ref
+                       :limits limits})))
     agent))
 
 (defn- cancelled-error? [t run-id]
@@ -876,11 +944,12 @@
               (recur))))
         (await-supervisor! supervisor)
         (return-unused-resources! control-room id parent-run allocated?)
-        (let [cleanup-error (:cleanup-error @(:state supervisor))
-              result (if cleanup-error
-                       {:run/id id :run/status :failed
-                        :run/error (ex-message cleanup-error)}
-                       (:result outcome))
+        (let [{:keys [cleanup-error llm-metrics]} @(:state supervisor)
+              result (cond-> (if cleanup-error
+                               {:run/id id :run/status :failed
+                                :run/error (ex-message cleanup-error)}
+                               (:result outcome))
+                       llm-metrics (assoc :run/metrics llm-metrics))
               execution-opts (merge
                               (:finish-opts outcome)
                               (when cleanup-error
@@ -890,13 +959,16 @@
                                        (merge execution-opts finish-opts)))))))
 
 (defn- execution-spin
-  [control-room work-room agent task trigger id chat-id supervisor outcome-promise]
+  [control-room work-room agent task trigger id chat-id supervisor limits outcome-promise]
   (sp/spin
    (let [outcome
          (try
            (let [{status ::status value ::value reason ::reason}
-                 (sp/await (execute-program control-room work-room id chat-id agent
-                                            task trigger supervisor))
+                 (sp/await
+                  (execute-program control-room work-room id chat-id
+                                   (cond-> agent
+                                     (seq limits) (assoc ::limits limits))
+                                   task trigger supervisor))
                  ;; Seal admits no further provider work, runs owned cleanup
                  ;; after all workers terminate, and publishes one stable
                  ;; quiescence acknowledgement.
@@ -908,28 +980,31 @@
                                cleanup-error)))
              (when (run/cancel-requested? id)
                (cancelled! id))
-             (case status
-               :completed
-               (let [output (d/reply (:agent/id agent) run-sink
-                                     (result-content value) trigger
-                                     {:role :assistant :run-id id})]
+             (let [llm-metrics (:llm-metrics @(:state supervisor))]
+               (case status
+                 :completed
+                 (let [output (d/reply (:agent/id agent) run-sink
+                                       (result-content value) trigger
+                                       {:role :assistant :run-id id})]
                  ;; Room posting is durability-first. Completion is acknowledged
                  ;; only after the correlated private output exists.
-                 (d/post! control-room output)
-                 {:result {:run/id id
-                           :run/status :completed
-                           :run/value value
-                           :run/output output}
-                  :finish-opts {}})
+                   (d/post! control-room output)
+                   {:result (cond-> {:run/id id
+                                     :run/status :completed
+                                     :run/value value
+                                     :run/output output}
+                              llm-metrics (assoc :run/metrics llm-metrics))
+                    :finish-opts {}})
 
-               :waiting
-               {:result {:run/id id :run/status :waiting :run/reason reason}
-                :finish-opts {:reason reason}}
+                 :waiting
+                 {:result (cond-> {:run/id id :run/status :waiting :run/reason reason}
+                            llm-metrics (assoc :run/metrics llm-metrics))
+                  :finish-opts {:reason reason}}
 
-               (throw (ex-info "Interpreter returned an unknown program status"
-                               {:type ::unknown-program-status
-                                :status status
-                                :agent/id (:agent/id agent)}))))
+                 (throw (ex-info "Interpreter returned an unknown program status"
+                                 {:type ::unknown-program-status
+                                  :status status
+                                  :agent/id (:agent/id agent)})))))
            (catch Throwable t
              (let [cancelled? (cancelled-error? t id)
                    graph-cancelled? (graph-cancelled-error? t)
@@ -951,13 +1026,16 @@
                    ;; still valid, so it returns an ordinary cancelled result.
                    (sp/await quiesced)
                    (let [cleanup-error (:cleanup-error @(:state supervisor))
-                         error (or cleanup-error t)]
+                         error (or cleanup-error t)
+                         llm-metrics (:llm-metrics @(:state supervisor))]
                      (if (and cancelled? (nil? cleanup-error))
-                       {:result {:run/id id :run/status :cancelled}
+                       {:result (cond-> {:run/id id :run/status :cancelled}
+                                  llm-metrics (assoc :run/metrics llm-metrics))
                         :finish-opts {:reason :cancel-requested}}
-                       {:result {:run/id id
-                                 :run/status :failed
-                                 :run/error (ex-message error)}
+                       {:result (cond-> {:run/id id
+                                         :run/status :failed
+                                         :run/error (ex-message error)}
+                                  llm-metrics (assoc :run/metrics llm-metrics))
                         :finish-opts {:reason (if cleanup-error
                                                 :cleanup-error
                                                 :program-error)
@@ -984,13 +1062,14 @@
    - `:task`       portable task value (required)
    - `:from`       triggering actor, default `:repl`
    - `:parent-run` explicit structural parent Run UUID
-   - `:settlement`  `:automatic` (default), `:review`, or `:discard`
+   - `:settlement`  `:automatic` (default), `:review`, `:discard`, or host-owned `:deferred`
    - `:resources`   positive conserved vector split from the parent Run/Room
+   - `:limits`      restrictive LLM `:max-model-steps` / `:budget-dollars`
    Built-in program kinds are deterministic `:scripted` / `:echo` and the
    bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
    interpreters implement the same boundary."
   [control-room world-parent roster agent-ref
-   {:keys [task from parent-run settlement resources]
+   {:keys [task from parent-run settlement resources limits]
     :or {from :repl settlement :automatic}
     :as raw-opts}]
   (let [opts      (assoc raw-opts :from from)
@@ -1054,7 +1133,7 @@
       (let [completion (sync/deferred)
             outcome-promise (promise)
             worker-execution (execution-spin control-room work-room agent task trigger id chat-id
-                                             supervisor outcome-promise)
+                                             supervisor limits outcome-promise)
             execution (sp/spin (sp/await completion))
             owner-fork-id (:fork-id (ec/current-execution-context))
             handle    (RunHandle. id (:id control-room) owner-fork-id execution completion

--- a/src/dvergr/agent/room_context.clj
+++ b/src/dvergr/agent/room_context.clj
@@ -31,7 +31,8 @@
             [org.replikativ.spindel.engine.core :as ec]
             [taoensso.telemere :as tel]))
 
-;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set}
+;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set
+;;                       :execution-ctx ExecutionContext :sandbox-opts map}
 (defonce ^:private room-agent-ctxs (atom {}))
 
 (defn room-system-id
@@ -92,8 +93,23 @@
            (catch Throwable _ nil))
       (some-> from name)))
 
+(defn- append-inbound-to!
+  [chat-ctx seen msg-id role content author ts reasoning]
+  (when (.add ^java.util.Set seen msg-id)
+    (let [decorated (if (and author (not= :system role))
+                      (str "[" author (when-let [t (fmt-clock ts)] (str " · " t)) "] " content)
+                      content)]
+      (append-signal-only! chat-ctx (cond-> {:role role :content decorated}
+                                      (seq reasoning) (assoc :reasoning reasoning))))
+    true))
+
 (defn append-inbound!
-  "Append one inbound conversational message to the (room, agent) ctx's signal,
+  "Append one inbound conversational message to the (room, agent) ctx's signal.
+
+   `room-or-id` should be the Room for lifecycle-safe admission during first
+   hydration; the id form remains for callers that target an already-published
+   cache entry.
+
    EXACTLY ONCE (deduped by `msg-id` via the entry's synchronized set). Used by
    the attention interpreter. Signal-only (the room store already holds it
    durably). Returns true if appended.
@@ -101,20 +117,28 @@
    `author` is the sender's display label (nil for the agent's own messages); when
    present the content is prefixed `[author · HH:mm]` so the agent knows WHO spoke
    and WHEN — essential in multi-party rooms where roles alone are ambiguous."
-  ([room-id agent-id msg-id role content author ts]
-   (append-inbound! room-id agent-id msg-id role content author ts nil))
-  ([room-id agent-id msg-id role content author ts reasoning]
-   (when-let [{:keys [chat-ctx seen]} (get @room-agent-ctxs [room-id agent-id])]
-     (when (.add ^java.util.Set seen msg-id)
-       (let [decorated (if (and author (not= :system role))
-                         (str "[" author (when-let [t (fmt-clock ts)] (str " · " t)) "] " content)
-                         content)]
-         ;; `reasoning` (the agent's OWN prior <think> trace) rides along so
-         ;; reasoning models keep it across a rehydrate — see create-message-entity
-         ;; (:reasoning → :message/reasoning) + messages->api-format.
-         (append-signal-only! chat-ctx (cond-> {:role role :content decorated}
-                                         (seq reasoning) (assoc :reasoning reasoning))))
-       true))))
+  ([room-or-id agent-id msg-id role content author ts]
+   (append-inbound! room-or-id agent-id msg-id role content author ts nil))
+  ([room-or-id agent-id msg-id role content author ts reasoning]
+   (let [room? (map? room-or-id)
+         room-id (if room? (:id room-or-id) room-or-id)
+         k [room-id agent-id]
+         room-meta (or (when room? (:meta room-or-id))
+                       (:room-meta (get @room-agent-ctxs k)))]
+     (when room-meta
+       ;; Admission may race first hydration. Sharing the lifecycle fence makes
+       ;; the append wait for the fully seeded cache publication instead of
+       ;; observing an absent/partial entry and dropping a durable attention fact.
+       (locking room-meta
+         (binding [ec/*execution-context* (if room?
+                                            (:ctx room-or-id)
+                                            ec/*execution-context*)]
+           (when (or (not room?) (rreg/admitted-incarnation? room-or-id))
+             (when-let [{:keys [chat-ctx seen]} (get @room-agent-ctxs k)]
+               ;; `reasoning` (the agent's OWN prior <think> trace) rides along so
+               ;; reasoning models keep it across a rehydrate — see create-message-entity
+               ;; (:reasoning → :message/reasoning) + messages->api-format.
+               (append-inbound-to! chat-ctx seen msg-id role content author ts reasoning)))))))))
 
 (defn raise-budget!
   "Set the live budget :total on every cached agent ctx of `room-id` to
@@ -134,6 +158,97 @@
             0
             @room-agent-ctxs)))
 
+(defn- hydration-messages!
+  "Complete all fallible durable hydration before allocating live signals.
+
+   Attention baseline writes are deterministic/idempotent, so an interrupted
+   attempt can retry. The returned messages are pure data ready to project into
+   a newly constructed ChatContext without further store access."
+  [room agent-id limit]
+  (let [messages (d/messages room {:limit (or limit 100)})
+        attention-store? (satisfies? rstore/PAttentionStore (:store room))
+        conversation-id (d/conversation-id room)
+        baseline-message-id
+        (rstore/attention-id conversation-id agent-id nil nil
+                             :legacy-baseline-message)
+        baseline-marker-id
+        (rstore/attention-id conversation-id agent-id baseline-message-id
+                             nil :legacy-baseline-complete)
+        baseline-complete?
+        (and attention-store?
+             (seq (rstore/-list-attention (:store room)
+                                          conversation-id
+                                          {:id baseline-marker-id})))
+        ;; Upgrade cutover: pre-attention rooms already have Runs but no
+        ;; participant projection. Materialize their exact provider baseline
+        ;; before any new policy decision can make the projection non-empty.
+        _ (when (and attention-store? (not baseline-complete?))
+            (doseq [m messages :when (conversational? m)]
+              (let [decision-id
+                    (rstore/attention-id conversation-id agent-id (:id m) nil
+                                         :legacy-baseline-decision)
+                    common {:attention/participant agent-id
+                            :attention/message-id (:id m)
+                            :attention/memory :include
+                            :attention/activation :none
+                            :attention/control :continue
+                            :attention/at :now
+                            :attention/priority 0.0
+                            :attention/reason :migration/provider-baseline
+                            :attention/created-at
+                            (java.util.Date. (long (or (:ts m)
+                                                       (System/currentTimeMillis))))}]
+                (rstore/-store-attention!
+                 (:store room) conversation-id
+                 (assoc common
+                        :attention/id decision-id
+                        :attention/status :ready))
+                (rstore/-store-attention!
+                 (:store room) conversation-id
+                 (assoc common
+                        :attention/id
+                        (rstore/attention-id conversation-id agent-id (:id m) nil
+                                             :legacy-baseline-applied)
+                        :attention/decision-id decision-id
+                        :attention/status :applied))))
+            ;; Written last. If any prior write fails, the next hydration
+            ;; retries every deterministic pair and completes the cutover.
+            (rstore/-store-attention!
+             (:store room) conversation-id
+             {:attention/id baseline-marker-id
+              :attention/participant agent-id
+              :attention/message-id baseline-message-id
+              :attention/status :baseline-complete
+              :attention/reason :migration/provider-baseline
+              :attention/created-at (java.util.Date.)}))
+        attention-facts
+        (if attention-store?
+          (rstore/-list-attention (:store room)
+                                  conversation-id
+                                  {:participant agent-id :limit 1000})
+          [])
+        ;; Admission is monotone: once a fact entered provider context (most
+        ;; notably when queued work becomes a Run trigger), a later observation
+        ;; cannot silently erase it. Deliberate forgetting is compaction policy.
+        included-message-ids
+        (into #{}
+              (keep #(when (and (= :applied (:attention/status %))
+                                (= :include (:attention/memory %)))
+                       (:attention/message-id %)))
+              attention-facts)
+        agent-runs (run/runs room {:actor agent-id :limit 1000})
+        trigger-ids (into #{} (map :run/trigger) agent-runs)
+        ;; Ephemeral/custom stores without the projection retain historical
+        ;; full-transcript behavior for compatibility.
+        legacy-history? (not attention-store?)]
+    (into []
+          (filter #(and (conversational? %)
+                        (or (= agent-id (:from %))
+                            (contains? included-message-ids (:id %))
+                            (contains? trigger-ids (:id %))
+                            legacy-history?)))
+          messages)))
+
 (defn ensure-ctx!
   "Get-or-create the long-lived working chat-ctx for `agent-id` in `room`.
 
@@ -143,164 +258,155 @@
   [room agent-id {:keys [system-prompt budget-dollars limit]}]
   (let [room-id (:id room)
         k       [room-id agent-id]]
-    (or (:chat-ctx (get @room-agent-ctxs k))
-        (binding [ec/*execution-context* (:ctx room)]
-          (let [;; The room's system-db UUID — the key the system resolvers
+    ;; Room forking and unregister hold the same monitor. Cache reads belong
+    ;; inside it too: a returned handle must remain live through this boundary.
+    (locking (:meta room)
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [_ (when-not (rreg/admitted-incarnation? room)
+                  (throw (ex-info "Working context requested for a closed Room incarnation"
+                                  {:type ::closed-room
+                                   :room-id room-id
+                                   :room/incarnation (:incarnation room)})))]
+          (or (:chat-ctx (get @room-agent-ctxs k))
+              (let [;; The room's system-db UUID — the key the system resolvers
                 ;; (room-kb-conn / room-kbs / room-msgs) want; distinct from the
                 ;; in-memory keyword `room-id`. Threads to the sandbox so `dvergr.room`
                 ;; + the guarded `d/connect`/`list-databases` resolve THIS room's
                 ;; fork-aware databases.
-                room-uuid (room-system-id room)
-                cctx (turn/new-working-ctx
-                      {:execution-ctx  (:ctx room)
-                       :chat-id        (stable-chat-id room-id agent-id)
-                       :title          (str (name agent-id) "-" (name room-id))
-                       :budget-dollars budget-dollars
+                    room-uuid (room-system-id room)
+                    sandbox-opts
+                    {:execution-ctx  (:ctx room)
+                     :chat-id        (stable-chat-id room-id agent-id)
+                     :title          (str (name agent-id) "-" (name room-id))
+                     :budget-dollars budget-dollars
                         ;; RF5 S4: the cost ledger (account-usage!) writes to THIS
                         ;; room's own msgs store — per-room, fork-aware — not the
                         ;; legacy chat-db. nil ⇒ create-chat-context auto-resolves
                         ;; (room-less fallback only).
-                       :db-conn        (some-> room :store :conn)
+                     :db-conn        (some-> room :store :conn)
                         ;; The agent's sandbox reaches its room's OWN knowledge base
                         ;; (fork-aware) through `dvergr.room/*kb*` — resolved here
                         ;; under the room's bound ctx (so a fork hands the branched
                         ;; KB). nil for room-less ctxs. The sandbox must NEVER touch
                         ;; system-db for knowledge; this is how the room KB gets in.
-                       :kb-conn        (some-> room-uuid srooms/room-kb-conn)
-                       :room-id        room-uuid
+                     :kb-conn        (some-> room-uuid srooms/room-kb-conn)
+                     :room-id        room-uuid
                        ;; Room registry identity is distinct from the system-db
                        ;; UUID above. SCI's agent-programming surface needs the
                        ;; former so a hired agent can recursively hire into this
                        ;; exact live Room, including an ephemeral fork.
-                       :room-runtime-id room-id
-                       :room-incarnation (:incarnation room)
+                     :room-runtime-id room-id
+                     :room-incarnation (:incarnation room)
                         ;; Per-agent network egress scope: an actor's optional
                         ;; `:config {:allowed-domains #{"https://…"}}` restricts the
                         ;; sandbox `http` primitive (nil/empty ⇒ open).
-                       :allowed-domains (some-> (actors/lookup (sdb/get-conn) agent-id)
-                                                :config :allowed-domains)
+                     :allowed-domains (some-> (actors/lookup (sdb/get-conn) agent-id)
+                                              :config :allowed-domains)
                         ;; The room store (bus→store listener) is the single durable
                         ;; writer for this conversation; the agent's own turn messages
                         ;; stay signal-only (no redundant datahike write). Token
-                        ;; accounting still persists.
-                       :durable?       false})
-                seen (java.util.Collections/synchronizedSet (java.util.HashSet.))]
-            ;; Register before seeding so append-inbound! finds the entry.
-            (swap! room-agent-ctxs assoc k {:chat-ctx cctx :seen seen})
+                     ;; accounting still persists.
+                     :durable?       false}
+                    messages (hydration-messages! room agent-id limit)
+                    cctx (turn/new-working-ctx sandbox-opts)
+                    bound-sandbox-opts (assoc sandbox-opts
+                                              :capability-id (:capability-id cctx))
+                    seen (java.util.Collections/synchronizedSet (java.util.HashSet.))
+                    entry {:chat-ctx cctx
+                           :seen seen
+                           :execution-ctx (:ctx room)
+                           :room-meta (:meta room)
+                           :sandbox-opts bound-sandbox-opts}]
+                (try
             ;; System prompt once, then seed the conversation from the store.
             ;; Signal-only: the prompt is regenerated each session, not durable.
-            (when system-prompt
-              (append-signal-only! cctx {:role :system :content system-prompt}))
-            ;; Seed the conversation from ONE query: `d/messages` reads the room's
-            ;; (for a fork, branched) store under the conversation :chat/id, so a
-            ;; fork already returns inherited (pre-fork) + its own messages — the
-            ;; agent sees exactly what the UI seeds. (doc/unified-fork-conversation.md)
-            (let [messages (d/messages room {:limit (or limit 100)})
-                  attention-store? (satisfies? rstore/PAttentionStore (:store room))
-                  conversation-id (d/conversation-id room)
-                  baseline-message-id
-                  (rstore/attention-id conversation-id agent-id nil nil
-                                       :legacy-baseline-message)
-                  baseline-marker-id
-                  (rstore/attention-id conversation-id agent-id baseline-message-id
-                                       nil :legacy-baseline-complete)
-                  baseline-complete?
-                  (and attention-store?
-                       (seq (rstore/-list-attention (:store room)
-                                                    conversation-id
-                                                    {:id baseline-marker-id})))
-                  ;; Upgrade cutover: pre-attention rooms already have Runs but
-                  ;; no participant projection. Materialize their exact current
-                  ;; provider baseline before any new policy decision can make
-                  ;; the projection non-empty. This is append-only and
-                  ;; idempotent by deterministic identity.
-                  _ (when (and attention-store? (not baseline-complete?))
-                      (doseq [m messages :when (conversational? m)]
-                        (let [decision-id
-                              (rstore/attention-id conversation-id agent-id (:id m) nil
-                                                   :legacy-baseline-decision)
-                              common {:attention/participant agent-id
-                                      :attention/message-id (:id m)
-                                      :attention/memory :include
-                                      :attention/activation :none
-                                      :attention/control :continue
-                                      :attention/at :now
-                                      :attention/priority 0.0
-                                      :attention/reason :migration/provider-baseline
-                                      :attention/created-at
-                                      (java.util.Date. (long (or (:ts m)
-                                                                 (System/currentTimeMillis))))}]
-                          (rstore/-store-attention!
-                           (:store room) conversation-id
-                           (assoc common
-                                  :attention/id decision-id
-                                  :attention/status :ready))
-                          (rstore/-store-attention!
-                           (:store room) conversation-id
-                           (assoc common
-                                  :attention/id
-                                  (rstore/attention-id conversation-id agent-id (:id m) nil
-                                                       :legacy-baseline-applied)
-                                  :attention/decision-id decision-id
-                                  :attention/status :applied))))
-                      ;; Written last. If any prior write fails, the next
-                      ;; hydration retries every deterministic pair and then
-                      ;; completes the cutover.
-                      (rstore/-store-attention!
-                       (:store room) conversation-id
-                       {:attention/id baseline-marker-id
-                        :attention/participant agent-id
-                        :attention/message-id baseline-message-id
-                        :attention/status :baseline-complete
-                        :attention/reason :migration/provider-baseline
-                        :attention/created-at (java.util.Date.)}))
-                  attention-facts
-                  (if attention-store?
-                    (rstore/-list-attention (:store room)
-                                            conversation-id
-                                            {:participant agent-id :limit 1000})
-                    [])
-                  included-message-ids
-                  ;; Admission is monotone: once a fact entered provider
-                  ;; context (most notably when queued work becomes a Run
-                  ;; trigger), a later observation cannot silently erase it.
-                  ;; Deliberate forgetting belongs to compaction/context policy,
-                  ;; not to attention races.
-                  (into #{}
-                        (keep #(when (and (= :applied (:attention/status %))
-                                          (= :include (:attention/memory %)))
-                                 (:attention/message-id %)))
-                        attention-facts)
-                  agent-runs (run/runs room {:actor agent-id :limit 1000})
-                  trigger-ids (into #{} (map :run/trigger) agent-runs)
-                  ;; Ephemeral/custom stores without the projection retain the
-                  ;; historical full-transcript behavior for compatibility.
-                  legacy-history? (not attention-store?)]
-              (doseq [m messages]
-                (when (and (conversational? m)
-                           (or (= agent-id (:from m))
-                               (contains? included-message-ids (:id m))
-                               (contains? trigger-ids (:id m))
-                               legacy-history?))
-                  (append-inbound! room-id agent-id (:id m)
-                                   (or (:role m) (if (= agent-id (:from m)) :assistant :user))
-                                   (:content m)
-                                 ;; author nil for the agent's OWN past messages
-                                   (when (not= agent-id (:from m)) (display-name room (:from m)))
-                                   (:ts m)
-                                 ;; feed back only the agent's OWN prior reasoning,
-                                 ;; not another participant's <think>
-                                   (when (= agent-id (:from m)) (:reasoning m))))))
-            (tel/log! {:level :debug :id ::created
-                       :data {:room room-id :agent agent-id
-                              :seeded (count (chat-ctx/get-messages cctx))}})
-            cctx)))))
+                  (when system-prompt
+                    (append-signal-only! cctx {:role :system :content system-prompt}))
+                  ;; Durable hydration above completed before signal allocation.
+                  ;; Project the staged pure messages into the fresh context.
+                  (doseq [m messages]
+                    (append-inbound-to! cctx seen (:id m)
+                                        (or (:role m) (if (= agent-id (:from m)) :assistant :user))
+                                        (:content m)
+                                        ;; author nil for the agent's own history
+                                        (when (not= agent-id (:from m))
+                                          (display-name room (:from m)))
+                                        (:ts m)
+                                        ;; feed back only the agent's own reasoning
+                                        (when (= agent-id (:from m)) (:reasoning m))))
+                  (tel/log! {:level :debug :id ::created
+                             :data {:room room-id :agent agent-id
+                                    :seeded (count (chat-ctx/get-messages cctx))}})
+                  ;; Publication is the commit point. Before this swap, no
+                  ;; concurrent fast path can observe partially hydrated state.
+                  (swap! room-agent-ctxs assoc k entry)
+                  cctx
+                  (catch Throwable error
+                    (try
+                      (chat-ctx/release-sci-in! cctx (:ctx room))
+                      (catch Throwable cleanup-error
+                        (.addSuppressed error cleanup-error)))
+                    (throw error))))))))))
+
+(defn fork-ctx!
+  "Project an existing parent room/agent working context into `child-room`.
+
+   Yggdrasil has already forked the Spindel world, including the ChatContext's
+   signals and SCI component. The child facade replaces persistence and ambient
+   capabilities without reconstructing the interpreter or replaying history;
+   provider admission remains exclusively controlled by attention."
+  [parent-room child-room agent-id]
+  (let [parent-k [(:id parent-room) agent-id]
+        child-k [(:id child-room) agent-id]]
+    (when-let [{:keys [chat-ctx seen sandbox-opts]} (get @room-agent-ctxs parent-k)]
+      (or (:chat-ctx (get @room-agent-ctxs child-k))
+          (when (try
+                  (chat-ctx/sci-context-in chat-ctx (:ctx child-room))
+                  true
+                  (catch clojure.lang.ExceptionInfo _ false))
+            (let [room-uuid (binding [ec/*execution-context* (:ctx child-room)]
+                              (room-system-id child-room))
+                  child-opts (assoc sandbox-opts
+                                    :execution-ctx (:ctx child-room)
+                                    :db-conn (some-> child-room :store :conn)
+                                    :kb-conn (some-> room-uuid srooms/room-kb-conn)
+                                    :room-id room-uuid
+                                    :room-runtime-id (:id child-room)
+                                    :room-incarnation (:incarnation child-room)
+                                    :fork-projection? true
+                                    :capability-id (:capability-id chat-ctx))
+                  projected (assoc chat-ctx
+                                   :spindel-ctx (:ctx child-room)
+                                   :db-conn (some-> child-room :store :conn))
+                  _ (turn/rebind-working-ctx! projected child-opts)
+                  child-seen (java.util.Collections/synchronizedSet
+                              (locking seen
+                                (java.util.HashSet. ^java.util.Collection seen)))
+                  entry {:chat-ctx projected
+                         :seen child-seen
+                         :execution-ctx (:ctx child-room)
+                         :room-meta (:meta child-room)
+                         :sandbox-opts child-opts}]
+              (swap! room-agent-ctxs
+                     (fn [m]
+                       (if (contains? m child-k) m (assoc m child-k entry))))
+              (:chat-ctx (get @room-agent-ctxs child-k))))))))
+
+(defn- drop-entry! [room-id agent-id]
+  (when-let [{:keys [chat-ctx execution-ctx]}
+             (get @room-agent-ctxs [room-id agent-id])]
+    (when chat-ctx
+      (try (chat-ctx/release-sci-in! chat-ctx
+                                     (or execution-ctx (:spindel-ctx chat-ctx)))
+           (catch Throwable _ nil)))
+    (swap! room-agent-ctxs dissoc [room-id agent-id])))
 
 (defn drop-ctx!
   "Tear down the (room, agent) provider projection."
   [room-id agent-id]
-  (when (get @room-agent-ctxs [room-id agent-id])
-    (swap! room-agent-ctxs dissoc [room-id agent-id]))
+  (if-let [room-meta (:room-meta (get @room-agent-ctxs [room-id agent-id]))]
+    (locking room-meta (drop-entry! room-id agent-id))
+    (drop-entry! room-id agent-id))
   nil)
 
 (defn drop-room!
@@ -309,6 +415,19 @@
   (doseq [[rid aid] (keys @room-agent-ctxs)
           :when (= rid room-id)]
     (drop-ctx! rid aid))
+  nil)
+
+(defn- close-room-contexts!
+  "Fence one registered Room incarnation against further context access.
+
+   Runs as a pre-unregister hook while the Room is still authoritative. The
+   shared monitor makes the closed marker and complete component teardown one
+   lifecycle transition, so a stale caller cannot publish after cleanup."
+  [room]
+  (locking (:meta room)
+    (doseq [[rid aid] (keys @room-agent-ctxs)
+            :when (= rid (:id room))]
+      (drop-entry! rid aid)))
   nil)
 
 (defn clear-all!
@@ -324,6 +443,7 @@
   [room-id agent-id]
   (:chat-ctx (get @room-agent-ctxs [room-id agent-id])))
 
-;; Tear down a room's cached ctxs whenever it leaves the registry (room delete,
-;; fork discard) — one hook covers all teardown paths. Idempotent across reload.
-(rreg/add-unregister-hook! ::drop-room drop-room!)
+;; Fence + tear down before registry removal. Keeping this in the lifecycle
+;; transaction prevents stale scheduler/MCP callers from recreating a component
+;; after a post-unregister key snapshot.
+(rreg/add-pre-unregister-hook! ::close-room-contexts close-room-contexts!)

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -212,6 +212,43 @@
        (notify! {:type :run/started :run run}))
      run)))
 
+(defn record-cause!
+  "Durably add `cause-run-id` to the causal inputs observed by a live Run.
+
+   Structural ownership remains in `:run/parent`; this cardinality-many edge
+   records that `run-id` actually crossed the completion boundary of another
+   Run. Both Runs must have a store, and the cause must already be durable and
+   terminal in that same Room store. Parallel
+   observations serialize through the lifecycle lock, so additions cannot
+   overwrite one another."
+  [run-id cause-run-id]
+  (when-not (and (uuid? run-id) (uuid? cause-run-id) (not= run-id cause-run-id))
+    (throw (ex-info "Run causality requires two distinct Run UUIDs"
+                    {:type ::invalid-cause
+                     :run/id run-id
+                     :cause-run/id cause-run-id})))
+  (locking lifecycle-lock
+    (let [entry (or (get @active run-id)
+                    (throw (ex-info "Causal consumer Run is not live"
+                                    {:type ::run-not-active :run/id run-id})))
+          room-store (:store entry)
+          store-room-id (:store-room-id entry)]
+      (when-not room-store
+        (throw (ex-info "Durable Run causality requires a Room store"
+                        {:type ::causal-store-required :run/id run-id})))
+      (let [now (java.util.Date.)
+            updated (-> (:run entry)
+                        (update :run/caused-by (fnil conj #{}) cause-run-id)
+                        (assoc :run/updated-at now))]
+        (when room-store
+          (when-not (store/-store-run! room-store store-room-id updated)
+            (throw (ex-info "Run causality update was not durable"
+                            {:type ::cause-not-durable
+                             :run/id run-id
+                             :cause-run/id cause-run-id}))))
+        (swap! active assoc-in [run-id :run] updated)
+        updated))))
+
 (defn finish!
   "End the live execution and persist its final/waiting projection. Idempotent
    after the live entry has gone. `:waiting` has no ended-at; terminal states do."

--- a/src/dvergr/agent/tool_commands.clj
+++ b/src/dvergr/agent/tool_commands.clj
@@ -21,6 +21,7 @@
   (:require [clojure.string :as str]
             [dvergr.discourse.commands :as commands]
             [dvergr.agent.room-context :as room-context]
+            [dvergr.chat.context :as chat-context]
             [dvergr.tools :as tools]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -72,7 +73,8 @@
                 (let [tool     (get @tools/registry tool-name)
                       tool-ctx (tools/make-context
                                 {:chat-ctx      cc
-                                 :sci-ctx       (:sci-ctx cc)   ; the agent's OWN session
+                                 :sci-ctx       (chat-context/sci-context-in
+                                                 cc (:ctx room)) ; fork-selected session
                                  :db-conn       (:db-conn cc)
                                  :tools         {tool-name tool} ; allowlist = just this tool
                                  :isolation     :sci

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -16,6 +16,7 @@
             [dvergr.discourse :as d]
             [dvergr.chat.context :as chat-ctx]
             [dvergr.agent.run :as run]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.io :as ns-io]
             ;; loaded so add-process-ns! can (find-ns 'dvergr.agent.process)
@@ -35,6 +36,41 @@
 ;; each room's own stores fork-aware off the registry (RF5 S4 — there is no shared
 ;; chat-db). Callers pass the room/agent execution-ctx; setup binds it.
 ;; ----------------------------------------------------------------------------
+(defn rebind-working-ctx!
+  "Refresh the world binding and namespace surface in a working context.
+
+   SCI forks copy the interpreter heap, including host function objects.  Those
+   Injected host functions are stable indirections through `capability-id`, so
+   even functions saved before a fork select the child binding. Namespace
+   refresh keeps newly added APIs visible; it is not the isolation boundary."
+  [cctx {:keys [execution-ctx db-conn kb-conn room-id room-runtime-id
+                room-incarnation capability-id fork-projection?
+                agent-program-ceiling allowed-domains]}]
+  (let [capability-id (or capability-id (:capability-id cctx)
+                          (throw (ex-info "Working context has no capability identity" {})))]
+    (runtime-ctx/install-sandbox-binding!
+     execution-ctx capability-id
+     (cond-> {:capability-id capability-id
+              :room-id room-id
+              :room-runtime-id room-runtime-id
+              :room-incarnation room-incarnation}
+       fork-projection? (assoc :ephemeral-databases {})))
+    (binding [rtc/*execution-context* execution-ctx]
+      (when-let [sci (chat-ctx/sci-context-in cctx execution-ctx)]
+        (sandbox/setup-agent-namespaces! sci execution-ctx
+                                         :room-conn db-conn :kb-conn kb-conn :room-id room-id
+                                         :room-runtime-id room-runtime-id
+                                         :room-incarnation room-incarnation
+                                         :capability-id capability-id
+                                         :agent-program-ceiling agent-program-ceiling
+                                         :allowed-http-domains allowed-domains)
+      ;; These capabilities close over the ChatContext itself, so a projected
+      ;; child facade must replace them as well.
+        (ns-io/add-bash-ns!    sci cctx)
+        (ns-io/add-media-ns!   sci cctx)
+        (ns-io/add-process-ns! sci cctx)))
+    cctx))
+
 (defn new-working-ctx
   "Create a ChatContext whose SCI sandbox has the ctx-bound agent namespaces
    injected (dh/room/intake/search/…). Does NOT seed a system prompt — callers do
@@ -43,40 +79,42 @@
    datahike-write behaviour (room folds pass false: the room store is the durable
    writer). Returns the ChatContext."
   [{:keys [execution-ctx chat-id title budget-dollars db-conn kb-conn room-id
-           room-runtime-id room-incarnation agent-program-ceiling durable? allowed-domains]}]
+           room-runtime-id room-incarnation capability-id agent-program-ceiling
+           durable? allowed-domains]}]
   (binding [rtc/*execution-context* execution-ctx]
-    (let [cctx (cond-> (chat-ctx/create-chat-context
-                        (cond-> {:budget-dollars (or budget-dollars 1.0)
-                                 :db-conn        db-conn
-                                 :with-sci?      true
-                                 :title          (or title "agent")}
-                          chat-id (assoc :chat-id chat-id)))
-                 (some? durable?) (assoc :durable? durable?)
+    (let [capability-id (or capability-id (random-uuid))
+          cctx (assoc (cond-> (chat-ctx/create-chat-context
+                               (cond-> {:budget-dollars (or budget-dollars 1.0)
+                                        :db-conn        db-conn
+                                        :with-sci?      true
+                                        :title          (or title "agent")}
+                                 chat-id (assoc :chat-id chat-id)))
+                        (some? durable?) (assoc :durable? durable?)
                  ;; the ctx knows its room: embedder hooks (e.g. the bash
                  ;; mount provider) resolve room-scoped resources from it
-                 room-id (assoc :room-id room-id))]
+                        room-id (assoc :room-id room-id))
+                      :capability-id capability-id)]
       ;; create-chat-context forks a sci-ctx but does NOT inject the ctx-bound
       ;; namespaces — do it here so clojure_eval has the room/kb/intake nses
       ;; everywhere. `db-conn` is the room's OWN messages store (= `*room*`);
       ;; `kb-conn` its OWN knowledge base (= `*kb*`) — both fork-aware, never sdb.
-      (when-let [sci (:sci-ctx cctx)]
-        (sandbox/setup-agent-namespaces! sci execution-ctx
-                                         :room-conn db-conn :kb-conn kb-conn :room-id room-id
-                                         :room-runtime-id room-runtime-id
-                                         :room-incarnation room-incarnation
-                                         :agent-program-ceiling agent-program-ceiling
-                                         ;; per-agent network egress scoping (nil/empty = open)
-                                         :allowed-http-domains allowed-domains)
-        ;; Two namespaces bound to THIS chat-ctx (not just the spindel ctx), so
-        ;; they can't live in setup-agent-namespaces!: `bash` (the muschel shell
-        ;; session this chat-ctx owns — same one the `shell` tool drives) and
-        ;; `processes` (the turn process registry — list/snapshot/directive! the
-        ;; agent's own work). The daemon path wired these per-turn; now every
-        ;; working ctx gets them at creation.
-        (ns-io/add-bash-ns!    sci cctx)
-        (ns-io/add-media-ns!   sci cctx)
-        (ns-io/add-process-ns! sci cctx))
-      cctx)))
+      (try
+        (rebind-working-ctx! cctx {:execution-ctx execution-ctx
+                                   :db-conn db-conn :kb-conn kb-conn
+                                   :room-id room-id :room-runtime-id room-runtime-id
+                                   :room-incarnation room-incarnation
+                                   :capability-id capability-id
+                                   :agent-program-ceiling agent-program-ceiling
+                                   :allowed-domains allowed-domains})
+        cctx
+        (catch Throwable error
+          ;; Namespace/resource installation is part of construction. A caller
+          ;; must never receive—or lose track of—a half-bound interpreter.
+          (try
+            (chat-ctx/release-sci-in! cctx execution-ctx)
+            (catch Throwable cleanup-error
+              (.addSuppressed error cleanup-error)))
+          (throw error))))))
 
 ;; Reserved `:to` id for agent tool-activity messages posted into a room.
 ;; Nothing subscribes to it, so no participant (agent or egress) receives these

--- a/src/dvergr/agent/world.clj
+++ b/src/dvergr/agent/world.clj
@@ -7,7 +7,7 @@
    review, or discarded without rewriting its execution outcome."
   (:require [dvergr.discourse :as d]))
 
-(def settlement-policies #{:automatic :review :discard})
+(def settlement-policies #{:automatic :review :discard :deferred})
 
 (defrecord RunWorld [id parent work policy settlement])
 
@@ -51,11 +51,20 @@
   [world execution-status]
   (settle-once!
    world
+   ;; Deferred settlement is a generic two-phase gate. The work plane stays
+   ;; inspectable, but cannot be merged or adopted until its host policy
+   ;; explicitly releases it after verification/approval.
    (fn []
      (cond
        (#{:failed :cancelled} execution-status)
-       (do (d/discard (:work world))
+       (do ((if (= :deferred (:policy world))
+              d/discard-deferred
+              d/discard)
+            (:work world))
            {:status :discarded :reason execution-status})
+
+       (= :deferred (:policy world))
+       {:status :deferred :reason :policy}
 
        (= :waiting execution-status)
        {:status :review :reason :execution-waiting}

--- a/src/dvergr/artifact.clj
+++ b/src/dvergr/artifact.clj
@@ -1,0 +1,49 @@
+(ns dvergr.artifact
+  "Content-addressed storage for exact portable values.
+
+   Durable domain projections keep typed, queryable attributes in Datahike and
+   place open-ended immutable values behind these references. The default
+   implementation reuses Dvergr's blob CAS; tests and ephemeral stores may use
+   the in-memory implementation."
+  (:require [clojure.edn :as edn]
+            [dvergr.drive.blobs :as blobs])
+  (:import [java.nio.charset StandardCharsets]))
+
+(defprotocol PArtifactStore
+  (-put-value! [this value]
+    "Store one EDN value and return its immutable string content reference.")
+  (-get-value [this ref]
+    "Load the value named by `ref`, or nil when the content is unavailable."))
+
+(defn- encode [value]
+  (.getBytes (pr-str value) StandardCharsets/UTF_8))
+
+(defn- decode [bytes]
+  (edn/read-string (String. ^bytes bytes StandardCharsets/UTF_8)))
+
+(defrecord BlobArtifactStore []
+  PArtifactStore
+  (-put-value! [_ value]
+    (:blob/id (blobs/store! (encode value) "application/edn")))
+  (-get-value [_ ref]
+    (some-> (blobs/get-bytes ref) decode)))
+
+(defn blob-store [] (->BlobArtifactStore))
+
+(defrecord MemoryArtifactStore [values]
+  PArtifactStore
+  (-put-value! [_ value]
+    (let [bytes (encode value)
+          ref (blobs/sha256-hex bytes)]
+      (swap! values #(if (contains? % ref) % (assoc % ref value)))
+      ref))
+  (-get-value [_ ref]
+    (get @values ref)))
+
+(defn memory-store [] (->MemoryArtifactStore (atom {})))
+
+(defn put-value! [store value]
+  (-put-value! store value))
+
+(defn get-value [store ref]
+  (-get-value store ref))

--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -20,6 +20,7 @@
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.signal :as sig]
             [org.replikativ.spindel.core :as d]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.accounting :as acct]
             [dvergr.chat.persist :as persist]
@@ -48,8 +49,32 @@
             db-conn           ; Datahike connection for persistence
 
      ;; SCI (optional - for agent computation)
-            sci-ctx           ; SCI context for sandboxed eval
+            sci-component     ; stable ref; resolves to this world's SCI interpreter
             ])
+
+(defn sci-context-in
+  "Resolve `chat-ctx`'s SCI interpreter in explicit `execution-context`.
+
+   The ChatContext retains only a stable world-component reference. A forked
+   Spindel context therefore selects a forked interpreter instead of retaining
+   the parent's mutable SCI heap."
+  [chat-ctx execution-context]
+  (sandbox/sci-context-in execution-context (:sci-component chat-ctx)))
+
+(defn selected-execution-context
+  "The world selected for ChatContext signals and ambient capabilities.
+
+   A bound descendant wins; calls made outside execution fall back to the
+   context's owner. This keeps the ChatContext value stable while its signals
+   and SCI interpreter select fork-local realizations."
+  [chat-ctx]
+  (runtime-ctx/selected-context (:spindel-ctx chat-ctx)))
+
+(defn sci-context
+  "Resolve `chat-ctx`'s SCI interpreter in the bound world, falling back to
+   the ChatContext's owning world when called outside a Spindel binding."
+  [chat-ctx]
+  (sci-context-in chat-ctx (selected-execution-context chat-ctx)))
 ;; ============================================================================
 ;; Signal Accessors (must be called with spindel context bound)
 ;; ============================================================================
@@ -57,19 +82,19 @@
 (defn get-messages
   "Get current messages vector from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:messages-signal chat-ctx)))
 
 (defn get-budget
   "Get current budget map from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:budget-signal chat-ctx)))
 
 (defn get-status
   "Get current status from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:status-signal chat-ctx)))
 
 ;; ============================================================================
@@ -95,7 +120,7 @@
         ;; and a side effect in it would record an abandoned computation. The
         ;; transient `::just-crossed` key always reflects this call (nil if none).
         new-state
-        (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
           (swap! (:budget-signal chat-ctx)
                  (fn [{:keys [total used by-type crossed-thresholds]}]
                    (let [new-used (+ used cost)
@@ -149,7 +174,7 @@
   (let [msg-entity (schema/create-message-entity
                     (assoc message :chat-id (:chat-id chat-ctx)))]
     ;; Update spindel signal (reactive)
-    (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+    (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
       (swap! (:messages-signal chat-ctx) conj msg-entity))
 
     ;; Persist to datahike (durable) — UNLESS this ctx delegates durability to
@@ -191,7 +216,7 @@
      chat-ctx - ChatContext
      new-messages - Complete replacement message vector"
   [chat-ctx new-messages]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     (reset! (:messages-signal chat-ctx) (d/deltaable-vector (vec new-messages)))))
 
 (defn set-status!
@@ -201,7 +226,7 @@
      chat-ctx - ChatContext
      status - :active :paused :completed :cancelled :budget-exceeded"
   [chat-ctx status]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     (reset! (:status-signal chat-ctx) status))
 
   ;; Persist status change
@@ -268,7 +293,7 @@
        :budget-dollars - Budget in dollars (default $1.00)
        :budget - Legacy: budget in microdollars
        :db-path - Path for datahike (default in-memory, or uses Yggdrasil db if registered)
-       :with-sci? - Create SCI context (default true)
+       :with-sci? - Register a fork-selected SCI world component (default true)
 
    Yggdrasil Integration:
      If a DatahikeSystem is registered in the current execution context
@@ -290,9 +315,9 @@
    the unit of work isolation: when a room is forked via
    `d/fork-room :isolation :ctx`, yggdrasil's registered systems
    (git worktree, datahike branch) live on the fork's ctx. The
-   chat-ctx anchoring on that ctx means tools that consult
-   `(:spindel-ctx chat-ctx)` for the workspace see the fork's
-   worktree."
+   ChatContext retains a stable SCI component ref; callers resolve its
+   interpreter through `sci-context-in`, so a fork selects a fork-local heap
+   without reconstructing the interpreter."
   [{:keys [chat-id title budget-dollars budget db-path with-sci?
            db-conn execution-context]
     :or {budget-dollars 1.0
@@ -380,12 +405,6 @@
            :by-type {}
            :crossed-thresholds #{}})
 
-        ;; Create SCI context if requested
-        ;; When *execution-context* is bound, create spindel-backed SCI with
-        ;; full FRP support (spin/await/track). Otherwise plain SCI.
-        sci-ctx (when with-sci?
-                  (sandbox/fork-for-session rtc/*execution-context*))
-
         ;; Create signals within the owning execution context.
         [messages-signal budget-signal status-signal]
         (binding [rtc/*execution-context* spindel-ctx]
@@ -400,7 +419,13 @@
                          [(schema/create-chat-entity
                            {:id chat-id
                             :title (or title "Untitled Chat")
-                            :budget budget-microdollars})]))]
+                            :budget budget-microdollars})]))
+
+        ;; Allocate the process-local interpreter only after every fallible
+        ;; durable/signal initialization step. Once registered, no operation
+        ;; below can strand the component without returning its ChatContext.
+        sci-component (when with-sci?
+                        (sandbox/create-spindel-sci-world! spindel-ctx))]
 
     (->ChatContext
      chat-id
@@ -410,7 +435,7 @@
      budget-signal
      status-signal
      db-conn
-     sci-ctx)))
+     sci-component)))
 
 ;; ============================================================================
 ;; Chat Lifecycle
@@ -432,10 +457,26 @@
   [chat-ctx]
   (set-status! chat-ctx :cancelled))
 
+(defn release-sci-in!
+  "Release `chat-ctx`'s SCI realization from one execution world.
+
+   This is idempotent and does not close the chat's durable connection. Forked
+   room caches use it when a child world is discarded."
+  [chat-ctx execution-context]
+  (try
+    (sandbox/release-agent-resources! execution-context (:capability-id chat-ctx))
+    (finally
+      ;; Disposable-resource cleanup is best-effort with respect to component
+      ;; reachability: even an unexpected backend failure must not strand the
+      ;; interpreter in Spindel after its cache handle is removed.
+      (sandbox/release-spindel-sci-world!
+       execution-context (:sci-component chat-ctx)))))
+
 (defn close-chat!
   "Close chat and release resources."
   [chat-ctx]
   (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+    (release-sci-in! chat-ctx (:spindel-ctx chat-ctx))
     ;; Close datahike connection
     (when-let [conn (:db-conn chat-ctx)]
       (dh/release conn)))
@@ -506,7 +547,7 @@
       (replace-messages! chat-ctx messages))
     ;; Restore budget (overwrite the fresh budget with saved state)
     (when budget
-      (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+      (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
         (reset! (:budget-signal chat-ctx) budget)))
     ;; Restore status
     (when (and status (not= status :active))

--- a/src/dvergr/chat/persist.clj
+++ b/src/dvergr/chat/persist.clj
@@ -28,8 +28,12 @@
   "Apply the shared retry/dead-letter policy, returning the Datahike report on
    success and false after terminal failure."
   ([conn tx-data] (persist-tx-result! conn tx-data {}))
-  ([conn tx-data {:keys [op room-id msg-id] :as ctx}]
-   (letfn [(attempt [] (d/transact conn tx-data))]
+  ([conn tx-data {:keys [op room-id msg-id tx-meta] :as ctx}]
+   (letfn [(attempt []
+             (d/transact conn
+                         (if tx-meta
+                           {:tx-data tx-data :tx-meta tx-meta}
+                           tx-data)))]
      (try
        (attempt)
        (catch Throwable t1

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -605,6 +605,12 @@
     :db/index true
     :db/doc "Explicit structural parent that spawned/contains this run"}
 
+   {:db/ident :run/caused-by
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/many
+    :db/index true
+    :db/doc "Runs whose resolved results this run explicitly observed; unlike :run/parent, this is a causal dependency and may have many values"}
+
    {:db/ident :run/roster
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one
@@ -695,6 +701,174 @@
    {:db/ident :run/error
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one}])
+
+;; ============================================================================
+;; Verified Attempt Schema
+;; ============================================================================
+
+(def attempt-schema
+  "Immutable typed index for one trusted evaluation certification.
+
+   Exact EnvironmentDef, AgentDef, receipt, and evidence values live in the
+   content-addressed payload. Runs, messages, and checks remain typed joins so
+   benchmark and UI queries never need to scan opaque payloads."
+  [{:db/ident :attempt.writer/token
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/doc "One-use process-local capability attached to a trusted certification transaction"}
+
+   {:db/ident :attempt/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/chat
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/run
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value
+    :db/doc "Terminal root Run; exactly one trusted Attempt per Run"}
+
+   {:db/ident :attempt/content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value
+    :db/doc "Exact trusted AttemptReceipt content identity"}
+
+   {:db/ident :attempt/payload-blob
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc "Immutable CAS reference for exact EnvironmentDef, AgentDef, receipt, and evidence"}
+
+   {:db/ident :attempt/payload-codec
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/environment-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/environment-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/environment-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/verifier-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/verifier-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/provider
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/model
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/started-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/elapsed-ms
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/certified-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/reward
+    :db/valueType :db.type/double
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/agent-def-hash
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/program-kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/interpreter-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/prompt-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt/model-resolution
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/model-steps
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/evidence-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/evidence-runs
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/index true}
+
+   {:db/ident :attempt/evidence-messages
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/index true}
+
+   {:db/ident :attempt/settlement-intent
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt/checks
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/isComponent true}
+
+   {:db/ident :attempt.check/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :attempt.check/key
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :attempt.check/passed?
+    :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one
+    :db/index true}])
 
 ;; ============================================================================
 ;; Attention Schema
@@ -1164,6 +1338,7 @@
   (vec (concat chat-schema
                message-schema
                run-schema
+               attempt-schema
                attention-schema
                tool-call-schema
                ledger-schema

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -1167,20 +1167,22 @@
          ;; peer-bus events).
            new-id     (rstore/slug->room-id new-slug)
            parent-log (log room)
+           room*       (volatile! nil)
            fork-handle (when (= :ctx isolation)
                          (binding [ec/*execution-context* (:ctx room)]
                            (ygg/fork! (merge {:purpose :workroom
                                               :owner new-id}
-                                             fork-opts))))
-           child-ctx  (case isolation
-                        :none (:ctx room)
-                        :ctx  (:child-ctx fork-handle))
+                                             fork-opts))))]
+       (try
+         (let [child-ctx  (case isolation
+                            :none (:ctx room)
+                            :ctx  (:child-ctx fork-handle))
          ;; Mark a `:ctx` fork TRANSIENT so create-room-db! defers the GLOBAL
          ;; system-db grant (reconciled on merge / dropped on discard) — a fork's
          ;; agent-created DB must not resurrect on restart (P2).
-           _          (when (= :ctx isolation)
-                        (binding [ec/*execution-context* child-ctx]
-                          (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
+               _          (when (= :ctx isolation)
+                            (binding [ec/*execution-context* child-ctx]
+                              (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
          ;; `:isolation :ctx` forks BRANCH the parent's conversation. The fork
          ;; gets its OWN store wrapping the fork ctx's BRANCHED chat-db conn
          ;; (NOT the parent's fixed-conn store), and persists under the parent's
@@ -1188,73 +1190,135 @@
          ;; the same logical conversation on a datahike branch, and
          ;; merge-fork! collapses them natively (no append-log!). It writes
          ;; no separate :chat entity. (doc/unified-fork-conversation.md)
-           conv-id    (conversation-id room)
+               conv-id    (conversation-id room)
          ;; RF5: the fork's store wraps the PARENT room's OWN messages conn under
          ;; the fork ctx (branched), so fork messages ride the per-room store's
          ;; branch and merge-fork! collapses them natively. (RF5 S4.3: no
          ;; chat-db fallback — every room is provisioned with its own :msgs system.)
-           fork-store (when (= :ctx isolation)
-                        (some-> (binding [ec/*execution-context* child-ctx]
-                                  (srooms/msgs-conn-for-slug (:slug room)))
-                                store-dh/make))
+               fork-store (when (= :ctx isolation)
+                            (some-> (binding [ec/*execution-context* child-ctx]
+                                      (srooms/msgs-conn-for-slug (:slug room)))
+                                    store-dh/make))
          ;; Durability-first for the fork too: fork-local messages persist
          ;; onto the BRANCH (under the root conversation id) inside post!,
          ;; before visibility — replacing the fork's persistence listener.
-           child-bus  (bus-with-peer-relay child-ctx new-id :fork
-                                           (when fork-store
-                                             {:durable-append!
-                                              (fn [msg]
-                                                (when (rstore/message-shape? msg)
-                                                  (rstore/-store-message! fork-store conv-id msg)))}))
+               child-bus  (bus-with-peer-relay child-ctx new-id :fork
+                                               (when fork-store
+                                                 {:durable-append!
+                                                  (fn [msg]
+                                                    (when (rstore/message-shape? msg)
+                                                      (rstore/-store-message! fork-store conv-id msg)))}))
          ;; Seed the fork's bus log with parent history so log-based
          ;; consumers see a continuous record (the cursor starts past it —
          ;; history is never re-delivered). Forks have their OWN bus so
          ;; live messages do not leak between parent and fork.
-           _          (bus/seed-log! child-bus parent-log)
-           new-room   (->Room new-id new-slug
-                              (str (:title room) " · fork " short-uuid)
-                              (:id room)
-                              (atom {})
-                              child-bus
-                              child-ctx
-                              (count parent-log)
-                              fork-store
-                              (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
-                                           :forked-from (:id room)
-                                           :conversation-id conv-id))
-                              (when fork-handle (atom fork-handle))
-                              (random-uuid))]
-       ;; The child is not registered or otherwise visible yet. Initializing its
+               _          (bus/seed-log! child-bus parent-log)
+               new-room   (->Room new-id new-slug
+                                  (str (:title room) " · fork " short-uuid)
+                                  (:id room)
+                                  (atom {})
+                                  child-bus
+                                  child-ctx
+                                  (count parent-log)
+                                  fork-store
+                                  (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
+                                               :forked-from (:id room)
+                                               :conversation-id conv-id))
+                                  (when fork-handle (atom fork-handle))
+                                  (random-uuid))
+           ;; The child is not registered or otherwise visible yet. Initializing its
        ;; admission without the global lifecycle lock avoids parent-meta ->
        ;; lifecycle lock inversion during concurrent parent teardown.
-       (agent-run/initialize-unpublished-room-admission! new-id child-ctx)
+               _ (vreset! room* new-room)
+               _ (agent-run/initialize-unpublished-room-admission! new-id child-ctx)]
      ;; (Fork-local persistence rides the bus's durable-append! hook now —
      ;; wired at child-bus construction above.)
-     ;; Register the fork in the PARENT ctx — where the daemon UI reads the
-     ;; registry. A `:ctx` fork's own child-ctx is invisible to the parent
-     ;; (CoW), so registering there would hide the fork from the tree (and it
-     ;; would render empty). The Room still carries its child-ctx in `:ctx`
-     ;; for merge/diff/git. For `:none`, child-ctx == parent ctx (no change).
-       (binding [ec/*execution-context* (:ctx room)]
-         (rreg/register! new-room)
-         (when (= :ctx isolation)
-           (rreg/track-fork! new-id (:id room) (:fork-id fork-handle))))
-       (when clone-participants?
-         (doseq [[_id p] @(:participants room)]
-           (when-let [fac (:factory p)]
-             (binding [ec/*execution-context* child-ctx]
-               (join new-room (fac child-ctx))))))
+     ;; Initialize participant/cache projections before publishing the Room.
+     ;; Otherwise an external registry reader could send work into a partially
+     ;; constructed child and win the inherited-context installation race.
+           (when clone-participants?
+             (doseq [[_id p] @(:participants room)]
+               (when-let [fac (:factory p)]
+             ;; Yggdrasil already forked every registered world component. If
+             ;; this participant has a live room working context, install its
+             ;; child projection before the factory runs so the clone selects
+             ;; that inherited SCI heap instead of constructing a second one.
+             ;; `requiring-resolve` avoids discourse <-> room-context cycles.
+                 (when (= :ctx isolation)
+                   (when-let [fork-working-ctx!
+                              (requiring-resolve 'dvergr.agent.room-context/fork-ctx!)]
+                     (fork-working-ctx! room new-room (:id p))))
+                 (binding [ec/*execution-context* child-ctx]
+                   (join new-room (fac child-ctx))))))
+     ;; Register the fully initialized fork in the PARENT ctx — where the daemon
+     ;; UI reads the registry. A `:ctx` fork's own child-ctx is invisible to the
+     ;; parent (CoW), so registering there would hide the fork from the tree.
+           ;; Publication and its control event share the child's lifecycle
+           ;; monitor. A reader may discover the complete Room+topology pair,
+           ;; but cannot begin settlement until the creation event is posted.
+           (locking (:meta new-room)
+             (binding [ec/*execution-context* (:ctx room)]
+               (if (= :ctx isolation)
+                 (rreg/register-fork! new-room (:id room) (:fork-id fork-handle))
+                 (rreg/register! new-room)))
      ;; Control-plane: announce the fork on the peer-bus so dashboards,
      ;; audit logs, and oversight agents see it without subscribing to
      ;; the fork's bus directly.
-       (binding [ec/*execution-context* child-ctx]
-         (peer-bus/post! {:type            :dvergr/fork-created
-                          :dvergr/origin   new-id
-                          :dvergr/parent   (:id room)
-                          :isolation       isolation
-                          :workspace-id    (when (= :ctx isolation)
-                                             (:id (geschichte/current-workspace)))}))
-       new-room))))
+             (binding [ec/*execution-context* child-ctx]
+               ;; Publication above is the authoritative commit point.  This
+               ;; observability event must therefore never turn successful
+               ;; construction into rollback after another thread has admitted
+               ;; settlement of the published affine handle.
+               (try
+                 (peer-bus/post! {:type            :dvergr/fork-created
+                                  :dvergr/origin   new-id
+                                  :dvergr/parent   (:id room)
+                                  :isolation       isolation
+                                  :workspace-id    (when (= :ctx isolation)
+                                                     (:id (geschichte/current-workspace)))})
+                 (catch Throwable event-error
+                   (tel/log! {:level :error :id ::fork-created-event-failed
+                              :error event-error
+                              :data {:room new-id :parent (:id room)}})))))
+           new-room)
+         (catch Throwable error
+           ;; Construction owns the affine handle until successful return. Any
+           ;; failure before then must settle it and retract every process-local
+           ;; projection; otherwise the caller has no capability with which to
+           ;; recover the unreachable branch.
+           (binding [ec/*execution-context* (:ctx room)]
+             (when-let [constructed @room*]
+               (try (leave-all! constructed)
+                    (catch Throwable cleanup-error
+                      (.addSuppressed error cleanup-error)))
+               (try
+                 (when-let [drop-room!
+                            (requiring-resolve 'dvergr.agent.room-context/drop-room!)]
+                   (drop-room! new-id))
+                 (catch Throwable cleanup-error
+                   (.addSuppressed error cleanup-error)))
+               (when (rreg/lookup new-id)
+                 (try
+                   (when fork-handle
+                     (rreg/untrack-fork! new-id (:fork-id fork-handle)))
+                   (catch Throwable cleanup-error
+                     (.addSuppressed error cleanup-error)))
+                 (rreg/unregister! new-id))))
+           (when fork-handle
+             (let [pending (try
+                             (binding [ec/*execution-context*
+                                       (or (some-> @room* :ctx)
+                                           (:child-ctx fork-handle))]
+                               (ec/get-state [:dvergr/pending-grants]))
+                             (catch Throwable cleanup-error
+                               (.addSuppressed error cleanup-error)
+                               nil))]
+               (try
+                 (ygg/discard-fork! fork-handle)
+                 (srooms/drop-fork-grants! pending)
+                 (catch Throwable cleanup-error
+                   (.addSuppressed error cleanup-error)))))
+           (throw error)))))))
 
 (defn fork-handle
   "Return an isolated Room fork's process-local canonical ForkHandle, or nil.
@@ -1268,6 +1332,23 @@
   (some-> (fork-handle room) ygg/fork-descriptor))
 
 (declare fork-home-ctx)
+
+(def ^:dynamic ^:private *deferred-settlement-authority* nil)
+
+(defn- assert-settlement-released! [fork operation]
+  (locking (:meta fork)
+    (let [meta @(:meta fork)
+          live (binding [ec/*execution-context* (fork-home-ctx fork)]
+                 (rreg/lookup (:id fork)))]
+      (when (and (= :deferred (:settlement-policy meta))
+                 (= fork live)
+                 (not (:settlement-released? meta))
+                 (not= (:id fork) *deferred-settlement-authority*))
+        (throw (ex-info "Deferred Run world must be released before settlement"
+                        {:type ::settlement-deferred
+                         :operation operation
+                         :fork/id (:id fork)
+                         :run/id (:run-id meta)}))))))
 
 (defn- fork-transfer-children [home fork-id]
   (binding [ec/*execution-context* home]
@@ -1311,11 +1392,12 @@
    process-local settlement capability; callers must never persist it. The
    returned `:fork/descriptor` is data and is the canonical durable identity.
 
-   `abort!` is required and is called with the preparation receipt if the live
+  `abort!` is required and is called with the preparation receipt if the live
    affine transfer fails. A failed compensation leaves the Room fenced in a
    visible recovery-required state. Once transfer succeeds the durable owner is
    authoritative; later projection/event failures never roll it back."
   [fork new-owner prepare-or-opts]
+  (assert-settlement-released! fork :transfer)
   (let [{:keys [prepare! abort!]}
         (if (fn? prepare-or-opts)
           {:prepare! prepare-or-opts}
@@ -1861,6 +1943,7 @@
    discard of the same fork is a no-op (the branched systems are deleted only
    once)."
   [fork]
+  (assert-settlement-released! fork :discard)
   ;; Idempotence: once unregistered, the fork is a zombie — re-discarding would
   ;; double-delete the yggdrasil branch (which errors). Guard on registry.
   (when (binding [ec/*execution-context* (fork-home-ctx fork)] (rreg/lookup (:id fork)))
@@ -1892,6 +1975,54 @@
           (recover-room-quiescence! fork callbacks @work-fence-token* error)))))
   fork)
 
+(defn discard-deferred
+  "Consume the host-owned discard side of a deferred Run world.
+
+   This is the narrow substrate capability used by evaluation cancellation and
+   failed certification. Ordinary `discard`, merge, and transfer remain gated."
+  ([fork]
+   (discard-deferred fork (constantly true) (constantly nil)))
+  ([fork claim!]
+   (discard-deferred fork claim! (constantly nil)))
+  ([fork claim! abort!]
+   (locking (:meta fork)
+     (let [meta @(:meta fork)
+           live (binding [ec/*execution-context* (fork-home-ctx fork)]
+                  (rreg/lookup (:id fork)))]
+       (when-not (and (= fork live)
+                      (= :deferred (:settlement-policy meta))
+                      (not (:settlement-released? meta))
+                      (nil? (:settlement-claim meta)))
+         (throw (ex-info "Deferred discard authority is no longer current"
+                         {:type ::stale-deferred-settlement
+                          :fork/id (:id fork)
+                          :run/id (:run-id meta)})))
+       (when-not (claim!)
+         (throw (ex-info "Deferred discard lost its settlement race"
+                         {:type ::deferred-settlement-aborted
+                          :fork/id (:id fork)})))
+       (swap! (:meta fork) assoc :settlement-claim :discard)
+       (try
+         (binding [*deferred-settlement-authority* (:id fork)]
+           (discard fork))
+         (catch Throwable error
+           ;; Abort while the same affine lock is still held. If its durable
+           ;; compensation fails, retain a closed recovery claim rather than
+           ;; opening a race or holding this lock through an unbounded retry.
+           (let [abort-error (try (abort!) nil
+                                  (catch Throwable abort-error abort-error))]
+             (if abort-error
+               (swap! (:meta fork) assoc :settlement-claim :discard-recovery)
+               (swap! (:meta fork) dissoc :settlement-claim))
+             (throw (if abort-error
+                      (ex-info "Deferred discard requires durable abort recovery"
+                               {:type ::deferred-discard-recovery-required
+                                :fork/id (:id fork)
+                                :abort-error (ex-message abort-error)}
+                               error)
+                      error)))))))
+   fork))
+
 (defn merge-room
   "Merge fork into parent.
 
@@ -1909,6 +2040,7 @@
    (doc/unified-fork-conversation.md, dvergr.rooms.forks/reconcile-merge!.)"
   ([parent fork] (merge-room parent fork {}))
   ([parent fork {:keys [merge-opts]}]
+   (assert-settlement-released! fork :merge)
    (let [callbacks (drain-room-listeners! fork :merge)
          work-fence-token* (volatile! nil)]
      (try

--- a/src/dvergr/discourse/commands.clj
+++ b/src/dvergr/discourse/commands.clj
@@ -440,6 +440,8 @@
              (nil? aid)  (say "Usage: /sandbox <agent> — e.g. /sandbox var")
              :else
              (if-let [cc (lookup (:id room) aid)]
-               (say (format-sandbox-report aid (status (:sci-ctx cc))))
+               (let [resolve-sci (resolve 'dvergr.chat.context/sci-context-in)]
+                 (say (format-sandbox-report
+                       aid (status (resolve-sci cc (:ctx room))))))
                (say (str "@" (name aid) " has no active sandbox yet "
                          "— message it once so its session spins up."))))))})

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -304,17 +304,18 @@
         ;; turn in on-message. Priority: :participant-context > :chat-ctx > fresh.
         ;; :with-sci? true so a room-less agent's clojure_eval has a sandbox.
         fallback-chat-ctx
-        (or (when participant-context
-              (pctx/->chat-context participant-context))
-            chat-ctx
-            (let [c (turn/new-working-ctx
-                     {:execution-ctx  ctx
-                      :title          (str "agent " (name id))
-                      :budget-dollars (:dollars budget 1.0)
-                      :db-conn        db-conn})]
-              (when-let [sp (:system-prompt spec)]
-                (cc/add-message! c {:role :system :content sp}))
-              c))
+        (delay
+          (or (when participant-context
+                (pctx/->chat-context participant-context))
+              chat-ctx
+              (let [c (turn/new-working-ctx
+                       {:execution-ctx  ctx
+                        :title          (str "agent " (name id))
+                        :budget-dollars (:dollars budget 1.0)
+                        :db-conn        db-conn})]
+                (when-let [sp (:system-prompt spec)]
+                  (cc/add-message! c {:role :system :content sp}))
+                c)))
         ;; Grace window for the manager to extend the budget after exhaustion.
         compaction-strategy (:strategy compaction :sync-before-turn)
         ;; In race mode, disable run-turn-fn's internal sync compaction — we
@@ -344,7 +345,7 @@
                                 (room-context/ensure-ctx! room id
                                                           {:system-prompt  (:system-prompt spec)
                                                            :budget-dollars (:dollars budget 1.0)})
-                                fallback-chat-ctx)]
+                                @fallback-chat-ctx)]
                  (case (:type msg)
 
                ;; --- directive: extend the dollar budget ---
@@ -392,7 +393,7 @@
                      ;; turn/new-working-ctx (room fold AND room-less fallback alike)
                      ;; with the agent namespaces injected — so clojure_eval has
                      ;; dh/room/intake without a per-turn re-fork.
-                         sci-ctx  (:sci-ctx chat-ctx)
+                         sci-ctx  (cc/sci-context chat-ctx)
                      ;; Normalize once: name→tool-def map (also the execute-side
                      ;; authoritative allowlist below).
                          tool-map (tools/normalize-tools tools)
@@ -489,7 +490,7 @@
                          fold-inbound!
                          (fn [m]
                            (if room
-                             (room-context/append-inbound! (:id room) id (:id m)
+                             (room-context/append-inbound! room id (:id m)
                                                            :user (:content m)
                                                            (room-context/display-name room (:from m))
                                                            (:ts m))
@@ -952,11 +953,10 @@
 
             :factory
             (fn [new-ctx]
-         ;; Fork-room semantics for an LLM agent: re-create fresh in the
-         ;; new context. The fork's agent has no prior conversation,
-         ;; matching the §6.5 ToM-probe semantics ("what would they say,
-         ;; given only the priming I set up?"). Future enhancement: pass
-         ;; an :init-snapshot to carry conversation forward.
+         ;; `fork-room :ctx` installs the inherited room working context before
+         ;; invoking this factory, so the clone selects forked signals and SCI
+         ;; through the stable component ref. `:none` remains a lightweight
+         ;; message-only clone. The room-less fallback stays lazy in both cases.
               (llm-agent {:id          id
                           :spec        spec
                           :tools       tools

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -405,32 +405,36 @@
 
    Stored under `[:dvergr/bash-session WORKSPACE-ID]`."
   [chat-ctx]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (let [ws (default-workspace)
-          key (if (map? ws) (:id ws) ws)
-          path (session-path key)]
-      (or (ec/get-state path)
+  (let [world ((requiring-resolve
+                'dvergr.chat.context/selected-execution-context) chat-ctx)]
+    (binding [ec/*execution-context* world]
+      (let [ws (default-workspace)
+            key (if (map? ws) (:id ws) ws)
+            path (session-path key)]
+        (or (ec/get-state path)
           ;; cwd is the SANDBOX root "/" (= the worktree via make-host's
           ;; :mount-at "/"); `ws` (the real path) stays only as the cache key.
-          (let [s (ms/spindel-session-using (:spindel-ctx chat-ctx)
-                                            (make-sandboxed-env {:cwd "/"}))]
-            (ec/swap-state! path (fn [existing] (or existing s)))
-            (ec/get-state path))))))
+            (let [s (ms/spindel-session-using world
+                                              (make-sandboxed-env {:cwd "/"}))]
+              (ec/swap-state! path (fn [existing] (or existing s)))
+              (ec/get-state path)))))))
 
 (defn get-or-create-host!
   "Return the chat-ctx's BuiltinHost for the current workspace,
    creating it on first use. See `get-or-create-session!` for why
    this is keyed by workspace path."
   [chat-ctx]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (let [ws (default-workspace)
-          key (if (map? ws) (:id ws) ws)
-          path (host-path key)]
-      (or (ec/get-state path)
-          (let [h (make-host {:workspace ws
-                              :mounts (resolve-mounts chat-ctx)})]
-            (ec/swap-state! path (fn [existing] (or existing h)))
-            (ec/get-state path))))))
+  (let [world ((requiring-resolve
+                'dvergr.chat.context/selected-execution-context) chat-ctx)]
+    (binding [ec/*execution-context* world]
+      (let [ws (default-workspace)
+            key (if (map? ws) (:id ws) ws)
+            path (host-path key)]
+        (or (ec/get-state path)
+            (let [h (make-host {:workspace ws
+                                :mounts (resolve-mounts chat-ctx)})]
+              (ec/swap-state! path (fn [existing] (or existing h)))
+              (ec/get-state path)))))))
 
 ;; ============================================================================
 ;; Public API
@@ -560,7 +564,9 @@
           ;; time (make-sandboxed-env), so the snapshot is already
           ;; secret-free. Pass it as the explicit starting env so
           ;; one-shot library use stays well-defined.
-          env0 (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+          env0 (binding [ec/*execution-context*
+                         ((requiring-resolve
+                           'dvergr.chat.context/selected-execution-context) chat-ctx)]
                  (msession/-env sess))
           interrupt-fn (mbudget/combine (process-abort-interrupt-fn process))
           {:keys [stdout stderr exit env permit trace]}

--- a/src/dvergr/mcp/server.clj
+++ b/src/dvergr/mcp/server.clj
@@ -18,6 +18,7 @@
             [dvergr.mcp.json-rpc :as json-rpc]
             [dvergr.ops :as ops]
             [dvergr.discourse :as d]
+            [dvergr.chat.context :as chat-context]
             [org.replikativ.spindel.engine.core :as ec]
             [jsonista.core :as json])
   (:import (java.net ServerSocket Socket)
@@ -92,9 +93,11 @@
     (if room
       (binding [ec/*execution-context* (:ctx room)]
         (let [cctx (ensure-ctx! room :mcp {})]
-          (execute tname input (make-context {:sci-ctx  (:sci-ctx cctx)
+          (execute tname input (make-context {:sci-ctx  (chat-context/sci-context-in
+                                                         cctx (:ctx room))
                                               :db-conn  (:db-conn cctx)
-                                              :chat-ctx cctx}))))
+                                              :chat-ctx cctx
+                                              :execution-ctx (:ctx room)}))))
       (execute tname input (make-context {})))))
 
 (defn- coding-tool [tname tdef]

--- a/src/dvergr/participant/context.clj
+++ b/src/dvergr/participant/context.clj
@@ -29,7 +29,7 @@
                             (often yggdrasil-managed so substrate-fork
                             branches it automatically).
      - `:role-data`       — map of role-specific extensions. LLM puts
-                            `:sci-ctx` and `:tool-ctx` here; human can
+                            `:sci-component` and `:tool-ctx` here; human can
                             stash UI prefs, presence signal, etc. Stays
                             out of the common record so role-specific
                             additions don't churn the API.
@@ -113,7 +113,7 @@
      :from-chat-ctx  — an existing dvergr.chat.context/ChatContext
      :chat-ctx-opts  — opts map passed to cc/create-chat-context
 
-   Role-data carries the chat-ctx-only fields (`:chat-ctx`, `:sci-ctx`)
+   Role-data carries the chat-ctx-only fields (`:chat-ctx`, `:sci-component`)
    so existing dvergr.chat.context callers can still reach them via
    `(:role-data pctx)`."
   [{:keys [participant-id from-chat-ctx chat-ctx-opts role-data]}]
@@ -128,7 +128,7 @@
                           (:status-signal chat-ctx)
                           (:db-conn chat-ctx)
                           (merge {:chat-ctx chat-ctx
-                                  :sci-ctx (:sci-ctx chat-ctx)}
+                                  :sci-component (:sci-component chat-ctx)}
                                  role-data))))
 
 ;; ===========================================================================

--- a/src/dvergr/resource.clj
+++ b/src/dvergr/resource.clj
@@ -5,7 +5,8 @@
    create or discard speculative application state, but they never copy or
    settle this authority: a child receives resources only through one governed
    Kontor transfer from its parent wallet."
-  (:require [dvergr.room.store :as store]
+  (:require [dvergr.agent.attempt.governance :as attempt-governance]
+            [dvergr.room.store :as store]
             [kontor.resource :as kontor])
   (:import [java.nio.charset StandardCharsets]
            [java.util Date UUID]))
@@ -50,6 +51,10 @@
    already exist so its lookup ref can own the wallet."
   [conn room-id chat-id]
   (kontor/install! conn)
+  ;; Kontor currently owns Datahike's single tx-predicate registration slot.
+  ;; Recompose the Attempt governor after every (idempotent) installation so
+  ;; neither invariant family can replace the other by boot order.
+  (attempt-governance/govern! conn)
   (kontor/install-unit! conn {:symbol microdollars
                               :name "Micro US dollars"
                               :precision 0})

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -118,6 +118,42 @@
       (finally
         (release-transition! key token)))))
 
+(defn register-fork!
+  "Atomically publish an isolated child Room and its structural topology edge.
+
+   Readers can never observe a globally reachable child without the settlement
+  identity needed to govern it. Register hooks run only after both projections
+   are visible."
+  [room parent-id ygg-fork-id]
+  (let [child-id (:id room)
+        [key token] (locking lifecycle-lock
+                      (reserve-transition! child-id :register-fork))]
+    (try
+      ;; A fork is still a Room incarnation. Run the same admission fences as
+      ;; ordinary registration before making either global projection visible.
+      (doseq [f (vals @pre-register-hooks)]
+        (f room))
+      (locking lifecycle-lock
+        (when-not (= token (get-in @transitions [key :token]))
+          (throw (ex-info "Fork registration reservation was lost"
+                          {:type ::lifecycle-reservation-lost
+                           :room-id child-id})))
+        (rctx/shared-swap-root!
+         (fn [state]
+           (-> (or state {})
+               (update-in registry-path #(assoc (or % {}) child-id room))
+               (update-in fork-topology-path
+                          #(assoc (or % {}) child-id
+                                  {:fork/id child-id
+                                   :fork/parent-id parent-id
+                                   :fork/ygg-id ygg-fork-id
+                                   :fork/state :local}))))))
+      (doseq [f (vals @register-hooks)]
+        (try (f room) (catch Throwable _ nil)))
+      room
+      (finally
+        (release-transition! key token)))))
+
 (defn unregister!
   "Remove a Room from the registry by id, then run unregister hooks."
   [room-id]
@@ -158,6 +194,21 @@
       (keyword? id-or-slug) (get m id-or-slug)
       (string? id-or-slug)  (some (fn [[_ r]] (when (= (:slug r) id-or-slug) r)) m)
       :else                 nil)))
+
+(defn admitted-incarnation?
+  "True when `room` is the currently published incarnation and no lifecycle
+   transition owns its registry slot.
+
+   Callers that allocate process-local Room resources use this while holding
+   the Room's own lifecycle fence. An unregister reservation therefore closes
+   admission before pre-unregister cleanup starts, and a failed unregister
+   automatically reopens admission when its reservation is released."
+  [room]
+  (locking lifecycle-lock
+    (let [room-id (:id room)
+          current (get (rctx/shared-get-state registry-path) room-id)]
+      (and (= (:incarnation room) (:incarnation current))
+           (not (contains? @transitions (transition-key room-id)))))))
 
 (defn list-rooms
   "All rooms in the registry. Optional :where filter as a predicate.

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -124,6 +124,26 @@
     "List attention facts, optionally restricted by exact :id, :participant,
      and :limit. Exact identity lookup is never subject to the history limit."))
 
+(defprotocol PAttemptStore
+  "Durable query projection for trusted, verified evaluation Attempts.
+
+   The Attempt is owned by the same Room store as its terminal Run. Exact
+   open-ended values may live in an immutable artifact store, but certification
+   is not durable until this typed index and all artifact references commit."
+
+  (-store-attempt! [this room-id attempt]
+    "Persist one immutable certified Attempt. The root Run must be terminal in
+     this Room. Repeating identical content is idempotent; reusing the Run
+     identity for different content is an error.")
+
+  (-load-attempt [this room-id attempt-id]
+    "Return one exact certified Attempt by UUID in `room-id`, else nil.")
+
+  (-list-attempts [this room-id opts]
+    "Return recent certified Attempts newest first. Optional exact filters are
+     :environment-id, :environment-content-id, :provider, :model, and :status;
+     :limit is applied after filtering."))
+
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
@@ -291,6 +311,7 @@
 
 (def durable-run-keys
   #{:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+    :run/caused-by
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error
     :run/world :run/isolation :run/settlement-policy
@@ -333,6 +354,17 @@
   (when (and (:run/parent run) (not (uuid? (:run/parent run))))
     (throw (ex-info ":run/parent must be a UUID"
                     {:type :room-store/invalid-run :key :run/parent :run run})))
+  (when-not (and (set? (or (:run/caused-by run) #{}))
+                 (every? uuid? (:run/caused-by run)))
+    (throw (ex-info ":run/caused-by must be a set of Run UUIDs"
+                    {:type :room-store/invalid-run
+                     :key :run/caused-by
+                     :run run})))
+  (when (contains? (:run/caused-by run) (:run/id run))
+    (throw (ex-info "A Run cannot causally depend on itself"
+                    {:type :room-store/invalid-run
+                     :key :run/caused-by
+                     :run run})))
   (when (and (:run/roster run) (not (keyword? (:run/roster run))))
     (throw (ex-info ":run/roster must be a keyword"
                     {:type :room-store/invalid-run :key :run/roster :run run})))
@@ -364,10 +396,14 @@
              (not (instance? java.util.Date (:run/ended-at run))))
     (throw (ex-info "A terminal run requires :run/ended-at"
                     {:type :room-store/invalid-run :key :run/ended-at :run run})))
+  (when (and (not (contains? terminal-run-statuses (:run/status run)))
+             (some? (:run/ended-at run)))
+    (throw (ex-info "A nonterminal run cannot have :run/ended-at"
+                    {:type :room-store/invalid-run :key :run/ended-at :run run})))
   run)
 
 (defn validate-run-update!
-  "Reject an update that changes the causal identity of an existing Run."
+  "Reject an update that changes identity or removes durable causal evidence."
   [existing run]
   (when (and existing
              (not= (select-keys existing immutable-run-keys)
@@ -377,6 +413,48 @@
                      :run-id (:run/id run)
                      :existing (select-keys existing immutable-run-keys)
                      :update (select-keys run immutable-run-keys)})))
+  (when (and existing
+             (not (every? (or (:run/caused-by run) #{})
+                          (or (:run/caused-by existing) #{}))))
+    (throw (ex-info "Durable Run causal inputs are append-only"
+                    {:type :room-store/causes-not-append-only
+                     :run-id (:run/id run)
+                     :existing (:run/caused-by existing)
+                     :update (:run/caused-by run)})))
+  (when (and existing
+             (contains? terminal-run-statuses (:run/status existing))
+             (or (not= (:run/status existing) (:run/status run))
+                 (not= (:run/ended-at existing) (:run/ended-at run))))
+    (throw (ex-info "A terminal Run lifecycle is immutable"
+                    {:type :room-store/terminal-run-update
+                     :run-id (:run/id run)
+                     :existing-status (:run/status existing)
+                     :update-status (:run/status run)
+                     :existing-ended-at (:run/ended-at existing)
+                     :update-ended-at (:run/ended-at run)})))
+  run)
+
+(defn validate-run-causes!
+  "Validate newly asserted causal edges through `load-cause`.
+
+   The loader is scoped to the same durable Room namespace by each store. A
+   causal input must already exist there and be terminal. Existing edges are
+   not rechecked on replay, but `validate-run-update!` prevents their removal."
+  [existing load-cause run]
+  (doseq [cause-id (remove (or (:run/caused-by existing) #{})
+                           (or (:run/caused-by run) #{}))]
+    (let [cause (load-cause cause-id)]
+      (when-not cause
+        (throw (ex-info "Causal input Run is not durable in the same Room"
+                        {:type :room-store/cause-not-durable
+                         :run-id (:run/id run)
+                         :cause-run/id cause-id})))
+      (when-not (contains? terminal-run-statuses (:run/status cause))
+        (throw (ex-info "Causal input Run has not resolved"
+                        {:type :room-store/cause-not-resolved
+                         :run-id (:run/id run)
+                         :cause-run/id cause-id
+                         :cause-run/status (:run/status cause)})))))
   run)
 
 (def durable-message-metadata-keys

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -9,11 +9,15 @@
    `dvergr.room.store`)."
   (:require [clojure.edn :as edn]
             [datahike.api :as dh]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.attempt.governance :as attempt-governance]
+            [dvergr.artifact :as artifact]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.persist :as persist]
             [dvergr.room.store :as store]
             [kontor.gate :as kontor-gate]
             [kontor.resource :as resource]
+            [hasch.core :as hasch]
             [taoensso.telemere :as tel]))
 
 ;; =============================================================================
@@ -229,6 +233,61 @@
                                :entity entity}))))))
       [entity])))
 
+(defn- store-attempt-if-absent
+  "Transaction function for immutable first-write-wins Attempt certification."
+  [db entity]
+  (if (dh/entity db [:attempt/id (:attempt/id entity)])
+    []
+    (let [chat-id (second (:attempt/chat entity))
+          run-id (second (:attempt/run entity))
+          run (dh/entity db [:run/id run-id])
+          terminal? #{:completed :failed :cancelled}]
+      (when-not run
+        (throw (ex-info "Attempt references a missing Run"
+                        {:type :room-store/invalid-attempt-run
+                         :attempt/id (:attempt/id entity) :run/id run-id})))
+      (when-not (= chat-id (:chat/id (:run/chat run)))
+        (throw (ex-info "Attempt Run crosses Room stores"
+                        {:type :room-store/attempt-room-mismatch
+                         :attempt/id (:attempt/id entity) :run/id run-id})))
+      (when-not (contains? terminal? (:run/status run))
+        (throw (ex-info "Attempt Run is not terminal"
+                        {:type :room-store/non-terminal-attempt-run
+                         :attempt/id (:attempt/id entity)
+                         :run/status (:run/status run)})))
+      (when-not (= (:run/status run) (:attempt/status entity))
+        (throw (ex-info "Attempt status differs from its Run"
+                        {:type :room-store/attempt-run-status-mismatch
+                         :run/status (:run/status run)
+                         :attempt/status (:attempt/status entity)})))
+      (doseq [[attempt-key run-key]
+              [[:attempt/agent-def-hash :run/agent-def-hash]
+               [:attempt/program-kind :run/program-kind]
+               [:attempt/interpreter-version :run/interpreter-version]]]
+        (when-not (= (get entity attempt-key) (get run run-key))
+          (throw (ex-info "Attempt provenance differs from its Run"
+                          {:type :room-store/attempt-run-provenance-mismatch
+                           :attempt/key attempt-key
+                           :attempt/value (get entity attempt-key)
+                           :run/value (get run run-key)}))))
+      (doseq [ref (:attempt/evidence-runs entity)]
+        (let [evidence-run (dh/entity db ref)]
+          (when-not (and evidence-run
+                         (= chat-id (:chat/id (:run/chat evidence-run))))
+            (throw (ex-info "Attempt evidence Run is missing or cross-Room"
+                            {:type :room-store/invalid-attempt-evidence-run
+                             :attempt/id (:attempt/id entity)
+                             :run/ref ref})))))
+      (doseq [ref (:attempt/evidence-messages entity)]
+        (let [message (dh/entity db ref)]
+          (when-not (and message
+                         (= chat-id (:chat/id (:message/chat message))))
+            (throw (ex-info "Attempt evidence message is missing or cross-Room"
+                            {:type :room-store/invalid-attempt-evidence-message
+                             :attempt/id (:attempt/id entity)
+                             :message/ref ref})))))
+      [entity])))
+
 (def ^:private message-pull-pattern
   '[:message/id :message/role :message/content
     :message/created-at :message/source-user
@@ -261,13 +320,30 @@
       :activity/outcome :activity/critical? :activity/at]}])
 
 (def ^:private run-pull-pattern
-  '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent
+  '[:run/id :run/kind :run/room :run/actor :run/trigger :run/parent :run/caused-by
     :run/roster :run/agent-version :run/program-kind :run/interpreter-version
     :run/agent-def-hash :run/chat-id
     :run/world :run/isolation :run/settlement-policy
     :run/settlement-status :run/settlement-reason
     :run/status :run/created-at :run/started-at :run/updated-at :run/ended-at
     :run/reason :run/error])
+
+(def ^:private attempt-pull-pattern
+  '[:attempt/id :attempt/content-id :attempt/payload-blob
+    :attempt/payload-codec :attempt/environment-id
+    :attempt/environment-version :attempt/environment-content-id
+    :attempt/verifier-id :attempt/verifier-version
+    :attempt/provider :attempt/model :attempt/status
+    :attempt/started-at :attempt/elapsed-ms :attempt/certified-at
+    :attempt/reward :attempt/agent-def-hash :attempt/program-kind
+    :attempt/interpreter-version :attempt/prompt-id
+    :attempt/model-resolution :attempt/model-steps
+    :attempt/evidence-content-id :attempt/settlement-intent
+    {:attempt/run [:run/id]}
+    {:attempt/evidence-runs [:run/id]}
+    {:attempt/evidence-messages [:message/id]}
+    {:attempt/checks [:attempt.check/id :attempt.check/key
+                      :attempt.check/passed?]}])
 
 (def ^:private attention-pull-pattern
   '[:attention/id :attention/participant :attention/message-id
@@ -289,6 +365,7 @@
            :run/started-at (:run/started-at run)
            :run/updated-at (:run/updated-at run)}
     (:run/parent run)   (assoc :run/parent (:run/parent run))
+    (seq (:run/caused-by run)) (assoc :run/caused-by (:run/caused-by run))
     (:run/roster run) (assoc :run/roster (:run/roster run))
     (:run/agent-version run) (assoc :run/agent-version (:run/agent-version run))
     (:run/program-kind run) (assoc :run/program-kind (:run/program-kind run))
@@ -307,6 +384,127 @@
     (:run/ended-at run) (assoc :run/ended-at (:run/ended-at run))
     (:run/reason run)   (assoc :run/reason (:run/reason run))
     (:run/error run)    (assoc :run/error (str (:run/error run)))))
+
+(defn- entity->run [entity]
+  (cond-> entity
+    (:run/caused-by entity) (update :run/caused-by set)))
+
+(defn- check-id [attempt-id check-key]
+  (hasch/uuid [:dvergr/attempt-check attempt-id check-key]))
+
+(defn- attempt->entity [chat-id value payload-ref]
+  (let [receipt (:attempt/receipt value)
+        definition (:attempt/environment value)
+        verifier (:environment/verifier definition)
+        metrics (:attempt/metrics receipt)]
+    (cond-> {:attempt/id (:attempt/id value)
+             :attempt/chat [:chat/id chat-id]
+             :attempt/run [:run/id (:attempt/run-id value)]
+             :attempt/content-id (:attempt/content-id value)
+             :attempt/payload-blob payload-ref
+             :attempt/payload-codec :edn-v1
+             :attempt/environment-id (:environment/id definition)
+             :attempt/environment-version (:environment/version definition)
+             :attempt/environment-content-id (:environment/content-id definition)
+             :attempt/verifier-id (:verifier/id verifier)
+             :attempt/verifier-version (:verifier/version verifier)
+             :attempt/provider (:attempt/provider receipt)
+             :attempt/model (:attempt/model receipt)
+             :attempt/status (:attempt/status receipt)
+             :attempt/started-at (java.util.Date. ^long (:attempt/started-at receipt))
+             :attempt/elapsed-ms (long (:attempt/elapsed-ms receipt))
+             :attempt/certified-at (java.util.Date. ^long (:attempt/certified-at value))
+             :attempt/reward (double (:attempt/reward receipt))
+             :attempt/agent-def-hash (:attempt/agent-def-hash value)
+             :attempt/program-kind (:program-kind metrics)
+             :attempt/interpreter-version (long (:interpreter-version metrics))
+             :attempt/evidence-content-id (:attempt/evidence-content-id value)
+             :attempt/evidence-runs
+             (mapv (fn [id] [:run/id id]) (:attempt/evidence-run-ids value))
+             :attempt/settlement-intent (:attempt/settlement-intent value)
+             :attempt/checks
+             (mapv (fn [[k passed?]]
+                     {:attempt.check/id (check-id (:attempt/id value) k)
+                      :attempt.check/key k
+                      :attempt.check/passed? passed?})
+                   (:attempt/checks receipt))}
+      (:prompt-id metrics) (assoc :attempt/prompt-id (:prompt-id metrics))
+      (:model-resolution metrics)
+      (assoc :attempt/model-resolution (:model-resolution metrics))
+      (:model-steps metrics) (assoc :attempt/model-steps (long (:model-steps metrics)))
+      (seq (:attempt/evidence-message-ids value))
+      (assoc :attempt/evidence-messages
+             (mapv (fn [id] [:message/id id])
+                   (:attempt/evidence-message-ids value))))))
+
+(defn- entity->attempt [entity artifacts]
+  (when entity
+    (when-not (= :edn-v1 (:attempt/payload-codec entity))
+      (throw (ex-info "Unsupported Attempt payload codec"
+                      {:type :room-store/unsupported-attempt-payload
+                       :codec (:attempt/payload-codec entity)})))
+    (let [value (artifact/get-value artifacts (:attempt/payload-blob entity))]
+      (when-not value
+        (throw (ex-info "Attempt payload artifact is unavailable"
+                        {:type :room-store/missing-attempt-payload
+                         :attempt/id (:attempt/id entity)
+                         :artifact/ref (:attempt/payload-blob entity)})))
+      (attempt/validate-attempt value)
+      (let [receipt (:attempt/receipt value)
+            definition (:attempt/environment value)
+            verifier (:environment/verifier definition)
+            metrics (:attempt/metrics receipt)
+            checks (into {}
+                         (map (juxt :attempt.check/key
+                                    :attempt.check/passed?))
+                         (:attempt/checks entity))
+            projected {:attempt/id (:attempt/id value)
+                       :attempt/content-id (:attempt/content-id value)
+                       :attempt/environment-id (:environment/id definition)
+                       :attempt/environment-version (:environment/version definition)
+                       :attempt/environment-content-id
+                       (:environment/content-id definition)
+                       :attempt/verifier-id (:verifier/id verifier)
+                       :attempt/verifier-version (:verifier/version verifier)
+                       :attempt/provider (:attempt/provider receipt)
+                       :attempt/model (:attempt/model receipt)
+                       :attempt/status (:attempt/status receipt)
+                       :attempt/started-at
+                       (java.util.Date. ^long (:attempt/started-at receipt))
+                       :attempt/elapsed-ms (:attempt/elapsed-ms receipt)
+                       :attempt/certified-at
+                       (java.util.Date. ^long (:attempt/certified-at value))
+                       :attempt/reward (double (:attempt/reward receipt))
+                       :attempt/agent-def-hash (:attempt/agent-def-hash value)
+                       :attempt/program-kind (:program-kind metrics)
+                       :attempt/interpreter-version (:interpreter-version metrics)
+                       :attempt/prompt-id (:prompt-id metrics)
+                       :attempt/model-resolution (:model-resolution metrics)
+                       :attempt/model-steps (:model-steps metrics)
+                       :attempt/evidence-content-id
+                       (:attempt/evidence-content-id value)
+                       :attempt/settlement-intent
+                       (:attempt/settlement-intent value)
+                       :attempt/check-map (:attempt/checks receipt)
+                       :attempt/evidence-run-ids
+                       (:attempt/evidence-run-ids value)
+                       :attempt/evidence-message-ids
+                       (or (:attempt/evidence-message-ids value) #{})}
+            actual (assoc entity
+                          :attempt/check-map checks
+                          :attempt/evidence-run-ids
+                          (into #{} (map :run/id)
+                                (:attempt/evidence-runs entity))
+                          :attempt/evidence-message-ids
+                          (into #{} (map :message/id)
+                                (:attempt/evidence-messages entity)))]
+        (doseq [[k expected] projected]
+          (when-not (= expected (get actual k))
+            (throw (ex-info "Attempt typed projection differs from exact payload"
+                            {:type :room-store/corrupt-attempt-projection
+                             :attempt/id (:attempt/id value)
+                             :key k :expected expected :actual (get actual k)}))))
+        value))))
 
 (defn- attention->entity [chat-id fact]
   (cond-> (-> fact
@@ -327,7 +525,7 @@
 ;; Store impl
 ;; =============================================================================
 
-(defrecord DatahikeStore [conn]
+(defrecord DatahikeStore [conn artifacts]
   store/PRoomStore
 
   (-store-room! [_ room-id metadata]
@@ -366,6 +564,13 @@
                               [?r :run/chat ?c]
                               [?r :run/id ?rid]]
                             @conn chat-id)
+              attempt-ids (dh/q '[:find [?aid ...]
+                                  :in $ ?cid
+                                  :where
+                                  [?c :chat/id ?cid]
+                                  [?a :attempt/chat ?c]
+                                  [?a :attempt/id ?aid]]
+                                @conn chat-id)
               attention-ids (dh/q '[:find [?aid ...]
                                     :in $ ?cid
                                     :where
@@ -373,7 +578,10 @@
                                     [?a :attention/chat ?c]
                                     [?a :attention/id ?aid]]
                                   @conn chat-id)]
-          (dh/transact conn (-> (mapv (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids)
+          (dh/transact conn (-> (mapv (fn [aid]
+                                        [:db/retractEntity [:attempt/id aid]])
+                                      attempt-ids)
+                                (into (map (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids))
                                 (into (map (fn [rid] [:db/retractEntity [:run/id rid]]) run-ids))
                                 (into (map (fn [aid]
                                              [:db/retractEntity [:attention/id aid]])
@@ -571,28 +779,36 @@
   (-store-run! [this room-id run]
     (let [slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
-        (let [run (->> run
-                       store/validate-run!
-                       (store/validate-run-update!
-                        (store/-load-run this room-id (:run/id run))))]
-          (when (persist/persist-tx!
-                 conn
-                 [(run->entity (:chat/id ent) run)
-                  {:db/id [:chat/id (:chat/id ent)]
-                   :chat/updated-at (java.util.Date.)}]
-                 {:op :store-run :room-id room-id :run-id (:run/id run)})
-            run)))))
+        ;; Serialize validation and assertion on the connection. Terminal cause
+        ;; Runs cannot be retracted through this store, and append-only checking
+        ;; prevents concurrent/stale writers from losing an accepted edge.
+        (locking conn
+          (let [run (store/validate-run! run)
+                existing (store/-load-run this room-id (:run/id run))
+                run (->> run
+                         (store/validate-run-update! existing)
+                         (store/validate-run-causes!
+                          existing
+                          #(store/-load-run this room-id %)))]
+            (when (persist/persist-tx!
+                   conn
+                   [(run->entity (:chat/id ent) run)
+                    {:db/id [:chat/id (:chat/id ent)]
+                     :chat/updated-at (java.util.Date.)}]
+                   {:op :store-run :room-id room-id :run-id (:run/id run)})
+              run))))))
 
   (-load-run [_ room-id run-id]
     (let [slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
-        (dh/q '[:find (pull ?r pattern) .
-                :in $ ?chat-id ?run-id pattern
-                :where
-                [?c :chat/id ?chat-id]
-                [?r :run/chat ?c]
-                [?r :run/id ?run-id]]
-              @conn (:chat/id ent) run-id run-pull-pattern))))
+        (some-> (dh/q '[:find (pull ?r pattern) .
+                        :in $ ?chat-id ?run-id pattern
+                        :where
+                        [?c :chat/id ?chat-id]
+                        [?r :run/chat ?c]
+                        [?r :run/id ?run-id]]
+                      @conn (:chat/id ent) run-id run-pull-pattern)
+                entity->run))))
 
   (-list-runs [_ room-id {:keys [limit status actor]}]
     (let [slug (store/room-id->slug room-id)]
@@ -603,6 +819,7 @@
                      [?c :chat/id ?chat-id]
                      [?r :run/chat ?c]]
                    @conn (:chat/id ent) run-pull-pattern)
+             (map entity->run)
              (filter #(if status (= status (:run/status %)) true))
              (filter #(if actor (= actor (:run/actor %)) true))
              (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
@@ -610,6 +827,97 @@
                       #(compare %2 %1))
              (take (or limit 100))
              vec)
+        [])))
+
+  store/PAttemptStore
+
+  (-store-attempt! [this room-id value]
+    (let [value (attempt/validate-attempt value)
+          slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        ;; CAS is immutable: a blob written before a failed Datahike commit is a
+        ;; harmless unreferenced object and can be collected independently.
+        (let [payload-ref (artifact/put-value! artifacts value)
+              entity (attempt->entity (:chat/id ent) value payload-ref)]
+          (locking conn
+            (if-let [existing (store/-load-attempt this room-id
+                                                   (:attempt/id value))]
+              (if (= existing value)
+                existing
+                (throw (ex-info "Attempt identity is immutable"
+                                {:type :room-store/attempt-identity-collision
+                                 :existing existing :attempt value})))
+              (let [report
+                    (attempt-governance/with-authorized-write
+                      conn (:attempt/id value)
+                      (fn [tx-meta]
+                        (persist/persist-tx-result!
+                         conn
+                         [[:db.fn/call store-attempt-if-absent entity]]
+                         {:op :store-attempt :room-id room-id
+                          :attempt-id (:attempt/id value)
+                          :tx-meta tx-meta})))]
+                (when report
+                  ;; A concurrent identical writer may have won. Always compare
+                  ;; the exact payload after the serialized first-write decision.
+                  (let [stored (store/-load-attempt this room-id
+                                                    (:attempt/id value))]
+                    (when-not (= stored value)
+                      (throw (ex-info "Concurrent Attempt identity collision"
+                                      {:type :room-store/attempt-identity-collision
+                                       :stored stored :attempt value})))
+                    stored)))))))))
+
+  (-load-attempt [_ room-id attempt-id]
+    (let [slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        (some-> (dh/q '[:find (pull ?a pattern) .
+                        :in $ ?chat-id ?attempt-id pattern
+                        :where
+                        [?c :chat/id ?chat-id]
+                        [?a :attempt/chat ?c]
+                        [?a :attempt/id ?attempt-id]]
+                      @conn (:chat/id ent) attempt-id attempt-pull-pattern)
+                (entity->attempt artifacts)))))
+
+  (-list-attempts [_ room-id {:keys [limit environment-id
+                                     environment-content-id provider model
+                                     status]}]
+    (let [slug (store/room-id->slug room-id)]
+      (if-let [ent (room-by-slug conn slug)]
+        (let [where (cond-> '[[?c :chat/id ?chat-id]
+                              [?a :attempt/chat ?c]]
+                      environment-id
+                      (conj '[?a :attempt/environment-id ?environment-id])
+                      environment-content-id
+                      (conj '[?a :attempt/environment-content-id
+                              ?environment-content-id])
+                      provider (conj '[?a :attempt/provider ?provider])
+                      model (conj '[?a :attempt/model ?model])
+                      status (conj '[?a :attempt/status ?status]))
+              inputs (cond-> '[$ ?chat-id pattern]
+                       environment-id (conj '?environment-id)
+                       environment-content-id (conj '?environment-content-id)
+                       provider (conj '?provider)
+                       model (conj '?model)
+                       status (conj '?status))
+              args (cond-> [@conn (:chat/id ent) attempt-pull-pattern]
+                     environment-id (conj environment-id)
+                     environment-content-id (conj environment-content-id)
+                     provider (conj provider)
+                     model (conj model)
+                     status (conj status))
+              query {:find '[(pull ?a pattern)]
+                     :in inputs
+                     :where where}]
+          (->> (apply dh/q query args)
+               (map first)
+               (sort-by (juxt #(some-> ^java.util.Date
+                                (:attempt/certified-at %) .getTime)
+                              #(str (:attempt/id %)))
+                        #(compare %2 %1))
+               (take (or limit 100))
+               (mapv #(entity->attempt % artifacts))))
         [])))
 
   store/PAttentionStore
@@ -750,6 +1058,10 @@
 
 (defn make
   "Create a DatahikeStore. `conn` must be an existing Datahike
-   connection whose db includes the dvergr.chat.schema attributes."
-  [conn]
-  (->DatahikeStore conn))
+   connection whose db includes the dvergr.chat.schema attributes. An optional
+   artifact store can be injected for tests; production uses the blob CAS."
+  ([conn]
+   (make conn (artifact/blob-store)))
+  ([conn artifacts]
+   (attempt-governance/govern! conn)
+   (->DatahikeStore conn artifacts)))

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -2,13 +2,15 @@
   "In-memory PRoomStore — atom-backed. For tests and ephemeral rooms
    (e.g. `:isolation :none` forks where the agent's substrate ctx is
    shared with the parent so persistence would be redundant)."
-  (:require [dvergr.room.store :as store]))
+  (:require [dvergr.agent.attempt :as attempt]
+            [dvergr.room.store :as store]))
 
 (defrecord MemoryStore [state]
   ;; state atom shape:
   ;;   {:rooms     {room-id metadata}
   ;;    :messages  {room-id [msg ...] (chronological)}
-  ;;    :runs      {room-id {run-id run}}}
+  ;;    :runs      {room-id {run-id run}}
+  ;;    :attempts  {room-id {attempt-id attempt}}}
   store/PRoomStore
 
   (-store-room! [_ room-id metadata]
@@ -28,6 +30,7 @@
                    (update :rooms    dissoc room-id)
                    (update :messages dissoc room-id)
                    (update :runs     dissoc room-id)
+                   (update :attempts dissoc room-id)
                    (update :attention dissoc room-id)
                    (update :attention-index
                            #(apply dissoc % attention-ids)))))))
@@ -89,11 +92,16 @@
       (vec (take-last n filtered))))
 
   (-store-run! [_ room-id run]
-    (let [run (->> run
-                   store/validate-run!
-                   (store/validate-run-update!
-                    (get-in @state [:runs room-id (:run/id run)])))]
-      (swap! state assoc-in [:runs room-id (:run/id run)] run)
+    (let [run (store/validate-run! run)]
+      (swap! state
+             (fn [snapshot]
+               (let [existing (get-in snapshot [:runs room-id (:run/id run)])
+                     run (->> run
+                              (store/validate-run-update! existing)
+                              (store/validate-run-causes!
+                               existing
+                               #(get-in snapshot [:runs room-id %])))]
+                 (assoc-in snapshot [:runs room-id (:run/id run)] run))))
       run))
 
   (-load-run [_ room-id run-id]
@@ -105,6 +113,106 @@
          (filter #(if actor (= actor (:run/actor %)) true))
          (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
                         #(str (:run/id %)))
+                  #(compare %2 %1))
+         (take (or limit 100))
+         vec))
+
+  store/PAttemptStore
+
+  (-store-attempt! [_ room-id value]
+    (let [value (attempt/validate-attempt value)
+          attempt-id (:attempt/id value)]
+      (swap! state
+             (fn [snapshot]
+               (let [run (get-in snapshot [:runs room-id
+                                           (:attempt/run-id value)])
+                     existing (get-in snapshot [:attempts room-id attempt-id])]
+                 (when-not (and run
+                                (contains? store/terminal-run-statuses
+                                           (:run/status run)))
+                   (throw (ex-info "Attempt references a missing or non-terminal Run"
+                                   {:type :room-store/invalid-attempt-run
+                                    :room-id room-id
+                                    :attempt/id attempt-id
+                                    :run/id (:attempt/run-id value)})))
+                 (when-not (= (:run/status run)
+                              (get-in value [:attempt/receipt :attempt/status]))
+                   (throw (ex-info "Attempt receipt status differs from its Run"
+                                   {:type :room-store/attempt-run-status-mismatch
+                                    :run/status (:run/status run)
+                                    :attempt/status
+                                    (get-in value [:attempt/receipt
+                                                   :attempt/status])})))
+                 (doseq [[attempt-key run-key]
+                         [[:attempt/agent-def-hash :run/agent-def-hash]
+                          [:program-kind :run/program-kind]
+                          [:interpreter-version :run/interpreter-version]]]
+                   (let [attempt-value
+                         (if (= :attempt/agent-def-hash attempt-key)
+                           (get value attempt-key)
+                           (get-in value [:attempt/receipt :attempt/metrics
+                                          attempt-key]))]
+                     (when-not (= attempt-value (get run run-key))
+                       (throw
+                        (ex-info "Attempt provenance differs from its Run"
+                                 {:type
+                                  :room-store/attempt-run-provenance-mismatch
+                                  :attempt/key attempt-key
+                                  :attempt/value attempt-value
+                                  :run/value (get run run-key)})))))
+                 (doseq [evidence-run-id (:attempt/evidence-run-ids value)]
+                   (when-not (get-in snapshot [:runs room-id evidence-run-id])
+                     (throw
+                      (ex-info "Attempt evidence Run is missing from this Room"
+                               {:type :room-store/invalid-attempt-evidence-run
+                                :room-id room-id
+                                :attempt/id attempt-id
+                                :run/id evidence-run-id}))))
+                 (doseq [evidence-message-id
+                         (:attempt/evidence-message-ids value)]
+                   (when-not (some #(= evidence-message-id (:id %))
+                                   (get-in snapshot [:messages room-id] []))
+                     (throw
+                      (ex-info "Attempt evidence message is missing from this Room"
+                               {:type :room-store/invalid-attempt-evidence-message
+                                :room-id room-id
+                                :attempt/id attempt-id
+                                :message/id evidence-message-id}))))
+                 (when (and existing (not= existing value))
+                   (throw (ex-info "Attempt identity is immutable"
+                                   {:type :room-store/attempt-identity-collision
+                                    :existing existing :attempt value})))
+                 (if existing snapshot
+                     (assoc-in snapshot [:attempts room-id attempt-id] value)))))
+      value))
+
+  (-load-attempt [_ room-id attempt-id]
+    (get-in @state [:attempts room-id attempt-id]))
+
+  (-list-attempts [_ room-id {:keys [limit environment-id
+                                     environment-content-id provider model
+                                     status]}]
+    (->> (vals (get-in @state [:attempts room-id] {}))
+         (filter #(if environment-id
+                    (= environment-id
+                       (get-in % [:attempt/environment :environment/id]))
+                    true))
+         (filter #(if environment-content-id
+                    (= environment-content-id
+                       (get-in % [:attempt/environment
+                                  :environment/content-id]))
+                    true))
+         (filter #(if provider
+                    (= provider (get-in % [:attempt/receipt
+                                           :attempt/provider]))
+                    true))
+         (filter #(if model
+                    (= model (get-in % [:attempt/receipt :attempt/model]))
+                    true))
+         (filter #(if status
+                    (= status (get-in % [:attempt/receipt :attempt/status]))
+                    true))
+         (sort-by (juxt :attempt/certified-at #(str (:attempt/id %)))
                   #(compare %2 %1))
          (take (or limit 100))
          vec))
@@ -152,5 +260,5 @@
 (defn make
   "Create a fresh in-memory store."
   []
-  (->MemoryStore (atom {:rooms {} :messages {} :runs {}
+  (->MemoryStore (atom {:rooms {} :messages {} :runs {} :attempts {}
                         :attention {} :attention-index {}})))

--- a/src/dvergr/rooms/forks.clj
+++ b/src/dvergr/rooms/forks.clj
@@ -19,6 +19,107 @@
 
 (declare fork-diff)
 
+(defn deferred?
+  "True when a Run world is retained behind its host-owned settlement gate."
+  [fork]
+  (let [meta (some-> fork :meta deref)]
+    (and (= :deferred (:settlement-policy meta))
+         (not (:settlement-released? meta)))))
+
+(defn release-deferred!
+  "Release an existing deferred Run world for ordinary review/settlement.
+
+   Durable projection is updated before the process-local gate opens, so a
+   reviewer can never merge a world whose certification state is still
+   `:deferred`. This does not merge, copy, or create another fork."
+  ([fork reason]
+   (release-deferred! fork reason (constantly true)))
+  ([fork reason claim!]
+   (locking (:meta fork)
+     (let [parent (rreg/lookup (:parent-id fork))
+           live (rreg/lookup (:id fork))
+           meta @(:meta fork)
+           run-id (:run-id meta)]
+       (when-not (and (= fork live)
+                      (= :deferred (:settlement-policy meta))
+                      (not (:settlement-released? meta))
+                      (nil? (:settlement-claim meta)))
+         (throw (ex-info "Fork is not awaiting deferred settlement"
+                         {:type ::not-deferred :fork/id (:id fork)})))
+       (when-not (and parent run-id)
+         (throw (ex-info "Deferred Run world has no live settlement owner"
+                         {:type ::missing-settlement-owner
+                          :fork/id (:id fork)
+                          :run/id run-id})))
+       (when-not (claim!)
+         (throw (ex-info "Deferred release lost its settlement race"
+                         {:type ::deferred-settlement-aborted
+                          :fork/id (:id fork)})))
+       (agent-run/update-durable-settlement! parent run-id :review reason)
+       (swap! (:meta fork) assoc :settlement-released? true
+              :settlement-claim :release)
+       {:ok? true :status :review :run/id run-id :fork/id (:id fork)}))))
+
+(defn discard-deferred!
+  "Durability-first consumption of a deferred Run world's discard capability.
+
+   The terminal projection is written by the claim callback while the fork's
+   affine settlement lock is held, before substrate destruction. A projection
+   failure therefore leaves the world live. If physical discard fails after
+   preparation, compensate the still-live world back to `:deferred`."
+  ([fork reason]
+   (discard-deferred! fork reason (constantly true)))
+  ([fork reason claim!]
+   (let [parent (rreg/lookup (:parent-id fork))
+         run-id (some-> fork :meta deref :run-id)
+         prepared? (atom false)
+         durable-claim!
+         (fn []
+           (when (claim!)
+             (when (and parent run-id)
+               (agent-run/update-durable-settlement! parent run-id :discarded
+                                                     reason))
+             (reset! prepared? true)
+             true))
+         durable-abort!
+         (fn []
+           (when (and @prepared? parent run-id)
+             (agent-run/update-durable-settlement!
+              parent run-id :deferred :discard-failed)))]
+     (try
+       (d/discard-deferred fork durable-claim! durable-abort!)
+       {:ok? true}
+       (catch Throwable error
+         {:ok? false :error (ex-message error)})))))
+
+(defn retry-deferred-discard-abort!
+  "Restore a live world fenced by a failed durable discard compensation."
+  [fork]
+  (locking (:meta fork)
+    (let [meta @(:meta fork)
+          parent (rreg/lookup (:parent-id fork))
+          live (rreg/lookup (:id fork))
+          run-id (:run-id meta)]
+      (when-not (and (= fork live)
+                     (= :deferred (:settlement-policy meta))
+                     (= :discard-recovery (:settlement-claim meta))
+                     parent run-id)
+        (throw (ex-info "Fork has no current deferred discard recovery"
+                        {:type ::no-discard-recovery
+                         :fork/id (:id fork)})))
+      (agent-run/update-durable-settlement! parent run-id :deferred
+                                            :discard-failed)
+      (swap! (:meta fork) dissoc :settlement-claim)
+      {:ok? true :status :deferred :run/id run-id :fork/id (:id fork)})))
+
+(defn- require-settleable! [fork operation]
+  (when (deferred? fork)
+    (throw (ex-info "Deferred Run world must be released before settlement"
+                    {:type ::settlement-deferred
+                     :operation operation
+                     :fork/id (:id fork)
+                     :run/id (some-> fork :meta deref :run-id)}))))
+
 (defn fork?
   "Is this Room a fork? The canonical marker is `:forked-from` in the room's
    meta — set by `fork-room` — the SAME thing `dvergr.rooms.tree` keys its
@@ -82,7 +183,8 @@
        :files       (vec (:files gdiff))
        :db-changes  db-changes
        :msgs-since  (max 0 (- total flen))
-       :mergeable?  (boolean parent)})))
+       :mergeable?  (boolean (and parent (not (deferred? fork))))
+       :settlement-deferred? (deferred? fork)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Unified diff + tier classification — the substrate the agent merge-reviewer
@@ -151,6 +253,7 @@
    {:ok? true :parent-slug ...} or {:ok? false :error ...}."
   [fork]
   (try
+    (require-settleable! fork :merge)
     (if-let [parent (rreg/lookup (:parent-id fork))]
       (let [run-id (some-> fork :meta deref :run-id)]
         (d/merge-room parent fork)
@@ -326,17 +429,20 @@
 
 (defn discard!
   "Discard a fork (`discourse/discard`) — deletes its branches. Returns
-   {:ok? true} or {:ok? false :error ...}."
-  [fork]
-  (try
-    (let [parent (rreg/lookup (:parent-id fork))
-          run-id (some-> fork :meta deref :run-id)]
-      (d/discard fork)
-      (when (and parent run-id)
-        (agent-run/update-durable-settlement! parent run-id :discarded
-                                              :review-rejected))
-      {:ok? true})
-    (catch Throwable t {:ok? false :error (.getMessage t)})))
+   {:ok? true} or {:ok? false :error ...}. An explicit reason lets trusted
+   policies distinguish rejection, evaluation policy, and failed certification."
+  ([fork]
+   (discard! fork :review-rejected))
+  ([fork reason]
+   (try
+     (require-settleable! fork :discard)
+     (let [parent (rreg/lookup (:parent-id fork))
+           run-id (some-> fork :meta deref :run-id)]
+       (d/discard fork)
+       (when (and parent run-id)
+         (agent-run/update-durable-settlement! parent run-id :discarded reason))
+       {:ok? true})
+     (catch Throwable t {:ok? false :error (.getMessage t)}))))
 
 (defn adopt!
   "Promote a retained isolated fork into an external durable owner.
@@ -352,6 +458,7 @@
    must never settle descriptor systems by bypassing those handles."
   [fork new-owner opts]
   (try
+    (require-settleable! fork :adopt)
     (let [parent (rreg/lookup (:parent-id fork))
           run-id (some-> fork :meta deref :run-id)
           transfer (d/transfer-fork! fork new-owner opts)

--- a/src/dvergr/rooms/messages.clj
+++ b/src/dvergr/rooms/messages.clj
@@ -12,7 +12,8 @@
    Same consistency story as everything else here: the bus is the per-room
    totally-ordered log; the store (disk) and this signal (memory) are two folds
    of it, consistent by construction, deduped by message id."
-  (:require [dvergr.discourse :as d]
+  (:require [dvergr.activity :as activity]
+            [dvergr.discourse :as d]
             [dvergr.runtime.bus :as bus]
             [dvergr.runtime.ctx :as rctx]
             [dvergr.room.registry :as rreg]
@@ -64,6 +65,8 @@
    :in-reply-to (:in-reply-to m)
    :thread-root-id (d/thread-root-id m)
    :role      (store/infer-role m)
+   :run-id    (activity/message-run-id m)
+   :activities (activity/message-activities m)
    :tool-uses (or (:tool-uses m) (:tool-uses (:metadata m)))
    :reasoning (or (:reasoning m) (:reasoning (:metadata m)) (:message/reasoning m))})
 

--- a/src/dvergr/rooms/scheduler.clj
+++ b/src/dvergr/rooms/scheduler.clj
@@ -21,6 +21,7 @@
    A negligible lingering no-op per deleted/discarded room until restart."
   (:require [datahike.api :as dh]
             [dvergr.agent.room-context :as room-context]
+            [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as disc]
             [dvergr.runtime.clock :as clock]
             [dvergr.runtime.ctx :as rctx]
@@ -73,8 +74,9 @@
             (let [cctx (room-context/ensure-ctx! room aid {})
                   {:keys [success value error]}
                   (sandbox/eval-code
-                   (:sci-ctx cctx) (:schedule/code s)
-                   :timeout-ms (* 5 60 1000) :realize? true)]
+                   (chat-context/sci-context-in cctx (:ctx room)) (:schedule/code s)
+                   :timeout-ms (* 5 60 1000) :realize? true
+                   :execution-context (:ctx room))]
               (if success
                 (str "⏱ " (or (:schedule/description s) "code task") " → "
                      (subs value 0 (min 500 (count value))))

--- a/src/dvergr/runtime/ctx.clj
+++ b/src/dvergr/runtime/ctx.clj
@@ -32,6 +32,74 @@
   [ctx]
   (if-let [p (:parent-ctx ctx)] (recur p) ctx))
 
+(defn descendant-context?
+  "True when `candidate` is `ancestor` or belongs to its fork lineage.
+
+   A dynamically bound context must not override an object's owning world when
+   it is the owner's parent or an unrelated sibling. That would make an async
+   coordinator accidentally read the parent projection of child-owned state."
+  [candidate ancestor]
+  (boolean
+   (when (and candidate ancestor)
+     (loop [ctx candidate]
+       (cond
+         (or (identical? ctx ancestor)
+             (= (:fork-id ctx) (:fork-id ancestor))) true
+         (:parent-ctx ctx) (recur (:parent-ctx ctx))
+         :else false)))))
+
+(defn selected-context
+  "Select a bound descendant of `owner`, otherwise retain `owner`.
+
+   This is the ambient-world rule for stable handles: child execution may
+   refine an owner into its fork, while parent/sibling execution cannot pull a
+   child-owned value out of its world."
+  [owner]
+  (let [bound (when (ec/execution-context-bound?)
+                (ec/current-execution-context))]
+    (if (descendant-context? bound owner) bound owner)))
+
+(def ^:private sandbox-bindings-path
+  "Fork-local bindings used by stable SCI host capabilities.  The binding key
+   is stable for the lifetime of one interpreter component; Yggdrasil copies
+   the map into a child and the child projection replaces only its data."
+  [:dvergr/sandbox-bindings])
+
+(defn install-sandbox-binding!
+  "Install serializable world data for `binding-id` in `ctx`.
+
+   Host functions injected into SCI must capture only `owner` + `binding-id`,
+   never a Room, connection, filesystem or workspace.  That makes functions
+   defined before a SCI fork select the child binding when invoked there."
+  [ctx binding-id data]
+  (binding [ec/*execution-context* ctx]
+    (ec/swap-state! (conj sandbox-bindings-path binding-id)
+                    #(merge (or % {}) data)))
+  data)
+
+(defn update-sandbox-binding!
+  "Update a capability binding in the ambient descendant world of `owner`."
+  [owner binding-id f & args]
+  (let [ctx (selected-context owner)]
+    (binding [ec/*execution-context* ctx]
+      (ec/swap-state! (conj sandbox-bindings-path binding-id)
+                      #(apply f (or % {}) args)))))
+
+(defn sandbox-binding
+  "Read `binding-id` in the ambient descendant world of `owner`."
+  [owner binding-id]
+  (let [ctx (selected-context owner)]
+    (binding [ec/*execution-context* ctx]
+      (ec/get-state (conj sandbox-bindings-path binding-id)))))
+
+(defn sandbox-binding-resolver
+  "Return a stable zero-argument resolver suitable for an SCI host closure."
+  [owner binding-id]
+  #(or (sandbox-binding owner binding-id)
+       (throw (ex-info "SCI capability has no world binding"
+                       {:binding-id binding-id
+                        :owner-fork-id (:fork-id owner)}))))
+
 (defn current-root
   "The root of the currently-bound execution context."
   []
@@ -43,6 +111,14 @@
    registry, tree/message signals, peer-bus — anything the UI reactively reads."
   [path f]
   (rtp/swap-state! (current-root) path f))
+
+(defn shared-swap-root!
+  "Atomically update the complete Tier-1 root state.
+
+   Use this sparingly for invariants spanning multiple Tier-1 paths, such as
+   publishing a Room together with its structural fork edge."
+  [f]
+  (rtp/swap-state! (current-root) [] f))
 
 (defn shared-get-state
   "Tier-1 read from the ROOT ctx (the authoritative copy)."

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -12,6 +12,8 @@
             [clojure.string :as str]
             [datahike.api :as dh]
             [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.sci.world :as sci-world]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [org.replikativ.spindel.core :as sync]
             [dvergr.sci.clojure-test :as sci-test]
@@ -27,6 +29,7 @@
             [dvergr.sandbox.workspace :as workspace]
             [dvergr.sandbox.ns.agent :as ns-agent]
             [dvergr.sandbox.ns.io :as ns-io]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.system.db :as sdb])
   (:import [java.io StringWriter]
            [java.lang.management ManagementFactory]))
@@ -38,16 +41,19 @@
 ;; A consumer (e.g. an accounting kernel) registers an injector fn here at
 ;; startup; the sandbox setup runs every registered injector so its surface is
 ;; available in `clojure_eval`, WITHOUT dvergr knowing what it is. Each injector
-;; is `(fn [sci-ctx opts])`, opts = {:room-id :room-conn :kb-conn}.
+;; is `(fn [sci-ctx opts])`; opts also carries a fork-safe `:world-binding`
+;; resolver for host closures that can survive an interpreter fork.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private ns-injectors* (atom []))
 
 (defn register-ns-injector!
   "Register an SCI namespace-injector `f` — `(fn [sci-ctx opts])`, opts =
-   {:room-id :room-conn :kb-conn} — run for every agent sandbox after the
+   {:room-id :room-conn :kb-conn :world-binding} — run for every agent sandbox after the
    built-in surface. Lets a consumer expose extra namespaces (a domain kernel)
-   in `clojure_eval` without dvergr depending on it. Idempotent per identical fn.
+   in `clojure_eval` without dvergr depending on it. A host closure which may
+   survive a fork MUST call the zero-argument `:world-binding` resolver rather
+   than capture a room id or raw resource. Idempotent per identical fn.
    Returns `f`."
   [f]
   (swap! ns-injectors* (fn [v] (if (some #{f} v) v (conj v f))))
@@ -337,6 +343,48 @@
                 ;; :sci-opts and merges it into sci/init.)
                 :sci-opts     {:load-fn workspace/load-fn}})))
 
+(defn create-spindel-sci-world!
+  "Create a fork-selected SCI interpreter component in `spindel-ctx`.
+
+   Returns a stable Spindel ComponentRef rather than the interpreter itself.
+   Resolve it with `sci-context-in`; a descendant execution context selects its
+   own SCI fork while the reference remains unchanged."
+  [spindel-ctx]
+  (let [ref (sci-world/create!
+             spindel-ctx
+             {:interrupt-fn (make-resource-limits)
+              :sci-opts {:load-fn workspace/load-fn}})
+        interpreter (sci-world/context-in spindel-ctx ref)]
+    ;; The world constructor starts from Spindel's SCI environment, not
+    ;; dvergr's plain base context. Restore the same safe classes/core shims and
+    ;; bind clojure.test to this interpreter before any descendant forks it.
+    (sci/merge-opts interpreter
+                    {:classes base-classes
+                     :namespaces {'clojure.core core-extras}})
+    (sci/merge-opts interpreter
+                    {:namespaces
+                     {'clojure.test
+                      (sci-test/ctx-aware-test-namespace interpreter)}})
+    ref))
+
+(defn sci-context-in
+  "Resolve stable SCI world `ref` in `spindel-ctx`."
+  [spindel-ctx ref]
+  (when ref
+    (sci-world/context-in spindel-ctx ref)))
+
+(defn release-spindel-sci-world!
+  "Remove stable SCI world `ref` from `spindel-ctx`.
+
+   This releases only the selected process-local interpreter realization. It is
+   deliberately separate from closing durable room resources: a forked room
+   may share a ChatContext identity while selecting an independent SCI heap."
+  [spindel-ctx ref]
+  (when ref
+    (binding [rtc/*execution-context* spindel-ctx]
+      (component/unregister! ref)))
+  nil)
+
 ;; ---------------------------------------------------------------------------
 ;; Session Context Management
 ;; ---------------------------------------------------------------------------
@@ -371,7 +419,7 @@
 ;; Evaluation
 ;; ---------------------------------------------------------------------------
 
-(defn eval-code
+(defn- eval-code*
   "Evaluate Clojure code in the session's SCI context.
 
    Returns map with:
@@ -567,6 +615,20 @@
            :stderr (str stderr)
            :success false})))))
 
+(defn eval-code
+  "Evaluate code in an SCI interpreter, selecting `:execution-context` for
+   ambient Spindel/Yggdrasil capabilities when supplied.
+
+   The interpreter selects the SCI world; the Spindel context selects the
+   matching substrate world. Other options are `:timeout-ms`, `:cancel?`, and
+   `:realize?`, as documented by the evaluator above."
+  [sci-ctx code & {:keys [execution-context] :as opts}]
+  (let [args (mapcat identity (dissoc opts :execution-context))]
+    (if execution-context
+      (binding [rtc/*execution-context* execution-context]
+        (apply eval-code* sci-ctx code args))
+      (apply eval-code* sci-ctx code args))))
+
 (defn eval-forms
   "Evaluate multiple forms sequentially in the same context.
    Returns vector of results (one per form)."
@@ -665,7 +727,7 @@
                        "(dvergr.scheduler/create {:agent-id :var :schedule {:every :hour :n 4} :code \"(require 'my.ns)(my.ns/run!)\" :description \"…\"})  (dvergr.scheduler/list)  (dvergr.scheduler/cancel id)"]
    "dvergr.tasks"    ["the shared task ledger — list/accept/complete work items"
                       "(dvergr.tasks/list)   (dvergr.tasks/complete! id)"]
-   "dvergr.agent"    ["program specialized agents as immutable rosters; exact programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm ...}; hire! starts a durable Run with an explicit result Spin"
+   "dvergr.agent"    ["program specialized agents as immutable rosters; define content-addressed verified environments as portable data; exact programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm ...}; hire! starts a durable Run with an explicit result Spin"
                       "join with result-spin; for a first-result race that really cancels losing Runs: (let [team (-> (dvergr.agent/roster) (dvergr.agent/make-agent {:id :fast :program {:kind :scripted :delay-ms 10 :reply :fast}}) (dvergr.agent/make-agent {:id :slow :program {:kind :scripted :delay-ms 5000 :reply :slow}})) a (dvergr.agent/hire! team :fast {:task :solve}) b (dvergr.agent/hire! team :slow {:task :solve})] @(spin (-> (await (spindel.comb/race (dvergr.agent/owned-result-spin a) (dvergr.agent/owned-result-spin b))) :run/value)))"]
    "spindel.work"    ["structured higher-order FRP admission: latest, serial, busy, and bounded parallel; each accepted value becomes owned work"
                       "(let [c (spindel.work/latest (fn [x] (spindel.work/task x)))] (spindel.work/submit! c :first) (spindel.work/submit! c :newest) (spindel.work/close! c) @(spin (await (spindel.work/completion c))))"]
@@ -805,7 +867,8 @@
        "this room, write `app/index.html` (+ assets under `app/`) in your "
        "workspace — served at `/apps/<room-slug>/`.\n\n"
        "**Reactive agent programs.** `dvergr.agent` provides immutable rosters "
-       "and Run-backed execution. Use the exact Spindel namespaces: "
+       "and Run-backed execution; `agent/environment` creates a content-addressed "
+       "task/verifier/policy definition without starting an attempt. Use the exact Spindel namespaces: "
        "`(require '[dvergr.agent :as agent] "
        "'[org.replikativ.spindel.spin.cps :refer [spin]] "
        "'[org.replikativ.spindel.effects.await :refer [await]])`. "
@@ -936,9 +999,21 @@
    Returns the audit-log atom — a vector of IO events ({:op :t :data}) accumulated
    during the agent's execution.  Attach to the agent result for post-hoc analysis."
   [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id
-                                 room-runtime-id room-incarnation agent-program-ceiling]
+                                 room-runtime-id room-incarnation capability-id
+                                 agent-program-ceiling]
                           :or   {proc-allow #{}}}]
   (let [audit-log  (make-audit-log)
+        binding-resolver (when capability-id
+                           (runtime-ctx/sandbox-binding-resolver spindel-ctx capability-id))
+        binding-swap! (when capability-id
+                        (fn [f & args]
+                          (apply runtime-ctx/update-sandbox-binding!
+                                 spindel-ctx capability-id f args)))
+        workspace-resolver
+        (fn []
+          (binding [rtc/*execution-context* (runtime-ctx/selected-context spindel-ctx)]
+            (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
+                 (catch Throwable _ nil))))
         workspace  (binding [rtc/*execution-context* spindel-ctx]
                      (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
                           (catch Throwable _ nil)))
@@ -964,15 +1039,21 @@
       ;; falls back to sys-conn so it still has a queryable db (flagged: give them a
       ;; scratch db so even room-less never writes the registry).
       (let [sys-conn (sdb/get-conn)]
-        (ns-datahike/add-datahike-ns! sci-ctx room-id spindel-ctx) ; the ONE datahike surface: faithful `d`/`datahike.api`
+        (when binding-swap!
+          (binding-swap! #(if (contains? % :ephemeral-databases)
+                            %
+                            (assoc % :ephemeral-databases {}))))
+        (ns-datahike/add-datahike-ns! sci-ctx room-id spindel-ctx
+                                      binding-resolver binding-swap!) ; the ONE datahike surface: faithful `d`/`datahike.api`
         ;; ONE `dvergr.room` (+ legacy `room` alias): the Room ops MERGED with the
         ;; room's DB surface (*room*/*kb*/databases/db + queries). The KB is reached
         ;; via `dvergr.room/*kb*` + `kb-find`/`kb-search` + `d` — no separate `entity`
         ;; namespace (dropped as redundant; a global entity CRM can return later).
         (ns-room/add-room-ns! sci-ctx room-conn kb-conn room-id spindel-ctx
                               agent-program-ceiling
-                              {:id (or room-runtime-id room-id)
-                               :incarnation room-incarnation})
+                              {:binding-resolver binding-resolver
+                               :source-room {:id (or room-runtime-id room-id)
+                                             :incarnation room-incarnation}})
         ;; dvergr.mail/*inbox* — the room's attached mailbox conn (fork-aware),
         ;; nil when no mailbox attached. Read helpers are seed source (dvergr/mail/).
         (ns-mail/add-mail-ns! sci-ctx)
@@ -984,18 +1065,26 @@
     ;; effect. No roster is kept in a host atom: callers thread the immutable
     ;; value, and live execution state belongs to the Room's Spindel context.
     (ns-agent/add-programming-ns! sci-ctx (or room-runtime-id room-id) spindel-ctx
-                                  agent-program-ceiling)
+                                  agent-program-ceiling binding-resolver)
     (ns-data/add-spindel-extras-ns!
      sci-ctx spindel-ctx
      {:room-id (or room-runtime-id room-id)
       :room-incarnation room-incarnation
-      :ceiling (:work-admission agent-program-ceiling)})
+      :ceiling (:work-admission agent-program-ceiling)
+      :world-binding binding-resolver})
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)
     (ns-io/add-fs-ns!   sci-ctx :base-path cwd :filesystem filesystem
+                        :filesystem-resolver
+                        (when workspace
+                          #(when-let [workspace (workspace-resolver)]
+                             ((requiring-resolve
+                               'dvergr.substrate.geschichte/filesystem)
+                              workspace)))
                         :audit-log audit-log)
     ;; (proc folded into the muschel-backed babashka.process — add-bash-ns! in turn.clj)
     (ns-io/add-git-ns!  sci-ctx :base-path cwd :workspace workspace
+                        :workspace-resolver (when workspace workspace-resolver)
                         :audit-log audit-log)
     (ns-kb/add-llm-ns!  sci-ctx agent-program-ceiling)
     ;; Boundary secret injection (doc/boundary-secret-injection.md): build the
@@ -1008,9 +1097,23 @@
           sandbox-env  (try ((requiring-resolve 'dvergr.substrate.config/sandbox-env))
                             (catch Throwable _ nil))
           secrets      (ns-io/build-secret-registry secret-specs)]
+      (when binding-swap!
+        (binding-swap! #(if (contains? % :sandbox-env)
+                          %
+                          (assoc % :sandbox-env (or sandbox-env {})))))
       ;; :user-config = non-secret config values returned verbatim (identifiers,
       ;; site URLs); :secrets = sensitive values returned as placeholders.
-      (ns-io/add-env-ns!  sci-ctx :user-config (atom (or sandbox-env {})) :secrets secrets)
+      (ns-io/add-env-ns! sci-ctx
+                         :user-config (atom (or sandbox-env {}))
+                         :config-resolver (when binding-resolver
+                                            #(or (:sandbox-env (binding-resolver)) {}))
+                         :config-swap! (when binding-swap!
+                                         (fn [f & args]
+                                           (binding-swap!
+                                            #(update % :sandbox-env
+                                                     (fn [m]
+                                                       (apply f (or m {}) args))))))
+                         :secrets secrets)
       (ns-io/add-http-ns! sci-ctx :audit-log audit-log :allowed-domains allowed-http-domains
                           :secrets secrets))
     (ns-agent/add-scheduler-ns! sci-ctx)
@@ -1024,7 +1127,8 @@
     ;; expose their surface here without dvergr depending on them. Run before
     ;; reflection so overview sees them; a failing injector never breaks setup.
     (doseq [f (registered-ns-injectors)]
-      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn})
+      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn
+                       :world-binding binding-resolver})
            (catch Throwable e
              (binding [*out* *err*] (println "ns-injector failed:" (.getMessage e))))))
     ;; Self-reflection LAST, so (sandbox/overview) sees every ns injected above.
@@ -1032,6 +1136,19 @@
     ;; SECURITY, last of all: lock JVM interop to the class allowlist.
     (lock-interop! sci-ctx)
     audit-log))
+
+(defn release-agent-resources!
+  "Release disposable host resources owned by one SCI capability in `ctx`.
+   Durable/mergeable world state is deliberately untouched."
+  [ctx capability-id]
+  (when capability-id
+    (try
+      (let [resolver (runtime-ctx/sandbox-binding-resolver ctx capability-id)
+            swap! (fn [f & args]
+                    (apply runtime-ctx/update-sandbox-binding!
+                           ctx capability-id f args))]
+        (ns-datahike/dispose-ephemeral-databases! resolver swap!))
+      (catch clojure.lang.ExceptionInfo _ nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; clojure.test Integration (from Babashka)

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -8,6 +8,7 @@
    `(find-doc …)` answer nothing for them inside the sandbox. See
    `dvergr.sandbox.ns.doc`."
   (:require [sci.core :as sci]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox.ns.doc :as doc]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -49,7 +50,7 @@
           (-> (await (comb/race (agent/owned-result-spin a)
                                 (agent/owned-result-spin b)))
               :run/value)))"
-  [sci-ctx room-id spindel-ctx agent-program-ceiling]
+  [sci-ctx room-id spindel-ctx agent-program-ceiling & [binding-resolver]]
   (let [make-roster*   (requiring-resolve 'dvergr.agent.roster/make-roster)
         make-agent*    (requiring-resolve 'dvergr.agent.roster/make-agent)
         revise-agent*  (requiring-resolve 'dvergr.agent.roster/revise-agent)
@@ -57,6 +58,8 @@
         agent-ref*     (requiring-resolve 'dvergr.agent.roster/agent-ref)
         agents*        (requiring-resolve 'dvergr.agent.roster/agents)
         select-agents* (requiring-resolve 'dvergr.agent.roster/select-agents)
+        make-environment* (requiring-resolve 'dvergr.agent.environment/make-environment)
+        environment-ref* (requiring-resolve 'dvergr.agent.environment/environment-ref)
         hire-in*       (requiring-resolve 'dvergr.agent.program/hire-in!)
         observe*       (requiring-resolve 'dvergr.agent.program/observe)
         cancel*        (requiring-resolve 'dvergr.agent.program/cancel!)
@@ -66,9 +69,13 @@
         room-balance*  (requiring-resolve 'dvergr.resource/balance)
         run-balance*   (requiring-resolve 'dvergr.resource/run-balance)
         room-lookup*   (requiring-resolve 'dvergr.room.registry/lookup)
+        selected-ctx   #(runtime-ctx/selected-context spindel-ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-runtime-id (binding-resolver)))
+                             room-id)
         current-room   (fn []
-                         (when room-id
-                           (binding [ec/*execution-context* spindel-ctx]
+                         (when-let [room-id (current-room-id)]
+                           (binding [ec/*execution-context* (selected-ctx)]
                              (room-lookup* room-id))))
         room!          (fn []
                          (or (current-room)
@@ -94,6 +101,10 @@
                                kind (get-in definition [:agent/program :kind])
                                allowed-kinds (:program-kinds agent-program-ceiling)
                                ambient-parent (:parent-run agent-program-ceiling)]
+                           (when (= :deferred (:settlement opts))
+                             (throw (ex-info
+                                     "Deferred settlement is reserved for trusted host policies"
+                                     {:type ::deferred-settlement-forbidden})))
                            (when (and allowed-kinds
                                       (not (contains? allowed-kinds kind)))
                              (throw (ex-info
@@ -133,6 +144,15 @@
                                control-room (control-room! work-room)]
                            (binding [ec/*execution-context* (:ctx work-room)]
                              (cancel* control-room handle-or-id))))
+        result-spin-fn (fn [handle]
+                         (if-let [run-id (:parent-run agent-program-ceiling)]
+                           (result-spin* run-id handle)
+                           (result-spin* handle)))
+        owned-result-spin-fn
+        (fn [handle]
+          (if-let [run-id (:parent-run agent-program-ceiling)]
+            (owned-result-spin* run-id handle)
+            (owned-result-spin* handle)))
         balance-fn     (fn []
                          (let [work-room (room!)
                                control-room (control-room! work-room)]
@@ -149,13 +169,16 @@
         'ref          agent-ref*
         'list         agents*
         'select       select-agents*
+        'environment  make-environment*
+        'environment-ref environment-ref*
+        'room-id      (fn [] (:id (room!)))
         'hire!        hire-fn
         'observe      observe-fn
         'cancel!      cancel-fn
         'balance      balance-fn
         'run-id       run-id*
-        'result-spin  result-spin*
-        'owned-result-spin owned-result-spin*}
+        'result-spin  result-spin-fn
+        'owned-result-spin owned-result-spin-fn}
        '{roster       [([] [opts]) "Create an immutable Roster value. Options may include portable :id, :defaults, :scope, and :metadata data."]
          make-agent   [([roster spec]) "Return a NEW Roster containing `spec`. Programs are {:kind :echo :delay-ms n}, {:kind :scripted :delay-ms n :reply value}, or {:kind :llm :max-model-steps n :budget-dollars n} plus :model-policy and :tools. Pure: input unchanged."]
          revise-agent [([roster id patch]) "Return a NEW Roster with AgentDef `id` revised and its version incremented."]
@@ -163,13 +186,16 @@
          ref          [([agent-def]) "Return the stable {:agent/id :agent/version} reference for an AgentDef."]
          list         [([roster]) "All AgentDefs in a Roster, deterministically ordered by id."]
          select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
+         environment  [([spec]) "Create a portable, content-addressed EnvironmentDef. Requires :id, :task, and trusted verifier ref {:id keyword :version n}; optional :limits/:world/:metadata stay data, never live functions or handles."]
+         environment-ref [([environment]) "Return the stable logical/version/content reference for one exact EnvironmentDef. Individual execution Run IDs remain unique."]
+         room-id      [([]) "Return the live identity of the current Room/world. In an isolated fork this is the child Room, not its parent."]
          hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
          cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]
          balance      [([]) "Return the conserved resource vector available to the current Run, or the Room root at top level."]
          run-id       [([handle]) "Return the durable Run UUID represented by a RunHandle."]
-         result-spin  [([handle]) "Return a passive Spindel observer Spin for a RunHandle. Multiple observers may await it; cancelling an observer does not cancel the Run."]
-         owned-result-spin [([handle]) "Return an ownership-coupled result Spin. Cancelling this observer also cancels the underlying Run; use only when the observer owns that child execution."]}))))
+         result-spin  [([handle]) "Return a passive Spindel observer Spin for a RunHandle. On resolution the current Run durably records the child as a causal input. Multiple observers may await it; cancelling an observer does not cancel the Run."]
+         owned-result-spin [([handle]) "Return an ownership-coupled result Spin. On resolution the current Run durably records the child as a causal input. Cancelling this observer also cancels the underlying Run; use only when the observer owns that child execution."]}))))
 
 (defn add-agents-ns!
   "Expose the agent registry as 'agents namespace in SCI.

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -4,10 +4,77 @@
   (:require [sci.core :as sci]
             [is.simm.partial-cps.sequence :as aseq]
             [datahike.api :as dh]
+            [dvergr.agent.roster :as roster]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox.ns.doc :as doc]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.effects.await :as sp-await]
+            [org.replikativ.spindel.spin.cps :as sp]
             [org.replikativ.spindel.core :as sync]))
+
+(defn- portable-posterior
+  "Project a native Spindel measure before it crosses into SCI. Execution
+   contexts and their process-local executors deliberately do not survive."
+  [measure]
+  (let [measure-ns  (find-ns 'org.replikativ.spindel.inference.measure)
+        contexts    (@(ns-resolve measure-ns 'get-contexts) measure)
+        value-of    @(ns-resolve measure-ns 'get-value)
+        log-weights (vec (@(ns-resolve measure-ns 'get-log-weights) measure))
+        values      (mapv value-of contexts)
+        worlds      (->> contexts
+                         (keep #(rtp/get-state % [:inference :world-descriptor]))
+                         vec)
+        posterior   {:posterior/values values
+                     :posterior/log-weights log-weights
+                     :posterior/weights
+                     (@(ns-resolve measure-ns 'normalize-log-weights) log-weights)
+                     :posterior/ess
+                     (@(ns-resolve measure-ns 'effective-sample-size) measure)
+                     :posterior/log-marginal
+                     (@(ns-resolve measure-ns 'log-marginal) measure)
+                     :posterior/worlds worlds}]
+    (when-not (roster/data-value? posterior)
+      (throw (ex-info "Inference result is not portable data"
+                      {:type ::non-portable-posterior})))
+    posterior))
+
+(defn- posterior-spin [native-spin]
+  (sp/spin
+   (portable-posterior (sp-await/await native-spin))))
+
+(defn- posterior-query [posterior query-fn]
+  (let [values  (mapv query-fn (:posterior/values posterior))
+        weights (:posterior/weights posterior)]
+    (when-not (every? number? values)
+      (throw (ex-info "infer/query requires numeric projected values"
+                      {:type ::non-numeric-query})))
+    (let [mean      (reduce + (map * weights values))
+          variance (reduce + (map (fn [weight value]
+                                    (* weight (Math/pow (- value mean) 2)))
+                                  weights values))
+          sorted    (vec (sort values))
+          n         (count sorted)
+          quantile  (fn [p]
+                      (nth sorted (min (dec n)
+                                       (long (Math/floor (* p n))))))]
+      {:mean mean
+       :variance variance
+       :std-dev (Math/sqrt variance)
+       :samples values
+       :weights weights
+       :quantiles {:p50 (quantile 0.5)
+                   :p025 (quantile 0.025)
+                   :p975 (quantile 0.975)}
+       :type :empirical})))
+
+(defn- posterior-predict [posterior pred-fn samples]
+  (let [measure-ns (find-ns 'org.replikativ.spindel.inference.measure)
+        indices    (@(ns-resolve measure-ns 'systematic-resample)
+                    (:posterior/weights posterior) samples)
+        values     (:posterior/values posterior)]
+    (mapv #(pred-fn (nth values %)) indices)))
 
 (defn add-spindel-extras-ns!
   "Expose spindel combinators, sync primitives, and signals to SCI.
@@ -21,11 +88,18 @@
    These are safe: they only coordinate within the SCI context."
   ([sci-ctx spindel-ctx]
    (add-spindel-extras-ns! sci-ctx spindel-ctx {}))
-  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling]}]
+  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling world-binding]}]
    (require 'org.replikativ.spindel.spin.combinators)
    (require 'org.replikativ.spindel.signal)
    (let [comb-ns (find-ns 'org.replikativ.spindel.spin.combinators)
-         sig-ns  (find-ns 'org.replikativ.spindel.signal)]
+         sig-ns  (find-ns 'org.replikativ.spindel.signal)
+         create-work (fn [strategy opts work-fn]
+                       (let [binding (when world-binding (world-binding))]
+                         (sandbox-work/create!
+                          (or (:room-runtime-id binding) room-id)
+                          (or (:room-incarnation binding) room-incarnation)
+                          (runtime-ctx/selected-context spindel-ctx)
+                          ceiling strategy opts work-fn)))]
      (binding [rtc/*execution-context* spindel-ctx]
        ;; Sync primitives (same as before but unified here)
        (sci/add-namespace! sci-ctx 'sync
@@ -51,32 +125,31 @@
                            (doc/with-docs
                              {'latest       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest {} work-fn))
+                                               (create-work :latest {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest opts work-fn)))
+                                               (create-work :latest opts work-fn)))
                               'serial       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
+                                               (create-work :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial opts work-fn)))
+                                               (create-work :serial opts work-fn)))
                               'busy         (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy {} work-fn))
+                                               (create-work :busy {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy opts work-fn)))
+                                               (create-work :busy opts work-fn)))
                               'parallel     (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel {} work-fn))
+                                               (create-work :parallel {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel opts work-fn)))
+                                               (create-work :parallel opts work-fn)))
                               'controller   (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
+                                               (create-work :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling
-                                                                     (:strategy opts :serial)
-                                                                     (dissoc opts :strategy)
-                                                                     work-fn)))
+                                               (create-work (:strategy opts :serial)
+                                                            (dissoc opts :strategy)
+                                                            work-fn)))
                               'submit!      sandbox-work/submit!
                               'events       sandbox-work/events!
                               'next-event   aseq/anext
@@ -207,7 +280,13 @@
 
      (spin
        (let [measure (await (infer/smc-infer (my-model) 100))]
-         (infer/query measure identity)))
+         (infer/values measure)))
+
+   Dvergr defaults SMC, importance sampling, and the generic kernel runner to
+   `:world-policy :fork`. Each particle therefore executes in a frozen
+   canonical Yggdrasil world and only its immutable result projection survives;
+   particle worlds are discarded before the inference Spin completes. Callers
+   may explicitly request `:fresh` for a proven-pure model.
 
    Namespaces added:
    - dist/   — Anglican distributions: normal, beta, gamma, uniform, flip, …
@@ -315,12 +394,54 @@
                          'chi-squared        @(ns-resolve ar 'chi-squared)
                          'student-t          (fn [nu] (@(ns-resolve ar 'student-t) nu))}))
 
-  ;; Inference runners — these take/return spins, compose with await in spin bodies
-  (sci/add-namespace! sci-ctx 'infer
-                      {'smc-infer          @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
-                       'importance-sampling @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
-                       'kernel-infer       @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
-                       'query              @(resolve 'org.replikativ.spindel.inference.inference/query)
-                       'predict            @(resolve 'org.replikativ.spindel.inference.inference/predict)
-                       'pimh-infer         @(resolve 'org.replikativ.spindel.inference.inference/pimh-infer)
-                       'pgibbs-infer       @(resolve 'org.replikativ.spindel.inference.inference/pgibbs-infer)}))
+  ;; Inference runners — these take/return Spins and compose with await in Spin
+  ;; bodies. Room-capable sandboxes default to canonical particle worlds: a
+  ;; model that happens to touch a registered Yggdrasil system must not alias
+  ;; the ambient room merely because its author omitted an expert-only option.
+  ;; `:fresh` remains an explicit fast path for known-pure models.
+  (let [smc*        @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
+        importance* @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
+        kernel*     @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
+        world-opts  (fn [opts]
+                      (merge {:world-policy :fork} (or opts {})))]
+    (sci/add-namespace!
+     sci-ctx 'infer
+     (doc/with-docs
+       {'smc-infer (fn
+                     ([model particles]
+                      (posterior-spin
+                       (smc* model particles (world-opts nil))))
+                     ([model particles opts]
+                      (posterior-spin
+                       (smc* model particles (world-opts opts)))))
+        'importance-sampling
+        (fn
+          ([model particles]
+           (posterior-spin
+            (importance* model particles (world-opts nil))))
+          ([model particles opts]
+           (posterior-spin
+            (importance* model particles (world-opts opts)))))
+        'kernel-infer
+        (fn
+          ([model kernel particles]
+           (posterior-spin
+            (kernel* model kernel particles (world-opts nil))))
+          ([model kernel particles opts]
+           (posterior-spin
+            (kernel* model kernel particles (world-opts opts)))))
+        'query       posterior-query
+        'predict     posterior-predict
+        'values      :posterior/values
+        'log-weights :posterior/log-weights
+        'ess         :posterior/ess
+        'worlds      :posterior/worlds}
+       '{smc-infer [([model particles] [model particles opts]) "Run SMC. Dvergr defaults opts :world-policy to :fork; pass :fresh only for a proven-pure model."]
+         importance-sampling [([model particles] [model particles opts]) "Run importance sampling with canonical particle worlds by default."]
+         kernel-infer [([model kernel particles] [model kernel particles opts]) "Run a Spindel inference kernel with canonical particle worlds by default."]
+         query [([posterior query-fn]) "Compute numeric posterior statistics from portable program results."]
+         predict [([posterior pred-fn samples]) "Resample portable posterior values and apply pred-fn; execution contexts never enter SCI."]
+         values [([posterior]) "Return each particle's portable program result in posterior order."]
+         log-weights [([measure]) "Return posterior particle log weights."]
+         ess [([measure]) "Return effective sample size."]
+         worlds [([measure]) "Return portable canonical world descriptors retained in posterior projections; never live settlement handles."]}))))

--- a/src/dvergr/sandbox/ns/datahike.clj
+++ b/src/dvergr/sandbox/ns/datahike.clj
@@ -24,52 +24,212 @@
    created data DBs — is dvergr-specific and lives in `dvergr.room`, not here.)"
   (:require [datahike.api :as d]
             [dvergr.system.rooms :as srooms]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
+            [sci.fork :as sci-fork]
             [sci.core :as sci]))
+
+(deftype WorldConnection [resolver]
+  clojure.lang.IDeref
+  (deref [_]
+    @(resolver))
+
+  sci-fork/Forkable
+  (fork-value [this]
+    ;; The handle is immutable. Its resolver consults the dynamically selected
+    ;; Spindel world, so sharing the handle selects a different Ygg connection
+    ;; after a world fork rather than sharing the connection itself.
+    this))
+
+(defn world-connection
+  "Create an ambient Datahike connection handle. Deref returns the selected
+   connection's DB; mirrored Datahike functions unwrap it to the connection."
+  [resolve-conn]
+  (WorldConnection. resolve-conn))
+
+(defn resolve-connection
+  "Resolve a WorldConnection, otherwise return `value` unchanged."
+  [value]
+  (if (instance? WorldConnection value)
+    (or ((.-resolver ^WorldConnection value))
+        (throw (ex-info "Ambient Datahike connection is unavailable in this world"
+                        {:type ::connection-unavailable})))
+    value))
 
 ;; The safe DATA surface of datahike.api — resolved from the real namespace so the
 ;; mirror never drifts. Lifecycle (connect/create/delete/exists?) is GUARDED below.
 (def ^:private data-ops
   '[q pull pull-many entity entity-db datoms seek-datoms
     schema reverse-schema metrics db history as-of since filter
-    transact transact! load-entities with])
+    transact transact! with])
+
+(defn- attempt-attr? [x]
+  (and (keyword? x)
+       (contains? #{"attempt" "attempt.check"} (namespace x))))
+
+(defn- attempt-entity? [conn eid]
+  (try
+    (let [entity (d/entity @conn eid)]
+      (boolean (or (:attempt/id entity) (:attempt.check/id entity))))
+    (catch Throwable _ false)))
+
+(defn- assert-no-attempt-write! [conn tx-data]
+  (doseq [form tx-data]
+    (let [protected?
+          (cond
+            (map? form)
+            (or (some attempt-attr? (keys form))
+                (attempt-entity? conn (:db/id form)))
+
+            (vector? form)
+            (let [[op eid attr] form]
+              (or (= :db.fn/call op)
+                  (attempt-attr? attr)
+                  (and (vector? eid) (attempt-attr? (first eid)))
+                  (and (#{:db/retractEntity :db.fn/retractEntity} op)
+                       (attempt-entity? conn eid))))
+
+            :else false)]
+      (when protected?
+        (throw (ex-info "Verified Attempt projections are host-certified and read-only in SCI"
+                        {:type ::protected-attempt-write :tx-form form})))))
+  tx-data)
 
 (defn- cfg-name
   "The logical database name from a datahike config: `:store :id`, else the
    basename of `:store :path`. We own placement, so this is the only handle."
   [cfg]
-  (or (some-> (get-in cfg [:store :id]) name not-empty)
+  (or (some-> (get-in cfg [:store :id]) str (str/replace #"^:" "") not-empty)
       (some-> (get-in cfg [:store :path]) str (str/split #"/") last not-empty)
       (throw (ex-info "datahike config needs a :store :id (the database name)" {:cfg cfg}))))
 
 (defn- mem? [cfg] (boolean (#{:mem :memory} (get-in cfg [:store :backend]))))
 
+(defn- entry-conn [entry]
+  (if (map? entry) (:connection entry) entry))
+
+(defn- world-memory-config
+  "Translate an agent-visible logical memory config into a process-global
+   Datahike config namespaced by the selected interpreter world."
+  [cfg binding-resolver]
+  (let [binding (when binding-resolver (binding-resolver))
+        logical-name (cfg-name cfg)
+        world-key (str (:capability-id binding) "|"
+                       (:room-runtime-id binding) "|"
+                       (:room-incarnation binding) "|"
+                       logical-name)
+        physical-id (if binding-resolver
+                      (java.util.UUID/nameUUIDFromBytes
+                       (.getBytes world-key java.nio.charset.StandardCharsets/UTF_8))
+                      (random-uuid))]
+    (-> cfg
+        (assoc-in [:store :backend] :memory)
+        (assoc-in [:store :id] physical-id))))
+
+(defn dispose-ephemeral-databases!
+  "Release and delete every process-global scratch database owned by the
+   currently selected interpreter world. Returns cleanup errors, if any."
+  [binding-resolver binding-swap!]
+  (when (and binding-resolver binding-swap!)
+    (let [entries (or (:ephemeral-databases (binding-resolver)) {})
+          errors (reduce-kv
+                  (fn [errors name entry]
+                    (let [conn (entry-conn entry)
+                          cfg (:config entry)]
+                      (try
+                        (when conn (d/release conn))
+                        (when (and cfg (d/database-exists? cfg))
+                          (d/delete-database cfg))
+                        errors
+                        (catch Throwable error
+                          (conj errors {:name name :error error})))))
+                  [] entries)]
+      (binding-swap! assoc :ephemeral-databases {})
+      errors)))
+
 (defn add-datahike-ns!
   "Mount the faithful datahike API under `datahike.api` and `d`, with lifecycle fns
    guarded to room `room-id` (resolved fork-aware under `ctx`)."
-  [sci-ctx room-id ctx]
+  [sci-ctx room-id ctx & [binding-resolver binding-swap!]]
   (let [data      (into {} (keep (fn [sym]
-                                   (when-let [v (ns-resolve 'datahike.api sym)] [sym @v]))
+                                   (when-let [v (ns-resolve 'datahike.api sym)]
+                                     (let [f @v]
+                                       [sym (fn [& args]
+                                              (let [resolved (mapv resolve-connection args)]
+                                                (try
+                                                  (apply f resolved)
+                                                  (catch Throwable error
+                                                    (throw
+                                                     (ex-info
+                                                      "Sandbox Datahike operation failed"
+                                                      {:operation sym
+                                                       :argument-types
+                                                       (mapv #(some-> % class str) resolved)}
+                                                      error))))))])))
                                  data-ops))
+        data      (assoc data
+                         'transact
+                         (fn [conn tx-data]
+                           (let [conn (resolve-connection conn)]
+                             (d/transact conn
+                                         (assert-no-attempt-write! conn tx-data))))
+                         'transact!
+                         (fn [conn tx-data]
+                           (let [conn (resolve-connection conn)]
+                             (d/transact! conn
+                                          (assert-no-attempt-write! conn tx-data)))))
         ;; per-sandbox ephemeral (:mem) databases, keyed by logical name
         ephemeral (atom {})
-        in-ctx    (fn [f] (binding [ec/*execution-context* ctx] (f)))
+        ephemeral-map #(if binding-resolver
+                         (or (:ephemeral-databases (binding-resolver)) {})
+                         @ephemeral)
+        swap-ephemeral! (fn [f & args]
+                          (if binding-swap!
+                            (binding-swap!
+                             #(update % :ephemeral-databases
+                                      (fn [m]
+                                        (apply f (or m {}) args))))
+                            (apply swap! ephemeral f args)))
+        selected-ctx #(runtime-ctx/selected-context ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-id (binding-resolver)))
+                             room-id)
+        in-ctx    (fn [f]
+                    (binding [ec/*execution-context* (selected-ctx)] (f)))
+        managed-connection
+        (fn [nm]
+          (world-connection
+           #(binding [ec/*execution-context* (selected-ctx)]
+              (or (srooms/room-conn-by-name (current-room-id) nm)
+                  (throw (ex-info (str "No database named " (pr-str nm)
+                                       " in this room")
+                                  {:name nm}))))))
         no-room   (fn [op] (throw (ex-info (str op " needs a room — this sandbox isn't attached to one "
                                                 "(only :mem databases are available here).") {})))
         guard
         {'create-database
          (fn [cfg]
            (in-ctx
-            (fn [] (let [nm (cfg-name cfg)]
+            (fn [] (let [nm (cfg-name cfg)
+                         room-id (current-room-id)]
                      (cond
-                       (mem? cfg) (let [c (assoc-in cfg [:store :id] nm)]
-                                    (when-not (d/database-exists? c) (d/create-database c))
-                                    (swap! ephemeral assoc nm (d/connect c)) cfg)
+                       (mem? cfg) (if (contains? (ephemeral-map) nm)
+                                    cfg
+                                    (let [c (world-memory-config cfg binding-resolver)]
+                                      (when (d/database-exists? c)
+                                        (throw (ex-info
+                                                "Scratch database exists without a live world owner"
+                                                {:name nm :physical-config c})))
+                                      (d/create-database c)
+                                      (swap-ephemeral! assoc nm
+                                                       {:connection (d/connect c)
+                                                        :config c})
+                                      cfg))
                        room-id    (do (srooms/create-room-db! room-id nm
-                                                               ;; honour datahike's own default (:write) — don't
-                                                               ;; silently downgrade to :read. Explicit :read in cfg
-                                                               ;; still wins (schema-free append-only scratch).
+                                                             ;; honour datahike's own default (:write) — don't
+                                                             ;; silently downgrade to :read. Explicit :read in cfg
+                                                             ;; still wins (schema-free append-only scratch).
                                                               :schema-flexibility (get cfg :schema-flexibility :write))
                                       cfg)
                        :else      (no-room "create-database"))))))
@@ -77,8 +237,8 @@
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (or (get @ephemeral nm)
-                         (when room-id (srooms/room-conn-by-name room-id nm))
+                     (or (some-> (get (ephemeral-map) nm) entry-conn)
+                         (when (current-room-id) (managed-connection nm))
                          (throw (ex-info (str "No database named " (pr-str nm)
                                               " in this room — create it with create-database, or see "
                                               "(dvergr.room/databases).")
@@ -87,15 +247,24 @@
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (boolean (or (get @ephemeral nm)
-                                  (when room-id (srooms/room-conn-by-name room-id nm))))))))
+                     (boolean (or (get (ephemeral-map) nm)
+                                  (when-let [room-id (current-room-id)]
+                                    (srooms/room-conn-by-name room-id nm))))))))
          'delete-database
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (if (contains? @ephemeral nm)
-                       (do (swap! ephemeral dissoc nm) true)
-                       (boolean (when room-id (srooms/delete-room-db! room-id nm))))))))}
+                     (if (contains? (ephemeral-map) nm)
+                       (let [{:keys [connection config] :as entry}
+                             (get (ephemeral-map) nm)]
+                         (when-let [conn (entry-conn entry)]
+                           (d/release conn))
+                         (when (and config (d/database-exists? config))
+                           (d/delete-database config))
+                         (swap-ephemeral! dissoc nm)
+                         true)
+                       (boolean (when-let [room-id (current-room-id)]
+                                  (srooms/delete-room-db! room-id nm))))))))}
         m (merge data guard)]
     ;; The real datahike.api name (the model aliases it `:as d` itself, as everyone does).
     (sci/add-namespace! sci-ctx 'datahike.api m)))

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -344,6 +344,36 @@
       (throw (ex-info "Virtual filesystem sink does not accept binary content"
                       {:path path})))))
 
+(defn- world-filesystem
+  "A stable Muschel handle whose every operation resolves the ambient world.
+
+   SCI code may retain this value across an interpreter fork.  Delegating at
+   the protocol boundary prevents such saved functions from retaining the
+   parent's Geschichte workspace."
+  [resolver]
+  (letfn [(fs! [] (or (resolver)
+                      (throw (ex-info "Current world has no filesystem" {}))))]
+    (reify mfs/FS
+      (-resolve [_ path] (mfs/-resolve (fs!) path))
+      (-cwd [_] (mfs/-cwd (fs!)))
+      (-cd! [_ path] (mfs/-cd! (fs!) path))
+      (-exists? [_ path] (mfs/-exists? (fs!) path))
+      (-stat [_ path] (mfs/-stat (fs!) path))
+      (-list-dir [_ path] (mfs/-list-dir (fs!) path))
+      (-read-file [_ path] (mfs/-read-file (fs!) path))
+      (-read-bytes [_ path] (mfs/-read-bytes (fs!) path))
+      (-open-source [_ path] (mfs/-open-source (fs!) path))
+      (-open-sink [_ path append?] (mfs/-open-sink (fs!) path append?))
+      (-mkdir [_ path] (mfs/-mkdir (fs!) path))
+      (-delete [_ path] (mfs/-delete (fs!) path))
+      (-rename [_ from to] (mfs/-rename (fs!) from to))
+      (-touch [_ path] (mfs/-touch (fs!) path))
+      (-chmod [_ path mode] (mfs/-chmod (fs!) path mode))
+      (-symlink [_ target link-path] (mfs/-symlink (fs!) target link-path))
+      (-chown [_ path owner group] (mfs/-chown (fs!) path owner group))
+      (-sandbox-relativize [_ path] (mfs/-sandbox-relativize (fs!) path))
+      (-physical-path [_ path] (mfs/-physical-path (fs!) path)))))
+
 (defn- glob-regex [pattern]
   (-> pattern
       (str/replace "." "\\.")
@@ -449,9 +479,13 @@
 (defn add-fs-ns!
   "Expose a filesystem namespace backed by Muschel when `:filesystem` is
   supplied; otherwise retain the transitional physical adapter."
-  [sci-ctx & {:keys [filesystem] :as options}]
-  (if filesystem
-    (add-virtual-fs-ns! sci-ctx filesystem (:audit-log options))
+  [sci-ctx & {:keys [filesystem filesystem-resolver] :as options}]
+  (if (or filesystem filesystem-resolver)
+    (add-virtual-fs-ns! sci-ctx
+                        (if filesystem-resolver
+                          (world-filesystem filesystem-resolver)
+                          filesystem)
+                        (:audit-log options))
     (apply add-physical-fs-ns! sci-ctx (mapcat identity options))))
 
 (defn add-git-ns!
@@ -481,11 +515,14 @@
 
      (git/commit \"Add feature\")
      ;; => \"[main abc1234] Add feature\""
-  [sci-ctx & {:keys [base-path audit-log workspace]
+  [sci-ctx & {:keys [base-path audit-log workspace workspace-resolver]
               :or   {base-path ((requiring-resolve 'dvergr.substrate.git/safe-workspace-root))}}]
-  (let [run!      (if workspace
+  (let [run!      (if (or workspace workspace-resolver)
                     (fn [& args]
-                      (let [result ((requiring-resolve
+                      (let [workspace (if workspace-resolver
+                                        (workspace-resolver)
+                                        workspace)
+                            result ((requiring-resolve
                                      'dvergr.substrate.geschichte/execute-git)
                                     workspace (vec args))]
                         (if (zero? (:exit result))
@@ -549,8 +586,9 @@
      (env/get \"API_KEY\" \"default\")   ;; with fallback
      (env/keys)                        ;; list granted keys (no values)
      (env/set \"KEY\" \"value\")         ;; store in user config (session-local)"
-  [sci-ctx & {:keys [user-config secrets]}]
+  [sci-ctx & {:keys [user-config config-resolver config-swap! secrets]}]
   (let [config-atom (or user-config (atom {}))
+        config      #(if config-resolver (config-resolver) @config-atom)
         ;; A configured boundary-injection SECRET resolves to its opaque
         ;; PLACEHOLDER (never the real value) — the HTTP egress substitutes the
         ;; real value at the destination. Non-secret granted keys still return
@@ -559,12 +597,16 @@
                  (let [k (str key)]
                    (if-let [s (get secrets k)]
                      (:placeholder s)
-                     (or (get @config-atom k) (get @config-atom (keyword key))))))
+                     (or (get (config) k) (get (config) (keyword key))))))
         get-fn (fn
                  ([key]         (get-1 key))
                  ([key default] (or (get-1 key) default)))
-        set-fn (fn [key value] (swap! config-atom assoc (str key) value) :ok)
-        keys-fn (fn [] (vec (distinct (concat (map str (keys @config-atom))
+        set-fn (fn [key value]
+                 (if config-swap!
+                   (config-swap! assoc (str key) value)
+                   (swap! config-atom assoc (str key) value))
+                 :ok)
+        keys-fn (fn [] (vec (distinct (concat (map str (keys (config)))
                                               (keys (or secrets {}))))))]
     (sci/add-namespace! sci-ctx 'env
                         (doc/with-docs

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -5,6 +5,7 @@
    datahike + spindel directly."
   (:require [sci.core :as sci]
             [datahike.api :as dh]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [org.replikativ.spindel.engine.core :as rtc]
             [dvergr.sandbox.ns.doc :as doc]))
 
@@ -54,7 +55,8 @@
   (require 'dvergr.room.registry)
   (require 'dvergr.room.store)
   (require 'dvergr.rooms.forks)
-  (let [fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
+  (let [selected-ctx    #(runtime-ctx/selected-context spindel-ctx)
+        fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
         fork-review*    @(ns-resolve 'dvergr.rooms.forks 'review)
         fork-classify*  @(ns-resolve 'dvergr.rooms.forks 'classify)
         post*           @(ns-resolve 'dvergr.discourse 'post!)
@@ -77,9 +79,13 @@
         rreg-children*  @(ns-resolve 'dvergr.room.registry 'children)
         registry*       (find-ns 'dvergr.room.registry)
         rstore-ns*      (find-ns 'dvergr.room.store)
+        current-source-room (fn []
+                              (if (fn? source-room)
+                                (source-room)
+                                source-room))
         ;; Helpers
         resolve-room    (fn [ref]
-                          (binding [rtc/*execution-context* spindel-ctx]
+                          (binding [rtc/*execution-context* (selected-ctx)]
                             (cond
                               (and (map? ref) (:id ref))
                               (rreg-lookup* (:id ref))            ; canonical Room only
@@ -90,20 +96,21 @@
         create-fn   (fn [{:keys [title slug type telegram-chat-id agents
                                  agent-ids parent-id]
                           :as _opts}]
-                      (binding [rtc/*execution-context* spindel-ctx]
-                        (let [aset (set (or agents agent-ids))]
-                          (create-room!*
-                           (cond-> {:title title
-                                    :slug  slug
-                                    :type  (or type :internal)
-                                    :ctx   spindel-ctx}
-                             telegram-chat-id (assoc :telegram-chat-id telegram-chat-id)
-                             (seq aset)       (assoc :agent-ids aset)
-                             parent-id        (assoc :parent-id parent-id)))
-                          {:slug slug :title (or title slug) :agents aset
-                           :room (rreg-lookup* (slug->id* slug))})))
+                      (let [world (selected-ctx)]
+                        (binding [rtc/*execution-context* world]
+                          (let [aset (set (or agents agent-ids))]
+                            (create-room!*
+                             (cond-> {:title title
+                                      :slug  slug
+                                      :type  (or type :internal)
+                                      :ctx   world}
+                               telegram-chat-id (assoc :telegram-chat-id telegram-chat-id)
+                               (seq aset)       (assoc :agent-ids aset)
+                               parent-id        (assoc :parent-id parent-id)))
+                            {:slug slug :title (or title slug) :agents aset
+                             :room (rreg-lookup* (slug->id* slug))}))))
         list-fn     (fn [& {:keys [where]}]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (if where (rreg-list* :where where) (rreg-list*))))
         get-fn      resolve-room
         post-fn     (fn [ref {:keys [content from source-user source-username source-user-id]}]
@@ -121,7 +128,7 @@
                         (messages* room (cond-> {} limit (assoc :limit limit)
                                                 since (assoc :since since)))))
         children-fn (fn [ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (when-let [room (resolve-room ref)]
                           (rreg-children* (:id room)))))
         set-parent-fn (fn [child-ref parent-ref]
@@ -140,18 +147,19 @@
                         (leave-agent!* room agent-id)
                         {:left agent-id :room (:id room)}))
         delete-fn   (fn [ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (if-let [room (resolve-room ref)]
                           (do
                             ;; An SCI evaluation cannot synchronously join its
                             ;; own controller/context teardown. Self-deletion is
                             ;; a supervisor effect; subordinate Rooms are safe.
-                            (when (and (= (:id source-room) (:id room))
-                                       (= (:incarnation source-room)
-                                          (:incarnation room)))
-                              (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
-                                              {:type ::self-delete
-                                               :room-id (:id room)})))
+                            (let [source-room (current-source-room)]
+                              (when (and (= (:id source-room) (:id room))
+                                         (= (:incarnation source-room)
+                                            (:incarnation room)))
+                                (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
+                                                {:type ::self-delete
+                                                 :room-id (:id room)}))))
                             (let [result (delete-room!* room)]
                               (if (:ok? result)
                                 {:deleted (:id room)}
@@ -163,7 +171,7 @@
         fork-fn     (fn fork-fn
                       ([ref] (fork-fn ref {}))
                       ([ref opts]
-                       (binding [rtc/*execution-context* spindel-ctx]
+                       (binding [rtc/*execution-context* (selected-ctx)]
                          (when-let [room (resolve-room ref)]
                            (binding [rtc/*execution-context* (:ctx room)]
                              (fork-room* room opts))))))
@@ -175,18 +183,18 @@
                         (discard* fork)))
         ;; Merge review — the per-system diff + tier the agent reads to decide.
         diff-fn     (fn [fork-ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (some-> (resolve-room fork-ref) fork-diff*)))
         review-fn   (fn [fork-ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (some-> (resolve-room fork-ref) fork-review*)))
         forks-fn    (fn []
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (rreg-list* :where #(some? (:forked-from @(:meta %))))))
         participants-fn (fn [room]
                           (when room (vec (keys @(:participants room)))))
         root-fn     (fn []
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (or (rreg-lookup* :daemon)
                             (rtc/get-state [:dvergr/discourse-root]))))]
     (doc/with-docs

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -16,6 +16,8 @@
   (:require [datahike.api :as d]
             [dvergr.system.rooms :as srooms]
             [dvergr.sandbox.ns.kb :as ns-kb]
+            [dvergr.sandbox.ns.datahike :as ns-datahike]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
@@ -34,8 +36,30 @@
    may be nil (room-less ctx) — the helpers degrade gracefully.
    `agent-program-ceiling` is forwarded to the room-bound SCI setup; bounded
    delegation itself lives only in the `dvergr.agent` namespace."
-  [sci-ctx room-conn kb-conn room-id ctx & [agent-program-ceiling source-room]]
-  (let [;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
+  [sci-ctx room-conn kb-conn room-id ctx
+   & [agent-program-ceiling {:keys [binding-resolver source-room]}]]
+  (let [selected-ctx   #(runtime-ctx/selected-context ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-id (binding-resolver)))
+                             room-id)
+        current-source-room #(if binding-resolver
+                               (let [binding (binding-resolver)]
+                                 {:id (:room-runtime-id binding)
+                                  :incarnation (:room-incarnation binding)})
+                               source-room)
+        room-view      (when (or room-id room-conn)
+                         (ns-datahike/world-connection
+                          #(if-let [room-id (current-room-id)]
+                             (binding [ec/*execution-context* (selected-ctx)]
+                               (srooms/room-msgs-conn room-id))
+                             room-conn)))
+        kb-view        (when (or room-id kb-conn)
+                         (ns-datahike/world-connection
+                          #(if-let [room-id (current-room-id)]
+                             (binding [ec/*execution-context* (selected-ctx)]
+                               (srooms/room-kb-conn room-id))
+                             kb-conn)))
+        ;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
         ;; its own KB plus whatever is granted to it, and the two are written
         ;; through different bindings of the same katzen schema — dvergr's
         ;; `:entity/title` and a product's `:S.Page/title`. Reading one store
@@ -46,8 +70,8 @@
         ;; address that KB by name (see `kbs` / `kb`).
         title-attrs    [:entity/title :S.Page/title]
         readable       (fn []
-                         (if room-id
-                           (binding [ec/*execution-context* ctx]
+                         (if-let [room-id (current-room-id)]
+                           (binding [ec/*execution-context* (selected-ctx)]
                              (srooms/room-kb-conns room-id))
                            (when kb-conn [{:conn kb-conn :slug "kb"}])))
         titled         (fn [db]
@@ -83,51 +107,59 @@
                                        (take 25) vec))))
         msg-time       (fn [m] (or (some-> ^java.util.Date (:message/created-at m) .getTime) 0))
         recent-msgs    (fn [n]
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (->> (d/q '[:find [(pull ?m [:message/content :message/role :message/created-at]) ...]
-                                              :where [?m :message/content _]] @room-conn)
+                                              :where [?m :message/content _]] @room-view)
                                        (sort-by msg-time >)
                                        (take (or n 20)) vec))))
         search-msgs    (fn [term]
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (let [lc (str/lower-case (str term))]
                                     (->> (d/q '[:find [(pull ?m [:message/content :message/role :message/created-at]) ...]
-                                                :where [?m :message/content _]] @room-conn)
+                                                :where [?m :message/content _]] @room-view)
                                          (filter (fn [m] (str/includes? (str/lower-case (str (:message/content m))) lc)))
                                          (take 50) vec)))))
         schedules      (fn []
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (d/q '[:find [(pull ?s [*]) ...]
-                                         :where [?s :schedule/id _]] @room-conn))))
+                                         :where [?s :schedule/id _]] @room-view))))
         ;; Discovery: WHERE the agent's databases are + by-name access. Resolved
         ;; fork-aware under `ctx` so a fork lists/returns its branched systems.
-        databases      (fn [] (safe #(when room-id
-                                       (binding [ec/*execution-context* ctx]
+        databases      (fn [] (safe #(when-let [room-id (current-room-id)]
+                                       (binding [ec/*execution-context* (selected-ctx)]
                                          (srooms/room-databases room-id)))))
-        db             (fn [db-name] (safe #(when room-id
-                                              (binding [ec/*execution-context* ctx]
-                                                (srooms/room-conn-by-name room-id db-name)))))
+        db             (fn [db-name]
+                         (safe #(when-let [room-id (current-room-id)]
+                                  (ns-datahike/world-connection
+                                   (fn []
+                                     (binding [ec/*execution-context* (selected-ctx)]
+                                       (srooms/room-conn-by-name room-id db-name)))))))
         ;; Reclaim unreachable storage for THIS room/fork's workspace (datahike
         ;; index blobs + git objects). Default keeps all history (orphan garbage
         ;; only); pass {:remove-before <Date>} to collapse old history.
         gc!            (fn gc!
                          ([] (gc! {}))
-                         ([opts] (safe #(binding [ec/*execution-context* ctx] (ygg/gc! opts)))))
+                         ([opts] (safe #(binding [ec/*execution-context* (selected-ctx)]
+                                          (ygg/gc! opts)))))
         ;; Which KBs this room may WRITE, and which one `*kb*` is. A room's own
         ;; KB is the default, but a room whose knowledge lives in an ATTACHED KB
         ;; would otherwise write into its own empty one with nothing saying so —
         ;; the agent could not even name the alternatives. These make the choice
         ;; visible and addressable.
-        kbs (fn [] (safe #(binding [ec/*execution-context* ctx]
-                            (let [ws (srooms/writable-kbs room-id)]
+        kbs (fn [] (safe #(binding [ec/*execution-context* (selected-ctx)]
+                            (let [ws (srooms/writable-kbs (current-room-id))]
                               (into [] (map-indexed
                                         (fn [i {:keys [slug permission]}]
                                           {:name slug :permission permission
                                            :default? (zero? i)}))
                                     ws)))))
-        kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
-                                (srooms/room-kb-conn room-id slug))))
-        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling source-room) ; create!/fork!/merge!/post!/messages/…
+        kb  (fn [slug]
+              (safe #(ns-datahike/world-connection
+                      (fn []
+                        (binding [ec/*execution-context* (selected-ctx)]
+                          (srooms/room-kb-conn (current-room-id) slug))))))
+        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling
+                                            current-source-room) ; create!/fork!/merge!/post!/messages/…
                         ;; Docs live HERE rather than only in these trailing
                         ;; comments: the comments never reached the sandbox, so
                         ;; `(clojure.repl/doc dvergr.room/kb-search)` answered
@@ -136,8 +168,8 @@
                         ;; (or nil) — values with no signature to state — so
                         ;; they carry no entry and are described in ns-guide.
                         (doc/with-docs
-                          {'*room*          room-conn      ; the room's own datahike (messages store)
-                           '*kb*            kb-conn         ; the DEFAULT writable KB (see kbs)
+                          {'*room*          room-view      ; ambient messages-store handle
+                           '*kb*            kb-view       ; ambient default-KB handle
                            'kbs             kbs             ; [{:name :permission :default?}] — writable KBs
                            'kb              kb              ; fork-aware conn to a writable KB by name
                            'databases       databases       ; [{:name :type :permission}] — your DBs

--- a/src/dvergr/sci/clojure_test.clj
+++ b/src/dvergr/sci/clojure_test.clj
@@ -4,7 +4,8 @@
    We've vendored babashka's clojure.test (EPL licensed) and adapted it
    to work without babashka's infrastructure."
   (:require [dvergr.sci.impl.clojure-test :as t]
-            [sci.core :as sci]))
+            [sci.core :as sci]
+            [sci.ctx-store :as sci-ctx-store]))
 
 ;; Create the test namespace object
 (def tns t/tns)
@@ -12,6 +13,16 @@
 ;; Helper to create SCI vars
 (defn new-var [var-sym f]
   (sci/new-var var-sym f {:ns tns}))
+
+(defn- shared-host-capability
+  "Declare a vendored clojure.test implementation object as an ambient
+   capability. Its mutable state is not agent memory: SCI code receives the
+   callable/output Var but Dvergr installs the implementation once at boot.
+   Marking the individual Var keeps SCI's fail-closed policy for every other
+   host value while allowing world forks to retain this implementation table."
+  [v]
+  (alter-meta! v assoc :sci.impl/fork-fn identity)
+  v)
 
 ;; Base namespace map — everything except the high-level runners that need ctx.
 ;; Combine with ctx-aware-test-namespace (below) for full functionality.
@@ -28,13 +39,13 @@
    '*initial-report-counters* t/initial-report-counters
    '*testing-vars*           t/testing-vars
    '*testing-contexts*       t/testing-contexts
-   '*test-out*               t/test-out
+   '*test-out*               (shared-host-capability t/test-out)
 
    ;; Utilities
    'testing-vars-str    (sci/copy-var t/testing-vars-str tns)
    'testing-contexts-str (sci/copy-var t/testing-contexts-str tns)
    'inc-report-counter  (sci/copy-var t/inc-report-counter tns)
-   'report              t/report
+   'report              (shared-host-capability t/report)
    'do-report           (sci/copy-var t/do-report tns)
 
    ;; Assertion utilities
@@ -43,7 +54,8 @@
    'assert-any          (sci/copy-var t/assert-any tns)
 
    ;; Assertion methods
-   'assert-expr         (sci/copy-var t/assert-expr tns)
+   'assert-expr         (shared-host-capability
+                         (sci/copy-var t/assert-expr tns))
    'try-expr            (sci/copy-var t/try-expr tns)
 
    ;; Assertion macros
@@ -58,7 +70,8 @@
    'set-test            (sci/copy-var t/set-test tns)
 
    ;; Fixtures
-   'use-fixtures        (sci/copy-var t/use-fixtures tns)
+   'use-fixtures        (shared-host-capability
+                         (sci/copy-var t/use-fixtures tns))
    'compose-fixtures    (sci/copy-var t/compose-fixtures tns)
    'join-fixtures       (sci/copy-var t/join-fixtures tns)
 
@@ -71,23 +84,30 @@
    'with-test-out       (sci/copy-var t/with-test-out tns)})
 
 (defn ctx-aware-test-namespace
-  "Build a clojure.test namespace map that closes over the real SCI ctx.
+  "Build a clojure.test namespace map that resolves the active SCI ctx.
 
    The high-level runners (run-tests, test-ns, test-all-vars, run-all-tests) need
-   the real SCI context to enumerate vars via sci-ns-interns*. Passing a dummy ctx
-   causes them to find 0 tests. Call this after (sci/init ...) with the real ctx.
+   the selected SCI context to enumerate vars via sci-ns-interns*. They resolve
+   it from sci.ctx-store at invocation, so a copied runner enumerates the child
+   world after a fork rather than retaining its parent. Call this after
+   (sci/init ...) with the initial ctx.
 
    Usage:
      (sci/merge-opts ctx {:namespaces {'clojure.test (ctx-aware-test-namespace ctx)}})"
-  [ctx]
+  [_ctx]
   (merge clojure-test-namespace
          {'test-all-vars (new-var 'test-all-vars
-                                  (fn [ns-obj] (t/test-all-vars ctx ns-obj)))
+                                  (fn [ns-obj]
+                                    (t/test-all-vars (sci-ctx-store/get-ctx) ns-obj)))
           'test-ns       (new-var 'test-ns
-                                  (fn [ns-sym] (t/test-ns ctx ns-sym)))
+                                  (fn [ns-sym]
+                                    (t/test-ns (sci-ctx-store/get-ctx) ns-sym)))
           'run-tests     (new-var 'run-tests
-                                  (fn [& namespaces] (apply t/run-tests ctx namespaces)))
+                                  (fn [& namespaces]
+                                    (apply t/run-tests
+                                           (sci-ctx-store/get-ctx) namespaces)))
           'run-all-tests (new-var 'run-all-tests
                                   (fn
-                                    ([] (t/run-all-tests ctx))
-                                    ([re] (t/run-all-tests ctx re))))}))
+                                    ([] (t/run-all-tests (sci-ctx-store/get-ctx)))
+                                    ([re] (t/run-all-tests
+                                           (sci-ctx-store/get-ctx) re))))}))

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -595,7 +595,8 @@
                :properties {:code {:type "string"
                                    :description "Clojure code to evaluate"}}
                :required ["code"]}
-  :execute (fn [{:keys [code]} {:keys [sci-ctx isolation eval-ns chat-ctx cancel?]}]
+  :execute (fn [{:keys [code]} {:keys [sci-ctx isolation eval-ns chat-ctx cancel?
+                                       execution-ctx]}]
               ;; Native mode: use real Clojure eval
              (cond
                (= :native isolation)
@@ -631,7 +632,8 @@
                                                  (catch Throwable _ false))))]
                                      (sandbox/eval-code sci-ctx code
                                                         :timeout-ms @eval-timeout-ms
-                                                        :cancel? proc-aborted?))))
+                                                        :cancel? proc-aborted?
+                                                        :execution-context execution-ctx))))
                   ;; Block on process completion / abort.
                  (let [{:keys [ok aborted]} @result-p]
                    (cond
@@ -674,7 +676,8 @@
                sci-ctx
                (let [result (sandbox/eval-code sci-ctx code
                                                :timeout-ms @eval-timeout-ms
-                                               :cancel? cancel?)]
+                                               :cancel? cancel?
+                                               :execution-context execution-ctx)]
                  (if (:success result)
                    {:type :success
                     :content (str "=> " (pr-str (:value result))
@@ -1487,7 +1490,7 @@ Note: changes take effect on the next agent restart or reload."
   ;; The sandbox already has a ctx-aware clojure.test (run-tests / run-all-tests
   ;; enumerate vars in THIS context), so running there is both correct and
   ;; actually isolated. `:sci-ctx` is the same handle clojure_eval receives.
-  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx]}]
+  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx execution-ctx]}]
              (if-not sci-ctx
                {:type :error
                 :error "No sandbox context available to run tests in."}
@@ -1496,7 +1499,8 @@ Note: changes take effect on the next agent restart or reload."
                             pattern (str "(clojure.test/run-all-tests #\""
                                          (str/replace pattern "\"" "\\\"") "\")")
                             :else   "(clojure.test/run-all-tests)")
-                     r    (sandbox/eval-code sci-ctx form)]
+                     r    (sandbox/eval-code sci-ctx form
+                                             :execution-context execution-ctx)]
                  (if-not (:success r)
                    {:type :error
                     :error (str "Test run failed: " (get-in r [:error :message]))}

--- a/src/dvergr/web/dashboard.clj
+++ b/src/dvergr/web/dashboard.clj
@@ -12,6 +12,7 @@
             [org.replikativ.spindel.engine.core :as ec]
             [nextjournal.markdown :as md]
             [nextjournal.markdown.transform :as mdt]
+            [dvergr.activity :as activity]
             [dvergr.rooms.tree :as rooms-tree]
             [dvergr.rooms.stats :as rstats]))
 
@@ -515,8 +516,21 @@
            [:span.tool-name (str (or (:tool-use/name tu) (:name tu)))]
            [:pre.msg-extra-body (pr-str (or (:tool-use/input tu) (:input tu)))]])]))))
 
+(defn- activity-hiccup
+  "Compact semantic facts; raw arguments remain in the existing trace details."
+  [message]
+  (when-let [facts (seq (activity/message-activities message))]
+    (let [run-id (or (activity/message-run-id message)
+                     (:activity/run-id (first facts)))]
+      [:div.msg-activities
+       (for [fact facts]
+         [:span.msg-activity
+          (activity/summary fact)
+          (when-let [id (activity/short-id (or (:activity/run-id fact) run-id))]
+            [:span.msg-run "run " id])])])))
+
 (defn- message-hiccup
-  [{:keys [id from content role ts reasoning tool-uses]}]
+  [{:keys [id from content role ts reasoning tool-uses] :as message}]
   (let [name-str (or (some-> from name) "—")
         ;; Per-speaker colour from the SHARED role→colour table — same hues the
         ;; TUI uses (dvergr.rooms.theme); was hardcoded green for every post.
@@ -530,6 +544,7 @@
       (when-let [t (fmt-ts ts)]
         [:span {:style "margin-left:auto;color:#666;font-weight:400;font-size:0.85em;"} t])]
      [:div.msg-body (md->hiccup content)]
+     (activity-hiccup message)
      (think-tool-details id reasoning tool-uses)]))
 
 (defn room-page
@@ -548,6 +563,10 @@
           .msg-body { color:#ddd; word-break:break-word; line-height:1.5; }
           .msg-body > :first-child { margin-top:0; }
           .msg-body > :last-child { margin-bottom:0; }
+          .msg-activities { display:flex;flex-wrap:wrap;gap:5px;margin-top:5px; }
+          .msg-activity { color:#c9a227;background:#25200f;border:1px solid #514519;
+                          border-radius:999px;padding:1px 7px;font-size:0.78em; }
+          .msg-run { color:#888;margin-left:7px;font-family:monospace; }
           .msg-body p { margin:0.4em 0; }
           .msg-body h1,.msg-body h2,.msg-body h3 { color:#e0e0e0; margin:0.6em 0 0.3em; line-height:1.2; }
           .msg-body h1 { font-size:1.25em; } .msg-body h2 { font-size:1.15em; } .msg-body h3 { font-size:1.05em; }

--- a/src/dvergr/web/dashboard.clj
+++ b/src/dvergr/web/dashboard.clj
@@ -416,7 +416,10 @@
             cs     (rstats/room-agent-contexts room)
             lookup (requiring-resolve 'dvergr.agent.room-context/lookup)
             sbstat (requiring-resolve 'dvergr.sandbox/sandbox-status)
-            sb-of  (fn [aid] (try (sbstat (:sci-ctx (lookup rid aid))) (catch Throwable _ nil)))]
+            sci-in (requiring-resolve 'dvergr.chat.context/sci-context-in)
+            sb-of  (fn [aid]
+                     (try (sbstat (sci-in (lookup rid aid) (:ctx room)))
+                          (catch Throwable _ nil)))]
         (str (h/html
               (if (seq cs)
                 (into [:div.ctx-agents] (map #(agent-context-row % (sb-of (:agent %))) cs))

--- a/test/dvergr/activity_test.clj
+++ b/test/dvergr/activity_test.clj
@@ -1,6 +1,7 @@
 (ns dvergr.activity-test
   (:require [clojure.test :refer [deftest is testing]]
-            [dvergr.activity :as activity]))
+            [dvergr.activity :as activity]
+            [dvergr.agent.environment :as environment]))
 
 (deftest tool-activity-identity-is-canonical-and-stable
   (testing "the same typed source identity hashes to the same activity UUID"
@@ -18,3 +19,50 @@
       (is (uuid? first-id))
       (is (= first-id replay-id))
       (is (not= first-id other-id)))))
+
+(deftest tool-traces-preserve-correlation-across-interleaved-runs
+  (let [run-a (random-uuid)
+        run-b (random-uuid)
+        message-a (random-uuid)
+        message-b (random-uuid)
+        use-a {:tool-use/id "call-a"
+               :tool-use/name "search"
+               :tool-use/input {:query "alpha"}}
+        use-b {:tool-use/id "call-b"
+               :tool-use/name "search"
+               :tool-use/input {:query "beta"}}
+        messages
+        [{:id message-a
+          :metadata {:run-id run-a
+                     :tool-uses [use-a]
+                     :activities (activity/tool-activities
+                                  run-a message-a [use-a])}}
+         {:id message-b
+          :metadata {:run-id run-b
+                     :tool-uses [use-b]
+                     :activities (activity/tool-activities
+                                  run-b message-b [use-b])}}]
+        trace (mapv activity/tool-trace-entry messages)]
+    (is (= [[message-a run-a "call-a" run-a]
+            [message-b run-b "call-b" run-b]]
+           (mapv (fn [entry]
+                   [(:message/id entry)
+                    (:run/id entry)
+                    (get-in entry [:tool-uses 0 :tool-use/id])
+                    (get-in entry [:activities 0 :activity/run-id])])
+                 trace)))
+    (is (= [{:query "alpha"} {:query "beta"}]
+           (mapv #(get-in % [:tool-uses 0 :tool-use/input]) trace)))
+    (is (every? integer? (map #(get-in % [:activities 0 :activity/at]) trace)))
+    (let [definition
+          (environment/make-environment
+           {:id :test/tool-trace
+            :task "trace"
+            :verifier {:id :test/trace :version 1}})
+          receipt
+          (environment/make-attempt-receipt
+           definition
+           {:run-id run-a :provider :test :model "stub" :status :completed
+            :started-at 0 :elapsed-ms 1 :metrics {} :checks {:trace? true}
+            :reward 1.0 :trace trace})]
+      (is (= receipt (environment/validate-attempt-receipt receipt))))))

--- a/test/dvergr/agent/attempt_test.clj
+++ b/test/dvergr/agent/attempt_test.clj
@@ -1,0 +1,128 @@
+(ns dvergr.agent.attempt-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.episode :as episode]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [hasch.core :as hasch]))
+
+(defn- fixture []
+  (let [run-id (random-uuid)
+        agent (-> (roster/make-roster)
+                  (roster/make-agent {:id :candidate
+                                      :program {:kind :echo}})
+                  (roster/agent :candidate))
+        definition
+        (environment/make-environment
+         {:id :bench/exact
+          :task {:answer 42}
+          :verifier {:id :bench/exact :version 2 :basis "git:abc"}
+          :limits {:timeout-ms 1000}
+          :world {:isolation :ctx :settlement :review}})
+        receipt
+        (environment/make-attempt-receipt
+         definition
+         {:run-id run-id :provider :dvergr :model "echo"
+          :status :completed :started-at 1000 :elapsed-ms 25
+          :metrics {:program-kind :echo :model-resolution :not-applicable
+                    :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                    :interpreter-version 5}
+          :checks {:exact? true} :reward 1.0
+          :result {:answer 42}
+          :trace {:runs [{:run/id run-id :run/status :completed}]}})
+        certified (attempt/make-attempt definition agent receipt
+                                        {:result {:answer 42}
+                                         :trace {:runs [{:run/id run-id
+                                                         :run/status :completed}]}}
+                                        :review)]
+    {:run-id run-id :agent agent :definition definition
+     :receipt receipt :attempt certified}))
+
+(defn- terminal-run [run-id room-id agent]
+  (let [now (java.util.Date. 1000)]
+    {:run/id run-id :run/kind :agent-task :run/room room-id
+     :run/actor (:agent/id agent) :run/trigger (random-uuid)
+     :run/status :completed :run/created-at now :run/started-at now
+     :run/updated-at now :run/ended-at (java.util.Date. 1025)
+     :run/agent-version (:agent/version agent) :run/program-kind :echo
+     :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)}))
+
+(defn- attempt-with-trace [run-id agent definition trace]
+  (let [receipt
+        (environment/make-attempt-receipt
+         definition
+         {:run-id run-id :provider :dvergr :model "echo"
+          :status :completed :started-at 1000 :elapsed-ms 25
+          :metrics {:program-kind :echo :model-resolution :not-applicable
+                    :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                    :interpreter-version 5}
+          :checks {:exact? true} :reward 1.0 :trace trace})]
+    (attempt/make-attempt definition agent receipt {:trace trace} :review)))
+
+(deftest certified-attempt-is-canonical-portable-data
+  (let [{:keys [attempt run-id]} (fixture)]
+    (is (= attempt (attempt/validate-attempt attempt)))
+    (is (= run-id (:attempt/id attempt)))
+    (is (= #{run-id} (:attempt/evidence-run-ids attempt)))
+    (is (= (get-in attempt [:attempt/receipt :attempt/content-id])
+           (:attempt/content-id attempt)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (attempt/validate-attempt
+                  (assoc attempt :attempt/certified-at 9999))))))
+
+(deftest memory-attempt-store-is-immutable-and-run-backed
+  (let [{:keys [attempt run-id agent]} (fixture)
+        room-id :attempt-memory
+        st (memory/make)]
+    (store/-store-room! st room-id {:slug (name room-id)})
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing or non-terminal"
+                          (store/-store-attempt! st room-id attempt)))
+    (store/-store-run! st room-id (terminal-run run-id room-id agent))
+    (let [missing-run (random-uuid)
+          missing-message (random-uuid)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"evidence Run is missing"
+           (store/-store-attempt!
+            st room-id
+            (attempt-with-trace
+             run-id agent (:attempt/environment attempt)
+             {:runs [{:run/id run-id} {:run/id missing-run}]}))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"evidence message is missing"
+           (store/-store-attempt!
+            st room-id
+            (attempt-with-trace
+             run-id agent (:attempt/environment attempt)
+             {:runs [{:run/id run-id}]
+              :messages [{:message/id missing-message}]})))))
+    (is (= attempt (store/-store-attempt! st room-id attempt)))
+    (is (= attempt (store/-store-attempt! st room-id attempt))
+        "identical certification replay is idempotent")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"identity is immutable"
+                          (store/-store-attempt!
+                           st room-id
+                           (assoc attempt :attempt/settlement-intent :discard))))
+    (is (= [attempt]
+           (store/-list-attempts st room-id
+                                 {:environment-id :bench/exact
+                                  :provider :dvergr :status :completed})))
+    (is (empty? (store/-list-attempts st room-id {:model "other"})))))
+
+(deftest episode-is-a-read-join-not-a-second-lifecycle
+  (let [{:keys [attempt run-id agent]} (fixture)
+        room-id :episode-read
+        st (memory/make)
+        room {:id room-id :store st}]
+    (store/-store-room! st room-id {:slug (name room-id)})
+    (store/-store-run! st room-id (terminal-run run-id room-id agent))
+    (store/-store-attempt! st room-id attempt)
+    (let [exported (episode/export room run-id)]
+      (is (= attempt (:episode/attempt exported)))
+      (is (= :completed (get-in exported [:episode/run :run/status])))
+      (is (integer? (get-in exported [:episode/run :run/started-at])))
+      (is (= [run-id] (mapv :run/id (:episode/evidence-runs exported)))))
+    (swap! (:state st) update-in [:runs room-id] dissoc run-id)
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing Run"
+                          (episode/export room run-id)))))

--- a/test/dvergr/agent/environment_test.clj
+++ b/test/dvergr/agent/environment_test.clj
@@ -1,0 +1,119 @@
+(ns dvergr.agent.environment-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.environment :as environment]
+            [hasch.core :as hasch]))
+
+(def base-spec
+  {:id :programming/join
+   :version 1
+   :task "Build and execute a two-agent join."
+   :verifier {:id :programming/join-checks :version 1
+              :basis "git:abc123"}
+   :limits {:timeout-ms 120000 :max-model-steps 8}
+   :world {:isolation :ctx}})
+
+(deftest definitions-have-stable-content-identity
+  (let [a (environment/make-environment base-spec)
+        b (environment/make-environment
+           (into (array-map) (reverse (seq base-spec))))]
+    (is (= a b))
+    (is (= {:environment/id :programming/join
+            :environment/version 1
+            :environment/content-id (:environment/content-id a)}
+           (environment/environment-ref a)))
+    (doseq [changed [(assoc base-spec :task "Different task")
+                     (assoc-in base-spec [:verifier :version] 2)
+                     (assoc-in base-spec [:limits :max-model-steps] 9)]]
+      (is (not= (:environment/content-id a)
+                (:environment/content-id
+                 (environment/make-environment changed)))))))
+
+(deftest definitions-reject-live-or-ambiguous-state
+  (testing "a trusted verifier is a versioned reference, never an embedded function"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"reference map"
+                          (environment/make-environment
+                           (assoc base-spec :verifier identity)))))
+  (testing "policy fields remain portable forkable data"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"portable data"
+                          (environment/make-environment
+                           (assoc base-spec :metadata {:state (atom 0)})))))
+  (testing "unknown keys fail rather than silently changing hash semantics"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"unknown keys"
+                          (environment/make-environment
+                           (assoc base-spec :verify identity))))))
+
+(deftest references-reject-stale-or-fabricated-content-identities
+  (let [definition (environment/make-environment base-spec)]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match"
+                          (environment/environment-ref
+                           (assoc definition :environment/task "mutated"))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"missing canonical"
+                          (environment/environment-ref
+                           (environment/environment-ref definition))))
+    (is (= definition (environment/validate-environment definition)))))
+
+(deftest trusted-attempt-receipts-bind-run-environment-evidence-and-reward
+  (let [definition (environment/make-environment base-spec)
+        run-id (random-uuid)
+        opts {:run-id run-id
+              :provider :codex-subscription
+              :model "codex-subscription-sol"
+              :status :failed
+              :started-at 1000
+              :elapsed-ms 42
+              :metrics {:prompt-id (random-uuid)
+                        :model-steps 8
+                        :usage {:by-type {:input-tokens 100}}}
+              :checks {:exact-result? false :quiescent? true}
+              :reward 0.0
+              :result nil
+              :trace {:runs [{:run/id run-id :run/status :failed}]}}
+        a (environment/make-attempt-receipt definition opts)
+        b (environment/make-attempt-receipt definition
+                                            (into (array-map) (reverse (seq opts))))
+        rehash (fn [changes]
+                 (let [changed (merge (dissoc a :attempt/content-id) changes)]
+                   (assoc changed :attempt/content-id
+                          (hasch/uuid [:dvergr/environment-attempt changed]))))]
+    (is (= a b))
+    (is (= run-id (:attempt/id a) (:attempt/run-id a)))
+    (is (= (environment/environment-ref definition)
+           (:attempt/environment a)))
+    (is (= a (environment/validate-attempt-receipt a)))
+    (is (uuid? (:attempt/content-id a)))
+    (is (not= (:attempt/content-id a)
+              (:attempt/content-id
+               (environment/make-attempt-receipt
+                definition (assoc opts :reward 1.0)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match"
+                          (environment/validate-attempt-receipt
+                           (assoc a :attempt/reward 1.0))))
+    (doseq [[message changes]
+            [[#"UUID" {:attempt/id "run" :attempt/run-id "run"}]
+             [#"EnvironmentRef" {:attempt/environment :garbage}]
+             [#"non-negative" {:attempt/elapsed-ms -1}]
+             [#"keywords to booleans" {:attempt/checks {:truth :unknown}}]
+             [#"finite" {:attempt/reward ##NaN}]]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo message
+                            (environment/validate-attempt-receipt
+                             (rehash changes)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"keywords to booleans"
+                          (environment/make-attempt-receipt
+                           (environment/make-environment base-spec)
+                           {:run-id (random-uuid) :provider :stub :model "stub"
+                            :status :completed :started-at 0 :elapsed-ms 0
+                            :checks {:truth :unknown} :reward 0.0}))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"finite"
+                        (environment/make-attempt-receipt
+                         (environment/make-environment base-spec)
+                         {:run-id (random-uuid) :provider :stub :model "stub"
+                          :status :completed :started-at 0 :elapsed-ms 0
+                          :checks {} :reward ##Inf}))))

--- a/test/dvergr/agent/evaluation_test.clj
+++ b/test/dvergr/agent/evaluation_test.clj
@@ -1,0 +1,557 @@
+(ns dvergr.agent.evaluation-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.episode :as episode]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [dvergr.rooms.forks :as forks]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.yggdrasil :as ygg]))
+
+(defn- test-room [id]
+  (d/make-room {:id id :store (memory/make)}))
+
+(defrecord RejectingAttemptStore [delegate]
+  store/PRoomStore
+  (-store-room! [_ room-id metadata]
+    (store/-store-room! delegate room-id metadata))
+  (-load-room [_ id] (store/-load-room delegate id))
+  (-delete-room! [_ room-id] (store/-delete-room! delegate room-id))
+  (-list-rooms [_] (store/-list-rooms delegate))
+  (-store-message! [_ room-id message]
+    (store/-store-message! delegate room-id message))
+  (-message-thread-root [_ room-id message-id]
+    (store/-message-thread-root delegate room-id message-id))
+  (-list-messages [_ room-id opts]
+    (store/-list-messages delegate room-id opts))
+  (-store-run! [_ room-id value]
+    (store/-store-run! delegate room-id value))
+  (-load-run [_ room-id run-id]
+    (store/-load-run delegate room-id run-id))
+  (-list-runs [_ room-id opts]
+    (store/-list-runs delegate room-id opts))
+
+  store/PAttemptStore
+  (-store-attempt! [_ _room-id _value] nil)
+  (-load-attempt [_ room-id attempt-id]
+    (store/-load-attempt delegate room-id attempt-id))
+  (-list-attempts [_ room-id opts]
+    (store/-list-attempts delegate room-id opts)))
+
+(defn- wait-until [pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (pred) true
+        (< (System/currentTimeMillis) deadline)
+        (do (Thread/sleep 5) (recur))
+        :else false))))
+
+(defn- definition [id opts]
+  (environment/make-environment
+   (merge {:id id
+           :task {:claim 42}
+           :verifier {:id :test/exact :version 1 :basis "test:v1"}
+           :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+           :world {:isolation :ctx :settlement :review}}
+          opts)))
+
+(def exact-evaluator
+  (evaluation/make-evaluator
+   {:id :test/exact
+    :version 1
+    :basis "test:v1"
+    :observe (fn [{:keys [default]}] default)
+    :verify (fn [environment evidence]
+              (let [exact? (= (:environment/task environment)
+                              (:result evidence))]
+                {:checks {:exact? exact?}
+                 :reward (if exact? 1.0 0.0)}))}))
+
+(defn- discard-retained! [result]
+  (when-let [fork (some-> result :run/result :run/world registry/lookup)]
+    (d/discard fork)))
+
+(deftest evaluation-is-a-lazy-composable-spin-over-ordinary-run-worlds
+  (let [room (test-room :evaluation-parallel)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :candidate
+               :program {:kind :echo}})
+        env (definition :test/parallel {})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [a (evaluation/evaluate room team :candidate env exact-evaluator)
+              b (evaluation/evaluate room team :candidate env exact-evaluator)]
+          (is (empty? (run/active-runs (:id room)))
+              "constructing evaluation Spins has no execution effect")
+          (let [results @(apply comb/parallel [a b])]
+            (try
+              (is (= 2 (count results)))
+              (is (= 2 (count (set (map :run/id results)))))
+              (is (every? #(= 1.0 (get-in % [:attempt-receipt :attempt/reward]))
+                          results))
+              (is (every? #(= {:exact? true}
+                              (get-in % [:attempt-receipt :attempt/checks]))
+                          results))
+              (is (every? #(= :review
+                              (get-in % [:run/result :run/settlement-status]))
+                          results))
+              (is (every? #(= [:dvergr "echo" :echo false]
+                              [(get-in % [:attempt-receipt :attempt/provider])
+                               (get-in % [:attempt-receipt :attempt/model])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :program-kind])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :timed-out?])])
+                          results))
+              (is (every? #(= [:not-applicable 1 5]
+                              [(get-in % [:attempt-receipt :attempt/metrics
+                                          :model-resolution])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :agent-version])
+                               (get-in % [:attempt-receipt :attempt/metrics
+                                          :interpreter-version])])
+                          results))
+              (is (every? uuid?
+                          (map #(get-in % [:attempt-receipt :attempt/metrics
+                                           :agent-def-hash])
+                               results)))
+              (is (every? #(= (:attempt %)
+                              (store/-load-attempt (:store room) (:id room)
+                                                   (:run/id %)))
+                          results)
+                  "certification is durable before a retained world is exposed")
+              (is (every? #(= (:attempt %)
+                              (:episode/attempt
+                               (episode/export room (:run/id %))))
+                          results))
+              (finally
+                (doseq [result results] (discard-retained! result)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-fails-closed-when-attempt-certification-is-not-durable
+  (let [delegate (memory/make)
+        room (d/make-room {:id :evaluation-attempt-durability
+                           :store (->RejectingAttemptStore delegate)})
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/attempt-durability {})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error (try
+                      @(evaluation/evaluate room team :candidate env
+                                            exact-evaluator)
+                      nil
+                      (catch Throwable error error))
+              run-id (:run/id (ex-data error))]
+          (is error)
+          (is (= ::evaluation/certification-failed
+                 (:type (ex-data error))))
+          (is (uuid? run-id))
+          (is (nil? (store/-load-attempt delegate (:id room) run-id)))
+          (is (= :discarded
+                 (:run/settlement-status
+                  (store/-load-run delegate (:id room) run-id))))
+          (is (nil? (registry/lookup
+                     (:run/world (store/-load-run delegate (:id room) run-id)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-rejects-a-mismatched-host-capability-before-admission
+  (let [room (test-room :evaluation-mismatch)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/mismatch {})
+        wrong (evaluation/make-evaluator
+               {:id :test/other :observe (constantly {})
+                :verify (fn [_ _] {:checks {} :reward 0.0})})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not match"
+                            (evaluation/evaluate room team :candidate env wrong)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-refuses-to-merge-before-trusted-scoring
+  (let [room (test-room :evaluation-unsafe-settlement)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/unsafe
+              {:world {:isolation :ctx :settlement :automatic}})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"retain successful worlds"
+                            (evaluation/evaluate
+                             room team :candidate env exact-evaluator)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-requires-portable-evidence
+  (let [room (test-room :evaluation-evidence)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/evidence {:world {:settlement :discard}})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [_] {:live (atom 1)})
+          :verify (fn [_ _] {:checks {} :reward 0.0})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error (try
+                      @(evaluation/evaluate room team :candidate env evaluator)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= :dvergr.agent.evaluation/certification-failed
+                 (:type (ex-data error))))
+          (is (re-find #"portable map" (ex-message (ex-cause error))))
+          (is (nil? (registry/lookup (:run/world (ex-data error)))))))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest deferred-world-cannot-settle-before-scoring
+  (let [room (test-room :evaluation-deferred-gate)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/deferred {})
+        premature (atom nil)
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [result default]}]
+                     (let [fork (registry/lookup (:run/world result))]
+                       (reset! premature {:merge (forks/merge! fork)
+                                          :discard (forks/discard! fork)
+                                          :direct-merge-blocked?
+                                          (try
+                                            (d/merge-room room fork)
+                                            false
+                                            (catch clojure.lang.ExceptionInfo _
+                                              true))
+                                          :direct-discard-blocked?
+                                          (try
+                                            (d/discard fork)
+                                            false
+                                            (catch clojure.lang.ExceptionInfo _
+                                              true))
+                                          :deferred? (forks/deferred? fork)}))
+                     default)
+          :verify (fn [_ _] {:checks {:verified? true} :reward 1.0})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result @(evaluation/evaluate room team :candidate env evaluator)
+              fork (registry/lookup (get-in result [:run/result :run/world]))]
+          (is (false? (get-in @premature [:merge :ok?])))
+          (is (false? (get-in @premature [:discard :ok?])))
+          (is (true? (:direct-merge-blocked? @premature)))
+          (is (true? (:direct-discard-blocked? @premature)))
+          (is (true? (:deferred? @premature)))
+          (is (= :review (get-in result [:run/result :run/settlement-status])))
+          (is (false? (forks/deferred? fork)))
+          (is (= :review (:run/settlement-status
+                          (program/observe room (:run/handle result)))))
+          (d/discard fork)))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-during-host-scoring-cannot-certify-or-release
+  (let [room (test-room :evaluation-cancel-scoring)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/cancel-scoring {})
+        entered (promise)
+        release (promise)
+        observed (atom nil)
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default run-id result]}]
+                     (reset! observed {:run/id run-id
+                                       :run/world (:run/world result)})
+                     (deliver entered true)
+                     @release
+                     default)
+          :verify (fn [_ _] {:checks {:verified? true} :reward 1.0})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [attempt (evaluation/evaluate room team :candidate env evaluator)]
+          (sp/spawn! attempt)
+          (is (= true (deref entered 5000 ::timeout)))
+          (spin-core/cancel-spin! attempt)
+          (deliver release true)
+          (is (wait-until
+               #(let [{:run/keys [id world]} @observed
+                      durable (when id (run/run room id))]
+                  (and (= :discarded (:run/settlement-status durable))
+                       (= :evaluation-cancelled
+                          (:run/settlement-reason durable))
+                       (nil? (registry/lookup world))))
+               5000))
+          (is (not= :review
+                    (:run/settlement-status
+                     (run/run room (:run/id @observed)))))
+          (is (nil? (store/-load-attempt (:store room) (:id room)
+                                         (:run/id @observed)))
+              "cancellation before certification leaves no durable Attempt")))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-at-the-settlement-gate-wins-before-release
+  (let [room (test-room :evaluation-cancel-release)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/cancel-release {})
+        entered (promise)
+        release (promise)
+        observed (atom nil)
+        original-release forks/release-deferred!
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default run-id result]}]
+                     (reset! observed {:run/id run-id
+                                       :run/world (:run/world result)})
+                     default)
+          :verify (fn [_ _] {:checks {:verified? true} :reward 1.0})})]
+    (try
+      (with-redefs [forks/release-deferred!
+                    (fn [fork reason claim!]
+                      (deliver entered true)
+                      @release
+                      (original-release fork reason claim!))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [attempt (evaluation/evaluate room team :candidate env evaluator)]
+            (sp/spawn! attempt)
+            (is (= true (deref entered 5000 ::timeout)))
+            (spin-core/cancel-spin! attempt)
+            (deliver release true)
+            (is (wait-until
+                 #(let [{:run/keys [id world]} @observed
+                        durable (when id (run/run room id))]
+                    (and (= :discarded (:run/settlement-status durable))
+                         (= :evaluation-cancelled
+                            (:run/settlement-reason durable))
+                         (nil? (registry/lookup world))))
+                 5000))
+            (is (nil? (store/-load-attempt (:store room) (:id room)
+                                           (:run/id @observed)))
+                "cancellation at the affine claim gate wins before persistence"))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest unsupported-world-setup-is-rejected-before-admission
+  (let [room (test-room :evaluation-unsupported-setup)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/setup {:world {:isolation :ctx
+                                             :settlement :review
+                                             :setup {:fixture :v1}}})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"trusted resolver"
+                            (evaluation/evaluate room team :candidate env
+                                                 exact-evaluator)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest malformed-verifier-result-discards-uncertified-world
+  (let [room (test-room :evaluation-malformed-score)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/malformed-score {})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default]}] default)
+          :verify (fn [_ _] {:checks {:not :boolean} :reward ##NaN})})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error (try
+                      @(evaluation/evaluate room team :candidate env evaluator)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= :dvergr.agent.evaluation/certification-failed
+                 (:type (ex-data error))))
+          (is (uuid? (:run/id (ex-data error))))
+          (is (nil? (registry/lookup (:run/world (ex-data error)))))
+          (is (= :evaluation-certification-failed
+                 (:run/settlement-reason
+                  (run/run room (:run/id (ex-data error))))))
+          (is (nil? (store/-load-attempt (:store room) (:id room)
+                                         (:run/id (ex-data error)))))))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest discard-projection-failure-preserves-the-deferred-world
+  (let [room (test-room :evaluation-discard-durability)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/discard-durability
+              {:world {:isolation :ctx :settlement :discard}})
+        world-id (atom nil)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error
+              (with-redefs [run/update-durable-settlement!
+                            (fn [& _]
+                              (throw (ex-info "store unavailable"
+                                              {:type ::store-unavailable})))]
+                (try
+                  @(evaluation/evaluate room team :candidate env exact-evaluator)
+                  nil
+                  (catch clojure.lang.ExceptionInfo error
+                    (reset! world-id (:run/world (ex-data error)))
+                    error)))
+              durable (run/run room (:run/id (ex-data error)))
+              fork (registry/lookup @world-id)]
+          (is (= :dvergr.agent.evaluation/settlement-recovery-required
+                 (:type (ex-data error))))
+          (is (= :deferred (:run/settlement-status durable)))
+          (is (some? fork))
+          (is (forks/deferred? fork))
+          (is (some? (store/-load-attempt (:store room) (:id room)
+                                          (:run/id (ex-data error))))
+              "certification remains truthful if later settlement projection fails")
+          ;; Restore the real durability boundary before consuming the world.
+          (is (:ok? (forks/discard-deferred!
+                     fork :test-cleanup
+                     (constantly true))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest review-projection-failure-retains-certified-world-for-recovery
+  (let [room (test-room :evaluation-review-durability)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/review-durability {})
+        original-update run/update-durable-settlement!
+        original-observe program/observe
+        calls (atom [])
+        observations (atom 0)
+        world-id (atom nil)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [error
+              (with-redefs [run/update-durable-settlement!
+                            (fn [parent id status & [reason]]
+                              (swap! calls conj status)
+                              (if (= :review status)
+                                (throw (ex-info "store unavailable"
+                                                {:type ::store-unavailable}))
+                                (original-update parent id status reason)))
+                            program/observe
+                            (fn [parent handle]
+                              (if (= 1 (swap! observations inc))
+                                (original-observe parent handle)
+                                (throw (ex-info "store remains unavailable"
+                                                {:type ::store-unavailable}))))]
+                (try
+                  @(evaluation/evaluate room team :candidate env exact-evaluator)
+                  nil
+                  (catch clojure.lang.ExceptionInfo error
+                    (reset! world-id (:run/world (ex-data error)))
+                    error)))
+              run-id (:run/id (ex-data error))
+              durable (run/run room run-id)
+              fork (registry/lookup @world-id)]
+          (is (= :dvergr.agent.evaluation/settlement-recovery-required
+                 (:type (ex-data error))))
+          (is (= [:review] @calls)
+              "failed settlement is not followed by destructive cleanup")
+          (is (= 1 @observations)
+              "recovery delivery does not depend on another store read")
+          (is (= :deferred (:run/settlement-status durable)))
+          (is (some? fork))
+          (is (forks/deferred? fork))
+          (is (some? (store/-load-attempt (:store room) (:id room) run-id)))
+          ;; Restore the real durability boundary before consuming the world.
+          (is (:ok? (forks/discard-deferred!
+                     fork :test-cleanup
+                     (constantly true))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest physical-discard-failure-compensates-or-retains-a-recovery-claim
+  (let [room (test-room :evaluation-discard-abort)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        original-update run/update-durable-settlement!]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle (program/hire! room team :candidate
+                                    {:task :work :settlement :deferred})
+              result @handle
+              run-id (program/run-id handle)
+              fork (registry/lookup (:run/world result))]
+          (with-redefs [ygg/discard-fork!
+                        (fn [& _] (throw (ex-info "substrate failed" {})))]
+            (is (false? (:ok? (forks/discard-deferred!
+                               fork :test-discard))))
+            (is (= [:deferred :discard-failed true]
+                   ((juxt :run/settlement-status :run/settlement-reason
+                          (constantly (forks/deferred? fork)))
+                    (run/run room run-id)))))
+          (with-redefs [ygg/discard-fork!
+                        (fn [& _] (throw (ex-info "substrate failed" {})))
+                        run/update-durable-settlement!
+                        (fn [parent id status & [reason]]
+                          (if (= :deferred status)
+                            (throw (ex-info "abort store unavailable" {}))
+                            (original-update parent id status reason)))]
+            (is (false? (:ok? (forks/discard-deferred!
+                               fork :test-discard))))
+            (is (= :discarded
+                   (:run/settlement-status (run/run room run-id))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"not awaiting deferred settlement"
+                                  (forks/release-deferred!
+                                   fork :must-remain-fenced))))
+          (is (:ok? (forks/retry-deferred-discard-abort! fork)))
+          (is (= :deferred
+                 (:run/settlement-status (run/run room run-id))))
+          (is (:ok? (forks/discard-deferred! fork :test-cleanup)))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest evaluation-timeout-cancels-and-quiesces-before-certification
+  (let [room (test-room :evaluation-timeout)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :slow
+               :program {:kind :scripted :delay-ms 1000 :reply :late}})
+        env (definition :test/timeout
+              {:task :late
+               :limits {:timeout-ms 10 :cancel-timeout-ms 2000}})
+        timeout-evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe (fn [{:keys [default durable]}]
+                     (assoc default :durable-status (:run/status durable)))
+          :verify (fn [_ evidence]
+                    (let [cancelled? (= :cancelled (:durable-status evidence))]
+                      {:checks {:cancelled? cancelled?}
+                       :reward (if cancelled? 1.0 0.0)}))})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result @(evaluation/evaluate room team :slow env timeout-evaluator)
+              receipt (:attempt-receipt result)]
+          (is (= :cancelled (:attempt/status receipt)))
+          (is (true? (get-in receipt [:attempt/metrics :timed-out?])))
+          (is (= {:cancelled? true} (:attempt/checks receipt)))
+          (is (= :discarded (get-in result [:run/result :run/settlement-status])))
+          (is (empty? (run/active-runs (:id room))))))
+      (finally
+        (d/close-room! room)))))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -479,6 +479,12 @@
               activity (first (filter #(= :_activity (:to %)) messages))]
           (is (= :completed (:run/status result)))
           (is (= "The result is 2." (:run/value result)))
+          (is (uuid? (get-in result [:run/metrics :prompt-id])))
+          (is (= {:provider :codex-subscription
+                  :model "codex-subscription-sol"
+                  :model-steps 2
+                  :usage {:used 0 :by-type {}}}
+                 (dissoc (:run/metrics result) :prompt-id)))
           (is (= :completed (:run/status durable)))
           (is (uuid? (:run/chat-id durable)))
           (is (= 2 (count @calls)))
@@ -533,6 +539,35 @@
                    (set (map :run/value [@a @b]))))
             (is (= 2 (count (set (map first @seen))))
                 "each particle gets a fresh ChatContext"))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest hire-limits-can-only-restrict-an-llm-agent-policy
+  (let [room (test-room :program-restrictive-limits)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :particle
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 4
+                         :budget-dollars 2.0}})
+        calls (atom 0)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [_ _]
+                      (swap! calls inc)
+                      :continue)]
+        (let [handle (binding [ec/*execution-context* (:ctx room)]
+                       (program/hire!
+                        room team :particle
+                        {:task :bounded
+                         :limits {:max-model-steps 1
+                                  :budget-dollars 0.01}}))
+              result (binding [ec/*execution-context* (:ctx room)] @handle)]
+          (is (= :failed (:run/status result)))
+          (is (= 1 @calls))
+          (is (= {:max-model-steps 1 :budget-dollars 0.01}
+                 (get-in result [:run/metrics :limits])))))
       (finally
         (d/close-room! room)))))
 
@@ -625,7 +660,9 @@
                   :run/reason :budget-exhausted
                   :run/settlement-status :review
                   :run/settlement-reason :execution-waiting}
-                 (dissoc result :run/world)))
+                 (dissoc result :run/world :run/metrics)))
+          (is (= 1 (get-in result [:run/metrics :model-steps])))
+          (is (uuid? (get-in result [:run/metrics :prompt-id])))
           (is (= :waiting (:run/status (program/observe room handle))))
           (is (empty? (filter #(= (program/run-id handle)
                                   (get-in % [:metadata :run-id]))
@@ -658,6 +695,71 @@
             (is (true? (program/cancel! handle)))
             (is (= :cancelled (:run/status (deref handle 2000 ::timeout))))
             (is (= :cancelled (:run/status (program/observe room handle)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest structured-llm-cancellation-retains-collected-metrics
+  (let [room (test-room :program-llm-structured-cancel)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm}})
+        calls (atom 0)
+        entered-second (promise)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [_ {:keys [cancel?]}]
+                      (if (= 1 (swap! calls inc))
+                        :continue
+                        (do
+                          (deliver entered-second true)
+                          (loop []
+                            (if (cancel?)
+                              :cancelled
+                              (do (Thread/sleep 5) (recur)))))))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle (program/hire! room team :worker {:task "stop structurally"})]
+            (is (= true (deref entered-second 10000 ::timeout)))
+            (is (= :winner
+                   @(comb/race (sp/spin :winner)
+                               (program/owned-result-spin handle))))
+            (let [result (deref handle 2000 ::timeout)]
+              (is (= :cancelled (:run/status result)))
+              (is (= {:provider :test
+                      :model "stub"
+                      :usage {:used 0 :by-type {}}}
+                     (dissoc (:run/metrics result)
+                             :prompt-id :model-steps)))
+              (is (<= 1 (get-in result [:run/metrics :model-steps]) 2)
+                  "cancellation may win before or after the worker acknowledges step two")
+              (is (uuid? (get-in result [:run/metrics :prompt-id])))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest llm-cleanup-failure-retains-collected-metrics
+  (let [room (test-room :program-llm-cleanup-failure)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :worker
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 1}})]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/run-agent-turn!
+                    (fn [chat-ctx _]
+                      (chat-context/add-message!
+                       chat-ctx {:role :assistant :content "done"})
+                      :complete)
+                    chat-context/close-chat!
+                    (fn [_] (throw (ex-info "cleanup exploded" {})))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [result @(program/hire! room team :worker {:task "clean up"})]
+            (is (= :failed (:run/status result)))
+            (is (= "cleanup exploded" (:run/error result)))
+            (is (= 1 (get-in result [:run/metrics :model-steps])))
+            (is (uuid? (get-in result [:run/metrics :prompt-id]))))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/agent/room_context_test.clj
+++ b/test/dvergr/agent/room_context_test.clj
@@ -9,9 +9,18 @@
             [dvergr.discourse :as d]
             [dvergr.room.store.memory :as mem]
             [dvergr.room.store :as rstore]
+            [dvergr.room.store.datahike :as store-dh]
+            [dvergr.room.registry :as registry]
+            [dvergr.sandbox :as sandbox]
             [dvergr.chat.context :as cctx]
+            [dvergr.chat.schema :as schema]
+            [datahike.api :as dh]
+            [org.replikativ.spindel.engine.component :as component]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]))
+
+(defn- ledger-count [conn]
+  (or (dh/q '[:find (count ?e) . :where [?e :ledger/id _]] @conn) 0))
 
 (defn- roles+contents [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
@@ -35,6 +44,177 @@
             (is (some #(str/includes? % "earlier message") (non-system-contents cc1))
                 "seeded the conversation from the room store")
             (finally (rc/drop-ctx! :rc-seed :var))))))))
+
+(deftest concurrent-first-context-creation-is-singleton
+  (testing "one Room fence covers component allocation and cache publication"
+    (let [c (ctx/create-execution-context)
+          room (d/make-room {:id :rc-concurrent-first :ctx c :store (mem/make)})
+          original turn/new-working-ctx
+          constructor-entered (promise)
+          second-started (promise)
+          release-constructor (promise)
+          calls (atom 0)]
+      (try
+        (with-redefs [turn/new-working-ctx
+                      (fn [opts]
+                        (swap! calls inc)
+                        (deliver constructor-entered true)
+                        @release-constructor
+                        (original opts))]
+          (let [first-result (future (rc/ensure-ctx! room :var
+                                                     {:budget-dollars 1.0}))]
+            (is (true? (deref constructor-entered 3000 ::timeout)))
+            (let [second-result
+                  (future
+                    (deliver second-started true)
+                    (rc/ensure-ctx! room :var {:budget-dollars 1.0}))]
+              (is (true? (deref second-started 3000 ::timeout)))
+              (deliver release-constructor true)
+              (let [first-ctx (deref first-result 10000 ::timeout)
+                    second-ctx (deref second-result 10000 ::timeout)]
+                (is (not= ::timeout first-ctx))
+                (is (identical? first-ctx second-ctx))
+                (is (= 1 @calls))
+                (is (= 1 (count (binding [ec/*execution-context* c]
+                                  (component/registered)))))))))
+        (finally
+          (deliver release-constructor true)
+          (rc/drop-ctx! :rc-concurrent-first :var)
+          (ctx/close-context! c))))))
+
+(deftest failed-hydration-is-unpublished-and-retryable
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-hydration-retry :ctx c :store (mem/make)})
+        original d/messages
+        original-constructor turn/new-working-ctx
+        hydration-calls (atom 0)
+        constructor-calls (atom 0)]
+    (try
+      (with-redefs [d/messages
+                    (fn [& args]
+                      (if (= 1 (swap! hydration-calls inc))
+                        (throw (ex-info "injected hydration failure" {}))
+                        (apply original args)))
+                    turn/new-working-ctx
+                    (fn [opts]
+                      (swap! constructor-calls inc)
+                      (original-constructor opts))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"injected hydration failure"
+                              (rc/ensure-ctx! room :var
+                                              {:budget-dollars 1.0
+                                               :system-prompt "must not leak"})))
+        (is (nil? (rc/lookup (:id room) :var)))
+        (is (empty? (binding [ec/*execution-context* c]
+                      (component/registered))))
+        (is (zero? @constructor-calls)
+            "fallible durable hydration precedes all ChatContext signals")
+        (let [retried (rc/ensure-ctx! room :var
+                                      {:budget-dollars 1.0
+                                       :system-prompt "must not leak"})]
+          (is (some? retried))
+          (is (= 1 @constructor-calls))
+          (is (= 1 (count (binding [ec/*execution-context* c]
+                            (component/registered)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest inbound-admission-waits-for-context-publication
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-admission-during-hydration
+                           :ctx c :store (mem/make)})
+        original d/messages
+        hydration-entered (promise)
+        release-hydration (promise)
+        msg-id (random-uuid)]
+    (try
+      (with-redefs [d/messages
+                    (fn [& args]
+                      (deliver hydration-entered true)
+                      @release-hydration
+                      (apply original args))]
+        (let [ensure-result (future (rc/ensure-ctx! room :var
+                                                    {:budget-dollars 1.0}))]
+          (is (true? (deref hydration-entered 10000 ::timeout)))
+          (let [append-result
+                (future (rc/append-inbound! room :var msg-id :user
+                                            "arrived during hydration"
+                                            "Alice" nil))]
+            (deliver release-hydration true)
+            (let [working (deref ensure-result 10000 ::timeout)]
+              (is (true? (deref append-result 10000 ::timeout)))
+              (is (some #(str/includes? % "arrived during hydration")
+                        (non-system-contents working)))))))
+      (finally
+        (deliver release-hydration true)
+        (d/close-room! room)))))
+
+(deftest working-context-construction-releases-on-rebind-failure
+  (let [c (ctx/create-execution-context)]
+    (try
+      (with-redefs [sandbox/setup-agent-namespaces!
+                    (fn [& _]
+                      (throw (ex-info "injected namespace failure" {})))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"injected namespace failure"
+                              (turn/new-working-ctx
+                               {:execution-ctx c :title "failing"})))
+        (is (empty? (binding [ec/*execution-context* c]
+                      (component/registered)))))
+      (finally
+        (ctx/close-context! c)))))
+
+(deftest unregister-fences-context-creation-and-stale-access
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-unregister-race :ctx c :store (mem/make)})
+        original turn/new-working-ctx
+        constructor-entered (promise)
+        release-constructor (promise)]
+    (try
+      (with-redefs [turn/new-working-ctx
+                    (fn [opts]
+                      (deliver constructor-entered true)
+                      @release-constructor
+                      (original opts))]
+        (let [ensure-result (future (rc/ensure-ctx! room :var
+                                                    {:budget-dollars 1.0}))]
+          (is (true? (deref constructor-entered 3000 ::timeout)))
+          (let [unregister-result
+                (future
+                  (binding [ec/*execution-context* c]
+                    (registry/unregister! (:id room))))]
+            (deliver release-constructor true)
+            (is (not= ::timeout (deref ensure-result 10000 ::timeout)))
+            (is (nil? (deref unregister-result 10000 ::timeout)))
+            (is (nil? (binding [ec/*execution-context* c]
+                        (registry/lookup (:id room)))))
+            (is (nil? (rc/lookup (:id room) :var)))
+            (is (empty? (binding [ec/*execution-context* c]
+                          (component/registered))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"closed Room incarnation"
+                                  (rc/ensure-ctx! room :var
+                                                  {:budget-dollars 1.0}))))))
+      (finally
+        (deliver release-constructor true)
+        (ctx/close-context! c)))))
+
+(deftest resource-cleanup-failure-still-unregisters-component
+  (let [c (ctx/create-execution-context)
+        working (turn/new-working-ctx {:execution-ctx c :title "cleanup"})]
+    (try
+      (is (= 1 (count (binding [ec/*execution-context* c]
+                        (component/registered)))))
+      (with-redefs [sandbox/release-agent-resources!
+                    (fn [& _] (throw (java.io.IOException. "injected cleanup failure")))]
+        (is (thrown-with-msg? java.io.IOException
+                              #"injected cleanup failure"
+                              (cctx/release-sci-in! working c))))
+      (is (empty? (binding [ec/*execution-context* c]
+                    (component/registered))))
+      (finally
+        (cctx/release-sci-in! working c)
+        (ctx/close-context! c)))))
 
 (deftest room-observation-does-not-bypass-attention
   (let [c (ctx/create-execution-context)]
@@ -66,6 +246,43 @@
           (is (= 1 (count (filter #(= "once" %) (non-system-contents cc))))
               "appended exactly once despite two calls with the same id")
           (finally (rc/drop-ctx! :rc-dedup :var)))))))
+
+(deftest forked-working-context-owns-child-persistence
+  (let [parent-ctx (ctx/create-execution-context)
+        child-ctx* (atom nil)
+        parent-conn (schema/create-chat-db!
+                     {:store {:backend :memory :id (random-uuid)}})
+        child-conn (schema/create-chat-db!
+                    {:store {:backend :memory :id (random-uuid)}})
+        parent (d/make-room {:id :rc-db-parent
+                             :ctx parent-ctx
+                             :store (store-dh/make parent-conn)})]
+    (try
+      (let [working (rc/ensure-ctx! parent :var {:budget-dollars 1.0})]
+        (let [child-ctx (ctx/fork-context parent-ctx :mode :frozen)
+              _ (reset! child-ctx* child-ctx)
+              child (d/make-room {:id :rc-db-child
+                                  :ctx child-ctx
+                                  :store (store-dh/make child-conn)})]
+          (dh/transact child-conn
+                       [(schema/create-chat-entity
+                         {:id (:chat-id working) :title (:title working)
+                          :budget 1000000})])
+          (let [projected (rc/fork-ctx! parent child :var)]
+            (is (identical? child-conn (:db-conn projected)))
+            (is (not (identical? parent-conn (:db-conn projected))))
+            (cctx/account-usage! projected :input-tokens 1
+                                 :model "claude-sonnet-4-5")
+            (is (= 0 (ledger-count parent-conn)))
+            (is (= 1 (ledger-count child-conn))))))
+      (finally
+        (rc/drop-ctx! :rc-db-child :var)
+        (rc/drop-ctx! :rc-db-parent :var)
+        (dh/release child-conn)
+        (dh/release parent-conn)
+        (when-let [child-ctx @child-ctx*]
+          (ctx/close-context! child-ctx))
+        (ctx/close-context! parent-ctx)))))
 
 (deftest durable-attention-rebuilds-provider-projection
   (testing "Run triggers and :include decisions enter provider input while

--- a/test/dvergr/agent/run_test.clj
+++ b/test/dvergr/agent/run_test.clj
@@ -133,6 +133,46 @@
         (run/finish! (:run/id explicit) :completed)
         (d/close-room! room)))))
 
+(deftest resolved-run-inputs-are-durable-causality-not-structure
+  (let [[room st] (run-room :explicit-causality)
+        parent (run/start! room :orchestrator (random-uuid) (live-ctx))
+        child (run/start! room :specialist (random-uuid) (live-ctx)
+                          {:parent (:run/id parent)})]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"has not resolved"
+           (run/record-cause! (:run/id parent) (:run/id child))))
+      (run/finish! (:run/id child) :completed)
+      (let [updated (run/record-cause! (:run/id parent) (:run/id child))]
+        (is (= #{(:run/id child)} (:run/caused-by updated)))
+        (is (= #{(:run/id child)}
+               (:run/caused-by
+                (store/-load-run st :explicit-causality (:run/id parent)))))
+        (is (= (:run/id parent) (:run/parent child))
+            "containment remains on the child, causality on the consumer"))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"not durable"
+           (run/record-cause! (:run/id parent) (random-uuid))))
+      (finally
+        (run/finish! (:run/id parent) :completed)
+        (d/close-room! room)))))
+
+(deftest storeless-runs-cannot-claim-durable-causality
+  (let [room (d/make-room {:id :storeless-causality})
+        parent (run/start! room :orchestrator (random-uuid) (live-ctx))]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"requires a Room store"
+           (run/record-cause! (:run/id parent) (random-uuid))))
+      (is (nil? (:run/caused-by
+                 (first (run/active-runs :storeless-causality)))))
+      (finally
+        (run/finish! (:run/id parent) :completed)
+        (d/close-room! room)))))
+
 (deftest provenance-cannot-override-core-run-identity
   (let [[room _st] (run-room :provenance-boundary)
         trigger (d/message :alice :agent "work")]

--- a/test/dvergr/chat/context_test.clj
+++ b/test/dvergr/chat/context_test.clj
@@ -2,7 +2,96 @@
   "Integration tests for ChatContext budget tracking."
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.chat.context :as ctx]
-            [dvergr.chat.accounting :as acct]))
+            [dvergr.chat.accounting :as acct]
+            [dvergr.runtime.ctx :as runtime-ctx]
+            [dvergr.sandbox :as sandbox]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as execution-context]))
+
+(deftest ambient-selection-only-refines-into-descendants
+  (let [parent (execution-context/create-execution-context)
+        owner (execution-context/fork-context parent :mode :frozen)
+        sibling (execution-context/fork-context parent :mode :frozen)
+        descendant (execution-context/fork-context owner :mode :frozen)]
+    (try
+      (is (identical? owner (runtime-ctx/selected-context owner)))
+      (binding [ec/*execution-context* parent]
+        (is (identical? owner (runtime-ctx/selected-context owner))))
+      (binding [ec/*execution-context* sibling]
+        (is (identical? owner (runtime-ctx/selected-context owner))))
+      (binding [ec/*execution-context* descendant]
+        (is (identical? descendant (runtime-ctx/selected-context owner))))
+      (finally
+        (execution-context/close-context! descendant)
+        (execution-context/close-context! sibling)
+        (execution-context/close-context! owner)
+        (execution-context/close-context! parent)))))
+
+(deftest sci-interpreter-is-selected-by-world
+  (testing "one stable ChatContext ref resolves independent SCI heaps after fork"
+    (let [parent (execution-context/create-execution-context)
+          chat   (ctx/create-chat-context
+                  {:title "forkable repl"
+                   :execution-context parent})]
+      (try
+        (let [ref (:sci-component chat)
+              parent-sci (ctx/sci-context-in chat parent)
+              eval-in (fn [world interpreter source]
+                        (sandbox/eval-code interpreter source
+                                           :execution-context world))]
+          (is (some? ref))
+          ;; Exercise the interpreter agents actually receive, not only the
+          ;; bare Spindel macro context. Every injected capability must either
+          ;; be world-relative or declare its ambient sharing policy.
+          (sandbox/setup-agent-namespaces! parent-sci parent)
+          (is (= {:value [:parent] :stdout "" :stderr "" :success true}
+                 (eval-in
+                  parent parent-sci
+                  "(def observations (atom [:parent])) @observations")))
+          (let [child (execution-context/fork-context parent :mode :frozen)]
+            (try
+              (let [child-sci (ctx/sci-context-in chat child)]
+                (is (not (identical? parent-sci child-sci)))
+                (is (= [:parent :child]
+                       (:value (eval-in
+                                child child-sci
+                                "(swap! observations conj :child)"))))
+                (is (= [:parent]
+                       (:value (eval-in parent parent-sci "@observations"))))
+                (is (= [:parent :child]
+                       (:value (eval-in child child-sci "@observations"))))
+                (let [result
+                      (eval-in
+                       child child-sci
+                       "(ns child-only-test
+                          (:require [clojure.test :refer [deftest is run-tests]]))
+                        (deftest child-proof (is (= 3 (+ 1 2))))
+                        (run-tests 'child-only-test)")]
+                  (is (:success result))
+                  (is (= {:test 1 :pass 1 :fail 0 :error 0}
+                         (select-keys (:value result)
+                                      [:test :pass :fail :error])))
+                  (is (false?
+                       (:value
+                        (eval-in
+                         parent parent-sci
+                         "(boolean (find-ns 'child-only-test))"))))))
+              (ctx/release-sci-in! chat child)
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"not available"
+                   (ctx/sci-context-in chat child)))
+              (is (contains?
+                   (binding [ec/*execution-context* parent]
+                     (component/registered))
+                   (:id ref))
+                  "releasing a child interpreter preserves its parent")
+              (finally
+                (execution-context/close-context! child)))))
+        (finally
+          (ctx/close-chat! chat)
+          (execution-context/close-context! parent))))))
 
 (deftest create-chat-context-test
   (testing "Create chat with dollar budget"

--- a/test/dvergr/discourse/llm_test.clj
+++ b/test/dvergr/discourse/llm_test.clj
@@ -8,10 +8,14 @@
             [dvergr.discourse.attention :as attention]
             [dvergr.discourse.llm :as llm]
             [dvergr.chat.context :as cc]
+            [dvergr.runtime.ctx :as runtime-ctx]
+            [dvergr.sandbox :as sandbox]
             [dvergr.agent.run :as run]
             [dvergr.agent.room-context :as room-context]
             [dvergr.room.store :as store]
-            [dvergr.room.store.memory :as memory]))
+            [dvergr.room.store.memory :as memory]
+            [datahike.api :as dh]
+            [org.replikativ.spindel.engine.component :as component]))
 
 ;; ============================================================================
 ;; Mock turn-fn — scripts the LLM responses
@@ -104,6 +108,163 @@
 ;; Tests
 ;; ============================================================================
 
+(deftest isolated-room-fork-reuses-the-forked-working-interpreter
+  (testing "participant cloning selects the inherited SCI world without registering another"
+    (let [parent (d/room :llm-world-parent)
+          parent-db (random-uuid)
+          fork* (atom nil)]
+      (try
+        (binding [ec/*execution-context* (:ctx parent)]
+          (d/join parent
+                  (llm/llm-agent
+                   {:id :researcher
+                    :spec {:provider :mock :model "mock"}
+                    :run-turn-fn (make-mock-turn-fn (atom []))})))
+        (is (empty? (binding [ec/*execution-context* (:ctx parent)]
+                      (component/registered)))
+            "a joined room participant does not eagerly allocate a room-less fallback")
+        (let [working (room-context/ensure-ctx!
+                       parent :researcher {:budget-dollars 1.0})
+              parent-sci (cc/sci-context-in working (:ctx parent))]
+          (is (= 1 (count (binding [ec/*execution-context* (:ctx parent)]
+                            (component/registered)))))
+          (is (= [:parent]
+                 (:value (sandbox/eval-code
+                          parent-sci
+                          (format
+                           "(def evidence (atom [:parent]))
+                            (defn captured-room [] (dvergr.agent/room-id))
+                            (def captured-room-fn dvergr.agent/room-id)
+                            (def captured-env-get env/get)
+                            (def captured-env-set env/set)
+                            (env/set \"WORLD\" \"parent\")
+                            (def captured-db-exists? datahike.api/database-exists?)
+                            (def captured-db-create! datahike.api/create-database)
+                            (def captured-db-connect! datahike.api/connect)
+                            (def captured-work-serial spindel.work/serial)
+                            (def parent-db {:store {:backend :mem :id %s}
+                                            :schema-flexibility :read})
+                            (captured-db-create! parent-db)
+                            (datahike.api/transact (captured-db-connect! parent-db)
+                              [{:marker/id :parent}])
+                            @evidence"
+                           (pr-str parent-db))
+                          :execution-context (:ctx parent)))))
+          (let [fork (d/fork-room parent {:isolation :ctx})]
+            (reset! fork* fork)
+            (let [child-working (room-context/lookup (:id fork) :researcher)
+                  child-sci (cc/sci-context-in child-working (:ctx fork))]
+              (is (not (identical? working child-working)))
+              (is (= (:sci-component working) (:sci-component child-working)))
+              (is (identical? (:ctx fork) (:spindel-ctx child-working)))
+              (is (not (identical? (:db-conn working) (:db-conn child-working)))
+                  "child persistence never retains the raw parent connection")
+              (is (= 1 (count (binding [ec/*execution-context* (:ctx fork)]
+                                (component/registered))))
+                  "the participant factory did not allocate a second interpreter")
+              (is (= (:id parent)
+                     (:value (sandbox/eval-code
+                              parent-sci "(dvergr.agent/room-id)"
+                              :execution-context (:ctx parent)))))
+              (is (= (:id fork)
+                     (:value (sandbox/eval-code
+                              child-sci "(dvergr.agent/room-id)"
+                              :execution-context (:ctx fork))))
+                  "fresh calls resolve the child Room")
+              (is (= [(:id fork) (:id fork)]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(captured-room) (captured-room-fn)]"
+                              :execution-context (:ctx fork))))
+                  "pre-fork helpers and first-class capabilities resolve through the child world")
+              (is (= true
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(let [controller
+                                     (captured-work-serial
+                                      (fn [value] (spindel.work/task value)))]
+                                 (spindel.work/close! controller)
+                                 true)"
+                              :execution-context (:ctx fork))))
+                  "retained FRP constructors allocate against the child Room incarnation")
+              (is (= ["parent" "parent"]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx fork))))
+                  "environment data is inherited through the child world binding")
+              (is (= :ok
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(captured-env-set \"WORLD\" \"child\")"
+                              :execution-context (:ctx fork)))))
+              (is (= ["child" "child"]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx fork)))))
+              (is (= ["parent" "parent"]
+                     (:value (sandbox/eval-code
+                              parent-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx parent))))
+                  "a retained child mutation does not escape into the parent")
+              (is (= [false false]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(datahike.api/database-exists? parent-db)
+                                (captured-db-exists? parent-db)]"
+                              :execution-context (:ctx fork))))
+                  "live ephemeral database handles are disposable across a fork")
+              (is (= true
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(captured-db-create! parent-db)
+                               (datahike.api/transact (captured-db-connect! parent-db)
+                                 [{:marker/id :child}])
+                               (captured-db-exists? parent-db)"
+                              :execution-context (:ctx fork)))))
+              (is (= [:child]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(datahike.api/q
+                                 '[:find [?v ...] :where [_ :marker/id ?v]]
+                                 @(captured-db-connect! parent-db))"
+                              :execution-context (:ctx fork))))
+                  "the inherited logical config maps to child-owned physical storage")
+              (is (= [:parent]
+                     (:value (sandbox/eval-code
+                              parent-sci
+                              "(datahike.api/q
+                                 '[:find [?v ...] :where [_ :marker/id ?v]]
+                                 @(captured-db-connect! parent-db))"
+                              :execution-context (:ctx parent))))
+                  "same-config child writes cannot reach the parent's physical database")
+              (is (= [:parent :child]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(swap! evidence conj :child)"
+                              :execution-context (:ctx fork)))))
+              (is (= [:parent]
+                     (:value (sandbox/eval-code
+                              parent-sci "@evidence"
+                              :execution-context (:ctx parent)))))
+              (let [binding (runtime-ctx/sandbox-binding
+                             (:ctx fork) (:capability-id child-working))
+                    physical-config (-> binding :ephemeral-databases vals first :config)]
+                (is (dh/database-exists? physical-config))
+                (room-context/drop-ctx! (:id fork) :researcher)
+                (is (not (dh/database-exists? physical-config))
+                    "dropping a world deletes its process-global scratch database"))
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"not available"
+                   (cc/sci-context-in child-working (:ctx fork)))))))
+        (finally
+          (when-let [fork @fork*]
+            (d/discard fork))
+          (d/close-room! parent))))))
+
 (deftest single-turn-replies
   (testing "Agent replies after a single :complete turn"
     (let [r (d/room :t)
@@ -191,14 +352,17 @@
                                   :run-turn-fn turn-fn})))
       (try
         (d/post! r (d/message :alice :worker "cancel this run"))
-        (is (= true (deref first-started 2000 ::timeout)))
+        ;; Creating the first room-bound interpreter can compile SCI/Spindel
+        ;; namespaces. Leave enough wall-clock headroom for contended CI hosts;
+        ;; the cancellation assertions below still test the semantic deadline.
+        (is (= true (deref first-started 10000 ::timeout)))
         (let [run-id (:run/id (first (run/active-runs :run-cancel-reuse)))]
           (is (uuid? run-id))
           (is (run/cancel-run! run-id))
           (is (await-condition
                #(= :cancelled (:run/status (run/run r run-id)))
-               3000)))
-        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 3000)]
+               10000)))
+        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 10000)]
           (is (= "second completed" (:content reply)))
           (is (= :completed
                  (:run/status (run/run r (get-in reply [:metadata :run-id])))))
@@ -833,7 +997,7 @@
                                   :run-turn-fn (make-queued-turn-fn steps calls)})))
       (let [reply-f (future (await-spin r #(d/ask % :quiescent-worker
                                                   {:content "start"}) 5000))]
-        (is (true? (deref entered 3000 ::timeout)))
+        (is (true? (deref entered 10000 ::timeout)))
         (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
           (d/post! r (d/reply :reviewer :quiescent-worker
                               "only at quiescence" trigger)))

--- a/test/dvergr/discourse/personas_test.clj
+++ b/test/dvergr/discourse/personas_test.clj
@@ -14,13 +14,21 @@
             [dvergr.chat.context :as cc]))
 
 (defn- await-spin
-  ([room spin-fn] (await-spin room spin-fn 3000))
+  ;; A first Room turn may need to initialize Datahike and the forkable SCI
+  ;; component before this deliberately trivial mock runs.  Three seconds made
+  ;; this an environment-speed assertion and hid the real failure behind nil
+  ;; map lookups in the callers.
+  ([room spin-fn] (await-spin room spin-fn 10000))
   ([room spin-fn wait-ms]
    (let [p (promise)]
      (binding [ec/*execution-context* (:ctx room)]
        (sp/spawn!
         (sp/spin (deliver p (sp/await (spin-fn room))))))
-     (deref p wait-ms ::timeout))))
+     (let [result (deref p wait-ms ::timeout)]
+       (when (= ::timeout result)
+         (throw (ex-info "Timed out waiting for persona mock turn"
+                         {:wait-ms wait-ms})))
+       result))))
 
 (defn- mock-turn-fn
   "A `run-turn-fn` that writes a single assistant message capturing the

--- a/test/dvergr/repl_meta_harness_test.clj
+++ b/test/dvergr/repl_meta_harness_test.clj
@@ -8,6 +8,8 @@
    registry and durable Datahike row."
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.agent.turn :as turn]
+            [dvergr.chat.context :as chat-context]
+            [dvergr.discourse :as discourse]
             [dvergr.discourse.definitions :as definitions]
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.room.registry :as room-registry]
@@ -63,7 +65,8 @@
            tool-ctx
            (binding [ec/*execution-context* (:ctx parent)]
              (tools/make-context
-              {:sci-ctx       (:sci-ctx chat-ctx)
+              {:sci-ctx       (chat-context/sci-context-in
+                               chat-ctx (:ctx parent))
                :chat-ctx      chat-ctx
                :execution-ctx (:ctx parent)
                :isolation     :sci
@@ -81,33 +84,75 @@
                 ":children (set (map :slug "
                 "(dvergr.room/children " (pr-str parent-slug) ")))}")
            inspect-result (eval! parent tool-ctx inspect-code)
-           create-value (get-in create-result [:metadata :value])
-           inspect-value (get-in inspect-result [:metadata :value])
-           live-child (binding [ec/*execution-context* execution-ctx]
-                        (room-registry/lookup child-id))
-           durable-child (binding [ec/*execution-context* execution-ctx]
-                           (rooms/get-room-by-slug child-slug))
-           checks
-           {:create-tool-succeeded (= :success (:type create-result))
-            :inspect-tool-succeeded (= :success (:type inspect-result))
-            :sandbox-created-child  (= child-slug (get-in create-value [:child :slug]))
-            :repl-state-persisted   (= child-slug (:session-child-slug inspect-value))
-            :sandbox-sees-child     (true? (:visible? inspect-value))
-            :sandbox-sees-nesting   (contains? (:children inspect-value) child-slug)
-            :host-sees-child        (= child-id (:id live-child))
-            :host-sees-nesting      (= (room-store/slug->room-id parent-slug)
-                                       (:parent-id live-child))
-            :datahike-sees-child    (= child-slug (:room/slug durable-child))
-            :datahike-sees-nesting  (= parent-slug (:room/parent-slug durable-child))}]
-       {:passed? (every? true? (vals checks))
-        :checks checks
-        :parent-slug parent-slug
-        :child-slug child-slug
-        :create-result create-result
-        :inspect-result inspect-result
-        :live-room (select-keys live-child [:id :slug :title :parent-id])
-        :durable-room (select-keys durable-child
-                                   [:room/id :room/slug :room/name :room/parent-slug])}))))
+           world-fork (binding [ec/*execution-context* (:ctx parent)]
+                        (discourse/fork-room parent {:isolation :ctx}))]
+       (try
+         (let [fork-tool-ctx
+               (tools/make-context
+                {:sci-ctx       (chat-context/sci-context-in
+                                 chat-ctx (:ctx world-fork))
+                 :chat-ctx      chat-ctx
+                 :execution-ctx (:ctx world-fork)
+                 :isolation     :sci
+                 :tools         {"clojure_eval" (tools/get-tool "clojure_eval")}})
+               probe-id (random-uuid)
+               fork-result
+               (eval!
+                world-fork fork-tool-ctx
+                (str "(require '[datahike.api :as d] '[dvergr.room :as room]) "
+                     "(def fork-local " (pr-str probe-id) ") "
+                     "(d/transact room/*room* [{:message/id " (pr-str probe-id)
+                     " :message/content \"child-world-probe\"}]) "
+                     "{:var fork-local "
+                     " :db (d/q '[:find ?v . :in $ ?id :where "
+                     "[?e :message/id ?id] [?e :message/content ?v]] "
+                     "@room/*room* " (pr-str probe-id) ")}"))
+               parent-after-fork
+               (eval!
+                parent tool-ctx
+                (str "(require '[datahike.api :as d] '[dvergr.room :as room]) "
+                     "{:var-defined? (boolean (resolve 'fork-local)) "
+                     " :db (d/q '[:find ?v . :in $ ?id :where "
+                     "[?e :message/id ?id] [?e :message/content ?v]] "
+                     "@room/*room* " (pr-str probe-id) ")}"))
+               create-value (get-in create-result [:metadata :value])
+               inspect-value (get-in inspect-result [:metadata :value])
+               fork-value (get-in fork-result [:metadata :value])
+               parent-after-fork-value (get-in parent-after-fork [:metadata :value])
+               live-child (binding [ec/*execution-context* execution-ctx]
+                            (room-registry/lookup child-id))
+               durable-child (binding [ec/*execution-context* execution-ctx]
+                               (rooms/get-room-by-slug child-slug))
+               checks
+               {:create-tool-succeeded (= :success (:type create-result))
+                :inspect-tool-succeeded (= :success (:type inspect-result))
+                :sandbox-created-child  (= child-slug (get-in create-value [:child :slug]))
+                :repl-state-persisted   (= child-slug (:session-child-slug inspect-value))
+                :sandbox-sees-child     (true? (:visible? inspect-value))
+                :sandbox-sees-nesting   (contains? (:children inspect-value) child-slug)
+                :host-sees-child        (= child-id (:id live-child))
+                :host-sees-nesting      (= (room-store/slug->room-id parent-slug)
+                                           (:parent-id live-child))
+                :datahike-sees-child    (= child-slug (:room/slug durable-child))
+                :datahike-sees-nesting  (= parent-slug (:room/parent-slug durable-child))
+                :fork-tool-succeeded    (= :success (:type fork-result))
+                :fork-repl-diverged     (= probe-id (:var fork-value))
+                :fork-db-diverged       (= "child-world-probe" (:db fork-value))
+                :parent-var-unchanged   (false? (:var-defined? parent-after-fork-value))
+                :parent-db-unchanged    (nil? (:db parent-after-fork-value))}]
+           {:passed? (every? true? (vals checks))
+            :checks checks
+            :parent-slug parent-slug
+            :child-slug child-slug
+            :create-result create-result
+            :inspect-result inspect-result
+            :fork-result fork-result
+            :parent-after-fork parent-after-fork
+            :live-room (select-keys live-child [:id :slug :title :parent-id])
+            :durable-room (select-keys durable-child
+                                       [:room/id :room/slug :room/name :room/parent-slug])})
+         (finally
+           (discourse/discard world-fork)))))))
 
 (defn run-contract!
   "Run the contract in an isolated, provider-free daemon.
@@ -148,5 +193,6 @@
 (deftest agent-facing-repl-constructs-a-durable-nested-room
   (let [result (run-contract!)]
     (testing "every layer observes the room created from clojure_eval"
-      (is (:passed? result) (pr-str (:checks result)))
+      (is (:passed? result)
+          (pr-str (select-keys result [:checks :fork-result :parent-after-fork])))
       (is (every? true? (vals (:checks result)))))))

--- a/test/dvergr/room/registry_test.clj
+++ b/test/dvergr/room/registry_test.clj
@@ -1,0 +1,42 @@
+(ns dvergr.room.registry-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(deftest fork-registration-runs-admission-fences-before-publication
+  (let [root-ctx (context/create-execution-context)
+        child-ctx (context/fork-context root-ctx :mode :frozen)
+        room-id (keyword (str "rejected-fork-" (random-uuid)))
+        parent-id (keyword (str "parent-" (random-uuid)))
+        room (d/make-room {:id room-id
+                           :ctx child-ctx
+                           :store (memory/make)})
+        hook-id ::reject-this-fork]
+    ;; make-room auto-registers ordinary Rooms; remove that initial projection
+    ;; so this test exercises register-fork!'s publication boundary itself.
+    (binding [ec/*execution-context* root-ctx]
+      (registry/unregister! room-id))
+    (try
+      (binding [ec/*execution-context* root-ctx]
+        (registry/add-pre-register-hook!
+         hook-id
+         (fn [candidate]
+           (when (= room-id (:id candidate))
+             (throw (ex-info "rejected by admission fence" {})))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"rejected by admission fence"
+             (registry/register-fork! room parent-id (random-uuid))))
+        (is (nil? (registry/lookup room-id))
+            "a rejected fork is never globally visible as a Room")
+        (is (empty? (filter #(= room-id (:fork/id %))
+                            (registry/structural-children parent-id)))
+            "a rejected fork publishes no topology edge"))
+      (finally
+        ;; Hooks are process-global and keyed for reload; neutralize this
+        ;; test-specific fence without disturbing production hooks.
+        (registry/add-pre-register-hook! hook-id (constantly nil))
+        (context/close-context! child-ctx)
+        (context/close-context! root-ctx)))))

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -113,6 +113,80 @@
            #":run/chat-id must be a UUID"
            (store/-store-run! st room-id (assoc completed :run/chat-id :not-a-uuid)))))))
 
+(defn assert-run-causality!
+  "Exercise terminal/same-room validation and append-only causal updates."
+  [st room-id]
+  (testing "causal inputs are resolved, scoped, append-only Run evidence"
+    (let [other-room-id (keyword (str (name room-id) "-other"))
+          now (java.util.Date. 1787860800000)
+          ended (java.util.Date. 1787860801000)
+          run-map (fn [id actor status]
+                    (cond-> {:run/id id
+                             :run/kind :workflow
+                             :run/room room-id
+                             :run/actor actor
+                             :run/trigger (random-uuid)
+                             :run/status status
+                             :run/created-at now
+                             :run/started-at now
+                             :run/updated-at (if (= :running status) now ended)}
+                      (store/terminal-run-statuses status)
+                      (assoc :run/ended-at ended)))
+          root-id (random-uuid)
+          child-id (random-uuid)
+          foreign-id (random-uuid)
+          root (run-map root-id :root :running)
+          child (run-map child-id :child :running)
+          foreign (assoc (run-map foreign-id :foreign :completed)
+                         :run/room other-room-id)]
+      (store/-store-room! st room-id {:slug (name room-id) :title "causes"})
+      (store/-store-room! st other-room-id
+                          {:slug (name other-room-id) :title "other causes"})
+      (store/-store-run! st room-id root)
+      (store/-store-run! st room-id child)
+      (store/-store-run! st other-room-id foreign)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"has not resolved"
+           (store/-store-run! st room-id
+                              (assoc root :run/caused-by #{child-id}))))
+      (store/-store-run! st room-id
+                         (assoc child :run/status :completed
+                                :run/updated-at ended :run/ended-at ended))
+      (let [caused (assoc root :run/caused-by #{child-id}
+                          :run/updated-at ended)]
+        (is (= caused (store/-store-run! st room-id caused)))
+        (is (= caused (store/-store-run! st room-id caused))
+            "replaying an existing causal set is idempotent")
+        (is (= #{child-id}
+               (:run/caused-by (store/-load-run st room-id root-id))))
+        (is (= #{child-id}
+               (:run/caused-by
+                (first (store/-list-runs st room-id {:actor :root})))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"append-only"
+             (store/-store-run! st room-id (dissoc caused :run/caused-by))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"not durable in the same Room"
+             (store/-store-run! st room-id
+                                (update caused :run/caused-by conj (random-uuid)))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"not durable in the same Room"
+             (store/-store-run! st room-id
+                                (update caused :run/caused-by conj foreign-id))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"terminal Run lifecycle is immutable"
+             (store/-store-run!
+              st room-id
+              (-> (store/-load-run st room-id child-id)
+                  (assoc :run/status :running :run/updated-at ended)
+                  (dissoc :run/ended-at))))
+            "accepted causal evidence cannot later regress to a live Run")))))
+
 (defn assert-attention-projection!
   "Exercise durable participant-specific attention storage and filtering."
   [st room-id]

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -5,10 +5,17 @@
    chat-ctx path kept)."
   (:require [clojure.test :refer [deftest is testing]]
             [datahike.api :as dh]
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.attempt.governance :as attempt-governance]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.artifact :as artifact]
             [dvergr.chat.schema :as schema]
             [dvergr.room.store :as store]
             [dvergr.room.store.contract :as contract]
-            [dvergr.room.store.datahike :as dhs]))
+            [dvergr.room.store.datahike :as dhs]
+            [hasch.core :as hasch]
+            [kontor.resource :as kontor]))
 
 (defn- mem-store []
   (let [cfg {:store {:backend :memory :id (random-uuid)}
@@ -32,6 +39,111 @@
       :run/created-at now
       :run/started-at now
       :run/updated-at now})))
+
+(defn- certified-attempt [run-id agent]
+  (let [definition
+        (environment/make-environment
+         {:id :datahike/exact :task {:answer 42}
+          :verifier {:id :datahike/exact :version 1}
+          :world {:isolation :ctx :settlement :review}})
+        receipt
+        (environment/make-attempt-receipt
+         definition
+         {:run-id run-id :provider :dvergr :model "echo"
+          :status :completed :started-at 1000 :elapsed-ms 10
+          :metrics {:program-kind :echo :model-resolution :not-applicable
+                    :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                    :interpreter-version 5}
+          :checks {:exact? true :portable? true} :reward 1.0
+          :trace {:runs [{:run/id run-id :run/status :completed}]}})]
+    (attempt/make-attempt definition agent receipt
+                          {:trace {:runs [{:run/id run-id
+                                           :run/status :completed}]}}
+                          :review)))
+
+(deftest certified-attempt-round-trips-through-typed-index-and-cas
+  (let [[conn _] (mem-store)
+        artifacts (artifact/memory-store)
+        st (dhs/make conn artifacts)
+        room-id :datahike-attempt
+        run-id (random-uuid)
+        agent (-> (roster/make-roster)
+                  (roster/make-agent {:id :candidate
+                                      :program {:kind :echo}})
+                  (roster/agent :candidate))
+        value (certified-attempt run-id agent)
+        now (java.util.Date. 1000)]
+    (store/-store-room! st room-id {:slug (name room-id)})
+    (store/-store-run!
+     st room-id
+     {:run/id run-id :run/kind :agent-task :run/room room-id
+      :run/actor :candidate :run/trigger (random-uuid)
+      :run/status :completed :run/created-at now :run/started-at now
+      :run/updated-at now :run/ended-at (java.util.Date. 1010)
+      :run/agent-version 1 :run/program-kind :echo
+      :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)})
+    (is (= value (store/-store-attempt! st room-id value)))
+    (is (= value (store/-load-attempt st room-id run-id)))
+    (is (= [value]
+           (store/-list-attempts st room-id
+                                 {:environment-content-id
+                                  (get-in value [:attempt/environment
+                                                 :environment/content-id])
+                                  :model "echo"})))
+    (is (= 2
+           (dh/q '[:find (count ?check) .
+                   :where [?a :attempt/checks ?check]] @conn)))
+    (testing "the mandatory writer predicate guards raw API writes"
+      (is (thrown-with-msg?
+           Throwable #"trusted writer"
+           (dh/transact conn [{:attempt/id (random-uuid)}])))
+      (is (thrown-with-msg?
+           Throwable #"immutable"
+           (dh/transact conn [[:db/add [:attempt/id run-id]
+                               :attempt/reward 0.0]]))))
+    (testing "an arbitrary transaction function is not a trusted writer"
+      (let [rogue-run-id (random-uuid)
+            rogue (certified-attempt rogue-run-id agent)
+            chat-id (dh/q '[:find ?chat-id . :in $ ?slug
+                            :where
+                            [?c :room/slug ?slug]
+                            [?c :chat/id ?chat-id]]
+                          @conn (name room-id))
+            rogue-entity (#'dhs/attempt->entity
+                          chat-id
+                          rogue (artifact/put-value! artifacts rogue))]
+        (store/-store-run!
+         st room-id
+         {:run/id rogue-run-id :run/kind :agent-task :run/room room-id
+          :run/actor :candidate :run/trigger (random-uuid)
+          :run/status :completed :run/created-at now :run/started-at now
+          :run/updated-at now :run/ended-at (java.util.Date. 1010)
+          :run/agent-version 1 :run/program-kind :echo
+          :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)})
+        (is (thrown-with-msg?
+             Throwable #"trusted writer"
+             (dh/transact conn [[:db.fn/call (fn [_] [])] rogue-entity])))
+        (is (nil? (store/-load-attempt st room-id rogue-run-id)))))
+    (testing "installing Kontor preserves both mandatory governors"
+      (kontor/install! conn)
+      (attempt-governance/govern! conn)
+      (is (thrown-with-msg?
+           Throwable #"immutable"
+           (dh/transact conn [[:db/add [:attempt/id run-id]
+                               :attempt/reward 0.25]]))))
+    (testing "the typed row points to the terminal Run rather than copying it"
+      (is (= run-id
+             (dh/q '[:find ?run-id .
+                     :where
+                     [?a :attempt/id _]
+                     [?a :attempt/run ?r]
+                     [?r :run/id ?run-id]] @conn))))
+    (testing "Room deletion removes Attempt components through the same governor"
+      (store/-delete-room! st room-id)
+      (is (nil? (store/-load-attempt st room-id run-id)))
+      (is (zero? (or (dh/q '[:find (count ?check) .
+                             :where [?a :attempt/checks ?check]] @conn)
+                     0))))))
 
 (deftest message-envelope-contract
   (let [[_conn st] (mem-store)]
@@ -82,6 +194,10 @@
 (deftest run-lifecycle-contract
   (let [[_conn st] (mem-store)]
     (contract/assert-run-lifecycle! st :runs-datahike)))
+
+(deftest run-causality-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-run-causality! st :run-causes-datahike)))
 
 (deftest attention-projection-contract
   (let [[_conn st] (mem-store)]

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -10,6 +10,9 @@
 (deftest run-lifecycle-contract
   (contract/assert-run-lifecycle! (memory/make) :runs-memory))
 
+(deftest run-causality-contract
+  (contract/assert-run-causality! (memory/make) :run-causes-memory))
+
 (deftest attention-projection-contract
   (contract/assert-attention-projection! (memory/make) :attention-memory))
 

--- a/test/dvergr/rooms/messages_test.clj
+++ b/test/dvergr/rooms/messages_test.clj
@@ -4,6 +4,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.rooms.messages :as rmsg]
             [dvergr.discourse :as d]
+            [dvergr.room.store :as store]
             [dvergr.room.store.memory :as mem]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]
@@ -42,6 +43,38 @@
             (is (contains? cs "agent reply") "room signal includes agent replies (unlike per-agent ctx)")
             (is (contains? cs "🔧 grep")     "room signal includes tool-activity rows"))
           (finally (rmsg/drop-room! :rm-fold)))))))
+
+(deftest normalizes-semantic-activity-and-run-correlation
+  (let [c      (ctx/create-execution-context)
+        run-id (random-uuid)
+        fact   {:activity/id (random-uuid)
+                :activity/run-id run-id
+                :activity/kind :tool
+                :activity/verb :invoke
+                :activity/tool-name "clojure_eval"}]
+    (binding [ec/*execution-context* c]
+      (let [st   (mem/make)
+            room (d/make-room {:id :rm-semantic-activity :ctx c :store st})
+            sig  (rmsg/messages-signal room)]
+        (try
+          (let [now (java.util.Date.)]
+            (store/-store-run! st :rm-semantic-activity
+                               {:run/id run-id
+                                :run/kind :agent-turn
+                                :run/room :rm-semantic-activity
+                                :run/actor :var
+                                :run/trigger (random-uuid)
+                                :run/status :running
+                                :run/created-at now
+                                :run/started-at now
+                                :run/updated-at now}))
+          (d/post! room (d/message :var :_activity "tool activity" nil
+                                   {:role :tool :run-id run-id :activities [fact]}))
+          (engine/await-drain-complete! c :timeout-ms 350)
+          (let [view (some #(when (= "tool activity" (:content %)) %) @sig)]
+            (is (= run-id (:run-id view)))
+            (is (= [fact] (:activities view))))
+          (finally (rmsg/drop-room! :rm-semantic-activity)))))))
 
 (deftest dedups-by-id-and-matches-store
   (testing "the room signal and the store are two folds of the same bus —

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -14,6 +14,7 @@
             [dvergr.intake.bash :as b]
             [dvergr.substrate.geschichte :as geschichte]
             [dvergr.room.registry :as registry]
+            [dvergr.system.rooms :as srooms]
             [dvergr.runtime.peer-bus :as peer-bus]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.core :as sp]
@@ -92,6 +93,65 @@
         (is (= (:id fork) (:dvergr/origin (first evts))))
         (is (= :parent (:dvergr/parent (first evts))))
         (is (vector? (:workspace-id (first evts))))))))
+
+(deftest failed-fork-construction-rolls-back-the-world
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :rollback-parent *base-ctx*)
+          bad (assoc (d/echo :bad)
+                     :factory (fn [_]
+                                (throw (ex-info "clone failed" {:type ::clone-failed}))))
+          rooms-before (set (keys (registry/snapshot)))
+          discarded (atom 0)
+          discard! ygg/discard-fork!]
+      (d/join parent bad)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"clone failed"
+           (with-redefs [ygg/discard-fork!
+                         (fn [& args]
+                           (swap! discarded inc)
+                           (apply discard! args))]
+             (d/fork-room parent {:isolation :ctx}))))
+      (is (pos? @discarded) "the unreachable affine fork handle was settled")
+      (is (= rooms-before (set (keys (registry/snapshot))))
+          "no partially constructed Room became reachable")
+      (is (empty? (registry/structural-children (:id parent)))
+          "no stale settlement topology survived rollback"))))
+
+(deftest failed-fork-construction-drops-deferred-grants
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :rollback-grant-parent *base-ctx*)
+          grant {:room-id (random-uuid) :name "scratch" :scope :room}
+          dropped (atom nil)
+          bad (assoc (d/echo :bad-grant)
+                     :factory (fn [_]
+                                (ec/swap-state! [:dvergr/pending-grants]
+                                                (constantly [grant]))
+                                (throw (ex-info "clone failed after grant" {}))))]
+      (d/join parent bad)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"clone failed after grant"
+           (with-redefs [srooms/drop-fork-grants! #(reset! dropped %)]
+             (d/fork-room parent {:isolation :ctx}))))
+      (is (= [grant] @dropped)
+          "rollback releases storage grants provisioned inside the child world"))))
+
+(deftest fork-created-observability-failure-does-not-roll-back-publication
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :event-failure-parent *base-ctx*)
+          discarded (atom 0)
+          fork (with-redefs [peer-bus/post! (fn [_]
+                                              (throw (ex-info "observer unavailable" {})))
+                             ygg/discard-fork! (fn [& _] (swap! discarded inc))]
+                 (d/fork-room parent {:isolation :ctx}))]
+      (try
+        (is (identical? fork (registry/lookup (:id fork)))
+            "the atomically published Room remains authoritative")
+        (is (zero? @discarded)
+            "a failed control-plane notification cannot settle its live handle")
+        (finally
+          ;; The test replaced settlement only during construction; normal
+          ;; cleanup owns and settles the retained fork now.
+          (d/discard fork))))))
 
 (deftest propose-merge!-emits-event-and-tagged-message
   (binding [ec/*execution-context* *base-ctx*]

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -71,8 +71,25 @@
           (is (re-find #":delay-ms" guide))
           (is (re-find #"result-spin" guide))
           (is (re-find #"owned-result-spin" guide))
+          (is (re-find #"content-addressed EnvironmentDef" guide))
           (is (re-find #"comb/race" guide))
           (is (re-find #"await" guide)))
+        (let [result
+              (sandbox/eval-code
+               sci-ctx
+               (str "(require '[dvergr.agent :as agent]) "
+                    "(let [a (agent/environment "
+                    "{:id :training/example :task {:input 42} "
+                    ":verifier {:id :checks/example :version 1} "
+                    ":limits {:timeout-ms 1000}}) "
+                    "b (agent/environment "
+                    "{:limits {:timeout-ms 1000} "
+                    ":verifier {:version 1 :id :checks/example} "
+                    ":task {:input 42} :id :training/example})] "
+                    "{:same? (= a b) :ref (agent/environment-ref a)})"))]
+          (is (:success result) (pr-str (:error result)))
+          (is (true? (get-in result [:value :same?])))
+          (is (uuid? (get-in result [:value :ref :environment/content-id]))))
         (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.comb)]
           (is (re-find #"cancel losing branches" guide))
           (is (re-find #"owned-result-spin" guide)))
@@ -115,6 +132,70 @@
           (is (= :completed (get-in result [:value :analyst-status])))
           (is (empty? (run/active-runs (:id room))))))
       (finally
+        (d/close-room! room)))))
+
+(deftest sci-can-author-particles-and-an-independent-verifier
+  (let [room      (d/make-room {:id :sci-self-programming-eval
+                                :store (memory/make)})
+        sci-ctx   (sandbox/fork-for-session (:ctx room))
+        parent-id (:run/id (run/start! room :orchestrator (random-uuid) nil))]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room)
+       {:program-kinds #{:scripted}
+        :parent-run parent-id})
+      (data-ns/add-spindel-extras-ns! sci-ctx (:ctx room))
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                "         '[spindel.comb :as comb]) "
+                "(let [team (-> (agent/roster {:id :particle-eval}) "
+                "               (agent/make-agent {:id :mod-five "
+                "                 :program {:kind :scripted :delay-ms 50 "
+                "                           :reply [8 23 38 53 68 83 98]}}) "
+                "               (agent/make-agent {:id :mod-seven "
+                "                 :program {:kind :scripted :delay-ms 50 "
+                "                           :reply [2 9 16 23 30 37 44 51 58 65 72 79 86 93]}}) "
+                "               (agent/make-agent {:id :verifier "
+                "                 :program {:kind :scripted :delay-ms 50 "
+                "                           :reply {:moduli [[3 2] [5 3] [7 2]] "
+                "                                   :upper-bound 100}}})) "
+                "      a (agent/hire! team :mod-five {:task :candidates}) "
+                "      b (agent/hire! team :mod-seven {:task :candidates}) "
+                "      v (agent/hire! team :verifier {:task :constraints}) "
+                "      [ra rb rv] @(spin (await (comb/parallel "
+                "                                  (agent/result-spin a) "
+                "                                  (agent/result-spin b) "
+                "                                  (agent/result-spin v)))) "
+                "      [xs ys spec] (mapv :run/value [ra rb rv]) "
+                "      candidates (filter (set ys) xs) "
+                "      valid? (fn [n] (and (pos? n) (< n (:upper-bound spec)) "
+                "                            (every? (fn [[m r]] (= r (mod n m))) "
+                "                                    (:moduli spec)))) "
+                "      answers (vec (filter valid? candidates))] "
+                "  {:answer (first answers) :particles 2 :verified (= [23] answers)})")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (= {:answer 23 :particles 2 :verified true} (:value result)))
+        (is (wait-until #(= [parent-id]
+                            (mapv :run/id (run/active-runs (:id room))))
+                        1000))
+        (run/finish! parent-id :completed)
+        (let [root (run/run room parent-id)
+              children (remove #(= parent-id (:run/id %)) (run/runs room))
+              by-actor (into {} (map (juxt :run/actor identity)) children)]
+          (is (= #{:mod-five :mod-seven :verifier} (set (keys by-actor))))
+          (is (every? #(= parent-id (:run/parent %)) children))
+          (is (= (into #{} (map :run/id) children)
+                 (set (:run/caused-by root))))
+          (is (every? #(= :completed (:run/status %)) children))
+          (is (every? #(= :merged (:run/settlement-status %)) children))))
+      (finally
+        (run/finish! parent-id :cancelled)
         (d/close-room! room)))))
 
 (deftest room-sci-programs-serial-work-without-an-llm
@@ -557,7 +638,7 @@
   (let [room      (d/make-room {:id :sci-agent-ambient-parent
                                 :store (memory/make)})
         sci-ctx   (sandbox/fork-for-session (:ctx room))
-        parent-id (random-uuid)]
+        parent-id (:run/id (run/start! room :parent (random-uuid) nil))]
     (try
       (agent-ns/add-programming-ns!
        sci-ctx (:id room) (:ctx room)
@@ -577,8 +658,13 @@
                 "  @(spin (await (agent/result-spin child))) "
                 "  (:run/parent (agent/observe child)))")))]
         (is (:success result) (pr-str (:error result)))
-        (is (= parent-id (:value result))))
+        (is (= parent-id (:value result)))
+        (let [child-id (:run/id (first (filter #(= :child (:run/actor %))
+                                               (run/runs room))))]
+          (is (= #{child-id}
+                 (:run/caused-by (run/run room parent-id))))))
       (finally
+        (run/finish! parent-id :completed)
         (d/close-room! room)))))
 
 (deftest sandbox-cannot-redirect-structural-parent-authority

--- a/test/dvergr/sandbox/datahike_attempt_guard_test.clj
+++ b/test/dvergr/sandbox/datahike_attempt_guard_test.clj
@@ -1,0 +1,30 @@
+(ns dvergr.sandbox.datahike-attempt-guard-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [dvergr.chat.schema :as schema]
+            [dvergr.sandbox.ns.datahike :as sandbox-datahike]))
+
+(defn- conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? false :schema-flexibility :write}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (schema/ensure-full-schema! conn)
+      conn)))
+
+(deftest sci-datahike-surface-rejects-certified-attempt-writes-and-retractions
+  (let [conn (conn)
+        attempt-id (random-uuid)
+        guard @#'sandbox-datahike/assert-no-attempt-write!]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"host-certified"
+         (guard conn [{:attempt/id attempt-id}])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"host-certified"
+         (guard conn [[:db/add -1 :attempt/reward 1.0]])))
+    ;; Host setup proves numeric retractEntity cannot bypass the namespace check.
+    (d/transact conn [{:attempt/id attempt-id}])
+    (let [eid (:db/id (d/entity @conn [:attempt/id attempt-id]))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"host-certified"
+           (guard conn [[:db/retractEntity eid]]))))))

--- a/test/dvergr/sandbox/escape_corpus_test.clj
+++ b/test/dvergr/sandbox/escape_corpus_test.clj
@@ -103,7 +103,14 @@
       (testing "the agent's own room-facing surface is present"
         (is (= true (:ok (eval-in sci ec "(some? dvergr.room/kb-search)")))))
       (testing "in-jail file access works"
-        (is (= true (:ok (eval-in sci ec "(babashka.fs/exists? \"deps.edn\")")))))
+        (is (= true
+               (:ok (eval-in sci ec
+                             "(let [p (str \".capability-probe-\" (random-uuid))]
+                                (try
+                                  (spit p \"ok\")
+                                  (babashka.fs/exists? p)
+                                  (finally
+                                    (babashka.fs/delete-if-exists p))))")))))
       (testing "but escapes past the jail are refused"
         (is (:err (eval-in sci ec "(babashka.fs/exists? \"/etc/passwd\")")))
         (is (:err (eval-in sci ec "(slurp \"/etc/passwd\")")))))))

--- a/test/dvergr/sandbox/inference_world_test.clj
+++ b/test/dvergr/sandbox/inference_world_test.clj
@@ -1,0 +1,104 @@
+(ns dvergr.sandbox.inference-world-test
+  "Dvergr's SCI inference surface defaults effectful particles to canonical worlds."
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.sandbox.ns.data :as data-ns]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [sci.core :as sci]
+            [yggdrasil.convergent.gset :as g]))
+
+(defn- memory-gset [id]
+  (g/gset id {:store-config {:backend :memory :id (random-uuid)}}
+          {:sync? true}))
+
+(deftest sci-smc-defaults-to-isolated-canonical-worlds
+  (let [root (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [knowledge (ygg/register!
+                         (-> (memory-gset "dvergr-inference-kb")
+                             (g/conj :root {:sync? true})))
+              sci-ctx (sandbox/fork-for-session root)]
+          (data-ns/add-inference-ns! sci-ctx)
+          ;; These are deliberately opaque host capabilities. SCI can request
+          ;; one mutation in its current particle world but cannot obtain a
+          ;; Yggdrasil handle or settlement authority.
+          (sci/add-namespace!
+           sci-ctx 'particle
+           {'id (fn []
+                  (rtp/get-state ec/*execution-context*
+                                 [:inference :particle-id]))
+            'write! (fn [value]
+                      (let [signal (ygg/system-signal "dvergr-inference-kb")]
+                        (reset! signal
+                                (g/conj @signal value {:sync? true})))
+                      value)
+            'values (fn []
+                      (g/elements @(ygg/system-signal "dvergr-inference-kb")
+                                  {:sync? true}))})
+          (let [result
+                (sandbox/eval-code
+                 sci-ctx
+                 (str
+                  "(require '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                  "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                  "         '[org.replikativ.spindel.inference.effects :refer [observe]] "
+                  "         '[dist] '[infer] '[particle]) "
+                  "(let [model (spin "
+                  "              (let [id (particle/id)] "
+                  "                (particle/write! id) "
+                  "                (observe (dist/normal 0.0 1.0) 0.0 :id :evidence) "
+                  "                (particle/values))) "
+                  "      posterior @(spin (await (infer/smc-infer "
+                  "                              model 4 {:resample-threshold 2.0})))] "
+                  "  {:values (infer/values posterior) "
+                  "   :weights (infer/log-weights posterior) "
+                  "   :ess (infer/ess posterior) "
+                  "   :worlds (infer/worlds posterior) "
+                  "   :raw-particles (:particles posterior) "
+                  "   :raw-executor (:executor posterior)})")
+                 ;; Canonical particle worlds fork and settle four complete
+                 ;; execution contexts. Keep the watchdog well above normal
+                 ;; latency so a memory-constrained full-suite worker does not
+                 ;; cancel healthy inference midway through settlement.
+                 :timeout-ms 60000)
+                {:keys [values weights ess worlds raw-particles raw-executor]}
+                (:value result)]
+            (is (:success result) (pr-str (:error result)))
+            (testing "posterior values retain independent selected ancestry"
+              (is (= 4 (count values)))
+              (is (every? #(and (= 2 (count %)) (contains? % :root)) values)))
+            (testing "portable inference projections contain no live authority"
+              (is (= 4 (count weights)))
+              (is (number? ess))
+              (is (= 4 (count worlds)))
+              (is (every? #(and (map? %)
+                                (= :particle (:fork/purpose %)))
+                          worlds))
+              (is (nil? raw-particles))
+              (is (nil? raw-executor)))
+            (testing "particle writes do not contaminate the ambient room world"
+              (is (= #{:root} (g/elements @knowledge {:sync? true})))))
+          (let [pure
+                (sandbox/eval-code
+                 sci-ctx
+                 (str
+                  "(let [posterior @(spin (await (infer/smc-infer "
+                  "                              (spin 7) 2 {:world-policy :fresh})))] "
+                  "  {:values (infer/values posterior) "
+                  "   :worlds (infer/worlds posterior) "
+                  "   :mean (:mean (infer/query posterior identity)) "
+                  "   :predictions (infer/predict posterior inc 3)})")
+                 :timeout-ms 30000)]
+            (testing "a proven-pure model may explicitly choose the cheap path"
+              (is (:success pure) (pr-str (:error pure)))
+              (is (= {:values [7 7]
+                      :worlds []
+                      :mean 7.0
+                      :predictions [8 8 8]}
+                     (:value pure)))))))
+      (finally
+        (context/stop-context! root)))))

--- a/test/dvergr/tui/app_test.clj
+++ b/test/dvergr/tui/app_test.clj
@@ -103,6 +103,19 @@
       (is (str/includes? on "I should compute the product") "reasoning shown in trace")
       (is (str/includes? on "(* 19 23)") "tool input shown in trace"))))
 
+(deftest render-room-message-shows-semantic-activity-correlation
+  (let [run-id (java.util.UUID/fromString "12345678-1234-1234-1234-123456789abc")
+        lines  (render-room-message
+                {:from :var :role :tool :content "used a tool"
+                 :run-id run-id
+                 :activities [{:activity/kind :tool
+                               :activity/verb :invoke
+                               :activity/tool-name "clojure_eval"}]}
+                60 false)
+        text   (strip (str/join "\n" lines))]
+    (is (str/includes? text "invoke · clojure_eval"))
+    (is (str/includes? text "run 12345678"))))
+
 (defn- room-harness [c room-id extra-signals]
   (h/harness
    {:execution-context c

--- a/test/dvergr/web/dashboard_test.clj
+++ b/test/dvergr/web/dashboard_test.clj
@@ -1,0 +1,21 @@
+(ns dvergr.web.dashboard-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [dvergr.web.dashboard :as dashboard]
+            [hiccup2.core :as h]))
+
+(def ^:private message-hiccup #'dashboard/message-hiccup)
+
+(deftest message-renders-semantic-activity-with-run-correlation
+  (let [html (str (h/html
+                   (message-hiccup
+                    {:id (random-uuid)
+                     :from :var
+                     :role :tool
+                     :content "used a tool"
+                     :run-id (java.util.UUID/fromString "12345678-1234-1234-1234-123456789abc")
+                     :activities [{:activity/kind :tool
+                                   :activity/verb :invoke
+                                   :activity/tool-name "clojure_eval"}]})))]
+    (is (str/includes? html "invoke · clojure_eval"))
+    (is (str/includes? html "run 12345678"))))


### PR DESCRIPTION
Projects canonical semantic activity metadata through the shared room signal into both first-party interfaces.

- preserves exact Run correlation across live and rehydrated message shapes
- renders compact semantic activity in web and TUI
- keeps raw tool arguments in the existing trace details
- introduces no second frontend lifecycle or effect authority

Verification:
- formatting and diff checks clean
- clj-kondo: 0 errors (2 pre-existing warnings)
- focused room/TUI/web tests: 15 tests, 49 assertions
- full suite: 587 tests, 2516 assertions
- live nREPL probe confirmed room signal, TUI, and web all expose the same Run/activity fact
- independent exact-head review: no medium-or-higher findings