### PR TITLE
Default SCI inference to canonical particle worlds

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,17 +279,14 @@ The standalone, runnable scenarios these import live in [`examples/`](examples/)
 | [hato](https://github.com/gnarroway/hato) | HTTP client for provider APIs |
 | [Telemere](https://github.com/taoensso/telemere) | Structured logging + observability |
 
-> **SCI fork note (Clojars library consumers only).** dvergr pins a fork of SCI
-> (`whilo/sci`, branch `resource-check`) for the `:interrupt-fn` cancellation the
-> sandbox relies on, pending an upstream PR. tools.build's `write-pom` emits only
-> Maven coords, so this git dep is **not** in the published pom. The uberjar/CLI
-> and git-dep consumers get it transitively and need nothing extra; a pure-Clojars
-> library consumer must add it themselves:
+> **SCI fork note.** dvergr directly depends on the published replikativ SCI
+> build for resource interruption and forkable interpreter worlds while the
+> corresponding changes are reviewed upstream. Maven and git consumers resolve
+> the same implementation:
 > ```clojure
-> org.babashka/sci {:git/url "https://github.com/whilo/sci"
->                   :git/sha "24762a163ef5b25c692d0e5cd4ea63a5bd6b0a16"}
+> org.replikativ/sci {:mvn/version "0.15.59-replikativ.1"}
 > ```
-> (Goes away once the fork lands upstream or is published to Maven.)
+> This returns to `org.babashka/sci` once the fork lands upstream.
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure       {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure       {:mvn/version "1.12.5"}
 
         ;; HTTP client for provider APIs
         hato/hato                  {:mvn/version "1.0.0"}
@@ -25,12 +25,13 @@
         ;; Async utilities
         org.clojure/core.async     {:mvn/version "1.6.681"}
 
-        ;; SCI — Small Clojure Interpreter for sandboxing.
-        org.babashka/sci           {:mvn/version "0.15.56"}
+        ;; SCI — Small Clojure Interpreter for sandboxing. The replikativ build
+        ;; carries forkable interpreter worlds while sci#1084 is upstreamed.
+        org.replikativ/sci         {:mvn/version "0.15.59-replikativ.1"}
 
-        ;; partial-cps (CPS transform for the SCI spin macro) comes TRANSITIVELY
-        ;; via spindel — not declared here, so spindel is the single source of its
-        ;; version. The `:local` alias's `../spindel` override carries it too.
+        ;; Dvergr uses the async sequence/CPS namespaces directly; keep this a
+        ;; direct dependency instead of relying on Spindel's implementation deps.
+        is.simm/partial-cps        {:mvn/version "0.1.60"}
 
         ;; Spindel — Reactive runtime with CoW forking.
         ;; 0.1.35 (#27 lost-wakeup redesign + follow-ups): continuation
@@ -48,15 +49,9 @@
         ;; (mailbox→mult→tap→pub→topic-mult→tap) under load.
         ;; Substrate for the durable-cursor bus pump + supervisor
         ;; restart.
-        ;; 0.1.43 includes structured cancellation and affine partitioned world
-        ;; authority, the substrate used by Run-world adoption and delegation.
-        ;; Structured work admission, cancellation hand-back, overlay
-        ;; materialization, and canonical inference worlds are currently
-        ;; stacked on spindel#44-#47. Pin the reviewed commit until
-        ;; that release reaches Clojars, then return this to an ordinary version
-        ;; coordinate.
-        org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "24f9e7cd679a534c8346d9bbb25958b444fb6471"}
+        ;; 0.1.44 includes structured work admission, cancellation hand-back,
+        ;; canonical inference worlds, and forkable SCI world components.
+        org.replikativ/spindel     {:mvn/version "0.1.44"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context
@@ -66,53 +61,44 @@
         ;; API this branch's agent workspaces are built on (isolated worktrees,
         ;; checkout semantics delegated to Geschichte, Git served from a virtual
         ;; GeschichteFS base) — so no local root is needed to build it.
-        org.replikativ/muschel     {:mvn/version "0.2.19"}
+        org.replikativ/muschel     {:mvn/version "0.2.19"
+                                    :exclusions  [org.babashka/sci]}
 
         ;; Geschichte — authoritative virtual filesystem + Git compatibility.
-        ;; 0.1.12 is the release where the Yggdrasil adapter MOVED OUT (#8), so
-        ;; there is exactly one GeschichteSystem record on the classpath — the
-        ;; one in yggdrasil.adapters.geschichte. No local root needed.
-        org.replikativ/geschichte  {:mvn/version "0.1.12"}
+        ;; Geschichte remains the authoritative virtual filesystem; its
+        ;; Yggdrasil adapter lives only in Yggdrasil.
+        org.replikativ/geschichte  {:mvn/version "0.1.15"}
 
         ;; rewrite-clj for structural editing
         rewrite-clj/rewrite-clj    {:mvn/version "1.1.48"}
 
         ;; Datahike — persistent Datalog storage
-        ;; 0.8.1861 provides writer-internal operation provenance to mandatory
-        ;; transaction predicates. Kontor uses it to keep purge/history
-        ;; validation internal without extending Datahike's public tx report.
-        org.replikativ/datahike    {:mvn/version "0.8.1861"}
+        ;; Keep the direct dependency current: Dvergr uses Datahike's API and
+        ;; transaction predicates itself, not merely through Geschichte.
+        org.replikativ/datahike    {:mvn/version "0.8.1865"}
         ;; 0.1.37 provides conserved resource vectors, durable receipts, and
         ;; mandatory Datahike invariants for Run resource delegation.
         org.replikativ/kontor      {:mvn/version "0.1.37"}
 
         ;; Yggdrasil — CoW branching for git and Datahike
-        ;; 0.3.38 adopts the Geschichte adapter (yggdrasil.adapters.geschichte,
-        ;; PR #16) and gives it the p/Mergeable it never had, so a room repo can
-        ;; finally produce a FILE diff instead of a datom count over
-        ;; Geschichte's internal schema.
-        org.replikativ/yggdrasil   {:mvn/version "0.3.38"}
+        ;; 0.3.41 includes the Geschichte content-level merge adapter and the
+        ;; current persistent-sorted-set substrate.
+        org.replikativ/yggdrasil   {:mvn/version "0.3.41"
+                                    :exclusions  [org.babashka/sci]}
 
         ;; Scriptum — CoW Lucene indices for fulltext search
-        org.replikativ/scriptum    {:mvn/version "0.1.30"}
+        org.replikativ/scriptum    {:mvn/version "0.1.32"}
 
         ;; Briefkasten (local IMAP mirror) is OPTIONAL — it backs dvergr.intake.mail
         ;; only, and pulls the jakarta-mail tree, so it lives in the
         ;; :dev/:test/:cli/:tui aliases (with clojure-mail), not core.
 
-        ;; Kabel — WebSocket peer-to-peer transport. 0.3.98 pins javac --release 11
-        ;; (0.3.97 shipped Java-25 bytecode → UnsupportedClassVersionError on JDK <25).
-        org.replikativ/kabel       {:mvn/version "0.3.98"}
-        ;; Compatibility alignment: Yggdrasil 0.3.38 still loads
-        ;; hasch.benc.HashRef, which was removed in Hasch 0.4.102. Drop this
-        ;; override when Yggdrasil moves to the new reference representation.
-        org.replikativ/hasch       {:mvn/version "0.4.101"}
+        ;; Dvergr derives stable activity and environment identities directly.
+        ;; Match Datahike's current array-hashing implementation.
+        org.replikativ/hasch       {:mvn/version "0.4.104"}
         ;; Dvergr's drive blob store uses Konserve directly. Keep this aligned
         ;; with Datahike rather than relying on Datahike's transitive API.
-        org.replikativ/konserve    {:mvn/version "0.9.385"}
-
-        ;; Distributed-scope — remote function invocation over Kabel
-        is.simm/distributed-scope  {:mvn/version "0.1.2"}
+        org.replikativ/konserve    {:mvn/version "0.9.391"}
 
         ;; tools.analyzer for code indexing
         org.clojure/tools.analyzer.jvm {:mvn/version "1.3.0"}
@@ -189,7 +175,7 @@
   ;; `:local/root "../datahike"` override uses datahike's DEFAULT :paths (which
   ;; exclude src-secondary), so we add it here for the source-override dev path.
   :local {:extra-paths ["../datahike/src-secondary"]
-          :extra-deps {org.babashka/sci           {:local/root "../sci"}
+          :extra-deps {org.replikativ/sci         {:local/root "../sci"}
                        org.replikativ/datahike    {:local/root "../datahike"}
                        org.replikativ/scriptum    {:local/root "../scriptum"}
                        org.replikativ/yggdrasil   {:local/root "../yggdrasil"}

--- a/deps.edn
+++ b/deps.edn
@@ -50,12 +50,13 @@
         ;; restart.
         ;; 0.1.43 includes structured cancellation and affine partitioned world
         ;; authority, the substrate used by Run-world adoption and delegation.
-        ;; Structured work admission and its cancellation hand-back fix are
-        ;; currently stacked on spindel#44/#45. Pin the reviewed commit until
+        ;; Structured work admission, cancellation hand-back, overlay
+        ;; materialization, and canonical inference worlds are currently
+        ;; stacked on spindel#44-#47. Pin the reviewed commit until
         ;; that release reaches Clojars, then return this to an ordinary version
         ;; coordinate.
         org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "1eb9ae72f52a863b8592d7a193442262bbc264fd"}
+                                    :git/sha "2afde316edbad31e784e86fd7aabb6e8de24a563"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/deps.edn
+++ b/deps.edn
@@ -56,7 +56,7 @@
         ;; that release reaches Clojars, then return this to an ordinary version
         ;; coordinate.
         org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "2afde316edbad31e784e86fd7aabb6e8de24a563"}
+                                    :git/sha "24f9e7cd679a534c8346d9bbb25958b444fb6471"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/deps.edn
+++ b/deps.edn
@@ -55,7 +55,7 @@
         ;; that release reaches Clojars, then return this to an ordinary version
         ;; coordinate.
         org.replikativ/spindel     {:git/url "https://github.com/replikativ/spindel.git"
-                                    :git/sha "286f2013ec68a29ce9e4c61d33b244ee9fafc854"}
+                                    :git/sha "1eb9ae72f52a863b8592d7a193442262bbc264fd"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -537,8 +537,10 @@ facts; it introduces no lifecycle, clock, mutable cell, or settlement authority.
 Probabilistic programs use the same placement rule. In SCI, Dvergr defaults
 `infer/smc-infer`, `infer/importance-sampling`, and `infer/kernel-infer` to
 Spindel's `:world-policy :fork`. Each particle and resampling descendant owns a
-canonical Yggdrasil fork; after completion only immutable execution contexts,
-results, weights, and portable world descriptors remain. For example:
+canonical Yggdrasil fork. Before a result crosses into SCI, Dvergr removes the
+execution contexts and exposes only portable results, weights, statistics, and
+world descriptors. `infer/predict` likewise receives values rather than native
+contexts. For example:
 
 ```clojure
 (spin
@@ -555,6 +557,17 @@ does not introduce an `AgentParticle` entity and does not turn every sample into
 a Run. A Run remains the durable identity of an application-level computation;
 particles are its internal execution placements unless the program explicitly
 launches separately audited evaluations.
+
+Particle-independent Metropolis-Hastings and particle Gibbs are not exposed in
+SCI yet. Their repeated-sweep ownership and settlement contract must be made
+canonical before they become part of this surface.
+
+The current canonical fork covers Spindel execution state and every registered
+Yggdrasil system. It does not yet fork mutable cells allocated inside SCI: a
+captured SCI atom or Var is shared by model invocations. Treat SCI closures as
+pure apart from the fork-aware operations above. Full interpreter-state
+isolation depends on the forkable SCI runtime work and will strengthen this
+contract without changing the portable posterior shape.
 
 Small JVM atoms used inside a native-worker supervisor or verifier hand-off are
 short-lived synchronization primitives for non-forkable capabilities. They may

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -579,9 +579,11 @@ one of the registered Yggdrasil systems instead.
 If a workflow needs changing state, allocate it through Spindel's fork-aware
 state vocabulary (signals or reactive atoms) in the relevant execution context.
 Do not place semantic workflow state in a JVM atom, dynamic singleton, or
-process-global registry. SCI Var forkability is a separate runtime project; do
-not rely on a top-level `def` as the portable state boundary until that work is
-complete.
+process-global registry. SCI vars, atoms, bindings, and continuations now fork
+with the interpreter world, so top-level definitions are valid transient
+branch-local program state. They are deliberately discarded rather than merged;
+durable or reviewable meaning still belongs in Room substrates and Run/effect
+records.
 
 A RunHandle is intentionally not durable state and should not be stored inside
 an AgentDef. Its awaitable result/cache belongs to the Spindel execution graph;

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -534,6 +534,28 @@ branch-correct Room store while the affine world-settlement gate is held.
 `episode/export` is only a read projection joining that Attempt to current Run
 facts; it introduces no lifecycle, clock, mutable cell, or settlement authority.
 
+Probabilistic programs use the same placement rule. In SCI, Dvergr defaults
+`infer/smc-infer`, `infer/importance-sampling`, and `infer/kernel-infer` to
+Spindel's `:world-policy :fork`. Each particle and resampling descendant owns a
+canonical Yggdrasil fork; after completion only immutable execution contexts,
+results, weights, and portable world descriptors remain. For example:
+
+```clojure
+(spin
+  (let [posterior (await (infer/smc-infer (scenario-model) 64))]
+    {:values  (infer/values posterior)
+     :weights (infer/log-weights posterior)
+     :ess     (infer/ess posterior)
+     :worlds  (infer/worlds posterior)}))
+```
+
+Pass `{:world-policy :fresh}` only when the model is proven not to touch Room,
+Datahike, repository, accounting, or other registered world state. Inference
+does not introduce an `AgentParticle` entity and does not turn every sample into
+a Run. A Run remains the durable identity of an application-level computation;
+particles are its internal execution placements unless the program explicitly
+launches separately audited evaluations.
+
 Small JVM atoms used inside a native-worker supervisor or verifier hand-off are
 short-lived synchronization primitives for non-forkable capabilities. They may
 decide which already-durable transition wins, but their contents are not the

--- a/doc/fork-and-world-model.md
+++ b/doc/fork-and-world-model.md
@@ -310,9 +310,19 @@ independent reactive state and an explicit external-system/effect policy.
 Observe evidence, resample descriptors/contexts, and discard unselected
 particles. Only an explicitly selected particle can be promoted or merged.
 
-Needs: the inference coordinator must stop using raw
-`snapshot-context`/`restore-snapshot` for worlds containing Yggdrasil handles;
-that path does not invoke `PForkable` and may alias external state.
+Spindel's inference coordinator now accepts `:world-policy :fork`: initial and
+resampled particles are frozen canonical Yggdrasil forks, and the complete
+speculative tree is discarded after immutable particle results have been
+captured. Dvergr's SCI `infer/smc-infer`, `infer/importance-sampling`, and
+`infer/kernel-infer` wrappers select that policy by default. A caller may pass
+`:world-policy :fresh` only for a model known to be pure. `infer/values`,
+`infer/log-weights`, `infer/ess`, and `infer/worlds` project results and portable
+world descriptors without exposing live settlement handles.
+
+This solves isolation and affine cleanup for one inference population. It does
+not promote a posterior particle automatically: promotion remains an explicit
+Run/proposal operation, and PGAS ancestor scoring is rejected for canonical
+worlds until retained-world ancestry has a sound ownership contract.
 
 ### MCTS
 

--- a/doc/state-model.md
+++ b/doc/state-model.md
@@ -50,7 +50,8 @@ pair (`dvergr.agent.room-context/ensure-ctx!`) — itself a **fold of Tier 1**:
 - `budget-signal` — `{:total :used :by-type}` token accounting
 - `status-signal` — `:active` / `:paused` / `:completed`
 - `db-conn` — the `dvergr-chat-db` connection (in a fork: the *branched* one)
-- `sci-ctx` — the agent's **SCI sandbox** (its `clojure_eval` world)
+- `sci-component` — a stable Spindel component reference selecting the agent's
+  **SCI sandbox** (`clojure_eval` world) in the current execution context
 
 The agent's own ctx is **`:durable? false`** — signal-only. The room store's
 bus→store listener is the *lone* durable writer for the conversation. So the durable
@@ -70,10 +71,22 @@ plus the per-session sandbox.
 - **git worktree** → a fresh worktree; the agent's file edits are isolated.
 - **muschel shell session** → its env-atom is CoW-forked alongside, so a worker's
   `cd` / shell state can't leak to the parent.
-- **per-agent SCI sandbox** → on its first turn in the fork, `ensure-ctx!` builds a
-  fresh `ChatContext` whose `sci-ctx` is a `sandbox/fork-for-session` fork —
-  **transient and isolated per fork, never shared** with the parent or siblings
-  (`(def x …)` in one fork is invisible to others).
+- **per-agent SCI sandbox** → the SCI interpreter is a Spindel world component.
+  Forking the execution context forks its heap (vars, atoms, bindings, and
+  continuations) from the effective parent state. The child reuses the stable
+  `ChatContext` identity while resolving an independent interpreter; `(def x …)`
+  in one fork is invisible to its parent and siblings. Discard unregisters the
+  child realization rather than merging transient interpreter state.
+
+Injected host capabilities follow a stricter rule than ordinary SCI values.
+They never close over a Room, Datahike connection, Geschichte workspace, or
+filesystem. Each interpreter component owns a stable capability identity whose
+serializable binding lives in the Spindel execution context. A copied function
+therefore resolves that identity in the currently selected descendant world at
+call time. This is why a helper defined *before* a fork cannot write back into
+its parent even though the helper's SCI function value itself was inherited.
+Namespace refresh after projection exposes new APIs; it is not the isolation
+mechanism.
 
 The fork's conversation is **seeded from the branched store**, so the agent sees
 inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
@@ -81,6 +94,15 @@ inherited (pre-fork) messages *plus* its own — exactly what the UI shows.
 fully **substrate-isolated world** you can review (`diff`) before adopting or
 discarding. The live handle is process-local; `dvergr.discourse/fork-descriptor`
 is the portable projection used by Runs, proposals, UIs, and audit state.
+
+### ChatContext SCI API migration
+
+`ChatContext` no longer exposes a raw `:sci-ctx` field. Embedders must call
+`dvergr.chat.context/sci-context-in` with the intended execution context, or
+`sci-context` while that context is bound. The record now carries
+`:sci-component`, which is an opaque stable reference and must not be passed to
+SCI directly. Tool contexts still use `:sci-ctx`; supply the interpreter returned
+by one of those resolver functions.
 
 ## Personas / agent config — managed, not files
 

--- a/src/dvergr/agent/process.clj
+++ b/src/dvergr/agent/process.clj
@@ -35,7 +35,7 @@
   "Run f with the chat-ctx's spindel-ctx bound. f sees a stable
    *execution-context* for ec/swap-state! and signal derefs."
   [chat-ctx f]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [ec/*execution-context* (chat-ctx/selected-execution-context chat-ctx)]
     (f)))
 
 (defn- registry
@@ -147,7 +147,8 @@
   "Return the latest progress snapshot for a process — a pure read.
    Does not disturb the parked spin."
   [process]
-  (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+  (binding [ec/*execution-context*
+            (chat-ctx/selected-execution-context (:chat-ctx process))]
     (let [now (System/currentTimeMillis)
           term-at (some-> (:terminated-at-ref process) .get)]
       {:id             (:id process)
@@ -195,7 +196,7 @@
   (if-let [process *current-process*]
     (let [chat-ctx  (:chat-ctx process)
           grace-ms  (:grace-ms process 5000)
-          chat-spc  (:spindel-ctx chat-ctx)]
+          chat-spc  (chat-ctx/selected-execution-context chat-ctx)]
       (binding [ec/*execution-context* chat-spc]
         (reset! (:progress-signal process)
                 (cond-> (or state {})
@@ -256,7 +257,7 @@
           ;; sees the latch — flip status directly so work-owners
           ;; polling (aborted? proc) see the abort.
           (when (and (:tracked-only? process) (= :abort (:type canonical)))
-            (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+            (binding [ec/*execution-context* (chat-ctx/selected-execution-context chat-ctx)]
               (reset! (:status-signal process) :aborted))
             (mark-terminated! process))
           :delivered)
@@ -285,13 +286,15 @@
              :or {grace-ms 5000}}]
   {:pre [(string? description)]}
   (let [pid (or id (random-uuid))
+        world (chat-ctx/selected-execution-context chat-ctx)
+        process-chat-ctx (assoc chat-ctx :spindel-ctx world)
         process
-        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [ec/*execution-context* world]
           (let [s (sig/signal :running)
                 p (sig/signal {})]
             (map->Proc
              {:id              pid
-              :chat-ctx        chat-ctx
+              :chat-ctx        process-chat-ctx
               :description     description
               :grace-ms        grace-ms
               :status-signal   s
@@ -301,13 +304,14 @@
               :started-at        (System/currentTimeMillis)
               :terminated-at-ref (AtomicReference. nil)
               :tracked-only?   true})))]
-    (swap-registry! chat-ctx assoc pid process)
+    (swap-registry! process-chat-ctx assoc pid process)
     process))
 
 (defn progress!
   "Update the progress signal on a tracked process."
   [process state]
-  (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+  (binding [ec/*execution-context*
+            (chat-ctx/selected-execution-context (:chat-ctx process))]
     (reset! (:progress-signal process) state))
   state)
 
@@ -317,7 +321,7 @@
    finishes normally."
   [process]
   (let [cctx (:chat-ctx process)]
-    (binding [ec/*execution-context* (:spindel-ctx cctx)]
+    (binding [ec/*execution-context* (chat-ctx/selected-execution-context cctx)]
       (reset! (:status-signal process) :completed))
     (mark-terminated! process)
     ;; Stays in registry briefly so a manager can still snapshot. We
@@ -357,7 +361,7 @@
    summary is wanted it should be an explicit choice — which is what the
    decision protocol makes it (see .internal/decision-protocol-assessment.md)."
   [agent-id chat-ctx]
-  (let [spc           (:spindel-ctx chat-ctx)
+  (let [spc           (chat-ctx/selected-execution-context chat-ctx)
         budget        (binding [ec/*execution-context* spc]
                         @(:budget-signal chat-ctx))
         used-dollars  (/ (:used budget) (double acct/MICRODOLLARS-PER-DOLLAR))
@@ -381,7 +385,8 @@
    at safe points."
   [process]
   (= :aborted
-     (binding [ec/*execution-context* (:spindel-ctx (:chat-ctx process))]
+     (binding [ec/*execution-context*
+               (chat-ctx/selected-execution-context (:chat-ctx process))]
        @(:status-signal process))))
 
 (defn ->process
@@ -403,13 +408,15 @@
    body-fn]
   {:pre [(string? description)]}
   (let [pid (or id (random-uuid))
+        world (chat-ctx/selected-execution-context chat-ctx)
+        process-chat-ctx (assoc chat-ctx :spindel-ctx world)
         process
-        (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [ec/*execution-context* world]
           (let [s (sig/signal :running)
                 p (sig/signal {})]
             (map->Proc
              {:id              pid
-              :chat-ctx        chat-ctx
+              :chat-ctx        process-chat-ctx
               :description     description
               :grace-ms        grace-ms
               :status-signal   s
@@ -418,10 +425,10 @@
               :directive-latch   (CountDownLatch. 1)
               :started-at        (System/currentTimeMillis)
               :terminated-at-ref (AtomicReference. nil)})))]
-    (swap-registry! chat-ctx assoc pid process)
+    (swap-registry! process-chat-ctx assoc pid process)
     (future
       (binding [*current-process*    process
-                ec/*execution-context* (:spindel-ctx chat-ctx)]
+                ec/*execution-context* world]
         (try
           (let [result (body-fn)]
             (reset! (:status-signal process) :completed)

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -514,7 +514,7 @@
      (-> (tools/make-context
           {:db-conn work-db
            :chat-ctx chat-ctx
-           :sci-ctx (:sci-ctx chat-ctx)
+           :sci-ctx (chat-context/sci-context-in chat-ctx (:ctx room))
            :tools tool-map
            :isolation :sci
            :execution-ctx (:ctx room)

--- a/src/dvergr/agent/room_context.clj
+++ b/src/dvergr/agent/room_context.clj
@@ -31,7 +31,8 @@
             [org.replikativ.spindel.engine.core :as ec]
             [taoensso.telemere :as tel]))
 
-;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set}
+;; [room-id agent-id] → {:chat-ctx ChatContext :seen java.util.Set
+;;                       :execution-ctx ExecutionContext :sandbox-opts map}
 (defonce ^:private room-agent-ctxs (atom {}))
 
 (defn room-system-id
@@ -92,8 +93,23 @@
            (catch Throwable _ nil))
       (some-> from name)))
 
+(defn- append-inbound-to!
+  [chat-ctx seen msg-id role content author ts reasoning]
+  (when (.add ^java.util.Set seen msg-id)
+    (let [decorated (if (and author (not= :system role))
+                      (str "[" author (when-let [t (fmt-clock ts)] (str " · " t)) "] " content)
+                      content)]
+      (append-signal-only! chat-ctx (cond-> {:role role :content decorated}
+                                      (seq reasoning) (assoc :reasoning reasoning))))
+    true))
+
 (defn append-inbound!
-  "Append one inbound conversational message to the (room, agent) ctx's signal,
+  "Append one inbound conversational message to the (room, agent) ctx's signal.
+
+   `room-or-id` should be the Room for lifecycle-safe admission during first
+   hydration; the id form remains for callers that target an already-published
+   cache entry.
+
    EXACTLY ONCE (deduped by `msg-id` via the entry's synchronized set). Used by
    the attention interpreter. Signal-only (the room store already holds it
    durably). Returns true if appended.
@@ -101,20 +117,28 @@
    `author` is the sender's display label (nil for the agent's own messages); when
    present the content is prefixed `[author · HH:mm]` so the agent knows WHO spoke
    and WHEN — essential in multi-party rooms where roles alone are ambiguous."
-  ([room-id agent-id msg-id role content author ts]
-   (append-inbound! room-id agent-id msg-id role content author ts nil))
-  ([room-id agent-id msg-id role content author ts reasoning]
-   (when-let [{:keys [chat-ctx seen]} (get @room-agent-ctxs [room-id agent-id])]
-     (when (.add ^java.util.Set seen msg-id)
-       (let [decorated (if (and author (not= :system role))
-                         (str "[" author (when-let [t (fmt-clock ts)] (str " · " t)) "] " content)
-                         content)]
-         ;; `reasoning` (the agent's OWN prior <think> trace) rides along so
-         ;; reasoning models keep it across a rehydrate — see create-message-entity
-         ;; (:reasoning → :message/reasoning) + messages->api-format.
-         (append-signal-only! chat-ctx (cond-> {:role role :content decorated}
-                                         (seq reasoning) (assoc :reasoning reasoning))))
-       true))))
+  ([room-or-id agent-id msg-id role content author ts]
+   (append-inbound! room-or-id agent-id msg-id role content author ts nil))
+  ([room-or-id agent-id msg-id role content author ts reasoning]
+   (let [room? (map? room-or-id)
+         room-id (if room? (:id room-or-id) room-or-id)
+         k [room-id agent-id]
+         room-meta (or (when room? (:meta room-or-id))
+                       (:room-meta (get @room-agent-ctxs k)))]
+     (when room-meta
+       ;; Admission may race first hydration. Sharing the lifecycle fence makes
+       ;; the append wait for the fully seeded cache publication instead of
+       ;; observing an absent/partial entry and dropping a durable attention fact.
+       (locking room-meta
+         (binding [ec/*execution-context* (if room?
+                                            (:ctx room-or-id)
+                                            ec/*execution-context*)]
+           (when (or (not room?) (rreg/admitted-incarnation? room-or-id))
+             (when-let [{:keys [chat-ctx seen]} (get @room-agent-ctxs k)]
+               ;; `reasoning` (the agent's OWN prior <think> trace) rides along so
+               ;; reasoning models keep it across a rehydrate — see create-message-entity
+               ;; (:reasoning → :message/reasoning) + messages->api-format.
+               (append-inbound-to! chat-ctx seen msg-id role content author ts reasoning)))))))))
 
 (defn raise-budget!
   "Set the live budget :total on every cached agent ctx of `room-id` to
@@ -134,6 +158,97 @@
             0
             @room-agent-ctxs)))
 
+(defn- hydration-messages!
+  "Complete all fallible durable hydration before allocating live signals.
+
+   Attention baseline writes are deterministic/idempotent, so an interrupted
+   attempt can retry. The returned messages are pure data ready to project into
+   a newly constructed ChatContext without further store access."
+  [room agent-id limit]
+  (let [messages (d/messages room {:limit (or limit 100)})
+        attention-store? (satisfies? rstore/PAttentionStore (:store room))
+        conversation-id (d/conversation-id room)
+        baseline-message-id
+        (rstore/attention-id conversation-id agent-id nil nil
+                             :legacy-baseline-message)
+        baseline-marker-id
+        (rstore/attention-id conversation-id agent-id baseline-message-id
+                             nil :legacy-baseline-complete)
+        baseline-complete?
+        (and attention-store?
+             (seq (rstore/-list-attention (:store room)
+                                          conversation-id
+                                          {:id baseline-marker-id})))
+        ;; Upgrade cutover: pre-attention rooms already have Runs but no
+        ;; participant projection. Materialize their exact provider baseline
+        ;; before any new policy decision can make the projection non-empty.
+        _ (when (and attention-store? (not baseline-complete?))
+            (doseq [m messages :when (conversational? m)]
+              (let [decision-id
+                    (rstore/attention-id conversation-id agent-id (:id m) nil
+                                         :legacy-baseline-decision)
+                    common {:attention/participant agent-id
+                            :attention/message-id (:id m)
+                            :attention/memory :include
+                            :attention/activation :none
+                            :attention/control :continue
+                            :attention/at :now
+                            :attention/priority 0.0
+                            :attention/reason :migration/provider-baseline
+                            :attention/created-at
+                            (java.util.Date. (long (or (:ts m)
+                                                       (System/currentTimeMillis))))}]
+                (rstore/-store-attention!
+                 (:store room) conversation-id
+                 (assoc common
+                        :attention/id decision-id
+                        :attention/status :ready))
+                (rstore/-store-attention!
+                 (:store room) conversation-id
+                 (assoc common
+                        :attention/id
+                        (rstore/attention-id conversation-id agent-id (:id m) nil
+                                             :legacy-baseline-applied)
+                        :attention/decision-id decision-id
+                        :attention/status :applied))))
+            ;; Written last. If any prior write fails, the next hydration
+            ;; retries every deterministic pair and completes the cutover.
+            (rstore/-store-attention!
+             (:store room) conversation-id
+             {:attention/id baseline-marker-id
+              :attention/participant agent-id
+              :attention/message-id baseline-message-id
+              :attention/status :baseline-complete
+              :attention/reason :migration/provider-baseline
+              :attention/created-at (java.util.Date.)}))
+        attention-facts
+        (if attention-store?
+          (rstore/-list-attention (:store room)
+                                  conversation-id
+                                  {:participant agent-id :limit 1000})
+          [])
+        ;; Admission is monotone: once a fact entered provider context (most
+        ;; notably when queued work becomes a Run trigger), a later observation
+        ;; cannot silently erase it. Deliberate forgetting is compaction policy.
+        included-message-ids
+        (into #{}
+              (keep #(when (and (= :applied (:attention/status %))
+                                (= :include (:attention/memory %)))
+                       (:attention/message-id %)))
+              attention-facts)
+        agent-runs (run/runs room {:actor agent-id :limit 1000})
+        trigger-ids (into #{} (map :run/trigger) agent-runs)
+        ;; Ephemeral/custom stores without the projection retain historical
+        ;; full-transcript behavior for compatibility.
+        legacy-history? (not attention-store?)]
+    (into []
+          (filter #(and (conversational? %)
+                        (or (= agent-id (:from %))
+                            (contains? included-message-ids (:id %))
+                            (contains? trigger-ids (:id %))
+                            legacy-history?)))
+          messages)))
+
 (defn ensure-ctx!
   "Get-or-create the long-lived working chat-ctx for `agent-id` in `room`.
 
@@ -143,164 +258,155 @@
   [room agent-id {:keys [system-prompt budget-dollars limit]}]
   (let [room-id (:id room)
         k       [room-id agent-id]]
-    (or (:chat-ctx (get @room-agent-ctxs k))
-        (binding [ec/*execution-context* (:ctx room)]
-          (let [;; The room's system-db UUID — the key the system resolvers
+    ;; Room forking and unregister hold the same monitor. Cache reads belong
+    ;; inside it too: a returned handle must remain live through this boundary.
+    (locking (:meta room)
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [_ (when-not (rreg/admitted-incarnation? room)
+                  (throw (ex-info "Working context requested for a closed Room incarnation"
+                                  {:type ::closed-room
+                                   :room-id room-id
+                                   :room/incarnation (:incarnation room)})))]
+          (or (:chat-ctx (get @room-agent-ctxs k))
+              (let [;; The room's system-db UUID — the key the system resolvers
                 ;; (room-kb-conn / room-kbs / room-msgs) want; distinct from the
                 ;; in-memory keyword `room-id`. Threads to the sandbox so `dvergr.room`
                 ;; + the guarded `d/connect`/`list-databases` resolve THIS room's
                 ;; fork-aware databases.
-                room-uuid (room-system-id room)
-                cctx (turn/new-working-ctx
-                      {:execution-ctx  (:ctx room)
-                       :chat-id        (stable-chat-id room-id agent-id)
-                       :title          (str (name agent-id) "-" (name room-id))
-                       :budget-dollars budget-dollars
+                    room-uuid (room-system-id room)
+                    sandbox-opts
+                    {:execution-ctx  (:ctx room)
+                     :chat-id        (stable-chat-id room-id agent-id)
+                     :title          (str (name agent-id) "-" (name room-id))
+                     :budget-dollars budget-dollars
                         ;; RF5 S4: the cost ledger (account-usage!) writes to THIS
                         ;; room's own msgs store — per-room, fork-aware — not the
                         ;; legacy chat-db. nil ⇒ create-chat-context auto-resolves
                         ;; (room-less fallback only).
-                       :db-conn        (some-> room :store :conn)
+                     :db-conn        (some-> room :store :conn)
                         ;; The agent's sandbox reaches its room's OWN knowledge base
                         ;; (fork-aware) through `dvergr.room/*kb*` — resolved here
                         ;; under the room's bound ctx (so a fork hands the branched
                         ;; KB). nil for room-less ctxs. The sandbox must NEVER touch
                         ;; system-db for knowledge; this is how the room KB gets in.
-                       :kb-conn        (some-> room-uuid srooms/room-kb-conn)
-                       :room-id        room-uuid
+                     :kb-conn        (some-> room-uuid srooms/room-kb-conn)
+                     :room-id        room-uuid
                        ;; Room registry identity is distinct from the system-db
                        ;; UUID above. SCI's agent-programming surface needs the
                        ;; former so a hired agent can recursively hire into this
                        ;; exact live Room, including an ephemeral fork.
-                       :room-runtime-id room-id
-                       :room-incarnation (:incarnation room)
+                     :room-runtime-id room-id
+                     :room-incarnation (:incarnation room)
                         ;; Per-agent network egress scope: an actor's optional
                         ;; `:config {:allowed-domains #{"https://…"}}` restricts the
                         ;; sandbox `http` primitive (nil/empty ⇒ open).
-                       :allowed-domains (some-> (actors/lookup (sdb/get-conn) agent-id)
-                                                :config :allowed-domains)
+                     :allowed-domains (some-> (actors/lookup (sdb/get-conn) agent-id)
+                                              :config :allowed-domains)
                         ;; The room store (bus→store listener) is the single durable
                         ;; writer for this conversation; the agent's own turn messages
                         ;; stay signal-only (no redundant datahike write). Token
-                        ;; accounting still persists.
-                       :durable?       false})
-                seen (java.util.Collections/synchronizedSet (java.util.HashSet.))]
-            ;; Register before seeding so append-inbound! finds the entry.
-            (swap! room-agent-ctxs assoc k {:chat-ctx cctx :seen seen})
+                     ;; accounting still persists.
+                     :durable?       false}
+                    messages (hydration-messages! room agent-id limit)
+                    cctx (turn/new-working-ctx sandbox-opts)
+                    bound-sandbox-opts (assoc sandbox-opts
+                                              :capability-id (:capability-id cctx))
+                    seen (java.util.Collections/synchronizedSet (java.util.HashSet.))
+                    entry {:chat-ctx cctx
+                           :seen seen
+                           :execution-ctx (:ctx room)
+                           :room-meta (:meta room)
+                           :sandbox-opts bound-sandbox-opts}]
+                (try
             ;; System prompt once, then seed the conversation from the store.
             ;; Signal-only: the prompt is regenerated each session, not durable.
-            (when system-prompt
-              (append-signal-only! cctx {:role :system :content system-prompt}))
-            ;; Seed the conversation from ONE query: `d/messages` reads the room's
-            ;; (for a fork, branched) store under the conversation :chat/id, so a
-            ;; fork already returns inherited (pre-fork) + its own messages — the
-            ;; agent sees exactly what the UI seeds. (doc/unified-fork-conversation.md)
-            (let [messages (d/messages room {:limit (or limit 100)})
-                  attention-store? (satisfies? rstore/PAttentionStore (:store room))
-                  conversation-id (d/conversation-id room)
-                  baseline-message-id
-                  (rstore/attention-id conversation-id agent-id nil nil
-                                       :legacy-baseline-message)
-                  baseline-marker-id
-                  (rstore/attention-id conversation-id agent-id baseline-message-id
-                                       nil :legacy-baseline-complete)
-                  baseline-complete?
-                  (and attention-store?
-                       (seq (rstore/-list-attention (:store room)
-                                                    conversation-id
-                                                    {:id baseline-marker-id})))
-                  ;; Upgrade cutover: pre-attention rooms already have Runs but
-                  ;; no participant projection. Materialize their exact current
-                  ;; provider baseline before any new policy decision can make
-                  ;; the projection non-empty. This is append-only and
-                  ;; idempotent by deterministic identity.
-                  _ (when (and attention-store? (not baseline-complete?))
-                      (doseq [m messages :when (conversational? m)]
-                        (let [decision-id
-                              (rstore/attention-id conversation-id agent-id (:id m) nil
-                                                   :legacy-baseline-decision)
-                              common {:attention/participant agent-id
-                                      :attention/message-id (:id m)
-                                      :attention/memory :include
-                                      :attention/activation :none
-                                      :attention/control :continue
-                                      :attention/at :now
-                                      :attention/priority 0.0
-                                      :attention/reason :migration/provider-baseline
-                                      :attention/created-at
-                                      (java.util.Date. (long (or (:ts m)
-                                                                 (System/currentTimeMillis))))}]
-                          (rstore/-store-attention!
-                           (:store room) conversation-id
-                           (assoc common
-                                  :attention/id decision-id
-                                  :attention/status :ready))
-                          (rstore/-store-attention!
-                           (:store room) conversation-id
-                           (assoc common
-                                  :attention/id
-                                  (rstore/attention-id conversation-id agent-id (:id m) nil
-                                                       :legacy-baseline-applied)
-                                  :attention/decision-id decision-id
-                                  :attention/status :applied))))
-                      ;; Written last. If any prior write fails, the next
-                      ;; hydration retries every deterministic pair and then
-                      ;; completes the cutover.
-                      (rstore/-store-attention!
-                       (:store room) conversation-id
-                       {:attention/id baseline-marker-id
-                        :attention/participant agent-id
-                        :attention/message-id baseline-message-id
-                        :attention/status :baseline-complete
-                        :attention/reason :migration/provider-baseline
-                        :attention/created-at (java.util.Date.)}))
-                  attention-facts
-                  (if attention-store?
-                    (rstore/-list-attention (:store room)
-                                            conversation-id
-                                            {:participant agent-id :limit 1000})
-                    [])
-                  included-message-ids
-                  ;; Admission is monotone: once a fact entered provider
-                  ;; context (most notably when queued work becomes a Run
-                  ;; trigger), a later observation cannot silently erase it.
-                  ;; Deliberate forgetting belongs to compaction/context policy,
-                  ;; not to attention races.
-                  (into #{}
-                        (keep #(when (and (= :applied (:attention/status %))
-                                          (= :include (:attention/memory %)))
-                                 (:attention/message-id %)))
-                        attention-facts)
-                  agent-runs (run/runs room {:actor agent-id :limit 1000})
-                  trigger-ids (into #{} (map :run/trigger) agent-runs)
-                  ;; Ephemeral/custom stores without the projection retain the
-                  ;; historical full-transcript behavior for compatibility.
-                  legacy-history? (not attention-store?)]
-              (doseq [m messages]
-                (when (and (conversational? m)
-                           (or (= agent-id (:from m))
-                               (contains? included-message-ids (:id m))
-                               (contains? trigger-ids (:id m))
-                               legacy-history?))
-                  (append-inbound! room-id agent-id (:id m)
-                                   (or (:role m) (if (= agent-id (:from m)) :assistant :user))
-                                   (:content m)
-                                 ;; author nil for the agent's OWN past messages
-                                   (when (not= agent-id (:from m)) (display-name room (:from m)))
-                                   (:ts m)
-                                 ;; feed back only the agent's OWN prior reasoning,
-                                 ;; not another participant's <think>
-                                   (when (= agent-id (:from m)) (:reasoning m))))))
-            (tel/log! {:level :debug :id ::created
-                       :data {:room room-id :agent agent-id
-                              :seeded (count (chat-ctx/get-messages cctx))}})
-            cctx)))))
+                  (when system-prompt
+                    (append-signal-only! cctx {:role :system :content system-prompt}))
+                  ;; Durable hydration above completed before signal allocation.
+                  ;; Project the staged pure messages into the fresh context.
+                  (doseq [m messages]
+                    (append-inbound-to! cctx seen (:id m)
+                                        (or (:role m) (if (= agent-id (:from m)) :assistant :user))
+                                        (:content m)
+                                        ;; author nil for the agent's own history
+                                        (when (not= agent-id (:from m))
+                                          (display-name room (:from m)))
+                                        (:ts m)
+                                        ;; feed back only the agent's own reasoning
+                                        (when (= agent-id (:from m)) (:reasoning m))))
+                  (tel/log! {:level :debug :id ::created
+                             :data {:room room-id :agent agent-id
+                                    :seeded (count (chat-ctx/get-messages cctx))}})
+                  ;; Publication is the commit point. Before this swap, no
+                  ;; concurrent fast path can observe partially hydrated state.
+                  (swap! room-agent-ctxs assoc k entry)
+                  cctx
+                  (catch Throwable error
+                    (try
+                      (chat-ctx/release-sci-in! cctx (:ctx room))
+                      (catch Throwable cleanup-error
+                        (.addSuppressed error cleanup-error)))
+                    (throw error))))))))))
+
+(defn fork-ctx!
+  "Project an existing parent room/agent working context into `child-room`.
+
+   Yggdrasil has already forked the Spindel world, including the ChatContext's
+   signals and SCI component. The child facade replaces persistence and ambient
+   capabilities without reconstructing the interpreter or replaying history;
+   provider admission remains exclusively controlled by attention."
+  [parent-room child-room agent-id]
+  (let [parent-k [(:id parent-room) agent-id]
+        child-k [(:id child-room) agent-id]]
+    (when-let [{:keys [chat-ctx seen sandbox-opts]} (get @room-agent-ctxs parent-k)]
+      (or (:chat-ctx (get @room-agent-ctxs child-k))
+          (when (try
+                  (chat-ctx/sci-context-in chat-ctx (:ctx child-room))
+                  true
+                  (catch clojure.lang.ExceptionInfo _ false))
+            (let [room-uuid (binding [ec/*execution-context* (:ctx child-room)]
+                              (room-system-id child-room))
+                  child-opts (assoc sandbox-opts
+                                    :execution-ctx (:ctx child-room)
+                                    :db-conn (some-> child-room :store :conn)
+                                    :kb-conn (some-> room-uuid srooms/room-kb-conn)
+                                    :room-id room-uuid
+                                    :room-runtime-id (:id child-room)
+                                    :room-incarnation (:incarnation child-room)
+                                    :fork-projection? true
+                                    :capability-id (:capability-id chat-ctx))
+                  projected (assoc chat-ctx
+                                   :spindel-ctx (:ctx child-room)
+                                   :db-conn (some-> child-room :store :conn))
+                  _ (turn/rebind-working-ctx! projected child-opts)
+                  child-seen (java.util.Collections/synchronizedSet
+                              (locking seen
+                                (java.util.HashSet. ^java.util.Collection seen)))
+                  entry {:chat-ctx projected
+                         :seen child-seen
+                         :execution-ctx (:ctx child-room)
+                         :room-meta (:meta child-room)
+                         :sandbox-opts child-opts}]
+              (swap! room-agent-ctxs
+                     (fn [m]
+                       (if (contains? m child-k) m (assoc m child-k entry))))
+              (:chat-ctx (get @room-agent-ctxs child-k))))))))
+
+(defn- drop-entry! [room-id agent-id]
+  (when-let [{:keys [chat-ctx execution-ctx]}
+             (get @room-agent-ctxs [room-id agent-id])]
+    (when chat-ctx
+      (try (chat-ctx/release-sci-in! chat-ctx
+                                     (or execution-ctx (:spindel-ctx chat-ctx)))
+           (catch Throwable _ nil)))
+    (swap! room-agent-ctxs dissoc [room-id agent-id])))
 
 (defn drop-ctx!
   "Tear down the (room, agent) provider projection."
   [room-id agent-id]
-  (when (get @room-agent-ctxs [room-id agent-id])
-    (swap! room-agent-ctxs dissoc [room-id agent-id]))
+  (if-let [room-meta (:room-meta (get @room-agent-ctxs [room-id agent-id]))]
+    (locking room-meta (drop-entry! room-id agent-id))
+    (drop-entry! room-id agent-id))
   nil)
 
 (defn drop-room!
@@ -309,6 +415,19 @@
   (doseq [[rid aid] (keys @room-agent-ctxs)
           :when (= rid room-id)]
     (drop-ctx! rid aid))
+  nil)
+
+(defn- close-room-contexts!
+  "Fence one registered Room incarnation against further context access.
+
+   Runs as a pre-unregister hook while the Room is still authoritative. The
+   shared monitor makes the closed marker and complete component teardown one
+   lifecycle transition, so a stale caller cannot publish after cleanup."
+  [room]
+  (locking (:meta room)
+    (doseq [[rid aid] (keys @room-agent-ctxs)
+            :when (= rid (:id room))]
+      (drop-entry! rid aid)))
   nil)
 
 (defn clear-all!
@@ -324,6 +443,7 @@
   [room-id agent-id]
   (:chat-ctx (get @room-agent-ctxs [room-id agent-id])))
 
-;; Tear down a room's cached ctxs whenever it leaves the registry (room delete,
-;; fork discard) — one hook covers all teardown paths. Idempotent across reload.
-(rreg/add-unregister-hook! ::drop-room drop-room!)
+;; Fence + tear down before registry removal. Keeping this in the lifecycle
+;; transaction prevents stale scheduler/MCP callers from recreating a component
+;; after a post-unregister key snapshot.
+(rreg/add-pre-unregister-hook! ::close-room-contexts close-room-contexts!)

--- a/src/dvergr/agent/tool_commands.clj
+++ b/src/dvergr/agent/tool_commands.clj
@@ -21,6 +21,7 @@
   (:require [clojure.string :as str]
             [dvergr.discourse.commands :as commands]
             [dvergr.agent.room-context :as room-context]
+            [dvergr.chat.context :as chat-context]
             [dvergr.tools :as tools]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -72,7 +73,8 @@
                 (let [tool     (get @tools/registry tool-name)
                       tool-ctx (tools/make-context
                                 {:chat-ctx      cc
-                                 :sci-ctx       (:sci-ctx cc)   ; the agent's OWN session
+                                 :sci-ctx       (chat-context/sci-context-in
+                                                 cc (:ctx room)) ; fork-selected session
                                  :db-conn       (:db-conn cc)
                                  :tools         {tool-name tool} ; allowlist = just this tool
                                  :isolation     :sci

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -16,6 +16,7 @@
             [dvergr.discourse :as d]
             [dvergr.chat.context :as chat-ctx]
             [dvergr.agent.run :as run]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox :as sandbox]
             [dvergr.sandbox.ns.io :as ns-io]
             ;; loaded so add-process-ns! can (find-ns 'dvergr.agent.process)
@@ -35,6 +36,41 @@
 ;; each room's own stores fork-aware off the registry (RF5 S4 — there is no shared
 ;; chat-db). Callers pass the room/agent execution-ctx; setup binds it.
 ;; ----------------------------------------------------------------------------
+(defn rebind-working-ctx!
+  "Refresh the world binding and namespace surface in a working context.
+
+   SCI forks copy the interpreter heap, including host function objects.  Those
+   Injected host functions are stable indirections through `capability-id`, so
+   even functions saved before a fork select the child binding. Namespace
+   refresh keeps newly added APIs visible; it is not the isolation boundary."
+  [cctx {:keys [execution-ctx db-conn kb-conn room-id room-runtime-id
+                room-incarnation capability-id fork-projection?
+                agent-program-ceiling allowed-domains]}]
+  (let [capability-id (or capability-id (:capability-id cctx)
+                          (throw (ex-info "Working context has no capability identity" {})))]
+    (runtime-ctx/install-sandbox-binding!
+     execution-ctx capability-id
+     (cond-> {:capability-id capability-id
+              :room-id room-id
+              :room-runtime-id room-runtime-id
+              :room-incarnation room-incarnation}
+       fork-projection? (assoc :ephemeral-databases {})))
+    (binding [rtc/*execution-context* execution-ctx]
+      (when-let [sci (chat-ctx/sci-context-in cctx execution-ctx)]
+        (sandbox/setup-agent-namespaces! sci execution-ctx
+                                         :room-conn db-conn :kb-conn kb-conn :room-id room-id
+                                         :room-runtime-id room-runtime-id
+                                         :room-incarnation room-incarnation
+                                         :capability-id capability-id
+                                         :agent-program-ceiling agent-program-ceiling
+                                         :allowed-http-domains allowed-domains)
+      ;; These capabilities close over the ChatContext itself, so a projected
+      ;; child facade must replace them as well.
+        (ns-io/add-bash-ns!    sci cctx)
+        (ns-io/add-media-ns!   sci cctx)
+        (ns-io/add-process-ns! sci cctx)))
+    cctx))
+
 (defn new-working-ctx
   "Create a ChatContext whose SCI sandbox has the ctx-bound agent namespaces
    injected (dh/room/intake/search/…). Does NOT seed a system prompt — callers do
@@ -43,40 +79,42 @@
    datahike-write behaviour (room folds pass false: the room store is the durable
    writer). Returns the ChatContext."
   [{:keys [execution-ctx chat-id title budget-dollars db-conn kb-conn room-id
-           room-runtime-id room-incarnation agent-program-ceiling durable? allowed-domains]}]
+           room-runtime-id room-incarnation capability-id agent-program-ceiling
+           durable? allowed-domains]}]
   (binding [rtc/*execution-context* execution-ctx]
-    (let [cctx (cond-> (chat-ctx/create-chat-context
-                        (cond-> {:budget-dollars (or budget-dollars 1.0)
-                                 :db-conn        db-conn
-                                 :with-sci?      true
-                                 :title          (or title "agent")}
-                          chat-id (assoc :chat-id chat-id)))
-                 (some? durable?) (assoc :durable? durable?)
+    (let [capability-id (or capability-id (random-uuid))
+          cctx (assoc (cond-> (chat-ctx/create-chat-context
+                               (cond-> {:budget-dollars (or budget-dollars 1.0)
+                                        :db-conn        db-conn
+                                        :with-sci?      true
+                                        :title          (or title "agent")}
+                                 chat-id (assoc :chat-id chat-id)))
+                        (some? durable?) (assoc :durable? durable?)
                  ;; the ctx knows its room: embedder hooks (e.g. the bash
                  ;; mount provider) resolve room-scoped resources from it
-                 room-id (assoc :room-id room-id))]
+                        room-id (assoc :room-id room-id))
+                      :capability-id capability-id)]
       ;; create-chat-context forks a sci-ctx but does NOT inject the ctx-bound
       ;; namespaces — do it here so clojure_eval has the room/kb/intake nses
       ;; everywhere. `db-conn` is the room's OWN messages store (= `*room*`);
       ;; `kb-conn` its OWN knowledge base (= `*kb*`) — both fork-aware, never sdb.
-      (when-let [sci (:sci-ctx cctx)]
-        (sandbox/setup-agent-namespaces! sci execution-ctx
-                                         :room-conn db-conn :kb-conn kb-conn :room-id room-id
-                                         :room-runtime-id room-runtime-id
-                                         :room-incarnation room-incarnation
-                                         :agent-program-ceiling agent-program-ceiling
-                                         ;; per-agent network egress scoping (nil/empty = open)
-                                         :allowed-http-domains allowed-domains)
-        ;; Two namespaces bound to THIS chat-ctx (not just the spindel ctx), so
-        ;; they can't live in setup-agent-namespaces!: `bash` (the muschel shell
-        ;; session this chat-ctx owns — same one the `shell` tool drives) and
-        ;; `processes` (the turn process registry — list/snapshot/directive! the
-        ;; agent's own work). The daemon path wired these per-turn; now every
-        ;; working ctx gets them at creation.
-        (ns-io/add-bash-ns!    sci cctx)
-        (ns-io/add-media-ns!   sci cctx)
-        (ns-io/add-process-ns! sci cctx))
-      cctx)))
+      (try
+        (rebind-working-ctx! cctx {:execution-ctx execution-ctx
+                                   :db-conn db-conn :kb-conn kb-conn
+                                   :room-id room-id :room-runtime-id room-runtime-id
+                                   :room-incarnation room-incarnation
+                                   :capability-id capability-id
+                                   :agent-program-ceiling agent-program-ceiling
+                                   :allowed-domains allowed-domains})
+        cctx
+        (catch Throwable error
+          ;; Namespace/resource installation is part of construction. A caller
+          ;; must never receive—or lose track of—a half-bound interpreter.
+          (try
+            (chat-ctx/release-sci-in! cctx execution-ctx)
+            (catch Throwable cleanup-error
+              (.addSuppressed error cleanup-error)))
+          (throw error))))))
 
 ;; Reserved `:to` id for agent tool-activity messages posted into a room.
 ;; Nothing subscribes to it, so no participant (agent or egress) receives these

--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -20,6 +20,7 @@
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.signal :as sig]
             [org.replikativ.spindel.core :as d]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.chat.schema :as schema]
             [dvergr.chat.accounting :as acct]
             [dvergr.chat.persist :as persist]
@@ -48,8 +49,32 @@
             db-conn           ; Datahike connection for persistence
 
      ;; SCI (optional - for agent computation)
-            sci-ctx           ; SCI context for sandboxed eval
+            sci-component     ; stable ref; resolves to this world's SCI interpreter
             ])
+
+(defn sci-context-in
+  "Resolve `chat-ctx`'s SCI interpreter in explicit `execution-context`.
+
+   The ChatContext retains only a stable world-component reference. A forked
+   Spindel context therefore selects a forked interpreter instead of retaining
+   the parent's mutable SCI heap."
+  [chat-ctx execution-context]
+  (sandbox/sci-context-in execution-context (:sci-component chat-ctx)))
+
+(defn selected-execution-context
+  "The world selected for ChatContext signals and ambient capabilities.
+
+   A bound descendant wins; calls made outside execution fall back to the
+   context's owner. This keeps the ChatContext value stable while its signals
+   and SCI interpreter select fork-local realizations."
+  [chat-ctx]
+  (runtime-ctx/selected-context (:spindel-ctx chat-ctx)))
+
+(defn sci-context
+  "Resolve `chat-ctx`'s SCI interpreter in the bound world, falling back to
+   the ChatContext's owning world when called outside a Spindel binding."
+  [chat-ctx]
+  (sci-context-in chat-ctx (selected-execution-context chat-ctx)))
 ;; ============================================================================
 ;; Signal Accessors (must be called with spindel context bound)
 ;; ============================================================================
@@ -57,19 +82,19 @@
 (defn get-messages
   "Get current messages vector from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:messages-signal chat-ctx)))
 
 (defn get-budget
   "Get current budget map from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:budget-signal chat-ctx)))
 
 (defn get-status
   "Get current status from chat context."
   [chat-ctx]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     @(:status-signal chat-ctx)))
 
 ;; ============================================================================
@@ -95,7 +120,7 @@
         ;; and a side effect in it would record an abandoned computation. The
         ;; transient `::just-crossed` key always reflects this call (nil if none).
         new-state
-        (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+        (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
           (swap! (:budget-signal chat-ctx)
                  (fn [{:keys [total used by-type crossed-thresholds]}]
                    (let [new-used (+ used cost)
@@ -149,7 +174,7 @@
   (let [msg-entity (schema/create-message-entity
                     (assoc message :chat-id (:chat-id chat-ctx)))]
     ;; Update spindel signal (reactive)
-    (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+    (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
       (swap! (:messages-signal chat-ctx) conj msg-entity))
 
     ;; Persist to datahike (durable) — UNLESS this ctx delegates durability to
@@ -191,7 +216,7 @@
      chat-ctx - ChatContext
      new-messages - Complete replacement message vector"
   [chat-ctx new-messages]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     (reset! (:messages-signal chat-ctx) (d/deltaable-vector (vec new-messages)))))
 
 (defn set-status!
@@ -201,7 +226,7 @@
      chat-ctx - ChatContext
      status - :active :paused :completed :cancelled :budget-exceeded"
   [chat-ctx status]
-  (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+  (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
     (reset! (:status-signal chat-ctx) status))
 
   ;; Persist status change
@@ -268,7 +293,7 @@
        :budget-dollars - Budget in dollars (default $1.00)
        :budget - Legacy: budget in microdollars
        :db-path - Path for datahike (default in-memory, or uses Yggdrasil db if registered)
-       :with-sci? - Create SCI context (default true)
+       :with-sci? - Register a fork-selected SCI world component (default true)
 
    Yggdrasil Integration:
      If a DatahikeSystem is registered in the current execution context
@@ -290,9 +315,9 @@
    the unit of work isolation: when a room is forked via
    `d/fork-room :isolation :ctx`, yggdrasil's registered systems
    (git worktree, datahike branch) live on the fork's ctx. The
-   chat-ctx anchoring on that ctx means tools that consult
-   `(:spindel-ctx chat-ctx)` for the workspace see the fork's
-   worktree."
+   ChatContext retains a stable SCI component ref; callers resolve its
+   interpreter through `sci-context-in`, so a fork selects a fork-local heap
+   without reconstructing the interpreter."
   [{:keys [chat-id title budget-dollars budget db-path with-sci?
            db-conn execution-context]
     :or {budget-dollars 1.0
@@ -380,12 +405,6 @@
            :by-type {}
            :crossed-thresholds #{}})
 
-        ;; Create SCI context if requested
-        ;; When *execution-context* is bound, create spindel-backed SCI with
-        ;; full FRP support (spin/await/track). Otherwise plain SCI.
-        sci-ctx (when with-sci?
-                  (sandbox/fork-for-session rtc/*execution-context*))
-
         ;; Create signals within the owning execution context.
         [messages-signal budget-signal status-signal]
         (binding [rtc/*execution-context* spindel-ctx]
@@ -400,7 +419,13 @@
                          [(schema/create-chat-entity
                            {:id chat-id
                             :title (or title "Untitled Chat")
-                            :budget budget-microdollars})]))]
+                            :budget budget-microdollars})]))
+
+        ;; Allocate the process-local interpreter only after every fallible
+        ;; durable/signal initialization step. Once registered, no operation
+        ;; below can strand the component without returning its ChatContext.
+        sci-component (when with-sci?
+                        (sandbox/create-spindel-sci-world! spindel-ctx))]
 
     (->ChatContext
      chat-id
@@ -410,7 +435,7 @@
      budget-signal
      status-signal
      db-conn
-     sci-ctx)))
+     sci-component)))
 
 ;; ============================================================================
 ;; Chat Lifecycle
@@ -432,10 +457,26 @@
   [chat-ctx]
   (set-status! chat-ctx :cancelled))
 
+(defn release-sci-in!
+  "Release `chat-ctx`'s SCI realization from one execution world.
+
+   This is idempotent and does not close the chat's durable connection. Forked
+   room caches use it when a child world is discarded."
+  [chat-ctx execution-context]
+  (try
+    (sandbox/release-agent-resources! execution-context (:capability-id chat-ctx))
+    (finally
+      ;; Disposable-resource cleanup is best-effort with respect to component
+      ;; reachability: even an unexpected backend failure must not strand the
+      ;; interpreter in Spindel after its cache handle is removed.
+      (sandbox/release-spindel-sci-world!
+       execution-context (:sci-component chat-ctx)))))
+
 (defn close-chat!
   "Close chat and release resources."
   [chat-ctx]
   (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+    (release-sci-in! chat-ctx (:spindel-ctx chat-ctx))
     ;; Close datahike connection
     (when-let [conn (:db-conn chat-ctx)]
       (dh/release conn)))
@@ -506,7 +547,7 @@
       (replace-messages! chat-ctx messages))
     ;; Restore budget (overwrite the fresh budget with saved state)
     (when budget
-      (binding [rtc/*execution-context* (:spindel-ctx chat-ctx)]
+      (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
         (reset! (:budget-signal chat-ctx) budget)))
     ;; Restore status
     (when (and status (not= status :active))

--- a/src/dvergr/discourse.clj
+++ b/src/dvergr/discourse.clj
@@ -1167,20 +1167,22 @@
          ;; peer-bus events).
            new-id     (rstore/slug->room-id new-slug)
            parent-log (log room)
+           room*       (volatile! nil)
            fork-handle (when (= :ctx isolation)
                          (binding [ec/*execution-context* (:ctx room)]
                            (ygg/fork! (merge {:purpose :workroom
                                               :owner new-id}
-                                             fork-opts))))
-           child-ctx  (case isolation
-                        :none (:ctx room)
-                        :ctx  (:child-ctx fork-handle))
+                                             fork-opts))))]
+       (try
+         (let [child-ctx  (case isolation
+                            :none (:ctx room)
+                            :ctx  (:child-ctx fork-handle))
          ;; Mark a `:ctx` fork TRANSIENT so create-room-db! defers the GLOBAL
          ;; system-db grant (reconciled on merge / dropped on discard) — a fork's
          ;; agent-created DB must not resurrect on restart (P2).
-           _          (when (= :ctx isolation)
-                        (binding [ec/*execution-context* child-ctx]
-                          (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
+               _          (when (= :ctx isolation)
+                            (binding [ec/*execution-context* child-ctx]
+                              (ec/swap-state! [:dvergr/transient-fork?] (constantly true))))
          ;; `:isolation :ctx` forks BRANCH the parent's conversation. The fork
          ;; gets its OWN store wrapping the fork ctx's BRANCHED chat-db conn
          ;; (NOT the parent's fixed-conn store), and persists under the parent's
@@ -1188,73 +1190,135 @@
          ;; the same logical conversation on a datahike branch, and
          ;; merge-fork! collapses them natively (no append-log!). It writes
          ;; no separate :chat entity. (doc/unified-fork-conversation.md)
-           conv-id    (conversation-id room)
+               conv-id    (conversation-id room)
          ;; RF5: the fork's store wraps the PARENT room's OWN messages conn under
          ;; the fork ctx (branched), so fork messages ride the per-room store's
          ;; branch and merge-fork! collapses them natively. (RF5 S4.3: no
          ;; chat-db fallback — every room is provisioned with its own :msgs system.)
-           fork-store (when (= :ctx isolation)
-                        (some-> (binding [ec/*execution-context* child-ctx]
-                                  (srooms/msgs-conn-for-slug (:slug room)))
-                                store-dh/make))
+               fork-store (when (= :ctx isolation)
+                            (some-> (binding [ec/*execution-context* child-ctx]
+                                      (srooms/msgs-conn-for-slug (:slug room)))
+                                    store-dh/make))
          ;; Durability-first for the fork too: fork-local messages persist
          ;; onto the BRANCH (under the root conversation id) inside post!,
          ;; before visibility — replacing the fork's persistence listener.
-           child-bus  (bus-with-peer-relay child-ctx new-id :fork
-                                           (when fork-store
-                                             {:durable-append!
-                                              (fn [msg]
-                                                (when (rstore/message-shape? msg)
-                                                  (rstore/-store-message! fork-store conv-id msg)))}))
+               child-bus  (bus-with-peer-relay child-ctx new-id :fork
+                                               (when fork-store
+                                                 {:durable-append!
+                                                  (fn [msg]
+                                                    (when (rstore/message-shape? msg)
+                                                      (rstore/-store-message! fork-store conv-id msg)))}))
          ;; Seed the fork's bus log with parent history so log-based
          ;; consumers see a continuous record (the cursor starts past it —
          ;; history is never re-delivered). Forks have their OWN bus so
          ;; live messages do not leak between parent and fork.
-           _          (bus/seed-log! child-bus parent-log)
-           new-room   (->Room new-id new-slug
-                              (str (:title room) " · fork " short-uuid)
-                              (:id room)
-                              (atom {})
-                              child-bus
-                              child-ctx
-                              (count parent-log)
-                              fork-store
-                              (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
-                                           :forked-from (:id room)
-                                           :conversation-id conv-id))
-                              (when fork-handle (atom fork-handle))
-                              (random-uuid))]
-       ;; The child is not registered or otherwise visible yet. Initializing its
+               _          (bus/seed-log! child-bus parent-log)
+               new-room   (->Room new-id new-slug
+                                  (str (:title room) " · fork " short-uuid)
+                                  (:id room)
+                                  (atom {})
+                                  child-bus
+                                  child-ctx
+                                  (count parent-log)
+                                  fork-store
+                                  (atom (assoc (dissoc @(:meta room) :dvergr/owned-listeners)
+                                               :forked-from (:id room)
+                                               :conversation-id conv-id))
+                                  (when fork-handle (atom fork-handle))
+                                  (random-uuid))
+           ;; The child is not registered or otherwise visible yet. Initializing its
        ;; admission without the global lifecycle lock avoids parent-meta ->
        ;; lifecycle lock inversion during concurrent parent teardown.
-       (agent-run/initialize-unpublished-room-admission! new-id child-ctx)
+               _ (vreset! room* new-room)
+               _ (agent-run/initialize-unpublished-room-admission! new-id child-ctx)]
      ;; (Fork-local persistence rides the bus's durable-append! hook now —
      ;; wired at child-bus construction above.)
-     ;; Register the fork in the PARENT ctx — where the daemon UI reads the
-     ;; registry. A `:ctx` fork's own child-ctx is invisible to the parent
-     ;; (CoW), so registering there would hide the fork from the tree (and it
-     ;; would render empty). The Room still carries its child-ctx in `:ctx`
-     ;; for merge/diff/git. For `:none`, child-ctx == parent ctx (no change).
-       (binding [ec/*execution-context* (:ctx room)]
-         (rreg/register! new-room)
-         (when (= :ctx isolation)
-           (rreg/track-fork! new-id (:id room) (:fork-id fork-handle))))
-       (when clone-participants?
-         (doseq [[_id p] @(:participants room)]
-           (when-let [fac (:factory p)]
-             (binding [ec/*execution-context* child-ctx]
-               (join new-room (fac child-ctx))))))
+     ;; Initialize participant/cache projections before publishing the Room.
+     ;; Otherwise an external registry reader could send work into a partially
+     ;; constructed child and win the inherited-context installation race.
+           (when clone-participants?
+             (doseq [[_id p] @(:participants room)]
+               (when-let [fac (:factory p)]
+             ;; Yggdrasil already forked every registered world component. If
+             ;; this participant has a live room working context, install its
+             ;; child projection before the factory runs so the clone selects
+             ;; that inherited SCI heap instead of constructing a second one.
+             ;; `requiring-resolve` avoids discourse <-> room-context cycles.
+                 (when (= :ctx isolation)
+                   (when-let [fork-working-ctx!
+                              (requiring-resolve 'dvergr.agent.room-context/fork-ctx!)]
+                     (fork-working-ctx! room new-room (:id p))))
+                 (binding [ec/*execution-context* child-ctx]
+                   (join new-room (fac child-ctx))))))
+     ;; Register the fully initialized fork in the PARENT ctx — where the daemon
+     ;; UI reads the registry. A `:ctx` fork's own child-ctx is invisible to the
+     ;; parent (CoW), so registering there would hide the fork from the tree.
+           ;; Publication and its control event share the child's lifecycle
+           ;; monitor. A reader may discover the complete Room+topology pair,
+           ;; but cannot begin settlement until the creation event is posted.
+           (locking (:meta new-room)
+             (binding [ec/*execution-context* (:ctx room)]
+               (if (= :ctx isolation)
+                 (rreg/register-fork! new-room (:id room) (:fork-id fork-handle))
+                 (rreg/register! new-room)))
      ;; Control-plane: announce the fork on the peer-bus so dashboards,
      ;; audit logs, and oversight agents see it without subscribing to
      ;; the fork's bus directly.
-       (binding [ec/*execution-context* child-ctx]
-         (peer-bus/post! {:type            :dvergr/fork-created
-                          :dvergr/origin   new-id
-                          :dvergr/parent   (:id room)
-                          :isolation       isolation
-                          :workspace-id    (when (= :ctx isolation)
-                                             (:id (geschichte/current-workspace)))}))
-       new-room))))
+             (binding [ec/*execution-context* child-ctx]
+               ;; Publication above is the authoritative commit point.  This
+               ;; observability event must therefore never turn successful
+               ;; construction into rollback after another thread has admitted
+               ;; settlement of the published affine handle.
+               (try
+                 (peer-bus/post! {:type            :dvergr/fork-created
+                                  :dvergr/origin   new-id
+                                  :dvergr/parent   (:id room)
+                                  :isolation       isolation
+                                  :workspace-id    (when (= :ctx isolation)
+                                                     (:id (geschichte/current-workspace)))})
+                 (catch Throwable event-error
+                   (tel/log! {:level :error :id ::fork-created-event-failed
+                              :error event-error
+                              :data {:room new-id :parent (:id room)}})))))
+           new-room)
+         (catch Throwable error
+           ;; Construction owns the affine handle until successful return. Any
+           ;; failure before then must settle it and retract every process-local
+           ;; projection; otherwise the caller has no capability with which to
+           ;; recover the unreachable branch.
+           (binding [ec/*execution-context* (:ctx room)]
+             (when-let [constructed @room*]
+               (try (leave-all! constructed)
+                    (catch Throwable cleanup-error
+                      (.addSuppressed error cleanup-error)))
+               (try
+                 (when-let [drop-room!
+                            (requiring-resolve 'dvergr.agent.room-context/drop-room!)]
+                   (drop-room! new-id))
+                 (catch Throwable cleanup-error
+                   (.addSuppressed error cleanup-error)))
+               (when (rreg/lookup new-id)
+                 (try
+                   (when fork-handle
+                     (rreg/untrack-fork! new-id (:fork-id fork-handle)))
+                   (catch Throwable cleanup-error
+                     (.addSuppressed error cleanup-error)))
+                 (rreg/unregister! new-id))))
+           (when fork-handle
+             (let [pending (try
+                             (binding [ec/*execution-context*
+                                       (or (some-> @room* :ctx)
+                                           (:child-ctx fork-handle))]
+                               (ec/get-state [:dvergr/pending-grants]))
+                             (catch Throwable cleanup-error
+                               (.addSuppressed error cleanup-error)
+                               nil))]
+               (try
+                 (ygg/discard-fork! fork-handle)
+                 (srooms/drop-fork-grants! pending)
+                 (catch Throwable cleanup-error
+                   (.addSuppressed error cleanup-error)))))
+           (throw error)))))))
 
 (defn fork-handle
   "Return an isolated Room fork's process-local canonical ForkHandle, or nil.

--- a/src/dvergr/discourse/commands.clj
+++ b/src/dvergr/discourse/commands.clj
@@ -440,6 +440,8 @@
              (nil? aid)  (say "Usage: /sandbox <agent> — e.g. /sandbox var")
              :else
              (if-let [cc (lookup (:id room) aid)]
-               (say (format-sandbox-report aid (status (:sci-ctx cc))))
+               (let [resolve-sci (resolve 'dvergr.chat.context/sci-context-in)]
+                 (say (format-sandbox-report
+                       aid (status (resolve-sci cc (:ctx room))))))
                (say (str "@" (name aid) " has no active sandbox yet "
                          "— message it once so its session spins up."))))))})

--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -304,17 +304,18 @@
         ;; turn in on-message. Priority: :participant-context > :chat-ctx > fresh.
         ;; :with-sci? true so a room-less agent's clojure_eval has a sandbox.
         fallback-chat-ctx
-        (or (when participant-context
-              (pctx/->chat-context participant-context))
-            chat-ctx
-            (let [c (turn/new-working-ctx
-                     {:execution-ctx  ctx
-                      :title          (str "agent " (name id))
-                      :budget-dollars (:dollars budget 1.0)
-                      :db-conn        db-conn})]
-              (when-let [sp (:system-prompt spec)]
-                (cc/add-message! c {:role :system :content sp}))
-              c))
+        (delay
+          (or (when participant-context
+                (pctx/->chat-context participant-context))
+              chat-ctx
+              (let [c (turn/new-working-ctx
+                       {:execution-ctx  ctx
+                        :title          (str "agent " (name id))
+                        :budget-dollars (:dollars budget 1.0)
+                        :db-conn        db-conn})]
+                (when-let [sp (:system-prompt spec)]
+                  (cc/add-message! c {:role :system :content sp}))
+                c)))
         ;; Grace window for the manager to extend the budget after exhaustion.
         compaction-strategy (:strategy compaction :sync-before-turn)
         ;; In race mode, disable run-turn-fn's internal sync compaction — we
@@ -344,7 +345,7 @@
                                 (room-context/ensure-ctx! room id
                                                           {:system-prompt  (:system-prompt spec)
                                                            :budget-dollars (:dollars budget 1.0)})
-                                fallback-chat-ctx)]
+                                @fallback-chat-ctx)]
                  (case (:type msg)
 
                ;; --- directive: extend the dollar budget ---
@@ -392,7 +393,7 @@
                      ;; turn/new-working-ctx (room fold AND room-less fallback alike)
                      ;; with the agent namespaces injected — so clojure_eval has
                      ;; dh/room/intake without a per-turn re-fork.
-                         sci-ctx  (:sci-ctx chat-ctx)
+                         sci-ctx  (cc/sci-context chat-ctx)
                      ;; Normalize once: name→tool-def map (also the execute-side
                      ;; authoritative allowlist below).
                          tool-map (tools/normalize-tools tools)
@@ -489,7 +490,7 @@
                          fold-inbound!
                          (fn [m]
                            (if room
-                             (room-context/append-inbound! (:id room) id (:id m)
+                             (room-context/append-inbound! room id (:id m)
                                                            :user (:content m)
                                                            (room-context/display-name room (:from m))
                                                            (:ts m))
@@ -952,11 +953,10 @@
 
             :factory
             (fn [new-ctx]
-         ;; Fork-room semantics for an LLM agent: re-create fresh in the
-         ;; new context. The fork's agent has no prior conversation,
-         ;; matching the §6.5 ToM-probe semantics ("what would they say,
-         ;; given only the priming I set up?"). Future enhancement: pass
-         ;; an :init-snapshot to carry conversation forward.
+         ;; `fork-room :ctx` installs the inherited room working context before
+         ;; invoking this factory, so the clone selects forked signals and SCI
+         ;; through the stable component ref. `:none` remains a lightweight
+         ;; message-only clone. The room-less fallback stays lazy in both cases.
               (llm-agent {:id          id
                           :spec        spec
                           :tools       tools

--- a/src/dvergr/intake/bash.clj
+++ b/src/dvergr/intake/bash.clj
@@ -405,32 +405,36 @@
 
    Stored under `[:dvergr/bash-session WORKSPACE-ID]`."
   [chat-ctx]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (let [ws (default-workspace)
-          key (if (map? ws) (:id ws) ws)
-          path (session-path key)]
-      (or (ec/get-state path)
+  (let [world ((requiring-resolve
+                'dvergr.chat.context/selected-execution-context) chat-ctx)]
+    (binding [ec/*execution-context* world]
+      (let [ws (default-workspace)
+            key (if (map? ws) (:id ws) ws)
+            path (session-path key)]
+        (or (ec/get-state path)
           ;; cwd is the SANDBOX root "/" (= the worktree via make-host's
           ;; :mount-at "/"); `ws` (the real path) stays only as the cache key.
-          (let [s (ms/spindel-session-using (:spindel-ctx chat-ctx)
-                                            (make-sandboxed-env {:cwd "/"}))]
-            (ec/swap-state! path (fn [existing] (or existing s)))
-            (ec/get-state path))))))
+            (let [s (ms/spindel-session-using world
+                                              (make-sandboxed-env {:cwd "/"}))]
+              (ec/swap-state! path (fn [existing] (or existing s)))
+              (ec/get-state path)))))))
 
 (defn get-or-create-host!
   "Return the chat-ctx's BuiltinHost for the current workspace,
    creating it on first use. See `get-or-create-session!` for why
    this is keyed by workspace path."
   [chat-ctx]
-  (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
-    (let [ws (default-workspace)
-          key (if (map? ws) (:id ws) ws)
-          path (host-path key)]
-      (or (ec/get-state path)
-          (let [h (make-host {:workspace ws
-                              :mounts (resolve-mounts chat-ctx)})]
-            (ec/swap-state! path (fn [existing] (or existing h)))
-            (ec/get-state path))))))
+  (let [world ((requiring-resolve
+                'dvergr.chat.context/selected-execution-context) chat-ctx)]
+    (binding [ec/*execution-context* world]
+      (let [ws (default-workspace)
+            key (if (map? ws) (:id ws) ws)
+            path (host-path key)]
+        (or (ec/get-state path)
+            (let [h (make-host {:workspace ws
+                                :mounts (resolve-mounts chat-ctx)})]
+              (ec/swap-state! path (fn [existing] (or existing h)))
+              (ec/get-state path)))))))
 
 ;; ============================================================================
 ;; Public API
@@ -560,7 +564,9 @@
           ;; time (make-sandboxed-env), so the snapshot is already
           ;; secret-free. Pass it as the explicit starting env so
           ;; one-shot library use stays well-defined.
-          env0 (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
+          env0 (binding [ec/*execution-context*
+                         ((requiring-resolve
+                           'dvergr.chat.context/selected-execution-context) chat-ctx)]
                  (msession/-env sess))
           interrupt-fn (mbudget/combine (process-abort-interrupt-fn process))
           {:keys [stdout stderr exit env permit trace]}

--- a/src/dvergr/mcp/server.clj
+++ b/src/dvergr/mcp/server.clj
@@ -18,6 +18,7 @@
             [dvergr.mcp.json-rpc :as json-rpc]
             [dvergr.ops :as ops]
             [dvergr.discourse :as d]
+            [dvergr.chat.context :as chat-context]
             [org.replikativ.spindel.engine.core :as ec]
             [jsonista.core :as json])
   (:import (java.net ServerSocket Socket)
@@ -92,9 +93,11 @@
     (if room
       (binding [ec/*execution-context* (:ctx room)]
         (let [cctx (ensure-ctx! room :mcp {})]
-          (execute tname input (make-context {:sci-ctx  (:sci-ctx cctx)
+          (execute tname input (make-context {:sci-ctx  (chat-context/sci-context-in
+                                                         cctx (:ctx room))
                                               :db-conn  (:db-conn cctx)
-                                              :chat-ctx cctx}))))
+                                              :chat-ctx cctx
+                                              :execution-ctx (:ctx room)}))))
       (execute tname input (make-context {})))))
 
 (defn- coding-tool [tname tdef]

--- a/src/dvergr/participant/context.clj
+++ b/src/dvergr/participant/context.clj
@@ -29,7 +29,7 @@
                             (often yggdrasil-managed so substrate-fork
                             branches it automatically).
      - `:role-data`       — map of role-specific extensions. LLM puts
-                            `:sci-ctx` and `:tool-ctx` here; human can
+                            `:sci-component` and `:tool-ctx` here; human can
                             stash UI prefs, presence signal, etc. Stays
                             out of the common record so role-specific
                             additions don't churn the API.
@@ -113,7 +113,7 @@
      :from-chat-ctx  — an existing dvergr.chat.context/ChatContext
      :chat-ctx-opts  — opts map passed to cc/create-chat-context
 
-   Role-data carries the chat-ctx-only fields (`:chat-ctx`, `:sci-ctx`)
+   Role-data carries the chat-ctx-only fields (`:chat-ctx`, `:sci-component`)
    so existing dvergr.chat.context callers can still reach them via
    `(:role-data pctx)`."
   [{:keys [participant-id from-chat-ctx chat-ctx-opts role-data]}]
@@ -128,7 +128,7 @@
                           (:status-signal chat-ctx)
                           (:db-conn chat-ctx)
                           (merge {:chat-ctx chat-ctx
-                                  :sci-ctx (:sci-ctx chat-ctx)}
+                                  :sci-component (:sci-component chat-ctx)}
                                  role-data))))
 
 ;; ===========================================================================

--- a/src/dvergr/room/registry.clj
+++ b/src/dvergr/room/registry.clj
@@ -118,6 +118,42 @@
       (finally
         (release-transition! key token)))))
 
+(defn register-fork!
+  "Atomically publish an isolated child Room and its structural topology edge.
+
+   Readers can never observe a globally reachable child without the settlement
+  identity needed to govern it. Register hooks run only after both projections
+   are visible."
+  [room parent-id ygg-fork-id]
+  (let [child-id (:id room)
+        [key token] (locking lifecycle-lock
+                      (reserve-transition! child-id :register-fork))]
+    (try
+      ;; A fork is still a Room incarnation. Run the same admission fences as
+      ;; ordinary registration before making either global projection visible.
+      (doseq [f (vals @pre-register-hooks)]
+        (f room))
+      (locking lifecycle-lock
+        (when-not (= token (get-in @transitions [key :token]))
+          (throw (ex-info "Fork registration reservation was lost"
+                          {:type ::lifecycle-reservation-lost
+                           :room-id child-id})))
+        (rctx/shared-swap-root!
+         (fn [state]
+           (-> (or state {})
+               (update-in registry-path #(assoc (or % {}) child-id room))
+               (update-in fork-topology-path
+                          #(assoc (or % {}) child-id
+                                  {:fork/id child-id
+                                   :fork/parent-id parent-id
+                                   :fork/ygg-id ygg-fork-id
+                                   :fork/state :local}))))))
+      (doseq [f (vals @register-hooks)]
+        (try (f room) (catch Throwable _ nil)))
+      room
+      (finally
+        (release-transition! key token)))))
+
 (defn unregister!
   "Remove a Room from the registry by id, then run unregister hooks."
   [room-id]
@@ -158,6 +194,21 @@
       (keyword? id-or-slug) (get m id-or-slug)
       (string? id-or-slug)  (some (fn [[_ r]] (when (= (:slug r) id-or-slug) r)) m)
       :else                 nil)))
+
+(defn admitted-incarnation?
+  "True when `room` is the currently published incarnation and no lifecycle
+   transition owns its registry slot.
+
+   Callers that allocate process-local Room resources use this while holding
+   the Room's own lifecycle fence. An unregister reservation therefore closes
+   admission before pre-unregister cleanup starts, and a failed unregister
+   automatically reopens admission when its reservation is released."
+  [room]
+  (locking lifecycle-lock
+    (let [room-id (:id room)
+          current (get (rctx/shared-get-state registry-path) room-id)]
+      (and (= (:incarnation room) (:incarnation current))
+           (not (contains? @transitions (transition-key room-id)))))))
 
 (defn list-rooms
   "All rooms in the registry. Optional :where filter as a predicate.

--- a/src/dvergr/rooms/scheduler.clj
+++ b/src/dvergr/rooms/scheduler.clj
@@ -21,6 +21,7 @@
    A negligible lingering no-op per deleted/discarded room until restart."
   (:require [datahike.api :as dh]
             [dvergr.agent.room-context :as room-context]
+            [dvergr.chat.context :as chat-context]
             [dvergr.discourse :as disc]
             [dvergr.runtime.clock :as clock]
             [dvergr.runtime.ctx :as rctx]
@@ -73,8 +74,9 @@
             (let [cctx (room-context/ensure-ctx! room aid {})
                   {:keys [success value error]}
                   (sandbox/eval-code
-                   (:sci-ctx cctx) (:schedule/code s)
-                   :timeout-ms (* 5 60 1000) :realize? true)]
+                   (chat-context/sci-context-in cctx (:ctx room)) (:schedule/code s)
+                   :timeout-ms (* 5 60 1000) :realize? true
+                   :execution-context (:ctx room))]
               (if success
                 (str "⏱ " (or (:schedule/description s) "code task") " → "
                      (subs value 0 (min 500 (count value))))

--- a/src/dvergr/runtime/ctx.clj
+++ b/src/dvergr/runtime/ctx.clj
@@ -32,6 +32,74 @@
   [ctx]
   (if-let [p (:parent-ctx ctx)] (recur p) ctx))
 
+(defn descendant-context?
+  "True when `candidate` is `ancestor` or belongs to its fork lineage.
+
+   A dynamically bound context must not override an object's owning world when
+   it is the owner's parent or an unrelated sibling. That would make an async
+   coordinator accidentally read the parent projection of child-owned state."
+  [candidate ancestor]
+  (boolean
+   (when (and candidate ancestor)
+     (loop [ctx candidate]
+       (cond
+         (or (identical? ctx ancestor)
+             (= (:fork-id ctx) (:fork-id ancestor))) true
+         (:parent-ctx ctx) (recur (:parent-ctx ctx))
+         :else false)))))
+
+(defn selected-context
+  "Select a bound descendant of `owner`, otherwise retain `owner`.
+
+   This is the ambient-world rule for stable handles: child execution may
+   refine an owner into its fork, while parent/sibling execution cannot pull a
+   child-owned value out of its world."
+  [owner]
+  (let [bound (when (ec/execution-context-bound?)
+                (ec/current-execution-context))]
+    (if (descendant-context? bound owner) bound owner)))
+
+(def ^:private sandbox-bindings-path
+  "Fork-local bindings used by stable SCI host capabilities.  The binding key
+   is stable for the lifetime of one interpreter component; Yggdrasil copies
+   the map into a child and the child projection replaces only its data."
+  [:dvergr/sandbox-bindings])
+
+(defn install-sandbox-binding!
+  "Install serializable world data for `binding-id` in `ctx`.
+
+   Host functions injected into SCI must capture only `owner` + `binding-id`,
+   never a Room, connection, filesystem or workspace.  That makes functions
+   defined before a SCI fork select the child binding when invoked there."
+  [ctx binding-id data]
+  (binding [ec/*execution-context* ctx]
+    (ec/swap-state! (conj sandbox-bindings-path binding-id)
+                    #(merge (or % {}) data)))
+  data)
+
+(defn update-sandbox-binding!
+  "Update a capability binding in the ambient descendant world of `owner`."
+  [owner binding-id f & args]
+  (let [ctx (selected-context owner)]
+    (binding [ec/*execution-context* ctx]
+      (ec/swap-state! (conj sandbox-bindings-path binding-id)
+                      #(apply f (or % {}) args)))))
+
+(defn sandbox-binding
+  "Read `binding-id` in the ambient descendant world of `owner`."
+  [owner binding-id]
+  (let [ctx (selected-context owner)]
+    (binding [ec/*execution-context* ctx]
+      (ec/get-state (conj sandbox-bindings-path binding-id)))))
+
+(defn sandbox-binding-resolver
+  "Return a stable zero-argument resolver suitable for an SCI host closure."
+  [owner binding-id]
+  #(or (sandbox-binding owner binding-id)
+       (throw (ex-info "SCI capability has no world binding"
+                       {:binding-id binding-id
+                        :owner-fork-id (:fork-id owner)}))))
+
 (defn current-root
   "The root of the currently-bound execution context."
   []
@@ -43,6 +111,14 @@
    registry, tree/message signals, peer-bus — anything the UI reactively reads."
   [path f]
   (rtp/swap-state! (current-root) path f))
+
+(defn shared-swap-root!
+  "Atomically update the complete Tier-1 root state.
+
+   Use this sparingly for invariants spanning multiple Tier-1 paths, such as
+   publishing a Room together with its structural fork edge."
+  [f]
+  (rtp/swap-state! (current-root) [] f))
 
 (defn shared-get-state
   "Tier-1 read from the ROOT ctx (the authoritative copy)."

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -12,6 +12,8 @@
             [clojure.string :as str]
             [datahike.api :as dh]
             [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.sci.world :as sci-world]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [org.replikativ.spindel.core :as sync]
             [dvergr.sci.clojure-test :as sci-test]
@@ -27,6 +29,7 @@
             [dvergr.sandbox.workspace :as workspace]
             [dvergr.sandbox.ns.agent :as ns-agent]
             [dvergr.sandbox.ns.io :as ns-io]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.system.db :as sdb])
   (:import [java.io StringWriter]
            [java.lang.management ManagementFactory]))
@@ -38,16 +41,19 @@
 ;; A consumer (e.g. an accounting kernel) registers an injector fn here at
 ;; startup; the sandbox setup runs every registered injector so its surface is
 ;; available in `clojure_eval`, WITHOUT dvergr knowing what it is. Each injector
-;; is `(fn [sci-ctx opts])`, opts = {:room-id :room-conn :kb-conn}.
+;; is `(fn [sci-ctx opts])`; opts also carries a fork-safe `:world-binding`
+;; resolver for host closures that can survive an interpreter fork.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private ns-injectors* (atom []))
 
 (defn register-ns-injector!
   "Register an SCI namespace-injector `f` — `(fn [sci-ctx opts])`, opts =
-   {:room-id :room-conn :kb-conn} — run for every agent sandbox after the
+   {:room-id :room-conn :kb-conn :world-binding} — run for every agent sandbox after the
    built-in surface. Lets a consumer expose extra namespaces (a domain kernel)
-   in `clojure_eval` without dvergr depending on it. Idempotent per identical fn.
+   in `clojure_eval` without dvergr depending on it. A host closure which may
+   survive a fork MUST call the zero-argument `:world-binding` resolver rather
+   than capture a room id or raw resource. Idempotent per identical fn.
    Returns `f`."
   [f]
   (swap! ns-injectors* (fn [v] (if (some #{f} v) v (conj v f))))
@@ -337,6 +343,48 @@
                 ;; :sci-opts and merges it into sci/init.)
                 :sci-opts     {:load-fn workspace/load-fn}})))
 
+(defn create-spindel-sci-world!
+  "Create a fork-selected SCI interpreter component in `spindel-ctx`.
+
+   Returns a stable Spindel ComponentRef rather than the interpreter itself.
+   Resolve it with `sci-context-in`; a descendant execution context selects its
+   own SCI fork while the reference remains unchanged."
+  [spindel-ctx]
+  (let [ref (sci-world/create!
+             spindel-ctx
+             {:interrupt-fn (make-resource-limits)
+              :sci-opts {:load-fn workspace/load-fn}})
+        interpreter (sci-world/context-in spindel-ctx ref)]
+    ;; The world constructor starts from Spindel's SCI environment, not
+    ;; dvergr's plain base context. Restore the same safe classes/core shims and
+    ;; bind clojure.test to this interpreter before any descendant forks it.
+    (sci/merge-opts interpreter
+                    {:classes base-classes
+                     :namespaces {'clojure.core core-extras}})
+    (sci/merge-opts interpreter
+                    {:namespaces
+                     {'clojure.test
+                      (sci-test/ctx-aware-test-namespace interpreter)}})
+    ref))
+
+(defn sci-context-in
+  "Resolve stable SCI world `ref` in `spindel-ctx`."
+  [spindel-ctx ref]
+  (when ref
+    (sci-world/context-in spindel-ctx ref)))
+
+(defn release-spindel-sci-world!
+  "Remove stable SCI world `ref` from `spindel-ctx`.
+
+   This releases only the selected process-local interpreter realization. It is
+   deliberately separate from closing durable room resources: a forked room
+   may share a ChatContext identity while selecting an independent SCI heap."
+  [spindel-ctx ref]
+  (when ref
+    (binding [rtc/*execution-context* spindel-ctx]
+      (component/unregister! ref)))
+  nil)
+
 ;; ---------------------------------------------------------------------------
 ;; Session Context Management
 ;; ---------------------------------------------------------------------------
@@ -371,7 +419,7 @@
 ;; Evaluation
 ;; ---------------------------------------------------------------------------
 
-(defn eval-code
+(defn- eval-code*
   "Evaluate Clojure code in the session's SCI context.
 
    Returns map with:
@@ -566,6 +614,20 @@
            :stdout (str stdout)
            :stderr (str stderr)
            :success false})))))
+
+(defn eval-code
+  "Evaluate code in an SCI interpreter, selecting `:execution-context` for
+   ambient Spindel/Yggdrasil capabilities when supplied.
+
+   The interpreter selects the SCI world; the Spindel context selects the
+   matching substrate world. Other options are `:timeout-ms`, `:cancel?`, and
+   `:realize?`, as documented by the evaluator above."
+  [sci-ctx code & {:keys [execution-context] :as opts}]
+  (let [args (mapcat identity (dissoc opts :execution-context))]
+    (if execution-context
+      (binding [rtc/*execution-context* execution-context]
+        (apply eval-code* sci-ctx code args))
+      (apply eval-code* sci-ctx code args))))
 
 (defn eval-forms
   "Evaluate multiple forms sequentially in the same context.
@@ -937,9 +999,21 @@
    Returns the audit-log atom — a vector of IO events ({:op :t :data}) accumulated
    during the agent's execution.  Attach to the agent result for post-hoc analysis."
   [sci-ctx spindel-ctx & {:keys [base-path proc-allow allowed-http-domains room-conn kb-conn room-id
-                                 room-runtime-id room-incarnation agent-program-ceiling]
+                                 room-runtime-id room-incarnation capability-id
+                                 agent-program-ceiling]
                           :or   {proc-allow #{}}}]
   (let [audit-log  (make-audit-log)
+        binding-resolver (when capability-id
+                           (runtime-ctx/sandbox-binding-resolver spindel-ctx capability-id))
+        binding-swap! (when capability-id
+                        (fn [f & args]
+                          (apply runtime-ctx/update-sandbox-binding!
+                                 spindel-ctx capability-id f args)))
+        workspace-resolver
+        (fn []
+          (binding [rtc/*execution-context* (runtime-ctx/selected-context spindel-ctx)]
+            (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
+                 (catch Throwable _ nil))))
         workspace  (binding [rtc/*execution-context* spindel-ctx]
                      (try ((requiring-resolve 'dvergr.substrate.geschichte/current-workspace))
                           (catch Throwable _ nil)))
@@ -965,15 +1039,21 @@
       ;; falls back to sys-conn so it still has a queryable db (flagged: give them a
       ;; scratch db so even room-less never writes the registry).
       (let [sys-conn (sdb/get-conn)]
-        (ns-datahike/add-datahike-ns! sci-ctx room-id spindel-ctx) ; the ONE datahike surface: faithful `d`/`datahike.api`
+        (when binding-swap!
+          (binding-swap! #(if (contains? % :ephemeral-databases)
+                            %
+                            (assoc % :ephemeral-databases {}))))
+        (ns-datahike/add-datahike-ns! sci-ctx room-id spindel-ctx
+                                      binding-resolver binding-swap!) ; the ONE datahike surface: faithful `d`/`datahike.api`
         ;; ONE `dvergr.room` (+ legacy `room` alias): the Room ops MERGED with the
         ;; room's DB surface (*room*/*kb*/databases/db + queries). The KB is reached
         ;; via `dvergr.room/*kb*` + `kb-find`/`kb-search` + `d` — no separate `entity`
         ;; namespace (dropped as redundant; a global entity CRM can return later).
         (ns-room/add-room-ns! sci-ctx room-conn kb-conn room-id spindel-ctx
                               agent-program-ceiling
-                              {:id (or room-runtime-id room-id)
-                               :incarnation room-incarnation})
+                              {:binding-resolver binding-resolver
+                               :source-room {:id (or room-runtime-id room-id)
+                                             :incarnation room-incarnation}})
         ;; dvergr.mail/*inbox* — the room's attached mailbox conn (fork-aware),
         ;; nil when no mailbox attached. Read helpers are seed source (dvergr/mail/).
         (ns-mail/add-mail-ns! sci-ctx)
@@ -985,18 +1065,26 @@
     ;; effect. No roster is kept in a host atom: callers thread the immutable
     ;; value, and live execution state belongs to the Room's Spindel context.
     (ns-agent/add-programming-ns! sci-ctx (or room-runtime-id room-id) spindel-ctx
-                                  agent-program-ceiling)
+                                  agent-program-ceiling binding-resolver)
     (ns-data/add-spindel-extras-ns!
      sci-ctx spindel-ctx
      {:room-id (or room-runtime-id room-id)
       :room-incarnation room-incarnation
-      :ceiling (:work-admission agent-program-ceiling)})
+      :ceiling (:work-admission agent-program-ceiling)
+      :world-binding binding-resolver})
     (ns-codec/add-codec-namespaces! sci-ctx)   ; cheshire.core / clojure.data.xml / dvergr.codec
     (ns-intake/add-intake-namespaces! sci-ctx)
     (ns-io/add-fs-ns!   sci-ctx :base-path cwd :filesystem filesystem
+                        :filesystem-resolver
+                        (when workspace
+                          #(when-let [workspace (workspace-resolver)]
+                             ((requiring-resolve
+                               'dvergr.substrate.geschichte/filesystem)
+                              workspace)))
                         :audit-log audit-log)
     ;; (proc folded into the muschel-backed babashka.process — add-bash-ns! in turn.clj)
     (ns-io/add-git-ns!  sci-ctx :base-path cwd :workspace workspace
+                        :workspace-resolver (when workspace workspace-resolver)
                         :audit-log audit-log)
     (ns-kb/add-llm-ns!  sci-ctx agent-program-ceiling)
     ;; Boundary secret injection (doc/boundary-secret-injection.md): build the
@@ -1009,9 +1097,23 @@
           sandbox-env  (try ((requiring-resolve 'dvergr.substrate.config/sandbox-env))
                             (catch Throwable _ nil))
           secrets      (ns-io/build-secret-registry secret-specs)]
+      (when binding-swap!
+        (binding-swap! #(if (contains? % :sandbox-env)
+                          %
+                          (assoc % :sandbox-env (or sandbox-env {})))))
       ;; :user-config = non-secret config values returned verbatim (identifiers,
       ;; site URLs); :secrets = sensitive values returned as placeholders.
-      (ns-io/add-env-ns!  sci-ctx :user-config (atom (or sandbox-env {})) :secrets secrets)
+      (ns-io/add-env-ns! sci-ctx
+                         :user-config (atom (or sandbox-env {}))
+                         :config-resolver (when binding-resolver
+                                            #(or (:sandbox-env (binding-resolver)) {}))
+                         :config-swap! (when binding-swap!
+                                         (fn [f & args]
+                                           (binding-swap!
+                                            #(update % :sandbox-env
+                                                     (fn [m]
+                                                       (apply f (or m {}) args))))))
+                         :secrets secrets)
       (ns-io/add-http-ns! sci-ctx :audit-log audit-log :allowed-domains allowed-http-domains
                           :secrets secrets))
     (ns-agent/add-scheduler-ns! sci-ctx)
@@ -1025,7 +1127,8 @@
     ;; expose their surface here without dvergr depending on them. Run before
     ;; reflection so overview sees them; a failing injector never breaks setup.
     (doseq [f (registered-ns-injectors)]
-      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn})
+      (try (f sci-ctx {:room-id room-id :room-conn room-conn :kb-conn kb-conn
+                       :world-binding binding-resolver})
            (catch Throwable e
              (binding [*out* *err*] (println "ns-injector failed:" (.getMessage e))))))
     ;; Self-reflection LAST, so (sandbox/overview) sees every ns injected above.
@@ -1033,6 +1136,19 @@
     ;; SECURITY, last of all: lock JVM interop to the class allowlist.
     (lock-interop! sci-ctx)
     audit-log))
+
+(defn release-agent-resources!
+  "Release disposable host resources owned by one SCI capability in `ctx`.
+   Durable/mergeable world state is deliberately untouched."
+  [ctx capability-id]
+  (when capability-id
+    (try
+      (let [resolver (runtime-ctx/sandbox-binding-resolver ctx capability-id)
+            swap! (fn [f & args]
+                    (apply runtime-ctx/update-sandbox-binding!
+                           ctx capability-id f args))]
+        (ns-datahike/dispose-ephemeral-databases! resolver swap!))
+      (catch clojure.lang.ExceptionInfo _ nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; clojure.test Integration (from Babashka)

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -8,6 +8,7 @@
    `(find-doc …)` answer nothing for them inside the sandbox. See
    `dvergr.sandbox.ns.doc`."
   (:require [sci.core :as sci]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox.ns.doc :as doc]
             [org.replikativ.spindel.engine.core :as ec]))
 
@@ -49,7 +50,7 @@
           (-> (await (comb/race (agent/owned-result-spin a)
                                 (agent/owned-result-spin b)))
               :run/value)))"
-  [sci-ctx room-id spindel-ctx agent-program-ceiling]
+  [sci-ctx room-id spindel-ctx agent-program-ceiling & [binding-resolver]]
   (let [make-roster*   (requiring-resolve 'dvergr.agent.roster/make-roster)
         make-agent*    (requiring-resolve 'dvergr.agent.roster/make-agent)
         revise-agent*  (requiring-resolve 'dvergr.agent.roster/revise-agent)
@@ -68,9 +69,13 @@
         room-balance*  (requiring-resolve 'dvergr.resource/balance)
         run-balance*   (requiring-resolve 'dvergr.resource/run-balance)
         room-lookup*   (requiring-resolve 'dvergr.room.registry/lookup)
+        selected-ctx   #(runtime-ctx/selected-context spindel-ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-runtime-id (binding-resolver)))
+                             room-id)
         current-room   (fn []
-                         (when room-id
-                           (binding [ec/*execution-context* spindel-ctx]
+                         (when-let [room-id (current-room-id)]
+                           (binding [ec/*execution-context* (selected-ctx)]
                              (room-lookup* room-id))))
         room!          (fn []
                          (or (current-room)
@@ -166,6 +171,7 @@
         'select       select-agents*
         'environment  make-environment*
         'environment-ref environment-ref*
+        'room-id      (fn [] (:id (room!)))
         'hire!        hire-fn
         'observe      observe-fn
         'cancel!      cancel-fn
@@ -182,6 +188,7 @@
          select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
          environment  [([spec]) "Create a portable, content-addressed EnvironmentDef. Requires :id, :task, and trusted verifier ref {:id keyword :version n}; optional :limits/:world/:metadata stay data, never live functions or handles."]
          environment-ref [([environment]) "Return the stable logical/version/content reference for one exact EnvironmentDef. Individual execution Run IDs remain unique."]
+         room-id      [([]) "Return the live identity of the current Room/world. In an isolated fork this is the child Room, not its parent."]
          hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
          cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -207,7 +207,13 @@
 
      (spin
        (let [measure (await (infer/smc-infer (my-model) 100))]
-         (infer/query measure identity)))
+         (infer/values measure)))
+
+   Dvergr defaults SMC, importance sampling, and the generic kernel runner to
+   `:world-policy :fork`. Each particle therefore executes in a frozen
+   canonical Yggdrasil world and only its immutable result projection survives;
+   particle worlds are discarded before the inference Spin completes. Callers
+   may explicitly request `:fresh` for a proven-pure model.
 
    Namespaces added:
    - dist/   — Anglican distributions: normal, beta, gamma, uniform, flip, …
@@ -315,12 +321,65 @@
                          'chi-squared        @(ns-resolve ar 'chi-squared)
                          'student-t          (fn [nu] (@(ns-resolve ar 'student-t) nu))}))
 
-  ;; Inference runners — these take/return spins, compose with await in spin bodies
-  (sci/add-namespace! sci-ctx 'infer
-                      {'smc-infer          @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
-                       'importance-sampling @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
-                       'kernel-infer       @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
-                       'query              @(resolve 'org.replikativ.spindel.inference.inference/query)
-                       'predict            @(resolve 'org.replikativ.spindel.inference.inference/predict)
-                       'pimh-infer         @(resolve 'org.replikativ.spindel.inference.inference/pimh-infer)
-                       'pgibbs-infer       @(resolve 'org.replikativ.spindel.inference.inference/pgibbs-infer)}))
+  ;; Inference runners — these take/return Spins and compose with await in Spin
+  ;; bodies. Room-capable sandboxes default to canonical particle worlds: a
+  ;; model that happens to touch a registered Yggdrasil system must not alias
+  ;; the ambient room merely because its author omitted an expert-only option.
+  ;; `:fresh` remains an explicit fast path for known-pure models.
+  (let [smc*        @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
+        importance* @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
+        kernel*     @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
+        query*      @(resolve 'org.replikativ.spindel.inference.inference/query)
+        predict*    @(resolve 'org.replikativ.spindel.inference.inference/predict)
+        pimh*       @(resolve 'org.replikativ.spindel.inference.inference/pimh-infer)
+        pgibbs*     @(resolve 'org.replikativ.spindel.inference.inference/pgibbs-infer)
+        contexts*   @(resolve 'org.replikativ.spindel.inference.measure/get-contexts)
+        values*     @(resolve 'org.replikativ.spindel.inference.measure/get-value)
+        weights*    @(resolve 'org.replikativ.spindel.inference.measure/get-log-weights)
+        ess*        @(resolve 'org.replikativ.spindel.inference.measure/effective-sample-size)
+        state*      @(resolve 'org.replikativ.spindel.engine.protocols/get-state)
+        world-opts  (fn [opts]
+                      (merge {:world-policy :fork} (or opts {})))]
+    (sci/add-namespace!
+     sci-ctx 'infer
+     (doc/with-docs
+       {'smc-infer (fn
+                     ([model particles]
+                      (smc* model particles (world-opts nil)))
+                     ([model particles opts]
+                      (smc* model particles (world-opts opts))))
+        'importance-sampling
+        (fn
+          ([model particles]
+           (importance* model particles (world-opts nil)))
+          ([model particles opts]
+           (importance* model particles (world-opts opts))))
+        'kernel-infer
+        (fn
+          ([model kernel particles]
+           (kernel* model kernel particles (world-opts nil)))
+          ([model kernel particles opts]
+           (kernel* model kernel particles (world-opts opts))))
+        'query       query*
+        'predict     predict*
+        'pimh-infer  pimh*
+        'pgibbs-infer pgibbs*
+        'values      (fn [measure]
+                       (mapv values* (contexts* measure)))
+        'log-weights (fn [measure] (vec (weights* measure)))
+        'ess         ess*
+        'worlds      (fn [measure]
+                       (->> (contexts* measure)
+                            (keep #(state* % [:inference :world-descriptor]))
+                            vec))}
+       '{smc-infer [([model particles] [model particles opts]) "Run SMC. Dvergr defaults opts :world-policy to :fork; pass :fresh only for a proven-pure model."]
+         importance-sampling [([model particles] [model particles opts]) "Run importance sampling with canonical particle worlds by default."]
+         kernel-infer [([model kernel particles] [model kernel particles opts]) "Run a Spindel inference kernel with canonical particle worlds by default."]
+         query [([measure query-fn]) "Compute numeric posterior statistics from program results."]
+         predict [([measure pred-fn samples]) "Draw contexts from a posterior and apply pred-fn."]
+         pimh-infer [([model particles iterations] [model particles iterations opts]) "Run particle independent Metropolis-Hastings."]
+         pgibbs-infer [([model particles iterations] [model particles iterations opts]) "Run particle Gibbs. Canonical worlds do not yet support PGAS ancestor scoring."]
+         values [([measure]) "Return each particle's immutable program result in posterior order."]
+         log-weights [([measure]) "Return posterior particle log weights."]
+         ess [([measure]) "Return effective sample size."]
+         worlds [([measure]) "Return portable canonical world descriptors retained in posterior projections; never live settlement handles."]}))))

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -4,10 +4,76 @@
   (:require [sci.core :as sci]
             [is.simm.partial-cps.sequence :as aseq]
             [datahike.api :as dh]
+            [dvergr.agent.roster :as roster]
             [dvergr.sandbox.ns.doc :as doc]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.engine.core :as rtc]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.effects.await :as sp-await]
+            [org.replikativ.spindel.spin.cps :as sp]
             [org.replikativ.spindel.core :as sync]))
+
+(defn- portable-posterior
+  "Project a native Spindel measure before it crosses into SCI. Execution
+   contexts and their process-local executors deliberately do not survive."
+  [measure]
+  (let [measure-ns  (find-ns 'org.replikativ.spindel.inference.measure)
+        contexts    (@(ns-resolve measure-ns 'get-contexts) measure)
+        value-of    @(ns-resolve measure-ns 'get-value)
+        log-weights (vec (@(ns-resolve measure-ns 'get-log-weights) measure))
+        values      (mapv value-of contexts)
+        worlds      (->> contexts
+                         (keep #(rtp/get-state % [:inference :world-descriptor]))
+                         vec)
+        posterior   {:posterior/values values
+                     :posterior/log-weights log-weights
+                     :posterior/weights
+                     (@(ns-resolve measure-ns 'normalize-log-weights) log-weights)
+                     :posterior/ess
+                     (@(ns-resolve measure-ns 'effective-sample-size) measure)
+                     :posterior/log-marginal
+                     (@(ns-resolve measure-ns 'log-marginal) measure)
+                     :posterior/worlds worlds}]
+    (when-not (roster/data-value? posterior)
+      (throw (ex-info "Inference result is not portable data"
+                      {:type ::non-portable-posterior})))
+    posterior))
+
+(defn- posterior-spin [native-spin]
+  (sp/spin
+   (portable-posterior (sp-await/await native-spin))))
+
+(defn- posterior-query [posterior query-fn]
+  (let [values  (mapv query-fn (:posterior/values posterior))
+        weights (:posterior/weights posterior)]
+    (when-not (every? number? values)
+      (throw (ex-info "infer/query requires numeric projected values"
+                      {:type ::non-numeric-query})))
+    (let [mean      (reduce + (map * weights values))
+          variance (reduce + (map (fn [weight value]
+                                    (* weight (Math/pow (- value mean) 2)))
+                                  weights values))
+          sorted    (vec (sort values))
+          n         (count sorted)
+          quantile  (fn [p]
+                      (nth sorted (min (dec n)
+                                       (long (Math/floor (* p n))))))]
+      {:mean mean
+       :variance variance
+       :std-dev (Math/sqrt variance)
+       :samples values
+       :weights weights
+       :quantiles {:p50 (quantile 0.5)
+                   :p025 (quantile 0.025)
+                   :p975 (quantile 0.975)}
+       :type :empirical})))
+
+(defn- posterior-predict [posterior pred-fn samples]
+  (let [measure-ns (find-ns 'org.replikativ.spindel.inference.measure)
+        indices    (@(ns-resolve measure-ns 'systematic-resample)
+                    (:posterior/weights posterior) samples)
+        values     (:posterior/values posterior)]
+    (mapv #(pred-fn (nth values %)) indices)))
 
 (defn add-spindel-extras-ns!
   "Expose spindel combinators, sync primitives, and signals to SCI.
@@ -329,15 +395,6 @@
   (let [smc*        @(resolve 'org.replikativ.spindel.inference.inference/smc-infer)
         importance* @(resolve 'org.replikativ.spindel.inference.inference/importance-sampling)
         kernel*     @(resolve 'org.replikativ.spindel.inference.inference/kernel-infer)
-        query*      @(resolve 'org.replikativ.spindel.inference.inference/query)
-        predict*    @(resolve 'org.replikativ.spindel.inference.inference/predict)
-        pimh*       @(resolve 'org.replikativ.spindel.inference.inference/pimh-infer)
-        pgibbs*     @(resolve 'org.replikativ.spindel.inference.inference/pgibbs-infer)
-        contexts*   @(resolve 'org.replikativ.spindel.inference.measure/get-contexts)
-        values*     @(resolve 'org.replikativ.spindel.inference.measure/get-value)
-        weights*    @(resolve 'org.replikativ.spindel.inference.measure/get-log-weights)
-        ess*        @(resolve 'org.replikativ.spindel.inference.measure/effective-sample-size)
-        state*      @(resolve 'org.replikativ.spindel.engine.protocols/get-state)
         world-opts  (fn [opts]
                       (merge {:world-policy :fork} (or opts {})))]
     (sci/add-namespace!
@@ -345,41 +402,39 @@
      (doc/with-docs
        {'smc-infer (fn
                      ([model particles]
-                      (smc* model particles (world-opts nil)))
+                      (posterior-spin
+                       (smc* model particles (world-opts nil))))
                      ([model particles opts]
-                      (smc* model particles (world-opts opts))))
+                      (posterior-spin
+                       (smc* model particles (world-opts opts)))))
         'importance-sampling
         (fn
           ([model particles]
-           (importance* model particles (world-opts nil)))
+           (posterior-spin
+            (importance* model particles (world-opts nil))))
           ([model particles opts]
-           (importance* model particles (world-opts opts))))
+           (posterior-spin
+            (importance* model particles (world-opts opts)))))
         'kernel-infer
         (fn
           ([model kernel particles]
-           (kernel* model kernel particles (world-opts nil)))
+           (posterior-spin
+            (kernel* model kernel particles (world-opts nil))))
           ([model kernel particles opts]
-           (kernel* model kernel particles (world-opts opts))))
-        'query       query*
-        'predict     predict*
-        'pimh-infer  pimh*
-        'pgibbs-infer pgibbs*
-        'values      (fn [measure]
-                       (mapv values* (contexts* measure)))
-        'log-weights (fn [measure] (vec (weights* measure)))
-        'ess         ess*
-        'worlds      (fn [measure]
-                       (->> (contexts* measure)
-                            (keep #(state* % [:inference :world-descriptor]))
-                            vec))}
+           (posterior-spin
+            (kernel* model kernel particles (world-opts opts)))))
+        'query       posterior-query
+        'predict     posterior-predict
+        'values      :posterior/values
+        'log-weights :posterior/log-weights
+        'ess         :posterior/ess
+        'worlds      :posterior/worlds}
        '{smc-infer [([model particles] [model particles opts]) "Run SMC. Dvergr defaults opts :world-policy to :fork; pass :fresh only for a proven-pure model."]
          importance-sampling [([model particles] [model particles opts]) "Run importance sampling with canonical particle worlds by default."]
          kernel-infer [([model kernel particles] [model kernel particles opts]) "Run a Spindel inference kernel with canonical particle worlds by default."]
-         query [([measure query-fn]) "Compute numeric posterior statistics from program results."]
-         predict [([measure pred-fn samples]) "Draw contexts from a posterior and apply pred-fn."]
-         pimh-infer [([model particles iterations] [model particles iterations opts]) "Run particle independent Metropolis-Hastings."]
-         pgibbs-infer [([model particles iterations] [model particles iterations opts]) "Run particle Gibbs. Canonical worlds do not yet support PGAS ancestor scoring."]
-         values [([measure]) "Return each particle's immutable program result in posterior order."]
+         query [([posterior query-fn]) "Compute numeric posterior statistics from portable program results."]
+         predict [([posterior pred-fn samples]) "Resample portable posterior values and apply pred-fn; execution contexts never enter SCI."]
+         values [([posterior]) "Return each particle's portable program result in posterior order."]
          log-weights [([measure]) "Return posterior particle log weights."]
          ess [([measure]) "Return effective sample size."]
          worlds [([measure]) "Return portable canonical world descriptors retained in posterior projections; never live settlement handles."]}))))

--- a/src/dvergr/sandbox/ns/data.clj
+++ b/src/dvergr/sandbox/ns/data.clj
@@ -5,6 +5,7 @@
             [is.simm.partial-cps.sequence :as aseq]
             [datahike.api :as dh]
             [dvergr.agent.roster :as roster]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox.ns.doc :as doc]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.engine.core :as rtc]
@@ -87,11 +88,18 @@
    These are safe: they only coordinate within the SCI context."
   ([sci-ctx spindel-ctx]
    (add-spindel-extras-ns! sci-ctx spindel-ctx {}))
-  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling]}]
+  ([sci-ctx spindel-ctx {:keys [room-id room-incarnation ceiling world-binding]}]
    (require 'org.replikativ.spindel.spin.combinators)
    (require 'org.replikativ.spindel.signal)
    (let [comb-ns (find-ns 'org.replikativ.spindel.spin.combinators)
-         sig-ns  (find-ns 'org.replikativ.spindel.signal)]
+         sig-ns  (find-ns 'org.replikativ.spindel.signal)
+         create-work (fn [strategy opts work-fn]
+                       (let [binding (when world-binding (world-binding))]
+                         (sandbox-work/create!
+                          (or (:room-runtime-id binding) room-id)
+                          (or (:room-incarnation binding) room-incarnation)
+                          (runtime-ctx/selected-context spindel-ctx)
+                          ceiling strategy opts work-fn)))]
      (binding [rtc/*execution-context* spindel-ctx]
        ;; Sync primitives (same as before but unified here)
        (sci/add-namespace! sci-ctx 'sync
@@ -117,32 +125,31 @@
                            (doc/with-docs
                              {'latest       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest {} work-fn))
+                                               (create-work :latest {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :latest opts work-fn)))
+                                               (create-work :latest opts work-fn)))
                               'serial       (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
+                                               (create-work :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial opts work-fn)))
+                                               (create-work :serial opts work-fn)))
                               'busy         (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy {} work-fn))
+                                               (create-work :busy {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :busy opts work-fn)))
+                                               (create-work :busy opts work-fn)))
                               'parallel     (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel {} work-fn))
+                                               (create-work :parallel {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :parallel opts work-fn)))
+                                               (create-work :parallel opts work-fn)))
                               'controller   (fn
                                               ([work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling :serial {} work-fn))
+                                               (create-work :serial {} work-fn))
                                               ([opts work-fn]
-                                               (sandbox-work/create! room-id room-incarnation spindel-ctx ceiling
-                                                                     (:strategy opts :serial)
-                                                                     (dissoc opts :strategy)
-                                                                     work-fn)))
+                                               (create-work (:strategy opts :serial)
+                                                            (dissoc opts :strategy)
+                                                            work-fn)))
                               'submit!      sandbox-work/submit!
                               'events       sandbox-work/events!
                               'next-event   aseq/anext

--- a/src/dvergr/sandbox/ns/datahike.clj
+++ b/src/dvergr/sandbox/ns/datahike.clj
@@ -24,9 +24,38 @@
    created data DBs — is dvergr-specific and lives in `dvergr.room`, not here.)"
   (:require [datahike.api :as d]
             [dvergr.system.rooms :as srooms]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
+            [sci.fork :as sci-fork]
             [sci.core :as sci]))
+
+(deftype WorldConnection [resolver]
+  clojure.lang.IDeref
+  (deref [_]
+    @(resolver))
+
+  sci-fork/Forkable
+  (fork-value [this]
+    ;; The handle is immutable. Its resolver consults the dynamically selected
+    ;; Spindel world, so sharing the handle selects a different Ygg connection
+    ;; after a world fork rather than sharing the connection itself.
+    this))
+
+(defn world-connection
+  "Create an ambient Datahike connection handle. Deref returns the selected
+   connection's DB; mirrored Datahike functions unwrap it to the connection."
+  [resolve-conn]
+  (WorldConnection. resolve-conn))
+
+(defn resolve-connection
+  "Resolve a WorldConnection, otherwise return `value` unchanged."
+  [value]
+  (if (instance? WorldConnection value)
+    (or ((.-resolver ^WorldConnection value))
+        (throw (ex-info "Ambient Datahike connection is unavailable in this world"
+                        {:type ::connection-unavailable})))
+    value))
 
 ;; The safe DATA surface of datahike.api — resolved from the real namespace so the
 ;; mirror never drifts. Lifecycle (connect/create/delete/exists?) is GUARDED below.
@@ -71,46 +100,136 @@
   "The logical database name from a datahike config: `:store :id`, else the
    basename of `:store :path`. We own placement, so this is the only handle."
   [cfg]
-  (or (some-> (get-in cfg [:store :id]) name not-empty)
+  (or (some-> (get-in cfg [:store :id]) str (str/replace #"^:" "") not-empty)
       (some-> (get-in cfg [:store :path]) str (str/split #"/") last not-empty)
       (throw (ex-info "datahike config needs a :store :id (the database name)" {:cfg cfg}))))
 
 (defn- mem? [cfg] (boolean (#{:mem :memory} (get-in cfg [:store :backend]))))
 
+(defn- entry-conn [entry]
+  (if (map? entry) (:connection entry) entry))
+
+(defn- world-memory-config
+  "Translate an agent-visible logical memory config into a process-global
+   Datahike config namespaced by the selected interpreter world."
+  [cfg binding-resolver]
+  (let [binding (when binding-resolver (binding-resolver))
+        logical-name (cfg-name cfg)
+        world-key (str (:capability-id binding) "|"
+                       (:room-runtime-id binding) "|"
+                       (:room-incarnation binding) "|"
+                       logical-name)
+        physical-id (if binding-resolver
+                      (java.util.UUID/nameUUIDFromBytes
+                       (.getBytes world-key java.nio.charset.StandardCharsets/UTF_8))
+                      (random-uuid))]
+    (-> cfg
+        (assoc-in [:store :backend] :memory)
+        (assoc-in [:store :id] physical-id))))
+
+(defn dispose-ephemeral-databases!
+  "Release and delete every process-global scratch database owned by the
+   currently selected interpreter world. Returns cleanup errors, if any."
+  [binding-resolver binding-swap!]
+  (when (and binding-resolver binding-swap!)
+    (let [entries (or (:ephemeral-databases (binding-resolver)) {})
+          errors (reduce-kv
+                  (fn [errors name entry]
+                    (let [conn (entry-conn entry)
+                          cfg (:config entry)]
+                      (try
+                        (when conn (d/release conn))
+                        (when (and cfg (d/database-exists? cfg))
+                          (d/delete-database cfg))
+                        errors
+                        (catch Throwable error
+                          (conj errors {:name name :error error})))))
+                  [] entries)]
+      (binding-swap! assoc :ephemeral-databases {})
+      errors)))
+
 (defn add-datahike-ns!
   "Mount the faithful datahike API under `datahike.api` and `d`, with lifecycle fns
    guarded to room `room-id` (resolved fork-aware under `ctx`)."
-  [sci-ctx room-id ctx]
+  [sci-ctx room-id ctx & [binding-resolver binding-swap!]]
   (let [data      (into {} (keep (fn [sym]
-                                   (when-let [v (ns-resolve 'datahike.api sym)] [sym @v]))
+                                   (when-let [v (ns-resolve 'datahike.api sym)]
+                                     (let [f @v]
+                                       [sym (fn [& args]
+                                              (let [resolved (mapv resolve-connection args)]
+                                                (try
+                                                  (apply f resolved)
+                                                  (catch Throwable error
+                                                    (throw
+                                                     (ex-info
+                                                      "Sandbox Datahike operation failed"
+                                                      {:operation sym
+                                                       :argument-types
+                                                       (mapv #(some-> % class str) resolved)}
+                                                      error))))))])))
                                  data-ops))
         data      (assoc data
                          'transact
                          (fn [conn tx-data]
-                           (d/transact conn
-                                       (assert-no-attempt-write! conn tx-data)))
+                           (let [conn (resolve-connection conn)]
+                             (d/transact conn
+                                         (assert-no-attempt-write! conn tx-data))))
                          'transact!
                          (fn [conn tx-data]
-                           (d/transact! conn
-                                        (assert-no-attempt-write! conn tx-data))))
+                           (let [conn (resolve-connection conn)]
+                             (d/transact! conn
+                                          (assert-no-attempt-write! conn tx-data)))))
         ;; per-sandbox ephemeral (:mem) databases, keyed by logical name
         ephemeral (atom {})
-        in-ctx    (fn [f] (binding [ec/*execution-context* ctx] (f)))
+        ephemeral-map #(if binding-resolver
+                         (or (:ephemeral-databases (binding-resolver)) {})
+                         @ephemeral)
+        swap-ephemeral! (fn [f & args]
+                          (if binding-swap!
+                            (binding-swap!
+                             #(update % :ephemeral-databases
+                                      (fn [m]
+                                        (apply f (or m {}) args))))
+                            (apply swap! ephemeral f args)))
+        selected-ctx #(runtime-ctx/selected-context ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-id (binding-resolver)))
+                             room-id)
+        in-ctx    (fn [f]
+                    (binding [ec/*execution-context* (selected-ctx)] (f)))
+        managed-connection
+        (fn [nm]
+          (world-connection
+           #(binding [ec/*execution-context* (selected-ctx)]
+              (or (srooms/room-conn-by-name (current-room-id) nm)
+                  (throw (ex-info (str "No database named " (pr-str nm)
+                                       " in this room")
+                                  {:name nm}))))))
         no-room   (fn [op] (throw (ex-info (str op " needs a room — this sandbox isn't attached to one "
                                                 "(only :mem databases are available here).") {})))
         guard
         {'create-database
          (fn [cfg]
            (in-ctx
-            (fn [] (let [nm (cfg-name cfg)]
+            (fn [] (let [nm (cfg-name cfg)
+                         room-id (current-room-id)]
                      (cond
-                       (mem? cfg) (let [c (assoc-in cfg [:store :id] nm)]
-                                    (when-not (d/database-exists? c) (d/create-database c))
-                                    (swap! ephemeral assoc nm (d/connect c)) cfg)
+                       (mem? cfg) (if (contains? (ephemeral-map) nm)
+                                    cfg
+                                    (let [c (world-memory-config cfg binding-resolver)]
+                                      (when (d/database-exists? c)
+                                        (throw (ex-info
+                                                "Scratch database exists without a live world owner"
+                                                {:name nm :physical-config c})))
+                                      (d/create-database c)
+                                      (swap-ephemeral! assoc nm
+                                                       {:connection (d/connect c)
+                                                        :config c})
+                                      cfg))
                        room-id    (do (srooms/create-room-db! room-id nm
-                                                               ;; honour datahike's own default (:write) — don't
-                                                               ;; silently downgrade to :read. Explicit :read in cfg
-                                                               ;; still wins (schema-free append-only scratch).
+                                                             ;; honour datahike's own default (:write) — don't
+                                                             ;; silently downgrade to :read. Explicit :read in cfg
+                                                             ;; still wins (schema-free append-only scratch).
                                                               :schema-flexibility (get cfg :schema-flexibility :write))
                                       cfg)
                        :else      (no-room "create-database"))))))
@@ -118,8 +237,8 @@
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (or (get @ephemeral nm)
-                         (when room-id (srooms/room-conn-by-name room-id nm))
+                     (or (some-> (get (ephemeral-map) nm) entry-conn)
+                         (when (current-room-id) (managed-connection nm))
                          (throw (ex-info (str "No database named " (pr-str nm)
                                               " in this room — create it with create-database, or see "
                                               "(dvergr.room/databases).")
@@ -128,15 +247,24 @@
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (boolean (or (get @ephemeral nm)
-                                  (when room-id (srooms/room-conn-by-name room-id nm))))))))
+                     (boolean (or (get (ephemeral-map) nm)
+                                  (when-let [room-id (current-room-id)]
+                                    (srooms/room-conn-by-name room-id nm))))))))
          'delete-database
          (fn [cfg]
            (in-ctx
             (fn [] (let [nm (cfg-name cfg)]
-                     (if (contains? @ephemeral nm)
-                       (do (swap! ephemeral dissoc nm) true)
-                       (boolean (when room-id (srooms/delete-room-db! room-id nm))))))))}
+                     (if (contains? (ephemeral-map) nm)
+                       (let [{:keys [connection config] :as entry}
+                             (get (ephemeral-map) nm)]
+                         (when-let [conn (entry-conn entry)]
+                           (d/release conn))
+                         (when (and config (d/database-exists? config))
+                           (d/delete-database config))
+                         (swap-ephemeral! dissoc nm)
+                         true)
+                       (boolean (when-let [room-id (current-room-id)]
+                                  (srooms/delete-room-db! room-id nm))))))))}
         m (merge data guard)]
     ;; The real datahike.api name (the model aliases it `:as d` itself, as everyone does).
     (sci/add-namespace! sci-ctx 'datahike.api m)))

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -344,6 +344,36 @@
       (throw (ex-info "Virtual filesystem sink does not accept binary content"
                       {:path path})))))
 
+(defn- world-filesystem
+  "A stable Muschel handle whose every operation resolves the ambient world.
+
+   SCI code may retain this value across an interpreter fork.  Delegating at
+   the protocol boundary prevents such saved functions from retaining the
+   parent's Geschichte workspace."
+  [resolver]
+  (letfn [(fs! [] (or (resolver)
+                      (throw (ex-info "Current world has no filesystem" {}))))]
+    (reify mfs/FS
+      (-resolve [_ path] (mfs/-resolve (fs!) path))
+      (-cwd [_] (mfs/-cwd (fs!)))
+      (-cd! [_ path] (mfs/-cd! (fs!) path))
+      (-exists? [_ path] (mfs/-exists? (fs!) path))
+      (-stat [_ path] (mfs/-stat (fs!) path))
+      (-list-dir [_ path] (mfs/-list-dir (fs!) path))
+      (-read-file [_ path] (mfs/-read-file (fs!) path))
+      (-read-bytes [_ path] (mfs/-read-bytes (fs!) path))
+      (-open-source [_ path] (mfs/-open-source (fs!) path))
+      (-open-sink [_ path append?] (mfs/-open-sink (fs!) path append?))
+      (-mkdir [_ path] (mfs/-mkdir (fs!) path))
+      (-delete [_ path] (mfs/-delete (fs!) path))
+      (-rename [_ from to] (mfs/-rename (fs!) from to))
+      (-touch [_ path] (mfs/-touch (fs!) path))
+      (-chmod [_ path mode] (mfs/-chmod (fs!) path mode))
+      (-symlink [_ target link-path] (mfs/-symlink (fs!) target link-path))
+      (-chown [_ path owner group] (mfs/-chown (fs!) path owner group))
+      (-sandbox-relativize [_ path] (mfs/-sandbox-relativize (fs!) path))
+      (-physical-path [_ path] (mfs/-physical-path (fs!) path)))))
+
 (defn- glob-regex [pattern]
   (-> pattern
       (str/replace "." "\\.")
@@ -449,9 +479,13 @@
 (defn add-fs-ns!
   "Expose a filesystem namespace backed by Muschel when `:filesystem` is
   supplied; otherwise retain the transitional physical adapter."
-  [sci-ctx & {:keys [filesystem] :as options}]
-  (if filesystem
-    (add-virtual-fs-ns! sci-ctx filesystem (:audit-log options))
+  [sci-ctx & {:keys [filesystem filesystem-resolver] :as options}]
+  (if (or filesystem filesystem-resolver)
+    (add-virtual-fs-ns! sci-ctx
+                        (if filesystem-resolver
+                          (world-filesystem filesystem-resolver)
+                          filesystem)
+                        (:audit-log options))
     (apply add-physical-fs-ns! sci-ctx (mapcat identity options))))
 
 (defn add-git-ns!
@@ -481,11 +515,14 @@
 
      (git/commit \"Add feature\")
      ;; => \"[main abc1234] Add feature\""
-  [sci-ctx & {:keys [base-path audit-log workspace]
+  [sci-ctx & {:keys [base-path audit-log workspace workspace-resolver]
               :or   {base-path ((requiring-resolve 'dvergr.substrate.git/safe-workspace-root))}}]
-  (let [run!      (if workspace
+  (let [run!      (if (or workspace workspace-resolver)
                     (fn [& args]
-                      (let [result ((requiring-resolve
+                      (let [workspace (if workspace-resolver
+                                        (workspace-resolver)
+                                        workspace)
+                            result ((requiring-resolve
                                      'dvergr.substrate.geschichte/execute-git)
                                     workspace (vec args))]
                         (if (zero? (:exit result))
@@ -549,8 +586,9 @@
      (env/get \"API_KEY\" \"default\")   ;; with fallback
      (env/keys)                        ;; list granted keys (no values)
      (env/set \"KEY\" \"value\")         ;; store in user config (session-local)"
-  [sci-ctx & {:keys [user-config secrets]}]
+  [sci-ctx & {:keys [user-config config-resolver config-swap! secrets]}]
   (let [config-atom (or user-config (atom {}))
+        config      #(if config-resolver (config-resolver) @config-atom)
         ;; A configured boundary-injection SECRET resolves to its opaque
         ;; PLACEHOLDER (never the real value) — the HTTP egress substitutes the
         ;; real value at the destination. Non-secret granted keys still return
@@ -559,12 +597,16 @@
                  (let [k (str key)]
                    (if-let [s (get secrets k)]
                      (:placeholder s)
-                     (or (get @config-atom k) (get @config-atom (keyword key))))))
+                     (or (get (config) k) (get (config) (keyword key))))))
         get-fn (fn
                  ([key]         (get-1 key))
                  ([key default] (or (get-1 key) default)))
-        set-fn (fn [key value] (swap! config-atom assoc (str key) value) :ok)
-        keys-fn (fn [] (vec (distinct (concat (map str (keys @config-atom))
+        set-fn (fn [key value]
+                 (if config-swap!
+                   (config-swap! assoc (str key) value)
+                   (swap! config-atom assoc (str key) value))
+                 :ok)
+        keys-fn (fn [] (vec (distinct (concat (map str (keys (config)))
                                               (keys (or secrets {}))))))]
     (sci/add-namespace! sci-ctx 'env
                         (doc/with-docs

--- a/src/dvergr/sandbox/ns/kb.clj
+++ b/src/dvergr/sandbox/ns/kb.clj
@@ -5,6 +5,7 @@
    datahike + spindel directly."
   (:require [sci.core :as sci]
             [datahike.api :as dh]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [org.replikativ.spindel.engine.core :as rtc]
             [dvergr.sandbox.ns.doc :as doc]))
 
@@ -54,7 +55,8 @@
   (require 'dvergr.room.registry)
   (require 'dvergr.room.store)
   (require 'dvergr.rooms.forks)
-  (let [fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
+  (let [selected-ctx    #(runtime-ctx/selected-context spindel-ctx)
+        fork-diff*      @(ns-resolve 'dvergr.rooms.forks 'fork-diff)
         fork-review*    @(ns-resolve 'dvergr.rooms.forks 'review)
         fork-classify*  @(ns-resolve 'dvergr.rooms.forks 'classify)
         post*           @(ns-resolve 'dvergr.discourse 'post!)
@@ -77,9 +79,13 @@
         rreg-children*  @(ns-resolve 'dvergr.room.registry 'children)
         registry*       (find-ns 'dvergr.room.registry)
         rstore-ns*      (find-ns 'dvergr.room.store)
+        current-source-room (fn []
+                              (if (fn? source-room)
+                                (source-room)
+                                source-room))
         ;; Helpers
         resolve-room    (fn [ref]
-                          (binding [rtc/*execution-context* spindel-ctx]
+                          (binding [rtc/*execution-context* (selected-ctx)]
                             (cond
                               (and (map? ref) (:id ref))
                               (rreg-lookup* (:id ref))            ; canonical Room only
@@ -90,20 +96,21 @@
         create-fn   (fn [{:keys [title slug type telegram-chat-id agents
                                  agent-ids parent-id]
                           :as _opts}]
-                      (binding [rtc/*execution-context* spindel-ctx]
-                        (let [aset (set (or agents agent-ids))]
-                          (create-room!*
-                           (cond-> {:title title
-                                    :slug  slug
-                                    :type  (or type :internal)
-                                    :ctx   spindel-ctx}
-                             telegram-chat-id (assoc :telegram-chat-id telegram-chat-id)
-                             (seq aset)       (assoc :agent-ids aset)
-                             parent-id        (assoc :parent-id parent-id)))
-                          {:slug slug :title (or title slug) :agents aset
-                           :room (rreg-lookup* (slug->id* slug))})))
+                      (let [world (selected-ctx)]
+                        (binding [rtc/*execution-context* world]
+                          (let [aset (set (or agents agent-ids))]
+                            (create-room!*
+                             (cond-> {:title title
+                                      :slug  slug
+                                      :type  (or type :internal)
+                                      :ctx   world}
+                               telegram-chat-id (assoc :telegram-chat-id telegram-chat-id)
+                               (seq aset)       (assoc :agent-ids aset)
+                               parent-id        (assoc :parent-id parent-id)))
+                            {:slug slug :title (or title slug) :agents aset
+                             :room (rreg-lookup* (slug->id* slug))}))))
         list-fn     (fn [& {:keys [where]}]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (if where (rreg-list* :where where) (rreg-list*))))
         get-fn      resolve-room
         post-fn     (fn [ref {:keys [content from source-user source-username source-user-id]}]
@@ -121,7 +128,7 @@
                         (messages* room (cond-> {} limit (assoc :limit limit)
                                                 since (assoc :since since)))))
         children-fn (fn [ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (when-let [room (resolve-room ref)]
                           (rreg-children* (:id room)))))
         set-parent-fn (fn [child-ref parent-ref]
@@ -140,18 +147,19 @@
                         (leave-agent!* room agent-id)
                         {:left agent-id :room (:id room)}))
         delete-fn   (fn [ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (if-let [room (resolve-room ref)]
                           (do
                             ;; An SCI evaluation cannot synchronously join its
                             ;; own controller/context teardown. Self-deletion is
                             ;; a supervisor effect; subordinate Rooms are safe.
-                            (when (and (= (:id source-room) (:id room))
-                                       (= (:incarnation source-room)
-                                          (:incarnation room)))
-                              (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
-                                              {:type ::self-delete
-                                               :room-id (:id room)})))
+                            (let [source-room (current-source-room)]
+                              (when (and (= (:id source-room) (:id room))
+                                         (= (:incarnation source-room)
+                                            (:incarnation room)))
+                                (throw (ex-info "A Room cannot delete itself from its own SCI runtime"
+                                                {:type ::self-delete
+                                                 :room-id (:id room)}))))
                             (let [result (delete-room!* room)]
                               (if (:ok? result)
                                 {:deleted (:id room)}
@@ -163,7 +171,7 @@
         fork-fn     (fn fork-fn
                       ([ref] (fork-fn ref {}))
                       ([ref opts]
-                       (binding [rtc/*execution-context* spindel-ctx]
+                       (binding [rtc/*execution-context* (selected-ctx)]
                          (when-let [room (resolve-room ref)]
                            (binding [rtc/*execution-context* (:ctx room)]
                              (fork-room* room opts))))))
@@ -175,18 +183,18 @@
                         (discard* fork)))
         ;; Merge review — the per-system diff + tier the agent reads to decide.
         diff-fn     (fn [fork-ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (some-> (resolve-room fork-ref) fork-diff*)))
         review-fn   (fn [fork-ref]
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (some-> (resolve-room fork-ref) fork-review*)))
         forks-fn    (fn []
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (rreg-list* :where #(some? (:forked-from @(:meta %))))))
         participants-fn (fn [room]
                           (when room (vec (keys @(:participants room)))))
         root-fn     (fn []
-                      (binding [rtc/*execution-context* spindel-ctx]
+                      (binding [rtc/*execution-context* (selected-ctx)]
                         (or (rreg-lookup* :daemon)
                             (rtc/get-state [:dvergr/discourse-root]))))]
     (doc/with-docs

--- a/src/dvergr/sandbox/ns/room.clj
+++ b/src/dvergr/sandbox/ns/room.clj
@@ -16,6 +16,8 @@
   (:require [datahike.api :as d]
             [dvergr.system.rooms :as srooms]
             [dvergr.sandbox.ns.kb :as ns-kb]
+            [dvergr.sandbox.ns.datahike :as ns-datahike]
+            [dvergr.runtime.ctx :as runtime-ctx]
             [clojure.string :as str]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
@@ -34,8 +36,30 @@
    may be nil (room-less ctx) — the helpers degrade gracefully.
    `agent-program-ceiling` is forwarded to the room-bound SCI setup; bounded
    delegation itself lives only in the `dvergr.agent` namespace."
-  [sci-ctx room-conn kb-conn room-id ctx & [agent-program-ceiling source-room]]
-  (let [;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
+  [sci-ctx room-conn kb-conn room-id ctx
+   & [agent-program-ceiling {:keys [binding-resolver source-room]}]]
+  (let [selected-ctx   #(runtime-ctx/selected-context ctx)
+        current-room-id #(or (when binding-resolver
+                               (:room-id (binding-resolver)))
+                             room-id)
+        current-source-room #(if binding-resolver
+                               (let [binding (binding-resolver)]
+                                 {:id (:room-runtime-id binding)
+                                  :incarnation (:room-incarnation binding)})
+                               source-room)
+        room-view      (when (or room-id room-conn)
+                         (ns-datahike/world-connection
+                          #(if-let [room-id (current-room-id)]
+                             (binding [ec/*execution-context* (selected-ctx)]
+                               (srooms/room-msgs-conn room-id))
+                             room-conn)))
+        kb-view        (when (or room-id kb-conn)
+                         (ns-datahike/world-connection
+                          #(if-let [room-id (current-room-id)]
+                             (binding [ec/*execution-context* (selected-ctx)]
+                               (srooms/room-kb-conn room-id))
+                             kb-conn)))
+        ;; EVERY readable KB, not just `*kb*`. A room's knowledge is spread over
         ;; its own KB plus whatever is granted to it, and the two are written
         ;; through different bindings of the same katzen schema — dvergr's
         ;; `:entity/title` and a product's `:S.Page/title`. Reading one store
@@ -46,8 +70,8 @@
         ;; address that KB by name (see `kbs` / `kb`).
         title-attrs    [:entity/title :S.Page/title]
         readable       (fn []
-                         (if room-id
-                           (binding [ec/*execution-context* ctx]
+                         (if-let [room-id (current-room-id)]
+                           (binding [ec/*execution-context* (selected-ctx)]
                              (srooms/room-kb-conns room-id))
                            (when kb-conn [{:conn kb-conn :slug "kb"}])))
         titled         (fn [db]
@@ -83,51 +107,59 @@
                                        (take 25) vec))))
         msg-time       (fn [m] (or (some-> ^java.util.Date (:message/created-at m) .getTime) 0))
         recent-msgs    (fn [n]
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (->> (d/q '[:find [(pull ?m [:message/content :message/role :message/created-at]) ...]
-                                              :where [?m :message/content _]] @room-conn)
+                                              :where [?m :message/content _]] @room-view)
                                        (sort-by msg-time >)
                                        (take (or n 20)) vec))))
         search-msgs    (fn [term]
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (let [lc (str/lower-case (str term))]
                                     (->> (d/q '[:find [(pull ?m [:message/content :message/role :message/created-at]) ...]
-                                                :where [?m :message/content _]] @room-conn)
+                                                :where [?m :message/content _]] @room-view)
                                          (filter (fn [m] (str/includes? (str/lower-case (str (:message/content m))) lc)))
                                          (take 50) vec)))))
         schedules      (fn []
-                         (safe #(when room-conn
+                         (safe #(when room-view
                                   (d/q '[:find [(pull ?s [*]) ...]
-                                         :where [?s :schedule/id _]] @room-conn))))
+                                         :where [?s :schedule/id _]] @room-view))))
         ;; Discovery: WHERE the agent's databases are + by-name access. Resolved
         ;; fork-aware under `ctx` so a fork lists/returns its branched systems.
-        databases      (fn [] (safe #(when room-id
-                                       (binding [ec/*execution-context* ctx]
+        databases      (fn [] (safe #(when-let [room-id (current-room-id)]
+                                       (binding [ec/*execution-context* (selected-ctx)]
                                          (srooms/room-databases room-id)))))
-        db             (fn [db-name] (safe #(when room-id
-                                              (binding [ec/*execution-context* ctx]
-                                                (srooms/room-conn-by-name room-id db-name)))))
+        db             (fn [db-name]
+                         (safe #(when-let [room-id (current-room-id)]
+                                  (ns-datahike/world-connection
+                                   (fn []
+                                     (binding [ec/*execution-context* (selected-ctx)]
+                                       (srooms/room-conn-by-name room-id db-name)))))))
         ;; Reclaim unreachable storage for THIS room/fork's workspace (datahike
         ;; index blobs + git objects). Default keeps all history (orphan garbage
         ;; only); pass {:remove-before <Date>} to collapse old history.
         gc!            (fn gc!
                          ([] (gc! {}))
-                         ([opts] (safe #(binding [ec/*execution-context* ctx] (ygg/gc! opts)))))
+                         ([opts] (safe #(binding [ec/*execution-context* (selected-ctx)]
+                                          (ygg/gc! opts)))))
         ;; Which KBs this room may WRITE, and which one `*kb*` is. A room's own
         ;; KB is the default, but a room whose knowledge lives in an ATTACHED KB
         ;; would otherwise write into its own empty one with nothing saying so —
         ;; the agent could not even name the alternatives. These make the choice
         ;; visible and addressable.
-        kbs (fn [] (safe #(binding [ec/*execution-context* ctx]
-                            (let [ws (srooms/writable-kbs room-id)]
+        kbs (fn [] (safe #(binding [ec/*execution-context* (selected-ctx)]
+                            (let [ws (srooms/writable-kbs (current-room-id))]
                               (into [] (map-indexed
                                         (fn [i {:keys [slug permission]}]
                                           {:name slug :permission permission
                                            :default? (zero? i)}))
                                     ws)))))
-        kb  (fn [slug] (safe #(binding [ec/*execution-context* ctx]
-                                (srooms/room-kb-conn room-id slug))))
-        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling source-room) ; create!/fork!/merge!/post!/messages/…
+        kb  (fn [slug]
+              (safe #(ns-datahike/world-connection
+                      (fn []
+                        (binding [ec/*execution-context* (selected-ctx)]
+                          (srooms/room-kb-conn (current-room-id) slug))))))
+        room-map (merge (ns-kb/room-ops-map ctx agent-program-ceiling
+                                            current-source-room) ; create!/fork!/merge!/post!/messages/…
                         ;; Docs live HERE rather than only in these trailing
                         ;; comments: the comments never reached the sandbox, so
                         ;; `(clojure.repl/doc dvergr.room/kb-search)` answered
@@ -136,8 +168,8 @@
                         ;; (or nil) — values with no signature to state — so
                         ;; they carry no entry and are described in ns-guide.
                         (doc/with-docs
-                          {'*room*          room-conn      ; the room's own datahike (messages store)
-                           '*kb*            kb-conn         ; the DEFAULT writable KB (see kbs)
+                          {'*room*          room-view      ; ambient messages-store handle
+                           '*kb*            kb-view       ; ambient default-KB handle
                            'kbs             kbs             ; [{:name :permission :default?}] — writable KBs
                            'kb              kb              ; fork-aware conn to a writable KB by name
                            'databases       databases       ; [{:name :type :permission}] — your DBs

--- a/src/dvergr/sci/clojure_test.clj
+++ b/src/dvergr/sci/clojure_test.clj
@@ -4,7 +4,8 @@
    We've vendored babashka's clojure.test (EPL licensed) and adapted it
    to work without babashka's infrastructure."
   (:require [dvergr.sci.impl.clojure-test :as t]
-            [sci.core :as sci]))
+            [sci.core :as sci]
+            [sci.ctx-store :as sci-ctx-store]))
 
 ;; Create the test namespace object
 (def tns t/tns)
@@ -12,6 +13,16 @@
 ;; Helper to create SCI vars
 (defn new-var [var-sym f]
   (sci/new-var var-sym f {:ns tns}))
+
+(defn- shared-host-capability
+  "Declare a vendored clojure.test implementation object as an ambient
+   capability. Its mutable state is not agent memory: SCI code receives the
+   callable/output Var but Dvergr installs the implementation once at boot.
+   Marking the individual Var keeps SCI's fail-closed policy for every other
+   host value while allowing world forks to retain this implementation table."
+  [v]
+  (alter-meta! v assoc :sci.impl/fork-fn identity)
+  v)
 
 ;; Base namespace map — everything except the high-level runners that need ctx.
 ;; Combine with ctx-aware-test-namespace (below) for full functionality.
@@ -28,13 +39,13 @@
    '*initial-report-counters* t/initial-report-counters
    '*testing-vars*           t/testing-vars
    '*testing-contexts*       t/testing-contexts
-   '*test-out*               t/test-out
+   '*test-out*               (shared-host-capability t/test-out)
 
    ;; Utilities
    'testing-vars-str    (sci/copy-var t/testing-vars-str tns)
    'testing-contexts-str (sci/copy-var t/testing-contexts-str tns)
    'inc-report-counter  (sci/copy-var t/inc-report-counter tns)
-   'report              t/report
+   'report              (shared-host-capability t/report)
    'do-report           (sci/copy-var t/do-report tns)
 
    ;; Assertion utilities
@@ -43,7 +54,8 @@
    'assert-any          (sci/copy-var t/assert-any tns)
 
    ;; Assertion methods
-   'assert-expr         (sci/copy-var t/assert-expr tns)
+   'assert-expr         (shared-host-capability
+                         (sci/copy-var t/assert-expr tns))
    'try-expr            (sci/copy-var t/try-expr tns)
 
    ;; Assertion macros
@@ -58,7 +70,8 @@
    'set-test            (sci/copy-var t/set-test tns)
 
    ;; Fixtures
-   'use-fixtures        (sci/copy-var t/use-fixtures tns)
+   'use-fixtures        (shared-host-capability
+                         (sci/copy-var t/use-fixtures tns))
    'compose-fixtures    (sci/copy-var t/compose-fixtures tns)
    'join-fixtures       (sci/copy-var t/join-fixtures tns)
 
@@ -71,23 +84,30 @@
    'with-test-out       (sci/copy-var t/with-test-out tns)})
 
 (defn ctx-aware-test-namespace
-  "Build a clojure.test namespace map that closes over the real SCI ctx.
+  "Build a clojure.test namespace map that resolves the active SCI ctx.
 
    The high-level runners (run-tests, test-ns, test-all-vars, run-all-tests) need
-   the real SCI context to enumerate vars via sci-ns-interns*. Passing a dummy ctx
-   causes them to find 0 tests. Call this after (sci/init ...) with the real ctx.
+   the selected SCI context to enumerate vars via sci-ns-interns*. They resolve
+   it from sci.ctx-store at invocation, so a copied runner enumerates the child
+   world after a fork rather than retaining its parent. Call this after
+   (sci/init ...) with the initial ctx.
 
    Usage:
      (sci/merge-opts ctx {:namespaces {'clojure.test (ctx-aware-test-namespace ctx)}})"
-  [ctx]
+  [_ctx]
   (merge clojure-test-namespace
          {'test-all-vars (new-var 'test-all-vars
-                                  (fn [ns-obj] (t/test-all-vars ctx ns-obj)))
+                                  (fn [ns-obj]
+                                    (t/test-all-vars (sci-ctx-store/get-ctx) ns-obj)))
           'test-ns       (new-var 'test-ns
-                                  (fn [ns-sym] (t/test-ns ctx ns-sym)))
+                                  (fn [ns-sym]
+                                    (t/test-ns (sci-ctx-store/get-ctx) ns-sym)))
           'run-tests     (new-var 'run-tests
-                                  (fn [& namespaces] (apply t/run-tests ctx namespaces)))
+                                  (fn [& namespaces]
+                                    (apply t/run-tests
+                                           (sci-ctx-store/get-ctx) namespaces)))
           'run-all-tests (new-var 'run-all-tests
                                   (fn
-                                    ([] (t/run-all-tests ctx))
-                                    ([re] (t/run-all-tests ctx re))))}))
+                                    ([] (t/run-all-tests (sci-ctx-store/get-ctx)))
+                                    ([re] (t/run-all-tests
+                                           (sci-ctx-store/get-ctx) re))))}))

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -595,7 +595,8 @@
                :properties {:code {:type "string"
                                    :description "Clojure code to evaluate"}}
                :required ["code"]}
-  :execute (fn [{:keys [code]} {:keys [sci-ctx isolation eval-ns chat-ctx cancel?]}]
+  :execute (fn [{:keys [code]} {:keys [sci-ctx isolation eval-ns chat-ctx cancel?
+                                       execution-ctx]}]
               ;; Native mode: use real Clojure eval
              (cond
                (= :native isolation)
@@ -631,7 +632,8 @@
                                                  (catch Throwable _ false))))]
                                      (sandbox/eval-code sci-ctx code
                                                         :timeout-ms @eval-timeout-ms
-                                                        :cancel? proc-aborted?))))
+                                                        :cancel? proc-aborted?
+                                                        :execution-context execution-ctx))))
                   ;; Block on process completion / abort.
                  (let [{:keys [ok aborted]} @result-p]
                    (cond
@@ -674,7 +676,8 @@
                sci-ctx
                (let [result (sandbox/eval-code sci-ctx code
                                                :timeout-ms @eval-timeout-ms
-                                               :cancel? cancel?)]
+                                               :cancel? cancel?
+                                               :execution-context execution-ctx)]
                  (if (:success result)
                    {:type :success
                     :content (str "=> " (pr-str (:value result))
@@ -1487,7 +1490,7 @@ Note: changes take effect on the next agent restart or reload."
   ;; The sandbox already has a ctx-aware clojure.test (run-tests / run-all-tests
   ;; enumerate vars in THIS context), so running there is both correct and
   ;; actually isolated. `:sci-ctx` is the same handle clojure_eval receives.
-  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx]}]
+  :execute (fn [{:keys [focus pattern]} {:keys [sci-ctx execution-ctx]}]
              (if-not sci-ctx
                {:type :error
                 :error "No sandbox context available to run tests in."}
@@ -1496,7 +1499,8 @@ Note: changes take effect on the next agent restart or reload."
                             pattern (str "(clojure.test/run-all-tests #\""
                                          (str/replace pattern "\"" "\\\"") "\")")
                             :else   "(clojure.test/run-all-tests)")
-                     r    (sandbox/eval-code sci-ctx form)]
+                     r    (sandbox/eval-code sci-ctx form
+                                             :execution-context execution-ctx)]
                  (if-not (:success r)
                    {:type :error
                     :error (str "Test run failed: " (get-in r [:error :message]))}

--- a/src/dvergr/web/dashboard.clj
+++ b/src/dvergr/web/dashboard.clj
@@ -416,7 +416,10 @@
             cs     (rstats/room-agent-contexts room)
             lookup (requiring-resolve 'dvergr.agent.room-context/lookup)
             sbstat (requiring-resolve 'dvergr.sandbox/sandbox-status)
-            sb-of  (fn [aid] (try (sbstat (:sci-ctx (lookup rid aid))) (catch Throwable _ nil)))]
+            sci-in (requiring-resolve 'dvergr.chat.context/sci-context-in)
+            sb-of  (fn [aid]
+                     (try (sbstat (sci-in (lookup rid aid) (:ctx room)))
+                          (catch Throwable _ nil)))]
         (str (h/html
               (if (seq cs)
                 (into [:div.ctx-agents] (map #(agent-context-row % (sb-of (:agent %))) cs))

--- a/test/dvergr/agent/room_context_test.clj
+++ b/test/dvergr/agent/room_context_test.clj
@@ -9,9 +9,18 @@
             [dvergr.discourse :as d]
             [dvergr.room.store.memory :as mem]
             [dvergr.room.store :as rstore]
+            [dvergr.room.store.datahike :as store-dh]
+            [dvergr.room.registry :as registry]
+            [dvergr.sandbox :as sandbox]
             [dvergr.chat.context :as cctx]
+            [dvergr.chat.schema :as schema]
+            [datahike.api :as dh]
+            [org.replikativ.spindel.engine.component :as component]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]))
+
+(defn- ledger-count [conn]
+  (or (dh/q '[:find (count ?e) . :where [?e :ledger/id _]] @conn) 0))
 
 (defn- roles+contents [chat-ctx]
   (binding [ec/*execution-context* (:spindel-ctx chat-ctx)]
@@ -35,6 +44,177 @@
             (is (some #(str/includes? % "earlier message") (non-system-contents cc1))
                 "seeded the conversation from the room store")
             (finally (rc/drop-ctx! :rc-seed :var))))))))
+
+(deftest concurrent-first-context-creation-is-singleton
+  (testing "one Room fence covers component allocation and cache publication"
+    (let [c (ctx/create-execution-context)
+          room (d/make-room {:id :rc-concurrent-first :ctx c :store (mem/make)})
+          original turn/new-working-ctx
+          constructor-entered (promise)
+          second-started (promise)
+          release-constructor (promise)
+          calls (atom 0)]
+      (try
+        (with-redefs [turn/new-working-ctx
+                      (fn [opts]
+                        (swap! calls inc)
+                        (deliver constructor-entered true)
+                        @release-constructor
+                        (original opts))]
+          (let [first-result (future (rc/ensure-ctx! room :var
+                                                     {:budget-dollars 1.0}))]
+            (is (true? (deref constructor-entered 3000 ::timeout)))
+            (let [second-result
+                  (future
+                    (deliver second-started true)
+                    (rc/ensure-ctx! room :var {:budget-dollars 1.0}))]
+              (is (true? (deref second-started 3000 ::timeout)))
+              (deliver release-constructor true)
+              (let [first-ctx (deref first-result 10000 ::timeout)
+                    second-ctx (deref second-result 10000 ::timeout)]
+                (is (not= ::timeout first-ctx))
+                (is (identical? first-ctx second-ctx))
+                (is (= 1 @calls))
+                (is (= 1 (count (binding [ec/*execution-context* c]
+                                  (component/registered)))))))))
+        (finally
+          (deliver release-constructor true)
+          (rc/drop-ctx! :rc-concurrent-first :var)
+          (ctx/close-context! c))))))
+
+(deftest failed-hydration-is-unpublished-and-retryable
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-hydration-retry :ctx c :store (mem/make)})
+        original d/messages
+        original-constructor turn/new-working-ctx
+        hydration-calls (atom 0)
+        constructor-calls (atom 0)]
+    (try
+      (with-redefs [d/messages
+                    (fn [& args]
+                      (if (= 1 (swap! hydration-calls inc))
+                        (throw (ex-info "injected hydration failure" {}))
+                        (apply original args)))
+                    turn/new-working-ctx
+                    (fn [opts]
+                      (swap! constructor-calls inc)
+                      (original-constructor opts))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"injected hydration failure"
+                              (rc/ensure-ctx! room :var
+                                              {:budget-dollars 1.0
+                                               :system-prompt "must not leak"})))
+        (is (nil? (rc/lookup (:id room) :var)))
+        (is (empty? (binding [ec/*execution-context* c]
+                      (component/registered))))
+        (is (zero? @constructor-calls)
+            "fallible durable hydration precedes all ChatContext signals")
+        (let [retried (rc/ensure-ctx! room :var
+                                      {:budget-dollars 1.0
+                                       :system-prompt "must not leak"})]
+          (is (some? retried))
+          (is (= 1 @constructor-calls))
+          (is (= 1 (count (binding [ec/*execution-context* c]
+                            (component/registered)))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest inbound-admission-waits-for-context-publication
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-admission-during-hydration
+                           :ctx c :store (mem/make)})
+        original d/messages
+        hydration-entered (promise)
+        release-hydration (promise)
+        msg-id (random-uuid)]
+    (try
+      (with-redefs [d/messages
+                    (fn [& args]
+                      (deliver hydration-entered true)
+                      @release-hydration
+                      (apply original args))]
+        (let [ensure-result (future (rc/ensure-ctx! room :var
+                                                    {:budget-dollars 1.0}))]
+          (is (true? (deref hydration-entered 10000 ::timeout)))
+          (let [append-result
+                (future (rc/append-inbound! room :var msg-id :user
+                                            "arrived during hydration"
+                                            "Alice" nil))]
+            (deliver release-hydration true)
+            (let [working (deref ensure-result 10000 ::timeout)]
+              (is (true? (deref append-result 10000 ::timeout)))
+              (is (some #(str/includes? % "arrived during hydration")
+                        (non-system-contents working)))))))
+      (finally
+        (deliver release-hydration true)
+        (d/close-room! room)))))
+
+(deftest working-context-construction-releases-on-rebind-failure
+  (let [c (ctx/create-execution-context)]
+    (try
+      (with-redefs [sandbox/setup-agent-namespaces!
+                    (fn [& _]
+                      (throw (ex-info "injected namespace failure" {})))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"injected namespace failure"
+                              (turn/new-working-ctx
+                               {:execution-ctx c :title "failing"})))
+        (is (empty? (binding [ec/*execution-context* c]
+                      (component/registered)))))
+      (finally
+        (ctx/close-context! c)))))
+
+(deftest unregister-fences-context-creation-and-stale-access
+  (let [c (ctx/create-execution-context)
+        room (d/make-room {:id :rc-unregister-race :ctx c :store (mem/make)})
+        original turn/new-working-ctx
+        constructor-entered (promise)
+        release-constructor (promise)]
+    (try
+      (with-redefs [turn/new-working-ctx
+                    (fn [opts]
+                      (deliver constructor-entered true)
+                      @release-constructor
+                      (original opts))]
+        (let [ensure-result (future (rc/ensure-ctx! room :var
+                                                    {:budget-dollars 1.0}))]
+          (is (true? (deref constructor-entered 3000 ::timeout)))
+          (let [unregister-result
+                (future
+                  (binding [ec/*execution-context* c]
+                    (registry/unregister! (:id room))))]
+            (deliver release-constructor true)
+            (is (not= ::timeout (deref ensure-result 10000 ::timeout)))
+            (is (nil? (deref unregister-result 10000 ::timeout)))
+            (is (nil? (binding [ec/*execution-context* c]
+                        (registry/lookup (:id room)))))
+            (is (nil? (rc/lookup (:id room) :var)))
+            (is (empty? (binding [ec/*execution-context* c]
+                          (component/registered))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"closed Room incarnation"
+                                  (rc/ensure-ctx! room :var
+                                                  {:budget-dollars 1.0}))))))
+      (finally
+        (deliver release-constructor true)
+        (ctx/close-context! c)))))
+
+(deftest resource-cleanup-failure-still-unregisters-component
+  (let [c (ctx/create-execution-context)
+        working (turn/new-working-ctx {:execution-ctx c :title "cleanup"})]
+    (try
+      (is (= 1 (count (binding [ec/*execution-context* c]
+                        (component/registered)))))
+      (with-redefs [sandbox/release-agent-resources!
+                    (fn [& _] (throw (java.io.IOException. "injected cleanup failure")))]
+        (is (thrown-with-msg? java.io.IOException
+                              #"injected cleanup failure"
+                              (cctx/release-sci-in! working c))))
+      (is (empty? (binding [ec/*execution-context* c]
+                    (component/registered))))
+      (finally
+        (cctx/release-sci-in! working c)
+        (ctx/close-context! c)))))
 
 (deftest room-observation-does-not-bypass-attention
   (let [c (ctx/create-execution-context)]
@@ -66,6 +246,43 @@
           (is (= 1 (count (filter #(= "once" %) (non-system-contents cc))))
               "appended exactly once despite two calls with the same id")
           (finally (rc/drop-ctx! :rc-dedup :var)))))))
+
+(deftest forked-working-context-owns-child-persistence
+  (let [parent-ctx (ctx/create-execution-context)
+        child-ctx* (atom nil)
+        parent-conn (schema/create-chat-db!
+                     {:store {:backend :memory :id (random-uuid)}})
+        child-conn (schema/create-chat-db!
+                    {:store {:backend :memory :id (random-uuid)}})
+        parent (d/make-room {:id :rc-db-parent
+                             :ctx parent-ctx
+                             :store (store-dh/make parent-conn)})]
+    (try
+      (let [working (rc/ensure-ctx! parent :var {:budget-dollars 1.0})]
+        (let [child-ctx (ctx/fork-context parent-ctx :mode :frozen)
+              _ (reset! child-ctx* child-ctx)
+              child (d/make-room {:id :rc-db-child
+                                  :ctx child-ctx
+                                  :store (store-dh/make child-conn)})]
+          (dh/transact child-conn
+                       [(schema/create-chat-entity
+                         {:id (:chat-id working) :title (:title working)
+                          :budget 1000000})])
+          (let [projected (rc/fork-ctx! parent child :var)]
+            (is (identical? child-conn (:db-conn projected)))
+            (is (not (identical? parent-conn (:db-conn projected))))
+            (cctx/account-usage! projected :input-tokens 1
+                                 :model "claude-sonnet-4-5")
+            (is (= 0 (ledger-count parent-conn)))
+            (is (= 1 (ledger-count child-conn))))))
+      (finally
+        (rc/drop-ctx! :rc-db-child :var)
+        (rc/drop-ctx! :rc-db-parent :var)
+        (dh/release child-conn)
+        (dh/release parent-conn)
+        (when-let [child-ctx @child-ctx*]
+          (ctx/close-context! child-ctx))
+        (ctx/close-context! parent-ctx)))))
 
 (deftest durable-attention-rebuilds-provider-projection
   (testing "Run triggers and :include decisions enter provider input while

--- a/test/dvergr/chat/context_test.clj
+++ b/test/dvergr/chat/context_test.clj
@@ -2,7 +2,96 @@
   "Integration tests for ChatContext budget tracking."
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.chat.context :as ctx]
-            [dvergr.chat.accounting :as acct]))
+            [dvergr.chat.accounting :as acct]
+            [dvergr.runtime.ctx :as runtime-ctx]
+            [dvergr.sandbox :as sandbox]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as execution-context]))
+
+(deftest ambient-selection-only-refines-into-descendants
+  (let [parent (execution-context/create-execution-context)
+        owner (execution-context/fork-context parent :mode :frozen)
+        sibling (execution-context/fork-context parent :mode :frozen)
+        descendant (execution-context/fork-context owner :mode :frozen)]
+    (try
+      (is (identical? owner (runtime-ctx/selected-context owner)))
+      (binding [ec/*execution-context* parent]
+        (is (identical? owner (runtime-ctx/selected-context owner))))
+      (binding [ec/*execution-context* sibling]
+        (is (identical? owner (runtime-ctx/selected-context owner))))
+      (binding [ec/*execution-context* descendant]
+        (is (identical? descendant (runtime-ctx/selected-context owner))))
+      (finally
+        (execution-context/close-context! descendant)
+        (execution-context/close-context! sibling)
+        (execution-context/close-context! owner)
+        (execution-context/close-context! parent)))))
+
+(deftest sci-interpreter-is-selected-by-world
+  (testing "one stable ChatContext ref resolves independent SCI heaps after fork"
+    (let [parent (execution-context/create-execution-context)
+          chat   (ctx/create-chat-context
+                  {:title "forkable repl"
+                   :execution-context parent})]
+      (try
+        (let [ref (:sci-component chat)
+              parent-sci (ctx/sci-context-in chat parent)
+              eval-in (fn [world interpreter source]
+                        (sandbox/eval-code interpreter source
+                                           :execution-context world))]
+          (is (some? ref))
+          ;; Exercise the interpreter agents actually receive, not only the
+          ;; bare Spindel macro context. Every injected capability must either
+          ;; be world-relative or declare its ambient sharing policy.
+          (sandbox/setup-agent-namespaces! parent-sci parent)
+          (is (= {:value [:parent] :stdout "" :stderr "" :success true}
+                 (eval-in
+                  parent parent-sci
+                  "(def observations (atom [:parent])) @observations")))
+          (let [child (execution-context/fork-context parent :mode :frozen)]
+            (try
+              (let [child-sci (ctx/sci-context-in chat child)]
+                (is (not (identical? parent-sci child-sci)))
+                (is (= [:parent :child]
+                       (:value (eval-in
+                                child child-sci
+                                "(swap! observations conj :child)"))))
+                (is (= [:parent]
+                       (:value (eval-in parent parent-sci "@observations"))))
+                (is (= [:parent :child]
+                       (:value (eval-in child child-sci "@observations"))))
+                (let [result
+                      (eval-in
+                       child child-sci
+                       "(ns child-only-test
+                          (:require [clojure.test :refer [deftest is run-tests]]))
+                        (deftest child-proof (is (= 3 (+ 1 2))))
+                        (run-tests 'child-only-test)")]
+                  (is (:success result))
+                  (is (= {:test 1 :pass 1 :fail 0 :error 0}
+                         (select-keys (:value result)
+                                      [:test :pass :fail :error])))
+                  (is (false?
+                       (:value
+                        (eval-in
+                         parent parent-sci
+                         "(boolean (find-ns 'child-only-test))"))))))
+              (ctx/release-sci-in! chat child)
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"not available"
+                   (ctx/sci-context-in chat child)))
+              (is (contains?
+                   (binding [ec/*execution-context* parent]
+                     (component/registered))
+                   (:id ref))
+                  "releasing a child interpreter preserves its parent")
+              (finally
+                (execution-context/close-context! child)))))
+        (finally
+          (ctx/close-chat! chat)
+          (execution-context/close-context! parent))))))
 
 (deftest create-chat-context-test
   (testing "Create chat with dollar budget"

--- a/test/dvergr/discourse/llm_test.clj
+++ b/test/dvergr/discourse/llm_test.clj
@@ -8,10 +8,14 @@
             [dvergr.discourse.attention :as attention]
             [dvergr.discourse.llm :as llm]
             [dvergr.chat.context :as cc]
+            [dvergr.runtime.ctx :as runtime-ctx]
+            [dvergr.sandbox :as sandbox]
             [dvergr.agent.run :as run]
             [dvergr.agent.room-context :as room-context]
             [dvergr.room.store :as store]
-            [dvergr.room.store.memory :as memory]))
+            [dvergr.room.store.memory :as memory]
+            [datahike.api :as dh]
+            [org.replikativ.spindel.engine.component :as component]))
 
 ;; ============================================================================
 ;; Mock turn-fn — scripts the LLM responses
@@ -104,6 +108,163 @@
 ;; Tests
 ;; ============================================================================
 
+(deftest isolated-room-fork-reuses-the-forked-working-interpreter
+  (testing "participant cloning selects the inherited SCI world without registering another"
+    (let [parent (d/room :llm-world-parent)
+          parent-db (random-uuid)
+          fork* (atom nil)]
+      (try
+        (binding [ec/*execution-context* (:ctx parent)]
+          (d/join parent
+                  (llm/llm-agent
+                   {:id :researcher
+                    :spec {:provider :mock :model "mock"}
+                    :run-turn-fn (make-mock-turn-fn (atom []))})))
+        (is (empty? (binding [ec/*execution-context* (:ctx parent)]
+                      (component/registered)))
+            "a joined room participant does not eagerly allocate a room-less fallback")
+        (let [working (room-context/ensure-ctx!
+                       parent :researcher {:budget-dollars 1.0})
+              parent-sci (cc/sci-context-in working (:ctx parent))]
+          (is (= 1 (count (binding [ec/*execution-context* (:ctx parent)]
+                            (component/registered)))))
+          (is (= [:parent]
+                 (:value (sandbox/eval-code
+                          parent-sci
+                          (format
+                           "(def evidence (atom [:parent]))
+                            (defn captured-room [] (dvergr.agent/room-id))
+                            (def captured-room-fn dvergr.agent/room-id)
+                            (def captured-env-get env/get)
+                            (def captured-env-set env/set)
+                            (env/set \"WORLD\" \"parent\")
+                            (def captured-db-exists? datahike.api/database-exists?)
+                            (def captured-db-create! datahike.api/create-database)
+                            (def captured-db-connect! datahike.api/connect)
+                            (def captured-work-serial spindel.work/serial)
+                            (def parent-db {:store {:backend :mem :id %s}
+                                            :schema-flexibility :read})
+                            (captured-db-create! parent-db)
+                            (datahike.api/transact (captured-db-connect! parent-db)
+                              [{:marker/id :parent}])
+                            @evidence"
+                           (pr-str parent-db))
+                          :execution-context (:ctx parent)))))
+          (let [fork (d/fork-room parent {:isolation :ctx})]
+            (reset! fork* fork)
+            (let [child-working (room-context/lookup (:id fork) :researcher)
+                  child-sci (cc/sci-context-in child-working (:ctx fork))]
+              (is (not (identical? working child-working)))
+              (is (= (:sci-component working) (:sci-component child-working)))
+              (is (identical? (:ctx fork) (:spindel-ctx child-working)))
+              (is (not (identical? (:db-conn working) (:db-conn child-working)))
+                  "child persistence never retains the raw parent connection")
+              (is (= 1 (count (binding [ec/*execution-context* (:ctx fork)]
+                                (component/registered))))
+                  "the participant factory did not allocate a second interpreter")
+              (is (= (:id parent)
+                     (:value (sandbox/eval-code
+                              parent-sci "(dvergr.agent/room-id)"
+                              :execution-context (:ctx parent)))))
+              (is (= (:id fork)
+                     (:value (sandbox/eval-code
+                              child-sci "(dvergr.agent/room-id)"
+                              :execution-context (:ctx fork))))
+                  "fresh calls resolve the child Room")
+              (is (= [(:id fork) (:id fork)]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(captured-room) (captured-room-fn)]"
+                              :execution-context (:ctx fork))))
+                  "pre-fork helpers and first-class capabilities resolve through the child world")
+              (is (= true
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(let [controller
+                                     (captured-work-serial
+                                      (fn [value] (spindel.work/task value)))]
+                                 (spindel.work/close! controller)
+                                 true)"
+                              :execution-context (:ctx fork))))
+                  "retained FRP constructors allocate against the child Room incarnation")
+              (is (= ["parent" "parent"]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx fork))))
+                  "environment data is inherited through the child world binding")
+              (is (= :ok
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(captured-env-set \"WORLD\" \"child\")"
+                              :execution-context (:ctx fork)))))
+              (is (= ["child" "child"]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx fork)))))
+              (is (= ["parent" "parent"]
+                     (:value (sandbox/eval-code
+                              parent-sci
+                              "[(env/get \"WORLD\") (captured-env-get \"WORLD\")]"
+                              :execution-context (:ctx parent))))
+                  "a retained child mutation does not escape into the parent")
+              (is (= [false false]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "[(datahike.api/database-exists? parent-db)
+                                (captured-db-exists? parent-db)]"
+                              :execution-context (:ctx fork))))
+                  "live ephemeral database handles are disposable across a fork")
+              (is (= true
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(captured-db-create! parent-db)
+                               (datahike.api/transact (captured-db-connect! parent-db)
+                                 [{:marker/id :child}])
+                               (captured-db-exists? parent-db)"
+                              :execution-context (:ctx fork)))))
+              (is (= [:child]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(datahike.api/q
+                                 '[:find [?v ...] :where [_ :marker/id ?v]]
+                                 @(captured-db-connect! parent-db))"
+                              :execution-context (:ctx fork))))
+                  "the inherited logical config maps to child-owned physical storage")
+              (is (= [:parent]
+                     (:value (sandbox/eval-code
+                              parent-sci
+                              "(datahike.api/q
+                                 '[:find [?v ...] :where [_ :marker/id ?v]]
+                                 @(captured-db-connect! parent-db))"
+                              :execution-context (:ctx parent))))
+                  "same-config child writes cannot reach the parent's physical database")
+              (is (= [:parent :child]
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(swap! evidence conj :child)"
+                              :execution-context (:ctx fork)))))
+              (is (= [:parent]
+                     (:value (sandbox/eval-code
+                              parent-sci "@evidence"
+                              :execution-context (:ctx parent)))))
+              (let [binding (runtime-ctx/sandbox-binding
+                             (:ctx fork) (:capability-id child-working))
+                    physical-config (-> binding :ephemeral-databases vals first :config)]
+                (is (dh/database-exists? physical-config))
+                (room-context/drop-ctx! (:id fork) :researcher)
+                (is (not (dh/database-exists? physical-config))
+                    "dropping a world deletes its process-global scratch database"))
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"not available"
+                   (cc/sci-context-in child-working (:ctx fork)))))))
+        (finally
+          (when-let [fork @fork*]
+            (d/discard fork))
+          (d/close-room! parent))))))
+
 (deftest single-turn-replies
   (testing "Agent replies after a single :complete turn"
     (let [r (d/room :t)
@@ -191,14 +352,17 @@
                                   :run-turn-fn turn-fn})))
       (try
         (d/post! r (d/message :alice :worker "cancel this run"))
-        (is (= true (deref first-started 2000 ::timeout)))
+        ;; Creating the first room-bound interpreter can compile SCI/Spindel
+        ;; namespaces. Leave enough wall-clock headroom for contended CI hosts;
+        ;; the cancellation assertions below still test the semantic deadline.
+        (is (= true (deref first-started 10000 ::timeout)))
         (let [run-id (:run/id (first (run/active-runs :run-cancel-reuse)))]
           (is (uuid? run-id))
           (is (run/cancel-run! run-id))
           (is (await-condition
                #(= :cancelled (:run/status (run/run r run-id)))
-               3000)))
-        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 3000)]
+               10000)))
+        (let [reply (await-spin r #(d/ask % :worker {:content "next run"}) 10000)]
           (is (= "second completed" (:content reply)))
           (is (= :completed
                  (:run/status (run/run r (get-in reply [:metadata :run-id])))))
@@ -833,7 +997,7 @@
                                   :run-turn-fn (make-queued-turn-fn steps calls)})))
       (let [reply-f (future (await-spin r #(d/ask % :quiescent-worker
                                                   {:content "start"}) 5000))]
-        (is (true? (deref entered 3000 ::timeout)))
+        (is (true? (deref entered 10000 ::timeout)))
         (let [trigger (some #(when (= "start" (:content %)) %) (d/log r))]
           (d/post! r (d/reply :reviewer :quiescent-worker
                               "only at quiescence" trigger)))

--- a/test/dvergr/discourse/personas_test.clj
+++ b/test/dvergr/discourse/personas_test.clj
@@ -14,13 +14,21 @@
             [dvergr.chat.context :as cc]))
 
 (defn- await-spin
-  ([room spin-fn] (await-spin room spin-fn 3000))
+  ;; A first Room turn may need to initialize Datahike and the forkable SCI
+  ;; component before this deliberately trivial mock runs.  Three seconds made
+  ;; this an environment-speed assertion and hid the real failure behind nil
+  ;; map lookups in the callers.
+  ([room spin-fn] (await-spin room spin-fn 10000))
   ([room spin-fn wait-ms]
    (let [p (promise)]
      (binding [ec/*execution-context* (:ctx room)]
        (sp/spawn!
         (sp/spin (deliver p (sp/await (spin-fn room))))))
-     (deref p wait-ms ::timeout))))
+     (let [result (deref p wait-ms ::timeout)]
+       (when (= ::timeout result)
+         (throw (ex-info "Timed out waiting for persona mock turn"
+                         {:wait-ms wait-ms})))
+       result))))
 
 (defn- mock-turn-fn
   "A `run-turn-fn` that writes a single assistant message capturing the

--- a/test/dvergr/repl_meta_harness_test.clj
+++ b/test/dvergr/repl_meta_harness_test.clj
@@ -8,6 +8,8 @@
    registry and durable Datahike row."
   (:require [clojure.test :refer [deftest is testing]]
             [dvergr.agent.turn :as turn]
+            [dvergr.chat.context :as chat-context]
+            [dvergr.discourse :as discourse]
             [dvergr.discourse.definitions :as definitions]
             [dvergr.orchestration.daemon :as daemon]
             [dvergr.room.registry :as room-registry]
@@ -63,7 +65,8 @@
            tool-ctx
            (binding [ec/*execution-context* (:ctx parent)]
              (tools/make-context
-              {:sci-ctx       (:sci-ctx chat-ctx)
+              {:sci-ctx       (chat-context/sci-context-in
+                               chat-ctx (:ctx parent))
                :chat-ctx      chat-ctx
                :execution-ctx (:ctx parent)
                :isolation     :sci
@@ -81,33 +84,75 @@
                 ":children (set (map :slug "
                 "(dvergr.room/children " (pr-str parent-slug) ")))}")
            inspect-result (eval! parent tool-ctx inspect-code)
-           create-value (get-in create-result [:metadata :value])
-           inspect-value (get-in inspect-result [:metadata :value])
-           live-child (binding [ec/*execution-context* execution-ctx]
-                        (room-registry/lookup child-id))
-           durable-child (binding [ec/*execution-context* execution-ctx]
-                           (rooms/get-room-by-slug child-slug))
-           checks
-           {:create-tool-succeeded (= :success (:type create-result))
-            :inspect-tool-succeeded (= :success (:type inspect-result))
-            :sandbox-created-child  (= child-slug (get-in create-value [:child :slug]))
-            :repl-state-persisted   (= child-slug (:session-child-slug inspect-value))
-            :sandbox-sees-child     (true? (:visible? inspect-value))
-            :sandbox-sees-nesting   (contains? (:children inspect-value) child-slug)
-            :host-sees-child        (= child-id (:id live-child))
-            :host-sees-nesting      (= (room-store/slug->room-id parent-slug)
-                                       (:parent-id live-child))
-            :datahike-sees-child    (= child-slug (:room/slug durable-child))
-            :datahike-sees-nesting  (= parent-slug (:room/parent-slug durable-child))}]
-       {:passed? (every? true? (vals checks))
-        :checks checks
-        :parent-slug parent-slug
-        :child-slug child-slug
-        :create-result create-result
-        :inspect-result inspect-result
-        :live-room (select-keys live-child [:id :slug :title :parent-id])
-        :durable-room (select-keys durable-child
-                                   [:room/id :room/slug :room/name :room/parent-slug])}))))
+           world-fork (binding [ec/*execution-context* (:ctx parent)]
+                        (discourse/fork-room parent {:isolation :ctx}))]
+       (try
+         (let [fork-tool-ctx
+               (tools/make-context
+                {:sci-ctx       (chat-context/sci-context-in
+                                 chat-ctx (:ctx world-fork))
+                 :chat-ctx      chat-ctx
+                 :execution-ctx (:ctx world-fork)
+                 :isolation     :sci
+                 :tools         {"clojure_eval" (tools/get-tool "clojure_eval")}})
+               probe-id (random-uuid)
+               fork-result
+               (eval!
+                world-fork fork-tool-ctx
+                (str "(require '[datahike.api :as d] '[dvergr.room :as room]) "
+                     "(def fork-local " (pr-str probe-id) ") "
+                     "(d/transact room/*room* [{:message/id " (pr-str probe-id)
+                     " :message/content \"child-world-probe\"}]) "
+                     "{:var fork-local "
+                     " :db (d/q '[:find ?v . :in $ ?id :where "
+                     "[?e :message/id ?id] [?e :message/content ?v]] "
+                     "@room/*room* " (pr-str probe-id) ")}"))
+               parent-after-fork
+               (eval!
+                parent tool-ctx
+                (str "(require '[datahike.api :as d] '[dvergr.room :as room]) "
+                     "{:var-defined? (boolean (resolve 'fork-local)) "
+                     " :db (d/q '[:find ?v . :in $ ?id :where "
+                     "[?e :message/id ?id] [?e :message/content ?v]] "
+                     "@room/*room* " (pr-str probe-id) ")}"))
+               create-value (get-in create-result [:metadata :value])
+               inspect-value (get-in inspect-result [:metadata :value])
+               fork-value (get-in fork-result [:metadata :value])
+               parent-after-fork-value (get-in parent-after-fork [:metadata :value])
+               live-child (binding [ec/*execution-context* execution-ctx]
+                            (room-registry/lookup child-id))
+               durable-child (binding [ec/*execution-context* execution-ctx]
+                               (rooms/get-room-by-slug child-slug))
+               checks
+               {:create-tool-succeeded (= :success (:type create-result))
+                :inspect-tool-succeeded (= :success (:type inspect-result))
+                :sandbox-created-child  (= child-slug (get-in create-value [:child :slug]))
+                :repl-state-persisted   (= child-slug (:session-child-slug inspect-value))
+                :sandbox-sees-child     (true? (:visible? inspect-value))
+                :sandbox-sees-nesting   (contains? (:children inspect-value) child-slug)
+                :host-sees-child        (= child-id (:id live-child))
+                :host-sees-nesting      (= (room-store/slug->room-id parent-slug)
+                                           (:parent-id live-child))
+                :datahike-sees-child    (= child-slug (:room/slug durable-child))
+                :datahike-sees-nesting  (= parent-slug (:room/parent-slug durable-child))
+                :fork-tool-succeeded    (= :success (:type fork-result))
+                :fork-repl-diverged     (= probe-id (:var fork-value))
+                :fork-db-diverged       (= "child-world-probe" (:db fork-value))
+                :parent-var-unchanged   (false? (:var-defined? parent-after-fork-value))
+                :parent-db-unchanged    (nil? (:db parent-after-fork-value))}]
+           {:passed? (every? true? (vals checks))
+            :checks checks
+            :parent-slug parent-slug
+            :child-slug child-slug
+            :create-result create-result
+            :inspect-result inspect-result
+            :fork-result fork-result
+            :parent-after-fork parent-after-fork
+            :live-room (select-keys live-child [:id :slug :title :parent-id])
+            :durable-room (select-keys durable-child
+                                       [:room/id :room/slug :room/name :room/parent-slug])})
+         (finally
+           (discourse/discard world-fork)))))))
 
 (defn run-contract!
   "Run the contract in an isolated, provider-free daemon.
@@ -148,5 +193,6 @@
 (deftest agent-facing-repl-constructs-a-durable-nested-room
   (let [result (run-contract!)]
     (testing "every layer observes the room created from clojure_eval"
-      (is (:passed? result) (pr-str (:checks result)))
+      (is (:passed? result)
+          (pr-str (select-keys result [:checks :fork-result :parent-after-fork])))
       (is (every? true? (vals (:checks result)))))))

--- a/test/dvergr/room/registry_test.clj
+++ b/test/dvergr/room/registry_test.clj
@@ -1,0 +1,42 @@
+(ns dvergr.room.registry-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(deftest fork-registration-runs-admission-fences-before-publication
+  (let [root-ctx (context/create-execution-context)
+        child-ctx (context/fork-context root-ctx :mode :frozen)
+        room-id (keyword (str "rejected-fork-" (random-uuid)))
+        parent-id (keyword (str "parent-" (random-uuid)))
+        room (d/make-room {:id room-id
+                           :ctx child-ctx
+                           :store (memory/make)})
+        hook-id ::reject-this-fork]
+    ;; make-room auto-registers ordinary Rooms; remove that initial projection
+    ;; so this test exercises register-fork!'s publication boundary itself.
+    (binding [ec/*execution-context* root-ctx]
+      (registry/unregister! room-id))
+    (try
+      (binding [ec/*execution-context* root-ctx]
+        (registry/add-pre-register-hook!
+         hook-id
+         (fn [candidate]
+           (when (= room-id (:id candidate))
+             (throw (ex-info "rejected by admission fence" {})))))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"rejected by admission fence"
+             (registry/register-fork! room parent-id (random-uuid))))
+        (is (nil? (registry/lookup room-id))
+            "a rejected fork is never globally visible as a Room")
+        (is (empty? (filter #(= room-id (:fork/id %))
+                            (registry/structural-children parent-id)))
+            "a rejected fork publishes no topology edge"))
+      (finally
+        ;; Hooks are process-global and keyed for reload; neutralize this
+        ;; test-specific fence without disturbing production hooks.
+        (registry/add-pre-register-hook! hook-id (constantly nil))
+        (context/close-context! child-ctx)
+        (context/close-context! root-ctx)))))

--- a/test/dvergr/runtime/peer_bus_review_test.clj
+++ b/test/dvergr/runtime/peer_bus_review_test.clj
@@ -14,6 +14,7 @@
             [dvergr.intake.bash :as b]
             [dvergr.substrate.geschichte :as geschichte]
             [dvergr.room.registry :as registry]
+            [dvergr.system.rooms :as srooms]
             [dvergr.runtime.peer-bus :as peer-bus]
             [dvergr.sandbox.work :as sandbox-work]
             [org.replikativ.spindel.core :as sp]
@@ -92,6 +93,65 @@
         (is (= (:id fork) (:dvergr/origin (first evts))))
         (is (= :parent (:dvergr/parent (first evts))))
         (is (vector? (:workspace-id (first evts))))))))
+
+(deftest failed-fork-construction-rolls-back-the-world
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :rollback-parent *base-ctx*)
+          bad (assoc (d/echo :bad)
+                     :factory (fn [_]
+                                (throw (ex-info "clone failed" {:type ::clone-failed}))))
+          rooms-before (set (keys (registry/snapshot)))
+          discarded (atom 0)
+          discard! ygg/discard-fork!]
+      (d/join parent bad)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"clone failed"
+           (with-redefs [ygg/discard-fork!
+                         (fn [& args]
+                           (swap! discarded inc)
+                           (apply discard! args))]
+             (d/fork-room parent {:isolation :ctx}))))
+      (is (pos? @discarded) "the unreachable affine fork handle was settled")
+      (is (= rooms-before (set (keys (registry/snapshot))))
+          "no partially constructed Room became reachable")
+      (is (empty? (registry/structural-children (:id parent)))
+          "no stale settlement topology survived rollback"))))
+
+(deftest failed-fork-construction-drops-deferred-grants
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :rollback-grant-parent *base-ctx*)
+          grant {:room-id (random-uuid) :name "scratch" :scope :room}
+          dropped (atom nil)
+          bad (assoc (d/echo :bad-grant)
+                     :factory (fn [_]
+                                (ec/swap-state! [:dvergr/pending-grants]
+                                                (constantly [grant]))
+                                (throw (ex-info "clone failed after grant" {}))))]
+      (d/join parent bad)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"clone failed after grant"
+           (with-redefs [srooms/drop-fork-grants! #(reset! dropped %)]
+             (d/fork-room parent {:isolation :ctx}))))
+      (is (= [grant] @dropped)
+          "rollback releases storage grants provisioned inside the child world"))))
+
+(deftest fork-created-observability-failure-does-not-roll-back-publication
+  (binding [ec/*execution-context* *base-ctx*]
+    (let [parent (d/room :event-failure-parent *base-ctx*)
+          discarded (atom 0)
+          fork (with-redefs [peer-bus/post! (fn [_]
+                                              (throw (ex-info "observer unavailable" {})))
+                             ygg/discard-fork! (fn [& _] (swap! discarded inc))]
+                 (d/fork-room parent {:isolation :ctx}))]
+      (try
+        (is (identical? fork (registry/lookup (:id fork)))
+            "the atomically published Room remains authoritative")
+        (is (zero? @discarded)
+            "a failed control-plane notification cannot settle its live handle")
+        (finally
+          ;; The test replaced settlement only during construction; normal
+          ;; cleanup owns and settles the retained fork now.
+          (d/discard fork))))))
 
 (deftest propose-merge!-emits-event-and-tagged-message
   (binding [ec/*execution-context* *base-ctx*]

--- a/test/dvergr/sandbox/escape_corpus_test.clj
+++ b/test/dvergr/sandbox/escape_corpus_test.clj
@@ -103,7 +103,14 @@
       (testing "the agent's own room-facing surface is present"
         (is (= true (:ok (eval-in sci ec "(some? dvergr.room/kb-search)")))))
       (testing "in-jail file access works"
-        (is (= true (:ok (eval-in sci ec "(babashka.fs/exists? \"deps.edn\")")))))
+        (is (= true
+               (:ok (eval-in sci ec
+                             "(let [p (str \".capability-probe-\" (random-uuid))]
+                                (try
+                                  (spit p \"ok\")
+                                  (babashka.fs/exists? p)
+                                  (finally
+                                    (babashka.fs/delete-if-exists p))))")))))
       (testing "but escapes past the jail are refused"
         (is (:err (eval-in sci ec "(babashka.fs/exists? \"/etc/passwd\")")))
         (is (:err (eval-in sci ec "(slurp \"/etc/passwd\")")))))))

--- a/test/dvergr/sandbox/inference_world_test.clj
+++ b/test/dvergr/sandbox/inference_world_test.clj
@@ -57,9 +57,12 @@
                   "  {:values (infer/values posterior) "
                   "   :weights (infer/log-weights posterior) "
                   "   :ess (infer/ess posterior) "
-                  "   :worlds (infer/worlds posterior)})")
+                  "   :worlds (infer/worlds posterior) "
+                  "   :raw-particles (:particles posterior) "
+                  "   :raw-executor (:executor posterior)})")
                  :timeout-ms 15000)
-                {:keys [values weights ess worlds]} (:value result)]
+                {:keys [values weights ess worlds raw-particles raw-executor]}
+                (:value result)]
             (is (:success result) (pr-str (:error result)))
             (testing "posterior values retain independent selected ancestry"
               (is (= 4 (count values)))
@@ -70,7 +73,9 @@
               (is (= 4 (count worlds)))
               (is (every? #(and (map? %)
                                 (= :particle (:fork/purpose %)))
-                          worlds)))
+                          worlds))
+              (is (nil? raw-particles))
+              (is (nil? raw-executor)))
             (testing "particle writes do not contaminate the ambient room world"
               (is (= #{:root} (g/elements @knowledge {:sync? true})))))
           (let [pure
@@ -80,10 +85,16 @@
                   "(let [posterior @(spin (await (infer/smc-infer "
                   "                              (spin 7) 2 {:world-policy :fresh})))] "
                   "  {:values (infer/values posterior) "
-                  "   :worlds (infer/worlds posterior)})")
+                  "   :worlds (infer/worlds posterior) "
+                  "   :mean (:mean (infer/query posterior identity)) "
+                  "   :predictions (infer/predict posterior inc 3)})")
                  :timeout-ms 10000)]
             (testing "a proven-pure model may explicitly choose the cheap path"
               (is (:success pure) (pr-str (:error pure)))
-              (is (= {:values [7 7] :worlds []} (:value pure)))))))
+              (is (= {:values [7 7]
+                      :worlds []
+                      :mean 7.0
+                      :predictions [8 8 8]}
+                     (:value pure)))))))
       (finally
         (context/stop-context! root)))))

--- a/test/dvergr/sandbox/inference_world_test.clj
+++ b/test/dvergr/sandbox/inference_world_test.clj
@@ -60,7 +60,11 @@
                   "   :worlds (infer/worlds posterior) "
                   "   :raw-particles (:particles posterior) "
                   "   :raw-executor (:executor posterior)})")
-                 :timeout-ms 15000)
+                 ;; Canonical particle worlds fork and settle four complete
+                 ;; execution contexts. Keep the watchdog well above normal
+                 ;; latency so a memory-constrained full-suite worker does not
+                 ;; cancel healthy inference midway through settlement.
+                 :timeout-ms 60000)
                 {:keys [values weights ess worlds raw-particles raw-executor]}
                 (:value result)]
             (is (:success result) (pr-str (:error result)))
@@ -88,7 +92,7 @@
                   "   :worlds (infer/worlds posterior) "
                   "   :mean (:mean (infer/query posterior identity)) "
                   "   :predictions (infer/predict posterior inc 3)})")
-                 :timeout-ms 10000)]
+                 :timeout-ms 30000)]
             (testing "a proven-pure model may explicitly choose the cheap path"
               (is (:success pure) (pr-str (:error pure)))
               (is (= {:values [7 7]

--- a/test/dvergr/sandbox/inference_world_test.clj
+++ b/test/dvergr/sandbox/inference_world_test.clj
@@ -1,0 +1,89 @@
+(ns dvergr.sandbox.inference-world-test
+  "Dvergr's SCI inference surface defaults effectful particles to canonical worlds."
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.sandbox.ns.data :as data-ns]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [sci.core :as sci]
+            [yggdrasil.convergent.gset :as g]))
+
+(defn- memory-gset [id]
+  (g/gset id {:store-config {:backend :memory :id (random-uuid)}}
+          {:sync? true}))
+
+(deftest sci-smc-defaults-to-isolated-canonical-worlds
+  (let [root (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [knowledge (ygg/register!
+                         (-> (memory-gset "dvergr-inference-kb")
+                             (g/conj :root {:sync? true})))
+              sci-ctx (sandbox/fork-for-session root)]
+          (data-ns/add-inference-ns! sci-ctx)
+          ;; These are deliberately opaque host capabilities. SCI can request
+          ;; one mutation in its current particle world but cannot obtain a
+          ;; Yggdrasil handle or settlement authority.
+          (sci/add-namespace!
+           sci-ctx 'particle
+           {'id (fn []
+                  (rtp/get-state ec/*execution-context*
+                                 [:inference :particle-id]))
+            'write! (fn [value]
+                      (let [signal (ygg/system-signal "dvergr-inference-kb")]
+                        (reset! signal
+                                (g/conj @signal value {:sync? true})))
+                      value)
+            'values (fn []
+                      (g/elements @(ygg/system-signal "dvergr-inference-kb")
+                                  {:sync? true}))})
+          (let [result
+                (sandbox/eval-code
+                 sci-ctx
+                 (str
+                  "(require '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                  "         '[org.replikativ.spindel.effects.await :refer [await]] "
+                  "         '[org.replikativ.spindel.inference.effects :refer [observe]] "
+                  "         '[dist] '[infer] '[particle]) "
+                  "(let [model (spin "
+                  "              (let [id (particle/id)] "
+                  "                (particle/write! id) "
+                  "                (observe (dist/normal 0.0 1.0) 0.0 :id :evidence) "
+                  "                (particle/values))) "
+                  "      posterior @(spin (await (infer/smc-infer "
+                  "                              model 4 {:resample-threshold 2.0})))] "
+                  "  {:values (infer/values posterior) "
+                  "   :weights (infer/log-weights posterior) "
+                  "   :ess (infer/ess posterior) "
+                  "   :worlds (infer/worlds posterior)})")
+                 :timeout-ms 15000)
+                {:keys [values weights ess worlds]} (:value result)]
+            (is (:success result) (pr-str (:error result)))
+            (testing "posterior values retain independent selected ancestry"
+              (is (= 4 (count values)))
+              (is (every? #(and (= 2 (count %)) (contains? % :root)) values)))
+            (testing "portable inference projections contain no live authority"
+              (is (= 4 (count weights)))
+              (is (number? ess))
+              (is (= 4 (count worlds)))
+              (is (every? #(and (map? %)
+                                (= :particle (:fork/purpose %)))
+                          worlds)))
+            (testing "particle writes do not contaminate the ambient room world"
+              (is (= #{:root} (g/elements @knowledge {:sync? true})))))
+          (let [pure
+                (sandbox/eval-code
+                 sci-ctx
+                 (str
+                  "(let [posterior @(spin (await (infer/smc-infer "
+                  "                              (spin 7) 2 {:world-policy :fresh})))] "
+                  "  {:values (infer/values posterior) "
+                  "   :worlds (infer/worlds posterior)})")
+                 :timeout-ms 10000)]
+            (testing "a proven-pure model may explicitly choose the cheap path"
+              (is (:success pure) (pr-str (:error pure)))
+              (is (= {:values [7 7] :worlds []} (:value pure)))))))
+      (finally
+        (context/stop-context! root)))))


### PR DESCRIPTION
## Summary
- stack Dvergr on the reviewed Spindel particle-world implementation
- default SCI SMC, importance sampling, and generic kernel inference to canonical Yggdrasil world forks
- expose immutable posterior values, weights, ESS, and portable world descriptors without settlement capabilities
- retain an explicit `:world-policy :fresh` fast path for proven-pure models
- document how inference composes with Runs, evaluations, and affine world settlement

## Verification
- `clojure -M:test --focus dvergr.sandbox.inference-world-test` — 1 test, 10 assertions, 0 failures
- `clojure -M:test` — 620 tests, 2718 assertions, 0 failures
- `clojure -M:format` — clean
- `git diff --check` — clean

## Dependency
Stacked on Dvergr #84 and pins Spindel PR #47 exact commit `1eb9ae72f52a863b8592d7a193442262bbc264fd`, which is itself stacked on Spindel #46.