### PR TITLE
fix(agent): start hired runs with fresh runtime components

### DIFF
--- a/src/dvergr/agent/world.clj
+++ b/src/dvergr/agent/world.clj
@@ -23,7 +23,17 @@
                      :allowed settlement-policies})))
   (let [work (d/fork-room parent {:isolation :ctx
                                   :fork-opts {:purpose :run
-                                              :owner run-id}
+                                              :owner run-id
+                                              ;; A hired agent receives the
+                                              ;; durable substrate of its
+                                              ;; parent world, but constructs
+                                              ;; a fresh process-local runtime.
+                                              ;; In particular, recursively
+                                              ;; hiring from SCI must not try
+                                              ;; to fork the interpreter that
+                                              ;; is currently evaluating the
+                                              ;; hire! call.
+                                              :forkable-components #{}}
                                   ;; A Run world is an internal transaction, not
                                   ;; a child conversation. Nested agents enter
                                   ;; only through explicit hire/tool effects.

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -513,6 +513,56 @@
       (finally
         (d/close-room! room)))))
 
+(deftest llm-clojure-eval-can-recursively-hire-from-its-active-sci-world
+  (let [room (test-room :program-llm-recursive-sci-hire)
+        team (roster/make-agent
+              (roster/make-roster {:id :recursive-team})
+              {:id :orchestrator
+               :tools #{:clojure_eval}
+               :model-policy {:provider :test :model "stub"}
+               :program {:kind :llm :max-model-steps 2 :auto-compact? false}})
+        calls (atom 0)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    chat-agent/messages->api-format (fn [messages _ _] messages)
+                    model-chat/chat
+                    (fn [_ _]
+                      (if (= 1 (swap! calls inc))
+                        {:content ""
+                         :tool-calls
+                         [{:id "recursive-hire"
+                           :name "clojure_eval"
+                           :input
+                           {:code
+                            (str
+                             "(require '[dvergr.agent :as agent] "
+                             "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                             "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                             "(let [team (-> (agent/roster) "
+                             "               (agent/make-agent {:id :child "
+                             "                                  :program {:kind :scripted :reply :ok}})) "
+                             "      child (agent/hire! team :child {:task :work})] "
+                             "  @(spin (-> (await (agent/result-spin child)) :run/value)))")}}]
+                         :usage {:input-tokens 0 :output-tokens 0}
+                         :stop-reason :tool-use}
+                        {:content "done"
+                         :tool-calls nil
+                         :usage {:input-tokens 0 :output-tokens 0}
+                         :stop-reason :end-turn}))]
+        (let [root (binding [ec/*execution-context* (:ctx room)]
+                     (program/hire! room team :orchestrator {:task "delegate"}))
+              result (binding [ec/*execution-context* (:ctx room)] @root)
+              children (remove #(= (program/run-id root) (:run/id %))
+                               (run/runs room))]
+          (is (= :completed (:run/status result)))
+          (is (= 1 (count children)))
+          (is (= :child (:run/actor (first children))))
+          (is (= (program/run-id root) (:run/parent (first children))))
+          (is (= :completed (:run/status (first children))))
+          (is (= :merged (:run/settlement-status (first children))))))
+      (finally
+        (d/close-room! room)))))
+
 (deftest parallel-llm-hires-have-independent-chat-contexts
   (let [room (test-room :program-llm-isolation)
         team (roster/make-agent


### PR DESCRIPTION
## Summary

- fork durable Yggdrasil systems for hired Run worlds without inheriting the caller's process-local components
- let every hired LLM actor construct its own SCI runtime instead of recursively forking the interpreter currently evaluating `hire!`
- retain interpreter-heap forking for explicit Room forks
- add a production-path regression through the actual LLM tool loop and `clojure_eval`

## Why

A Codex-subscription orchestrator could author the correct recursive Dvergr program, but `agent/hire!` failed inside `clojure_eval` with:

> Cannot fork a SCI world from inside its active evaluation; suspend it first.

A hired actor is a fresh runtime over a forked durable world, whereas an explicit Room fork is a speculative continuation of the current runtime. This change makes that distinction explicit using Spindel's existing component-selection mechanism.

## Verification

- real REPL Codex-subscription join environment: reward 1.0, two completed/merged child Runs
- real REPL Codex-subscription self-programming environment: reward 1.0, three completed/merged specialist Runs
- focused program and SCI programming suites: 55 tests, 324 assertions
- focused program suite after adding the regression: 37 tests, 229 assertions
- formatting check
