### PR TITLE
fix(model): normalize Fireworks base URL

### DIFF
--- a/src/dvergr/model/api/openai.clj
+++ b/src/dvergr/model/api/openai.clj
@@ -380,9 +380,10 @@
   ([config env-lookup]
    (let [api-key (or (:api-key config)
                      (env-lookup "FIREWORKS_API_KEY"))
-         base-url (or (:base-url config)
-                      (env-lookup "FIREWORKS_BASE_URL")
-                      default-fireworks-base-url)
+         base-url (normalize-base-url
+                   (or (:base-url config)
+                       (env-lookup "FIREWORKS_BASE_URL")
+                       default-fireworks-base-url))
          credentials (or (:credentials config)
                          (when api-key
                            (gateway/static-credentials

--- a/test/dvergr/model/providers_test.clj
+++ b/test/dvergr/model/providers_test.clj
@@ -117,6 +117,19 @@
           (is (= "Bearer fireworks-only-credential" (bearer request)))
           (is (not (contains? (:body request) :reasoning_effort))))))))
 
+(deftest fireworks-custom-base-normalizes-like-catalog-discovery
+  (let [base-url "https://fireworks-gateway.example.test/v1"
+        env {"FIREWORKS_API_KEY" "fireworks-custom-credential"
+             "FIREWORKS_BASE_URL" (str base-url "///")}]
+    (with-provider-env
+      env
+      (fn []
+        (let [request (request-for :fireworks)]
+          (is (= (str base-url "/chat/completions") (:url request)))
+          (is (= "Bearer fireworks-custom-credential" (bearer request)))
+          (is (= #{"https://fireworks-gateway.example.test"}
+                 (gateway/allowed-origins (:credentials request)))))))))
+
 (deftest both-provider-credentials
   (let [env {"OPENAI_API_KEY" "openai-both-credential"
              "FIREWORKS_API_KEY" "fireworks-both-credential"}]


### PR DESCRIPTION
Normalize configured Fireworks base URLs before request URL construction and credential-origin scoping. This aligns execution with Simmis model catalog discovery and prevents trailing slashes from producing double-slash chat completion paths. Adds provider-boundary regression coverage.\n\nVerification:\n- focused provider tests: 7 tests, 45 assertions\n- format check: clean\n- harness uberjar: built successfully\n- isolated inference-world test: 1 test, 12 assertions\n- full suite completed 658 tests / 2982 assertions; the known system-memory-pressure SMC watchdog timed out and passed immediately in isolation