### PR TITLE
feat(agent): add scoped recursive observability

### DIFF
--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -10,6 +10,7 @@
             [datahike.api :as dh]
             [dvergr.activity :as activity]
             [dvergr.agent.environment :as environment]
+            [dvergr.agent.observation :as observation]
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
@@ -87,6 +88,35 @@
 (def expected-self-programming-v1
   {:answer 23 :particles 2 :verified true})
 
+(def renewal-risk-task-v1
+  (str "Use clojure_eval to build and execute a small business-analysis harness. "
+       "Construct an immutable roster with two cheap simulated specialists. "
+       "The :sales specialist is scripted to return "
+       "{:account :acme :renewal 120000 :days 14}. The :support specialist is "
+       "scripted to return {:account :acme :severity :high :open-critical 3}. "
+       "Hire and compositionally await both specialists. Then call "
+       "(agent/inspect) from this Run and derive its Run count, active count, "
+       "and actor set; do not guess them. Combine the evidence into exactly "
+       "this EDN shape, setting :scope to the UUID returned by "
+       ":observation/scope-run-id and :inspection to the UUID returned by "
+       ":observation/receipt-id rather than guessing either: "
+       "{:account :acme :risk :high :renewal 120000 "
+       ":open-critical 3 :observed-runs 3 :active 1 "
+       ":observed-actors #{:orchestrator :sales :support} "
+       ":scope <UUID> :inspection <UUID>}. "
+       "The host Room also "
+       "contains private work outside your structural Run tree; it must not "
+       "appear in agent/inspect. Execute the program rather than describing it."))
+
+(def expected-renewal-risk-v1
+  {:account :acme
+   :risk :high
+   :renewal 120000
+   :open-critical 3
+   :observed-runs 3
+   :active 1
+   :observed-actors #{:orchestrator :sales :support}})
+
 (defn- parse-edn [value]
   (when (string? value)
     (with-open [reader (PushbackReader. (StringReader. value))]
@@ -140,6 +170,32 @@
       :specialists-merged? (every? #(= :merged (:run/settlement-status %))
                                    child-runs)})))
 
+(defn- renewal-risk-checks
+  [{:keys [result parsed-value durable-status active-after root-run-id
+           root-causes child-runs inspection-receipts]}]
+  (let [owned (filterv #(= root-run-id (:run/parent %)) child-runs)
+        outside (remove #(= root-run-id (:run/parent %)) child-runs)
+        owned-ids (into #{} (map :run/id) owned)
+        reported (dissoc parsed-value :scope :inspection)]
+    {:root-completed? (= :completed (:run/status result))
+     :durably-completed? (= :completed durable-status)
+     :quiescent? (zero? active-after)
+     :business-result? (= expected-renewal-risk-v1 reported)
+     :scope-from-observation? (= root-run-id (:scope parsed-value))
+     :inspection-executed?
+     (and (contains? inspection-receipts (:inspection parsed-value))
+          (observation/consume-receipt! root-run-id
+                                        (:inspection parsed-value)))
+     :two-specialists? (= 2 (count owned))
+     :expected-specialists? (= #{:sales :support}
+                               (set (map :run/actor owned)))
+     :all-results-observed? (= owned-ids root-causes)
+     :specialists-completed? (every? #(= :completed (:run/status %)) owned)
+     :private-control-run-present? (= #{:private-audit}
+                                      (set (map :run/actor outside)))
+     :private-control-run-not-reported?
+     (not (contains? (:observed-actors parsed-value) :private-audit))}))
+
 (defn- receipt-view [receipt]
   (select-keys receipt [:id :kind :source :destination :resources]))
 
@@ -190,6 +246,13 @@
 
 (defn- memory-environment [room-id _definition]
   (let [room (d/make-room {:id room-id :store (memory/make)})]
+    {:room room
+     :close! #(d/close-room! room)}))
+
+(defn- renewal-risk-environment [room-id _definition]
+  (let [room (d/make-room {:id room-id :store (memory/make)})
+        private-run (run/start! room :private-audit (random-uuid) nil)]
+    (run/finish! (:run/id private-run) :completed)
     {:room room
      :close! #(d/close-room! room)}))
 
@@ -272,9 +335,13 @@
 (def ^:private resource-setup-ref
   {:setup/id :dvergr.environment/resource-room :setup/version 1})
 
+(def ^:private renewal-risk-setup-ref
+  {:setup/id :dvergr.environment/renewal-risk-room :setup/version 1})
+
 (def ^:private trusted-setups
   {memory-setup-ref memory-environment
-   resource-setup-ref resource-environment})
+   resource-setup-ref resource-environment
+   renewal-risk-setup-ref renewal-risk-environment})
 
 (def ^:private trusted-verifiers
   {#:verifier{:id :programming/join-checks-v1 :version 1} join-checks
@@ -282,7 +349,9 @@
    #:verifier{:id :programming/self-programming-checks-v1 :version 1}
    self-programming-checks
    #:verifier{:id :programming/resource-delegation-checks-v1 :version 1}
-   resource-checks})
+   resource-checks
+   #:verifier{:id :business/renewal-risk-checks-v1 :version 1}
+   renewal-risk-checks})
 
 (defn- environment-case
   [id task verifier-id expected & [{:keys [setup limits world metadata]}]]
@@ -328,7 +397,18 @@
                      {:setup resource-setup-ref
                       :limits {:room-resources {resource/microdollars 20000M}
                                :run-resources {resource/microdollars 10000M}}
-                      :metadata {:kind :conserved-resource-delegation}})})
+                      :metadata {:kind :conserved-resource-delegation}})
+
+   :business/renewal-risk-brief-v1
+   (environment-case :business/renewal-risk-brief-v1 renewal-risk-task-v1
+                     :business/renewal-risk-checks-v1
+                     expected-renewal-risk-v1
+                     {:setup renewal-risk-setup-ref
+                      :metadata {:kind :business-workflow
+                                 :domain :revenue-operations
+                                 :capabilities #{:delegation
+                                                 :scoped-observation
+                                                 :evidence-synthesis}}})})
 
 (defn environment-definition
   "Return the exact portable definition for a named benchmark environment."
@@ -413,6 +493,7 @@
             all-runs (run/runs room {:limit 20})
             messages (d/messages room {:limit 100})
             activity (filter #(= :_activity (:to %)) messages)
+            tool-trace (mapv activity/tool-trace-entry activity)
             parsed (parse-edn (:run/value result))
             root-run-id (program/run-id handle)
             child-runs (remove #(= root-run-id (:run/id %)) all-runs)
@@ -423,6 +504,17 @@
                          :room-id room-id
                          :root-run-id root-run-id
                          :child-runs child-runs
+                         :tool-calls tool-trace
+                         :inspection-receipts
+                         (into #{}
+                               (comp
+                                (mapcat activity/message-activities)
+                                (filter #(and (= root-run-id (:activity/run-id %))
+                                              (= :observation
+                                                 (:activity/kind %))
+                                              (= :inspect (:activity/verb %))))
+                                (map :activity/id))
+                               messages)
                          :active-after (count (run/active-runs room-id))}
             observation (merge observation
                                (when resource-observation
@@ -435,8 +527,6 @@
                                              :run/actor :run/status :run/error
                                              :run/settlement-status])
                             all-runs)
-            tool-trace
-            (mapv activity/tool-trace-entry activity)
             resources (when resource-observation
                         (select-keys observation
                                      [:room-balance :root-balance :child-balances
@@ -506,3 +596,8 @@
   "Run the model-authored particle and verifier environment."
   [provider model]
   (run-environment! :programming/self-programming-v1 provider model))
+
+(defn run-renewal-risk-v1!
+  "Run the first simulated business workflow and recursive-observation eval."
+  [provider model]
+  (run-environment! :business/renewal-risk-brief-v1 provider model))

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -290,6 +290,42 @@ ceiling, so changing interface cannot mint provider authority. A trusted
 top-level Participant/tool context may delegate an LLM child; a paid AgentDef
 Run must first receive an eventual Kontor-backed provider allocation.
 
+## Scoped reflective observation
+
+The host REPL and a nested SCI harness use the same bounded projection over
+execution facts. From a hired program, `(agent/inspect)` returns the ambient Run
+and its structural descendants, correlated trigger/output/activity messages,
+active frontier, failures, settlement facts, and conserved balances when
+installed. It cannot enumerate its parent or siblings. A trusted Room operator
+uses `dvergr.clients.client/inspect-runs` with a nil scope to inspect the whole
+Room, or supplies a Run UUID to inspect exactly that subtree.
+
+```clojure
+(let [child (agent/hire! team :analyst {:task :renewal-risk})
+      _     (await (agent/result-spin child))
+      view  (agent/inspect)]
+  {:actors   (mapv :run/actor (:observation/runs view))
+   :frontier (:observation/frontier view)
+   :failures (:observation/failures view)})
+```
+
+The snapshot is a read model, not a second trace or mutable harness object.
+Durable Runs, Room messages, semantic activities, and Kontor receipts remain
+authoritative. Tool names and compact content previews are included; raw tool
+inputs are intentionally omitted. Per-message detail, total preview content,
+and live resource balances are independently capped because the value may enter
+an LLM context. A later reactive observer should fold the same facts into a
+Spindel signal rather than introduce another event family.
+
+SCI inspection also emits a correlated semantic observation receipt and returns
+its UUID. The durable activity is the audit projection; a bounded, single-use
+process-local issuance record supplies verifier authority, so writable Room data
+cannot forge proof that the trusted closure ran. This lets a live evaluator
+distinguish an actual inspection from generated code that merely mentions the
+API. A future cross-process verifier should replace the live issuance record
+with a governed signed receipt. The host snapshot remains a pure Room-operator
+query.
+
 ## Evaluation ladder
 
 An evaluation environment is an immutable `EnvironmentDef`, separate from any
@@ -417,7 +453,9 @@ queue/observe/restart, run-local cancellation, and reactive boundaries;
 `latest`/`serial`/`busy`/`parallel` work admission covers computation overlap as
 a separate FRP layer.
 Passing only one model is not sufficient evidence that the programming surface
-is clear.
+is clear. The broader business and machine-work portfolio, simulation ladder,
+and related Hermes reliability findings are tracked in
+[`practical-agent-evaluation.md`](practical-agent-evaluation.md).
 
 The first opt-in environments live in `dvergr.agent.program-bench` on the
 `:dev` classpath. They run through the production prompt, provider, tool, SCI,
@@ -430,6 +468,7 @@ their reports:
 (bench/run-race-v1! :claude-code "claude-code-sonnet")
 (bench/run-resource-v1! :codex-subscription "codex-subscription-sol")
 (bench/run-self-programming-v1! :codex-subscription "codex-subscription-sol")
+(bench/run-renewal-risk-v1! :codex-subscription "codex-subscription-sol")
 
 ;; The generic entry point makes the task/version explicit.
 (bench/run-environment! :programming/race-v1
@@ -439,7 +478,13 @@ their reports:
 It is an explicit REPL benchmark rather than a CI test because it is
 nondeterministic, needs local subscription authentication, and consumes model
 resources. Its language and lifecycle contracts are duplicated as
-provider-free deterministic tests. In the 2026-08-28 probe, Codex Sol and Claude
+provider-free deterministic tests. The renewal-risk environment is the first
+simulated business workflow: a model must construct sales/support specialists,
+join their evidence, and use scoped reflection while a private sibling Run
+exists in the control Room. Withheld Run and durable inspection-receipt UUIDs
+must be copied from the projection, so returning the right static business facts
+without actually inspecting cannot pass. The trusted verifier also checks the
+durable execution topology. In the 2026-08-28 probe, Codex Sol and Claude
 Code Sonnet each discovered the API, created and joined two child Runs, and
 returned the expected value with two `clojure_eval` calls. Earlier attempts
 exposed two real harness defects: the native interpreter omitted the shared

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -1,0 +1,131 @@
+# Practical agent evaluation
+
+Dvergr should measure complete useful work, not only code generation or clean
+single-turn tool use. The same evaluation boundary must cover a simulated
+workflow in CI, a frozen integration fixture during development, and a live
+provider/service probe from the REPL. Only the effect interpreter changes.
+
+## Workloads
+
+The first portfolio follows workflows people run with general personal and
+business agents such as Hermes:
+
+| Workflow | Observable outcome | Required effects |
+| --- | --- | --- |
+| Daily operations brief | Accurate, delivered brief with evidence | schedule, intake, search, artifact, delivery |
+| Revenue-risk review | Correct account actions and prioritization | CRM, support, calendar, delegation |
+| Inbox/support triage | Correct state changes with no missed SLA | mail, ticketing, knowledge, approval |
+| Competitive/market report | Supported claims and actionable positioning | web intake, browser, citations, report |
+| Campaign operation | Approved variants and measured outcomes | analytics, content, publication, accounting |
+| Incident response | Restored service and auditable changes | terminal, monitoring, notification, rollback |
+| Document/spreadsheet work | Semantically and visually correct artifact | office tools, files, rendering, review |
+
+Hermes' own documentation emphasizes scheduled briefs and monitoring,
+cross-platform messaging, browser/terminal work, skills, memory, and delegated
+research. Its implementation history also exposes useful reliability contracts:
+
+- scheduled work needs preflight validation, exact attempt admission, overlap
+  prevention, restart classification, and explicit delivery outcome;
+- child process lifecycle is not the same as verified task success;
+- gateway restarts must not silently interrupt message delivery;
+- large reports need artifact/chunk semantics rather than transport truncation;
+- broad tool registries need progressive disclosure and measurable context cost;
+- credentials given to a sandbox need an egress/secret boundary rather than
+  ambient host access.
+
+Related references:
+
+- [Hermes scheduled tasks](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron/)
+- [Hermes delegation](https://hermes-agent.nousresearch.com/docs/user-guide/features/delegation)
+- [Hermes tools](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools/)
+- [Lifecycle versus delegated task outcome](https://github.com/NousResearch/hermes-agent/pull/68499)
+- [Gateway restart and lost delivery](https://github.com/NousResearch/hermes-agent/issues/83683)
+- [Tool-schema context overhead](https://github.com/NousResearch/hermes-agent/issues/6839)
+- [Sandbox credential egress boundary](https://github.com/NousResearch/hermes-agent/pull/30179)
+- [AutomationBench business environments](https://github.com/zapier/AutomationBench)
+
+These are requirements to express through Dvergr's programming model, not a
+reason to port another monolithic agent loop.
+
+## Dvergr interpretation
+
+```text
+trigger stream
+  -> work-admission policy
+  -> Run in an isolated world
+  -> capability-scoped effects
+  -> durable semantic observations
+  -> trusted verification
+  -> Attempt / Episode
+  -> settlement and delivery
+```
+
+A schedule tick, incoming email, user message, webhook, analytics update, or
+model completion is an event. Spindel programs combine those events and effects;
+there is no separate cron-agent, browser-agent, or business-workflow runtime.
+Rooms hold discourse and durable control facts. Runs delimit causal execution.
+Worlds isolate speculative effects. Kontor accounts for resources. Evaluators
+certify outcomes independently of agent prose.
+
+Machine, container, VM, managed browser, SaaS simulator, and frozen fixture are
+world/effect interpreters selected by an EnvironmentDef. Cheap forked state is
+the default. Stronger substrates are explicit resources used only when the task
+requires their compatibility or isolation.
+
+## Recursive visibility contract
+
+An agent building a nested harness needs the same debugger as the host, within
+its authority. `agent/inspect` therefore projects the ambient structural Run
+subtree from durable facts. It includes a bounded Run tree, active frontier,
+correlated message/activity summaries, failures, settlement, and available
+resource balances. It excludes parents, siblings, hidden verifier state, and raw
+tool arguments. The host REPL uses the same projection with a wider scope.
+
+This snapshot is the first query. Reactive inspection should later be a Spindel
+signal folding the same Run/message/resource facts, not a second event log.
+Useful next fields are context composition/pressure, current effect and elapsed
+time, world diff/artifact summary, delivery status, retry safety, and the reason
+a Run is waiting.
+
+## Evaluation ladder
+
+Each practical EnvironmentDef should have four modes:
+
+1. **Laws** — provider-free tests for authority, lifecycle, cancellation,
+   conservation, idempotency, and visibility.
+2. **Simulation** — forkable deterministic business state and stubbed effects;
+   exact final-state assertions provide dense and binary rewards.
+3. **Frozen integration** — recorded mail/web/CRM/browser inputs exercise real
+   adapters without network drift or external writes.
+4. **Live probe** — opt-in provider and service access from the REPL, with
+   approvals and real resource accounting.
+
+Failures are classified at least as setup/configuration, model/provider,
+context/tool discovery, orchestration, effect execution, verification,
+settlement, delivery, or external-system drift. A failed setup must not be
+reported as deficient model reasoning.
+
+The first environment, `:business/renewal-risk-brief-v1`, is deliberately small.
+It requires a model to construct sales and support specialists, join evidence,
+inspect its own execution tree, and produce an exact risk brief while unrelated
+private work exists in the same control Room. Its deterministic SCI contract and
+trusted model-backed verifier establish the recursive boundary before real CRM,
+support, scheduling, or delivery effects are added.
+
+## Port order driven by failures
+
+1. Complete scoped observation and expose it in the REPL/UI.
+2. Add DatasetDef/ExperimentDef/Scorecard projections and repeated paired runs.
+3. Build a forkable business-state simulator and import an AutomationBench
+   smoke subset.
+4. Add scheduled trigger/execution/delivery receipts using ordinary Runs.
+5. Add browser/session ownership, cleanup, artifacts, and replayable frozen
+   snapshots.
+6. Add credential/egress capabilities for container and VM interpreters.
+7. Add mail/CRM/calendar/support adapters where a benchmark demonstrates demand.
+8. Add offline report judges and, later, randomized campaign/analytics outcomes.
+
+Every port should arrive with a task that fails without it, a deterministic
+contract where possible, and a paired model-backed measurement. Agent-authored
+tasks and verifiers remain proposals until a trusted parent reviews and admits
+them.

--- a/src/dvergr/agent/observation.clj
+++ b/src/dvergr/agent/observation.clj
@@ -1,0 +1,338 @@
+(ns dvergr.agent.observation
+  "Bounded, capability-scoped projections over one agent execution tree.
+
+   This is an observer, not a lifecycle owner or a second event log. Durable
+   Runs and Room messages remain authoritative; this namespace joins them into
+   a compact value suitable for the host REPL, SCI programs, UIs, and eval
+   traces. A non-nil scope Run can see only itself and structural descendants."
+  (:require [dvergr.activity :as activity]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as discourse]
+            [dvergr.resource :as resource]
+            [dvergr.room.store :as store]))
+
+(def ^:private default-run-limit 200)
+(def ^:private default-message-limit 200)
+(def ^:private default-content-limit 240)
+(def ^:private default-content-budget 12000)
+(def ^:private default-detail-limit 100)
+(def ^:private maximum-run-limit 500)
+(def ^:private maximum-message-limit 500)
+(def ^:private maximum-content-limit 1000)
+(def ^:private maximum-content-budget 64000)
+(def ^:private maximum-detail-limit 500)
+(def ^:private maximum-message-activities 20)
+(def ^:private maximum-message-tool-uses 20)
+(def ^:private maximum-resource-runs 32)
+(def ^:private active-statuses #{:running :cancelling})
+(def ^:private option-keys
+  #{:run-limit :message-limit :content-limit :content-budget :detail-limit})
+(def ^:private missing-balance ::missing-balance)
+(def ^:private maximum-live-receipts 4096)
+(defonce ^:private issued-receipts (atom {}))
+
+(defn issue-receipt!
+  "Issue a process-authenticated receipt for one scoped SCI inspection.
+
+   The durable activity is the audit projection. This bounded live registry is
+   separate verifier authority: writable Room data alone cannot forge proof
+   that the trusted SCI closure actually executed."
+  [run-id]
+  (let [receipt-id (random-uuid)
+        key [run-id receipt-id]
+        issued-at (System/nanoTime)]
+    (swap! issued-receipts
+           (fn [receipts]
+             (let [receipts (assoc receipts key issued-at)]
+               (if (<= (count receipts) maximum-live-receipts)
+                 receipts
+                 (into {} (take-last maximum-live-receipts
+                                     (sort-by val receipts)))))))
+    receipt-id))
+
+(defn revoke-receipt!
+  "Remove an issued receipt when its durable activity could not be written."
+  [run-id receipt-id]
+  (swap! issued-receipts dissoc [run-id receipt-id])
+  nil)
+
+(defn consume-receipt!
+  "Verify and consume a live receipt exactly once. Intended for trusted evals."
+  [run-id receipt-id]
+  (let [key [run-id receipt-id]
+        [before _] (swap-vals! issued-receipts dissoc key)]
+    (contains? before key)))
+
+(defn- validate-options [opts]
+  (when-not (map? opts)
+    (throw (ex-info "Observation options must be a map"
+                    {:type ::invalid-options :value opts})))
+  (when-let [unknown (seq (remove option-keys (keys opts)))]
+    (throw (ex-info "Unknown observation options"
+                    {:type ::unknown-options
+                     :unknown (set unknown)
+                     :allowed option-keys})))
+  opts)
+
+(defn- bounded-positive [opts key default maximum]
+  (let [value (get opts key default)]
+    (when-not (and (integer? value) (pos? value) (<= value maximum))
+      (throw (ex-info (str key " must be a positive integer no greater than " maximum)
+                      {:type ::invalid-limit
+                       :key key
+                       :value value
+                       :maximum maximum})))
+    value))
+
+(defn- content-preview [content limit]
+  (when (and (some? content) (pos? limit))
+    (let [value (str content)]
+      (if (<= (count value) limit)
+        value
+        (str (subs value 0 (dec limit)) "…")))))
+
+(defn- compact-value [value]
+  (when (some? value)
+    (content-preview value 80)))
+
+(defn- run-summary [candidate cause-limit]
+  (let [all-causes (vec (:run/caused-by candidate))
+        causes (take cause-limit all-causes)]
+    (cond->
+     (select-keys candidate
+                  [:run/id :run/kind :run/room :run/actor :run/trigger
+                   :run/parent :run/status :run/started-at
+                   :run/ended-at :run/world-id :run/settlement-status
+                   :run/settlement-reason])
+      (seq causes)
+      (assoc :run/caused-by (set causes)
+             :run/caused-by-count (count all-causes)
+             :run/caused-by-truncated? (> (count all-causes) cause-limit))
+      (:run/reason candidate)
+      (assoc :run/reason (compact-value (:run/reason candidate)))
+      (:run/error candidate)
+      (assoc :run/error (compact-value (:run/error candidate))))))
+
+(defn- run-summaries [runs detail-limit]
+  (reduce (fn [{:keys [remaining] :as state} candidate]
+            (let [cause-count (count (:run/caused-by candidate))
+                  allowed (min remaining cause-count)]
+              (-> state
+                  (update :summaries conj (run-summary candidate allowed))
+                  (assoc :remaining (- remaining allowed)))))
+          {:remaining detail-limit :summaries []}
+          runs))
+
+(defn- structural-depth [runs-by-id candidate]
+  (loop [current candidate depth 0 seen #{}]
+    (let [parent-id (:run/parent current)]
+      (if (and parent-id (not (contains? seen parent-id)))
+        (if-let [parent (get runs-by-id parent-id)]
+          (recur parent (inc depth) (conj seen parent-id))
+          depth)
+        depth))))
+
+(defn- run-order [runs-by-id candidate]
+  [(structural-depth runs-by-id candidate)
+   (some-> ^java.util.Date (:run/started-at candidate) .getTime)
+   (str (:run/id candidate))])
+
+(defn- activity-summary [fact]
+  (cond->
+   (select-keys fact
+                [:activity/id :activity/kind :activity/verb :activity/at
+                 :activity/run-id :activity/tool-use-id :activity/status
+                 :activity/critical?])
+    (:activity/tool-name fact)
+    (assoc :activity/tool-name (compact-value (:activity/tool-name fact)))
+    (:activity/outcome fact)
+    (assoc :activity/outcome (compact-value (:activity/outcome fact)))))
+
+(defn- message-summary [message preview-limit activity-limit tool-use-limit]
+  (let [all-facts (activity/message-activities message)
+        all-tool-uses (or (:tool-uses message)
+                          (get-in message [:metadata :tool-uses]))
+        facts (take activity-limit all-facts)
+        tool-uses (take tool-use-limit all-tool-uses)
+        content (some-> (:content message) str)]
+    (cond-> {:message/id (:id message)
+             :message/from (:from message)
+             :message/to (:to message)
+             :message/at (:ts message)
+             :message/in-reply-to (:in-reply-to message)
+             :message/thread-root-id (discourse/thread-root-id message)
+             :message/run-id (activity/message-run-id message)}
+      content
+      (assoc :message/content-truncated? (> (count content) preview-limit))
+
+      (and content (pos? preview-limit))
+      (assoc :message/content-preview (content-preview content preview-limit))
+
+      (seq facts)
+      (assoc :message/activities (mapv activity-summary facts)
+             :message/activity-count (count all-facts)
+             :message/activities-truncated?
+             (> (count all-facts) activity-limit))
+
+      (seq tool-uses)
+      (assoc :message/tool-uses
+             (mapv (fn [tool-use]
+                     {:tool-use/id (compact-value
+                                    (or (:tool-use/id tool-use)
+                                        (:id tool-use)))
+                      :tool-use/name (compact-value
+                                      (or (:tool-use/name tool-use)
+                                          (:name tool-use)))})
+                   tool-uses)
+             :message/tool-use-count (count all-tool-uses)
+             :message/tool-uses-truncated?
+             (> (count all-tool-uses) tool-use-limit)))))
+
+(defn- message-summaries [messages content-limit content-budget detail-limit]
+  (reduce (fn [{:keys [content-remaining detail-remaining] :as state} message]
+            (let [content-size (count (str (or (:content message) "")))
+                  preview-limit (min content-limit content-remaining content-size)
+                  activity-count (count (activity/message-activities message))
+                  activity-limit (min maximum-message-activities
+                                      detail-remaining activity-count)
+                  after-activities (- detail-remaining activity-limit)
+                  tool-use-count
+                  (count (or (:tool-uses message)
+                             (get-in message [:metadata :tool-uses])))
+                  tool-use-limit (min maximum-message-tool-uses
+                                      after-activities tool-use-count)]
+              (-> state
+                  (update :summaries conj
+                          (message-summary message preview-limit
+                                           activity-limit tool-use-limit))
+                  (assoc :content-remaining (- content-remaining preview-limit)
+                         :detail-remaining (- after-activities tool-use-limit)))))
+          {:content-remaining content-budget
+           :detail-remaining detail-limit
+           :summaries []}
+          messages))
+
+(defn- balance-if-present [read-balance]
+  (try
+    (read-balance)
+    (catch clojure.lang.ExceptionInfo error
+      (if (= :kontor.resource/account-not-found (:type (ex-data error)))
+        missing-balance
+        (throw error)))))
+
+(defn- resource-view [room scope-run-id frontier-runs]
+  (when (satisfies? store/PResourceStore (:store room))
+    (let [scope-balance
+          (balance-if-present
+           #(if scope-run-id
+              (resource/run-balance room scope-run-id)
+              (resource/balance room)))]
+      (when-not (= missing-balance scope-balance)
+        (let [bounded-runs (take maximum-resource-runs frontier-runs)]
+          {:scope scope-balance
+           :runs
+           (into (sorted-map-by #(compare (str %1) (str %2)))
+                 (keep (fn [candidate]
+                         (let [balance
+                               (balance-if-present
+                                #(resource/run-balance room (:run/id candidate)))]
+                           (when-not (= missing-balance balance)
+                             [(:run/id candidate) balance]))))
+                 bounded-runs)
+           :possibly-truncated?
+           (> (count frontier-runs) maximum-resource-runs)})))))
+
+(defn snapshot
+  "Return a compact observation of a Room's execution tree.
+
+   `scope-run-id` is a capability boundary: when present, only that structural
+   Run subtree and messages correlated with it are visible. Nil is the trusted
+   Room-operator view. Trigger messages are included even though they precede
+   and therefore are not produced by the Run.
+
+   Options are deliberately bounded because the returned value may enter an
+   LLM context: :run-limit (default 200, max 500), :message-limit (default 200,
+   max 500), :content-limit per message (default 240, max 1000),
+   :content-budget across the snapshot (default 12000, max 64000), and
+   :detail-limit across causes, activities, and tool uses (default 100, max
+   500)."
+  ([room scope-run-id] (snapshot room scope-run-id {}))
+  ([room scope-run-id opts]
+   (validate-options opts)
+   (when (and scope-run-id (not (uuid? scope-run-id)))
+     (throw (ex-info "Observation scope must be a Run UUID"
+                     {:type ::invalid-scope :scope-run-id scope-run-id})))
+   (let [run-limit (bounded-positive opts :run-limit default-run-limit
+                                     maximum-run-limit)
+         message-limit (bounded-positive opts :message-limit
+                                         default-message-limit
+                                         maximum-message-limit)
+         content-limit (bounded-positive opts :content-limit
+                                         default-content-limit
+                                         maximum-content-limit)
+         content-budget (bounded-positive opts :content-budget
+                                          default-content-budget
+                                          maximum-content-budget)
+         detail-limit (bounded-positive opts :detail-limit default-detail-limit
+                                        maximum-detail-limit)
+         runs (run/runs room (cond-> {:limit run-limit}
+                               scope-run-id (assoc :root-run-id scope-run-id)))]
+     (when (and scope-run-id
+                (not-any? #(= scope-run-id (:run/id %)) runs))
+       (throw (ex-info "Observation scope is not a Run in this Room"
+                       {:type ::unknown-scope
+                        :room-id (:id room)
+                        :scope-run-id scope-run-id})))
+     (let [runs-by-id (into {} (map (juxt :run/id identity)) runs)
+           ordered-runs (sort-by #(run-order runs-by-id %) runs)
+           run-projection (run-summaries ordered-runs detail-limit)
+           visible-runs (:summaries run-projection)
+           visible-ids (into #{} (map :run/id) visible-runs)
+           trigger-ids (into #{} (keep :run/trigger) visible-runs)
+           raw-messages (discourse/messages
+                         room {:limit message-limit
+                               :run-ids visible-ids
+                               :message-ids trigger-ids})
+           message-projection
+           (message-summaries raw-messages content-limit content-budget
+                              (:remaining run-projection))
+           visible-messages (:summaries message-projection)
+           activities (into []
+                            (mapcat #(or (:message/activities %) []))
+                            visible-messages)
+           frontier-runs (filterv #(contains? active-statuses (:run/status %))
+                                  visible-runs)
+           frontier (mapv :run/id frontier-runs)
+           failures (->> visible-runs
+                         (filter #(or (= :failed (:run/status %))
+                                      (:run/error %)
+                                      (= :settlement-failed
+                                         (:run/settlement-reason %))))
+                         (mapv #(select-keys % [:run/id :run/actor :run/status
+                                                :run/reason :run/error
+                                                :run/settlement-status
+                                                :run/settlement-reason])))
+           resources (resource-view room scope-run-id frontier-runs)
+           preview-size (reduce + 0
+                                (map #(count (or (:message/content-preview %) ""))
+                                     visible-messages))]
+       (cond->
+        {:observation/room-id (:id room)
+         :observation/scope-run-id scope-run-id
+         :observation/runs visible-runs
+         :observation/frontier frontier
+         :observation/messages visible-messages
+         :observation/activities activities
+         :observation/failures failures
+         :observation/summary
+         {:runs (count visible-runs)
+          :active (count frontier)
+          :messages (count visible-messages)
+          :activities (count activities)
+          :failures (count failures)
+          :possibly-truncated?
+          (or (= run-limit (count runs))
+              (= message-limit (count raw-messages))
+              (>= preview-size content-budget)
+              (zero? (:detail-remaining message-projection)))}}
+         resources (assoc :observation/resources resources))))))

--- a/src/dvergr/agent/run.clj
+++ b/src/dvergr/agent/run.clj
@@ -499,7 +499,10 @@
     (store/-load-run room-store (store-room-id room) run-id)))
 
 (defn runs
-  "List recent durable Runs from a Room store. Options: :limit, :status, :actor."
+  "List durable Runs from a Room store.
+
+   Options: :limit, :status, :actor, and :root-run-id. The structural root
+   restricts the query to that Run and descendants before applying the limit."
   ([room] (runs room {}))
   ([room opts]
    (if-let [room-store (:store room)]

--- a/src/dvergr/clients/client.clj
+++ b/src/dvergr/clients/client.clj
@@ -33,6 +33,7 @@
             [dvergr.discourse :as d]
             [dvergr.discourse.personas :as personas]
             [dvergr.agent.run :as run]
+            [dvergr.agent.observation :as observation]
             [dvergr.room.registry :as rreg]
             [dvergr.ops :as ops]
             [dvergr.orchestration.skills :as skills]
@@ -136,6 +137,13 @@
   "Recent durable Runs for a Room, newest first."
   ([room] (run/runs room))
   ([room opts] (run/runs room opts)))
+
+(defn inspect-runs
+  "Inspect a Room execution tree. With `scope-run-id`, restrict the projection
+   to that Run and its structural descendants; nil is the Room-operator view."
+  ([room] (observation/snapshot room nil))
+  ([room scope-run-id] (observation/snapshot room scope-run-id))
+  ([room scope-run-id opts] (observation/snapshot room scope-run-id opts)))
 
 (defn cancel-run!
   "Cooperatively cancel one live Run by UUID."

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -67,11 +67,15 @@
      This bounded lookup lets the authoritative Room derive and validate a
      reply's thread without trusting a client-supplied ancestor.")
 
-  (-list-messages [this room-id {:keys [limit since thread-root-id]}]
+  (-list-messages [this room-id {:keys [limit since thread-root-id run-ids message-ids]}]
     "Return messages in chronological order. :limit caps result size
      (default impl-specific); :since is an instant — only messages
      after that ts are returned; :thread-root-id restricts the result to one
-     topical projection before the limit is applied.")
+     topical projection before the limit is applied. :run-ids and :message-ids
+     select execution-correlated or exact envelope identities before limiting;
+     they are combined as a union and support bounded Run-tree observation.
+     Thread and execution projections are distinct query modes and cannot be
+     combined.")
 
   (-store-run! [this room-id run]
     "Create or update a durable Run projection owned by `room-id`. Run identity,
@@ -81,9 +85,12 @@
   (-load-run [this room-id run-id]
     "Return one durable Run by UUID when it belongs to `room-id`, else nil.")
 
-  (-list-runs [this room-id {:keys [limit status actor]}]
+  (-list-runs [this room-id {:keys [limit status actor root-run-id]}]
     "Return recent Runs, newest first. Optional :status and :actor filters are
-     applied before :limit."))
+     applied before :limit. :root-run-id restricts to that structural Run and
+     all descendants before limiting. Structural traversal cannot be combined
+     with :status or :actor; callers should project the bounded subtree and
+     filter it explicitly."))
 
 (defprotocol PResourceStore
   "Conserved resource authority cohabiting with durable Room control state.

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -644,18 +644,24 @@
               (:message/in-reply-to message)
               (:message/id message))))))
 
-  (-list-messages [_ room-id {:keys [limit since thread-root-id]}]
+  (-list-messages [_ room-id {:keys [limit since thread-root-id
+                                     run-ids message-ids]}]
+    (when (and thread-root-id (or (some? run-ids) (some? message-ids)))
+      (throw (ex-info "Thread and execution message filters cannot be combined"
+                      {:type :room-store/incompatible-message-filters})))
     (let [slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
         (let [chat-id (:chat/id ent)
+              n (or limit 100)
               ;; Resolve matching entity ids in Datalog before pulling message
               ;; bodies. In particular, the indexed thread root now bounds the
               ;; amount of data crossing the store boundary instead of loading
               ;; the whole Room and filtering it in Clojure. The two legacy
               ;; branches retain compatibility only for rows written before the
               ;; typed root existed.
-              message-ids
-              (if thread-root-id
+              thread-message-eids
+              (cond
+                thread-root-id
                 (dh/q '[:find [?m ...]
                         :in $ ?cid ?root
                         :where
@@ -668,13 +674,66 @@
                                  (and [?m :message/in-reply-to ?root]
                                       (not [?m :message/thread-root-id _])))]
                       @conn chat-id thread-root-id)
+
+                (or (some? run-ids) (some? message-ids))
+                nil
+
+                :else
                 (dh/q '[:find [?m ...]
                         :in $ ?cid
                         :where
                         [?c :chat/id ?cid]
                         [?m :message/chat ?c]]
                       @conn chat-id))
-              base    (dh/pull-many @conn message-pull-pattern message-ids)
+              execution-message-eids
+              (when (or (some? run-ids) (some? message-ids))
+                (let [run-rows
+                      (when (seq run-ids)
+                        (dh/q
+                         {:query
+                          '[:find ?m ?created ?id
+                            :in $ ?cid [?rid ...]
+                            :where
+                            [?c :chat/id ?cid]
+                            [?m :message/chat ?c]
+                            [?m :message/run-id ?rid]
+                            [?m :message/created-at ?created]
+                            [?m :message/id ?id]]
+                          :args [@conn chat-id (vec run-ids)]
+                          :order-by '[?created :desc ?id :asc]
+                          :limit n}))
+                      exact-rows
+                      (when (seq message-ids)
+                        (dh/q
+                         {:query
+                          '[:find ?m ?created ?id
+                            :in $ ?cid [?id ...]
+                            :where
+                            [?c :chat/id ?cid]
+                            [?m :message/chat ?c]
+                            [?m :message/id ?id]
+                            [?m :message/created-at ?created]]
+                          :args [@conn chat-id (vec message-ids)]
+                          :order-by '[?created :desc ?id :asc]
+                          :limit n}))]
+                  (->> (concat run-rows exact-rows)
+                       distinct
+                       (sort (fn [[_ left-time left-id]
+                                  [_ right-time right-id]]
+                               (let [time-order (compare right-time left-time)]
+                                 (if (zero? time-order)
+                                   (compare (str left-id) (str right-id))
+                                   time-order))))
+                       (take n)
+                       (mapv first))))
+              selected-message-eids
+              (cond
+                (nil? thread-message-eids) execution-message-eids
+                (some? execution-message-eids)
+                (filterv (set execution-message-eids) thread-message-eids)
+                :else thread-message-eids)
+              base    (dh/pull-many @conn message-pull-pattern
+                                    selected-message-eids)
               sorted  (sort-by #(.getTime (or (:message/created-at %)
                                               (java.util.Date. 0))) base)
               filtered (if since
@@ -810,15 +869,54 @@
                       @conn (:chat/id ent) run-id run-pull-pattern)
                 entity->run))))
 
-  (-list-runs [_ room-id {:keys [limit status actor]}]
+  (-list-runs [_ room-id {:keys [limit status actor root-run-id]}]
+    (when (and root-run-id (or status actor))
+      (throw (ex-info "Structural Run queries do not combine with status/actor"
+                      {:type :room-store/incompatible-run-filters
+                       :root-run-id root-run-id :status status :actor actor})))
     (let [slug (store/room-id->slug room-id)]
       (if-let [ent (room-by-slug conn slug)]
-        (->> (dh/q '[:find [(pull ?r pattern) ...]
-                     :in $ ?chat-id pattern
-                     :where
-                     [?c :chat/id ?chat-id]
-                     [?r :run/chat ?c]]
-                   @conn (:chat/id ent) run-pull-pattern)
+        (->> (if root-run-id
+               (let [db @conn
+                     chat-id (:chat/id ent)
+                     n (or limit 100)
+                     root (dh/q '[:find (pull ?r pattern) .
+                                  :in $ ?chat-id ?root-id pattern
+                                  :where
+                                  [?c :chat/id ?chat-id]
+                                  [?r :run/chat ?c]
+                                  [?r :run/id ?root-id]]
+                                db chat-id root-run-id run-pull-pattern)]
+                 (if-not root
+                   []
+                   (loop [selected [root]
+                          frontier [root-run-id]]
+                     (let [remaining (- n (count selected))]
+                       (if (or (zero? remaining) (empty? frontier))
+                         selected
+                         (let [rows
+                               (dh/q
+                                {:query
+                                 '[:find (pull ?r pattern) ?started ?id
+                                   :in $ ?chat-id [?parent-id ...] pattern
+                                   :where
+                                   [?c :chat/id ?chat-id]
+                                   [?r :run/chat ?c]
+                                   [?r :run/parent ?parent-id]
+                                   [?r :run/started-at ?started]
+                                   [?r :run/id ?id]]
+                                 :args [db chat-id frontier run-pull-pattern]
+                                 :order-by '[?started :desc ?id :asc]
+                                 :limit remaining})
+                               children (mapv first rows)]
+                           (recur (into selected children)
+                                  (mapv :run/id children))))))))
+               (dh/q '[:find [(pull ?r pattern) ...]
+                       :in $ ?chat-id pattern
+                       :where
+                       [?c :chat/id ?chat-id]
+                       [?r :run/chat ?c]]
+                     @conn (:chat/id ent) run-pull-pattern))
              (map entity->run)
              (filter #(if status (= status (:run/status %)) true))
              (filter #(if actor (= actor (:run/actor %)) true))

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -78,8 +78,14 @@
     (some #(when (= message-id (:id %)) (:thread-root-id %))
           (get-in @state [:messages room-id] [])))
 
-  (-list-messages [_ room-id {:keys [limit since thread-root-id]}]
+  (-list-messages [_ room-id {:keys [limit since thread-root-id
+                                     run-ids message-ids]}]
+    (when (and thread-root-id (or (some? run-ids) (some? message-ids)))
+      (throw (ex-info "Thread and execution message filters cannot be combined"
+                      {:type :room-store/incompatible-message-filters})))
     (let [all (get-in @state [:messages room-id] [])
+          selected-run-ids (set run-ids)
+          selected-message-ids (set message-ids)
           filtered (cond->> all
                      since
                      (filter #(let [t (:ts %)]
@@ -87,7 +93,13 @@
                                           (.getTime ^java.util.Date since)))))
 
                      thread-root-id
-                     (filter #(= thread-root-id (:thread-root-id %))))
+                     (filter #(= thread-root-id (:thread-root-id %)))
+
+                     (or (some? run-ids) (some? message-ids))
+                     (filter #(or (contains? selected-run-ids
+                                             (or (:run-id %)
+                                                 (get-in % [:metadata :run-id])))
+                                  (contains? selected-message-ids (:id %)))))
           n (or limit (count filtered))]
       (vec (take-last n filtered))))
 
@@ -107,15 +119,50 @@
   (-load-run [_ room-id run-id]
     (get-in @state [:runs room-id run-id]))
 
-  (-list-runs [_ room-id {:keys [limit status actor]}]
-    (->> (vals (get-in @state [:runs room-id] {}))
-         (filter #(if status (= status (:run/status %)) true))
-         (filter #(if actor (= actor (:run/actor %)) true))
-         (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
-                        #(str (:run/id %)))
-                  #(compare %2 %1))
-         (take (or limit 100))
-         vec))
+  (-list-runs [_ room-id {:keys [limit status actor root-run-id]}]
+    (when (and root-run-id (or status actor))
+      (throw (ex-info "Structural Run queries do not combine with status/actor"
+                      {:type :room-store/incompatible-run-filters
+                       :root-run-id root-run-id :status status :actor actor})))
+    (let [runs (vals (get-in @state [:runs room-id] {}))
+          n (or limit 100)
+          visible-runs
+          (when root-run-id
+            (when-let [root (some #(when (= root-run-id (:run/id %)) %) runs)]
+              (loop [selected [root]
+                     frontier [root-run-id]]
+                (let [remaining (- n (count selected))]
+                  (if (or (zero? remaining) (empty? frontier))
+                    selected
+                    (let [parents (set frontier)
+                          children
+                          (->> runs
+                               (filter #(contains? parents (:run/parent %)))
+                               (sort
+                                (fn [left right]
+                                  (let [left-time
+                                        (some-> ^java.util.Date
+                                         (:run/started-at left) .getTime)
+                                        right-time
+                                        (some-> ^java.util.Date
+                                         (:run/started-at right) .getTime)
+                                        time-order (compare right-time left-time)]
+                                    (if (zero? time-order)
+                                      (compare (str (:run/id left))
+                                               (str (:run/id right)))
+                                      time-order))))
+                               (take remaining)
+                               vec)]
+                      (recur (into selected children)
+                             (mapv :run/id children))))))))]
+      (->> (if root-run-id visible-runs runs)
+           (filter #(if status (= status (:run/status %)) true))
+           (filter #(if actor (= actor (:run/actor %)) true))
+           (sort-by (juxt #(some-> ^java.util.Date (:run/started-at %) .getTime)
+                          #(str (:run/id %)))
+                    #(compare %2 %1))
+           (take n)
+           vec)))
 
   store/PAttemptStore
 

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -62,6 +62,12 @@
         environment-ref* (requiring-resolve 'dvergr.agent.environment/environment-ref)
         hire-in*       (requiring-resolve 'dvergr.agent.program/hire-in!)
         observe*       (requiring-resolve 'dvergr.agent.program/observe)
+        snapshot*      (requiring-resolve 'dvergr.agent.observation/snapshot)
+        issue-receipt* (requiring-resolve 'dvergr.agent.observation/issue-receipt!)
+        revoke-receipt* (requiring-resolve 'dvergr.agent.observation/revoke-receipt!)
+        lifecycle-activity* (requiring-resolve 'dvergr.activity/lifecycle-activity)
+        message*       (requiring-resolve 'dvergr.discourse/message)
+        post*          (requiring-resolve 'dvergr.discourse/post!)
         cancel*        (requiring-resolve 'dvergr.agent.program/cancel!)
         run-id*        (requiring-resolve 'dvergr.agent.program/run-id)
         result-spin*   (requiring-resolve 'dvergr.agent.program/result-spin)
@@ -136,6 +142,39 @@
                                control-room (control-room! work-room)]
                            (binding [ec/*execution-context* (:ctx work-room)]
                              (observe* control-room handle-or-id))))
+        inspect-fn     (fn inspect-fn
+                         ([] (inspect-fn {}))
+                         ([opts]
+                          (let [work-room (room!)
+                                control-room (control-room! work-room)
+                                scope-run-id (:parent-run agent-program-ceiling)]
+                            (when-not scope-run-id
+                              (throw
+                               (ex-info
+                                "agent/inspect requires an ambient Run scope"
+                                {:type ::inspection-scope-required})))
+                            (binding [ec/*execution-context* (:ctx work-room)]
+                              (let [view (snapshot* control-room scope-run-id opts)
+                                    receipt-id (issue-receipt* scope-run-id)
+                                    receipt
+                                    (assoc
+                                     (lifecycle-activity*
+                                      scope-run-id :observation :inspect
+                                      :completed nil)
+                                     :activity/id receipt-id)]
+                                (try
+                                  (post* control-room
+                                         (message*
+                                          :system :_activity
+                                          "Inspected scoped execution tree"
+                                          nil
+                                          {:role :tool
+                                           :run-id scope-run-id
+                                           :activities [receipt]}))
+                                  (assoc view :observation/receipt-id receipt-id)
+                                  (catch Throwable error
+                                    (revoke-receipt* scope-run-id receipt-id)
+                                    (throw error))))))))
         cancel-fn      (fn [handle-or-id]
                          ;; Run cancellation tokens are process-local. Binding
                          ;; the Room ctx keeps this boundary consistent with
@@ -174,6 +213,7 @@
         'room-id      (fn [] (:id (room!)))
         'hire!        hire-fn
         'observe      observe-fn
+        'inspect      inspect-fn
         'cancel!      cancel-fn
         'balance      balance-fn
         'run-id       run-id*
@@ -191,6 +231,7 @@
          room-id      [([]) "Return the live identity of the current Room/world. In an isolated fork this is the child Room, not its parent."]
          hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]
+         inspect      [([] [opts]) "Inspect the current Run and its structural descendants as one bounded snapshot of Runs, frontier, correlated messages, semantic activities, failures, and conserved balances. Inside a hired agent this cannot see parent or sibling Runs, and inspection without an ambient Run fails closed. A durable semantic receipt identifies the inspection. Options: :run-limit, :message-limit, :content-limit, :content-budget, :detail-limit."]
          cancel!      [([handle-or-run-id]) "Request cooperative cancellation of exactly one live Run. Returns true when the Run was found."]
          balance      [([]) "Return the conserved resource vector available to the current Run, or the Room root at top level."]
          run-id       [([handle]) "Return the durable Run UUID represented by a RunHandle."]

--- a/test/dvergr/agent/observation_test.clj
+++ b/test/dvergr/agent/observation_test.clj
@@ -1,0 +1,207 @@
+(ns dvergr.agent.observation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as dh]
+            [dvergr.activity :as activity]
+            [dvergr.agent.observation :as observation]
+            [dvergr.agent.run :as run]
+            [dvergr.chat.schema :as schema]
+            [dvergr.discourse :as d]
+            [dvergr.room.store.datahike :as datahike]
+            [dvergr.room.store.memory :as memory]))
+
+(deftest snapshots-are-bounded-to-one-structural-run-tree
+  (let [room (d/make-room {:id :scoped-observation :store (memory/make)})
+        root-trigger (d/post! room (d/message :operator :orchestrator
+                                              "prepare the revenue brief"))
+        sibling-trigger (d/post! room (d/message :operator :unrelated
+                                                 "unrelated private work"))
+        root (run/start! room :orchestrator root-trigger nil)
+        sibling (run/start! room :unrelated sibling-trigger nil)
+        child-trigger (d/post! room (d/message :orchestrator :analyst
+                                               "inspect renewal risk"))
+        child (run/start! room :analyst child-trigger nil
+                          {:parent (:run/id root)})
+        fact {:activity/id (random-uuid)
+              :activity/run-id (:run/id child)
+              :activity/kind :tool
+              :activity/verb :invoke
+              :activity/tool-name "crm_query"
+              :activity/tool-use-id "crm-1"
+              :activity/at (java.util.Date.)}]
+    (try
+      (d/post! room
+               (d/reply :analyst :_activity
+                        (apply str (repeat 80 "risk "))
+                        child-trigger
+                        {:role :tool
+                         :run-id (:run/id child)
+                         :activities [fact]
+                         :tool-uses [{:id "crm-1" :name "crm_query"
+                                      :input {:account :private}}]}))
+      (run/finish! (:run/id child) :completed)
+      (let [scoped (observation/snapshot room (:run/id root)
+                                         {:content-limit 32})
+            operator (observation/snapshot room nil)
+            actors (mapv :run/actor (:observation/runs scoped))
+            tool-message (some #(when (= (:run/id child)
+                                         (:message/run-id %))
+                                  %)
+                               (:observation/messages scoped))]
+        (testing "a nested observer sees its root and descendants, not siblings"
+          (is (= [:orchestrator :analyst] actors))
+          (is (= [(:run/id root)] (:observation/frontier scoped)))
+          (is (= 1 (get-in scoped [:observation/summary :activities])))
+          (is (empty? (:observation/failures scoped)))
+          (is (= #{:orchestrator :analyst :unrelated}
+                 (set (map :run/actor (:observation/runs operator))))))
+        (testing "tool inputs stay out of the compact observation"
+          (is (= [{:tool-use/id "crm-1" :tool-use/name "crm_query"}]
+                 (:message/tool-uses tool-message)))
+          (is (not (re-find #"private" (pr-str tool-message))))
+          (is (.endsWith ^String (:message/content-preview tool-message) "…")))
+        (testing "the semantic activity keeps exact Run correlation"
+          (is (= (:run/id child)
+                 (-> scoped :observation/activities first
+                     :activity/run-id)))
+          (is (= (activity/message-run-id
+                  {:metadata {:run-id (:run/id child)}})
+                 (:run/id child)))))
+      (testing "a foreign or stale scope fails closed"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"not a Run in this Room"
+                              (observation/snapshot room (random-uuid)))))
+      (finally
+        (run/finish! (:run/id child) :completed)
+        (run/finish! (:run/id root) :completed)
+        (run/finish! (:run/id sibling) :completed)
+        (d/close-room! room)))))
+
+(deftest observation-limits-are-context-safety-boundaries
+  (let [room (d/make-room {:id :observation-limits :store (memory/make)})]
+    (try
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (observation/snapshot room nil {:run-limit 0})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (observation/snapshot room nil {:message-limit 5001})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (observation/snapshot room nil {:content-budget 64001})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (observation/snapshot room nil {:detail-limit 501})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (observation/snapshot room nil {:raw-tool-inputs? true})))
+      (finally
+        (d/close-room! room)))))
+
+(deftest observation-bounds-total-content-and-nested-detail
+  (let [room (d/make-room {:id :observation-detail-limits
+                           :store (memory/make)})
+        trigger (d/post! room (d/message :human :agent "start"))
+        current (run/start! room :agent trigger nil)
+        facts (mapv (fn [index]
+                      {:activity/id (random-uuid)
+                       :activity/run-id (:run/id current)
+                       :activity/kind :tool
+                       :activity/verb :invoke
+                       :activity/tool-name (str "tool-" index)})
+                    (range 25))
+        tool-uses (mapv (fn [index]
+                          {:id (str "tool-" index)
+                           :name (str "tool-" index)
+                           :input {:secret index}})
+                        (range 25))]
+    (try
+      (dotimes [_ 2]
+        (d/post! room
+                 (d/message :agent :_activity (apply str (repeat 20 "x"))
+                            nil
+                            {:run-id (:run/id current)
+                             :activities facts
+                             :tool-uses tool-uses})))
+      (let [view (observation/snapshot room (:run/id current)
+                                       {:content-limit 10 :content-budget 12})
+            messages (:observation/messages view)
+            detailed (filter :message/activity-count messages)]
+        (is (<= (reduce + 0 (map #(count (or (:message/content-preview %) ""))
+                                 messages))
+                12))
+        (is (every? #(= 25 (:message/activity-count %)) detailed))
+        (is (every? #(= 20 (count (:message/activities %))) detailed))
+        (is (every? :message/activities-truncated? detailed))
+        (is (every? #(= 20 (count (:message/tool-uses %))) detailed))
+        (is (not (re-find #"secret" (pr-str messages)))))
+      (let [view (observation/snapshot room (:run/id current)
+                                       {:detail-limit 10})]
+        (is (<= (+ (count (:observation/activities view))
+                   (reduce + 0
+                           (map #(count (:message/tool-uses %))
+                                (:observation/messages view))))
+                10)))
+      (finally
+        (run/finish! (:run/id current) :completed)
+        (d/close-room! room)))))
+
+(deftest an-unfunded-datahike-room-has-no-resource-view
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :keep-history? false
+             :schema-flexibility :write}]
+    (dh/create-database cfg)
+    (let [conn (dh/connect cfg)]
+      (try
+        (schema/ensure-full-schema! conn)
+        (let [room (d/make-room {:id :observation-unfunded
+                                 :store (datahike/make conn)})]
+          (try
+            (let [root-trigger (d/post! room (d/message :human :root "root"))
+                  sibling-trigger (d/post! room (d/message :human :sibling
+                                                           "private"))
+                  root (run/start! room :root root-trigger nil)
+                  child-trigger (d/post! room (d/message :root :child "child"))
+                  child (run/start! room :child child-trigger nil
+                                    {:parent (:run/id root)})
+                  sibling (run/start! room :sibling sibling-trigger nil)]
+              (try
+                (let [view (observation/snapshot room (:run/id root)
+                                                 {:run-limit 2
+                                                  :message-limit 2})]
+                  (is (= [:root :child]
+                         (mapv :run/actor (:observation/runs view))))
+                  (is (= #{(:id root-trigger) (:id child-trigger)}
+                         (set (map :message/id
+                                   (:observation/messages view)))))
+                  (is (not (contains? view :observation/resources))))
+                (finally
+                  (run/finish! (:run/id child) :completed)
+                  (run/finish! (:run/id root) :completed)
+                  (run/finish! (:run/id sibling) :completed))))
+            (finally
+              (d/close-room! room))))
+        (finally
+          (dh/release conn)
+          (dh/delete-database cfg))))))
+
+(deftest scope-filtering-happens-before-room-global-limits
+  (let [room (d/make-room {:id :observation-noisy-room :store (memory/make)})
+        root-trigger (d/post! room (d/message :human :root "root"))
+        root (run/start! room :root root-trigger nil)
+        child-trigger (d/post! room (d/message :root :child "child"))
+        child (run/start! room :child child-trigger nil {:parent (:run/id root)})]
+    (try
+      (dotimes [index 205]
+        (let [trigger (d/post! room (d/message :noise :noise (str index)))
+              sibling (run/start! room :noise trigger nil)]
+          (run/finish! (:run/id sibling) :completed)))
+      (let [view (observation/snapshot room (:run/id root)
+                                       {:run-limit 2 :message-limit 2})]
+        (is (= [:root :child]
+               (mapv :run/actor (:observation/runs view))))
+        (is (= #{(:id root-trigger) (:id child-trigger)}
+               (set (map :message/id (:observation/messages view))))))
+      (is (= [:root]
+             (mapv :run/actor
+                   (:observation/runs
+                    (observation/snapshot room (:run/id root)
+                                          {:run-limit 1})))))
+      (finally
+        (run/finish! (:run/id child) :completed)
+        (run/finish! (:run/id root) :completed)
+        (d/close-room! room)))))

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -104,6 +104,31 @@
       (is (= completed (store/-store-run! st room-id completed)))
       (is (= [completed] (store/-list-runs st room-id {:actor :agent/researcher})))
       (is (empty? (store/-list-runs st room-id {:status :failed})))
+      (let [lower-id (java.util.UUID/fromString
+                      "00000000-0000-0000-0000-000000000001")
+            upper-id (java.util.UUID/fromString
+                      "00000000-0000-0000-0000-000000000002")
+            child (fn [id actor]
+                    (-> completed
+                        (assoc :run/id id
+                               :run/actor actor
+                               :run/trigger (random-uuid)
+                               :run/parent run-id)
+                        (dissoc :run/caused-by)))]
+        (store/-store-run! st room-id (child upper-id :upper))
+        (store/-store-run! st room-id (child lower-id :lower))
+        (is (= #{run-id lower-id}
+               (set (map :run/id
+                         (store/-list-runs st room-id
+                                           {:root-run-id run-id :limit 2}))))
+            "bounded subtree selection is root-first with ascending UUID ties")
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"do not combine"
+             (store/-list-runs st room-id
+                               {:root-run-id run-id
+                                :status :completed
+                                :limit 1}))))
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"immutable"

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -1,6 +1,8 @@
 (ns dvergr.sandbox.agent-programming-test
   "Provider-free acceptance tests for the functional agent surface in room SCI."
   (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.activity :as activity]
+            [dvergr.agent.observation :as observation]
             [dvergr.agent.program :as program]
             [dvergr.agent.run :as run]
             [dvergr.agent.world :as world]
@@ -665,6 +667,71 @@
                  (:run/caused-by (run/run room parent-id))))))
       (finally
         (run/finish! parent-id :completed)
+        (d/close-room! room)))))
+
+(deftest nested-sci-harness-inspects-only-its-run-tree
+  (let [room       (d/make-room {:id :sci-agent-scoped-inspection
+                                 :store (memory/make)})
+        sci-ctx    (sandbox/fork-for-session (:ctx room))
+        parent-id  (:run/id (run/start! room :orchestrator (random-uuid) nil))
+        sibling-id (:run/id (run/start! room :private-sibling (random-uuid) nil))]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room)
+       {:program-kinds #{:echo :scripted}
+        :parent-run parent-id})
+      (let [result
+            (binding [ec/*execution-context* (:ctx room)]
+              (sandbox/eval-code
+               sci-ctx
+               (str
+                "(require '[dvergr.agent :as agent] "
+                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+                "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+                "(let [team (agent/make-agent (agent/roster) "
+                "                             {:id :analyst :program {:kind :echo}}) "
+                "      child (agent/hire! team :analyst {:task :renewal-risk})] "
+                "  @(spin (await (agent/result-spin child))) "
+                "  (let [view (agent/inspect)] "
+                "    {:scope (:observation/scope-run-id view) "
+                "     :receipt (:observation/receipt-id view) "
+                "     :actors (mapv :run/actor (:observation/runs view)) "
+                "     :runs (get-in view [:observation/summary :runs])}))")))]
+        (is (:success result) (pr-str (:error result)))
+        (is (= parent-id (get-in result [:value :scope])))
+        (is (= [:orchestrator :analyst] (get-in result [:value :actors])))
+        (is (= 2 (get-in result [:value :runs])))
+        (is (not-any? #{:private-sibling} (get-in result [:value :actors])))
+        (is (some #(= (get-in result [:value :receipt]) (:activity/id %))
+                  (mapcat activity/message-activities
+                          (d/messages room {:limit 20}))))
+        (is (false? (observation/consume-receipt! parent-id (random-uuid)))
+            "writable Room activity alone cannot mint verifier authority")
+        (is (observation/consume-receipt!
+             parent-id (get-in result [:value :receipt])))
+        (is (false? (observation/consume-receipt!
+                     parent-id (get-in result [:value :receipt])))
+            "inspection proof is single-use"))
+      (finally
+        (run/finish! parent-id :completed)
+        (run/finish! sibling-id :completed)
+        (d/close-room! room)))))
+
+(deftest sci-inspection-without-an-ambient-run-fails-closed
+  (let [room (d/make-room {:id :sci-agent-unscoped-inspection
+                           :store (memory/make)})
+        sci-ctx (sandbox/fork-for-session (:ctx room))]
+    (try
+      (agent-ns/add-programming-ns!
+       sci-ctx (:id room) (:ctx room) {:program-kinds #{:echo}})
+      (let [result (binding [ec/*execution-context* (:ctx room)]
+                     (sandbox/eval-code
+                      sci-ctx
+                      "(require '[dvergr.agent :as agent]) (agent/inspect)"))]
+        (is (false? (:success result)))
+        (is (re-find #"requires an ambient Run scope"
+                     (str (:error result)))))
+      (finally
         (d/close-room! room)))))
 
 (deftest sandbox-cannot-redirect-structural-parent-authority


### PR DESCRIPTION
## Summary

- add one bounded Run/message/resource projection shared by the trusted REPL and nested SCI harnesses
- fail closed at the SCI boundary, preserve structural scope before limits, and audit inspection with durable plus single-use live verifier receipts
- bound Datahike reads before pull and share global content/detail budgets suitable for model context
- add the first practical business EnvironmentDef: an orchestrator hires simulated sales/support specialists, joins evidence, and must prove scoped inspection while private sibling work exists
- document a practical eval portfolio derived from Hermes workflows/reliability gaps and AutomationBench

## Verification

- `clojure -M:format`
- focused observation/SCI/store contracts: 60 tests, 292 assertions, 0 failures
- focused SMC world regression after the system-pressure full run: 1 test, 12 assertions, 0 failures
- `clojure -T:build harness`
- Codex subscription live REPL eval: reward 1.0, all 12 checks pass, authenticated inspection receipt returned, 2 isolated specialists completed/merged, 0 active Runs afterward
- review agent final pass: no medium-or-higher findings

A full-suite pass earlier in this implementation cycle completed 657 tests / 2,968 assertions. The latest full run reached 657 tests / 2,972 assertions but the SMC world test hit its 60s watchdog under host memory pressure (swap was full); that namespace passed immediately in isolation. CI should provide the clean-room full-suite result.