### PR TITLE
feat(agent): compose certified experiments

### DIFF
--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -404,8 +404,8 @@ Dataset acceptance, train/eval splits, particles, and proposal status are
 separate projections; none mutate certification.
 
 A `DatasetDef` groups exact EnvironmentDefs. An `ExperimentDef` binds that
-dataset to the complete Hasch identity of every candidate AgentDef, a repetition
-count, and bounded parallelism:
+dataset to the complete Hasch identity of every candidate AgentDef and a
+repetition count:
 
 ```clojure
 (let [dataset (agent/dataset
@@ -416,17 +416,21 @@ count, and bounded parallelism:
                    :dataset dataset
                    :candidates [(agent/lookup team :codex)
                                 (agent/lookup team :claude)]
-                   :repetitions 5
-                   :parallelism 2})]
+                   :repetitions 5})]
   ;; Host code supplies exact trusted Evaluator capabilities.
-  @(experiment/run room team experiment evaluator-map))
+  @(experiment/run room team experiment evaluator-map
+                   {:parallelism 2 :max-attempts 100}))
 ```
 
 Dataset and experiment construction is pure and available inside SCI. Execution
 and reward certification are host-only: an agent can propose the benchmark it
 should face, but it cannot install its verifier or certify itself. Before any
 Run is admitted, execution rejects a changed candidate definition or a missing
-exact Evaluator. It then composes ordinary evaluation Spins in bounded batches.
+exact Evaluator. Host policy—not agent-authored data—caps the attempt matrix and
+parallelism, then realizes ordinary evaluation Spins one bounded batch at a
+time. Batch execution initially accepts only `:discard` environments so a late
+failure cannot orphan earlier reviewable worlds without a recoverable partial
+experiment identity.
 The result contains every certified Attempt plus a content-addressed Scorecard
 with one entry per candidate/environment/repetition cell and deterministic
 per-candidate aggregates. Scorecards are immutable projections, not a mutable

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -400,20 +400,41 @@ Episode = immutable certified Attempt
 
 Review may later merge or discard the Run world. That changes the joined Run
 projection while the historical AttemptReceipt stays content-identical.
-Dataset acceptance, train/eval splits, rankings, particles, and proposal status
-are separate later projections; none mutate certification.
+Dataset acceptance, train/eval splits, particles, and proposal status are
+separate projections; none mutate certification.
 
-An ensemble is composition, not another primitive:
+A `DatasetDef` groups exact EnvironmentDefs. An `ExperimentDef` binds that
+dataset to the complete Hasch identity of every candidate AgentDef, a repetition
+count, and bounded parallelism:
 
 ```clojure
-(let [attempts (mapv #(evaluation/evaluate room team % environment evaluator)
-                     candidate-agent-refs)]
-  @(apply comb/parallel attempts))
+(let [dataset (agent/dataset
+               {:id :programming/core-v1
+                :environments [review-env race-env resource-env]})
+      experiment (agent/experiment
+                  {:id :models/paired-v1
+                   :dataset dataset
+                   :candidates [(agent/lookup team :codex)
+                                (agent/lookup team :claude)]
+                   :repetitions 5
+                   :parallelism 2})]
+  ;; Host code supplies exact trusted Evaluator capabilities.
+  @(experiment/run room team experiment evaluator-map))
 ```
 
-Pure policy can rank/select the resulting receipts. Existing room-fork
+Dataset and experiment construction is pure and available inside SCI. Execution
+and reward certification are host-only: an agent can propose the benchmark it
+should face, but it cannot install its verifier or certify itself. Before any
+Run is admitted, execution rejects a changed candidate definition or a missing
+exact Evaluator. It then composes ordinary evaluation Spins in bounded batches.
+The result contains every certified Attempt plus a content-addressed Scorecard
+with one entry per candidate/environment/repetition cell and deterministic
+per-candidate aggregates. Scorecards are immutable projections, not a mutable
+leaderboard or scheduler.
+
+Pure policy can rank/select the scorecards. Existing room-fork
 merge/discard/adoption remains the only settlement authority. SMC, MCTS,
-Anglican-style inference, and Raster training can consume this same boundary
+Anglican-style inference, and Raster training can consume the same Attempts
 without changing Run, Room, or world semantics.
 
 For training, an accepted episode is a projection across the exact

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -112,10 +112,30 @@ private work exists in the same control Room. Its deterministic SCI contract and
 trusted model-backed verifier establish the recursive boundary before real CRM,
 support, scheduling, or delivery effects are added.
 
+The comparison unit is now explicit. A DatasetDef fixes a non-empty ordered set
+of exact environments; an ExperimentDef fixes exact candidate AgentDef content,
+repetitions, and bounded parallelism. Its lazy Spindel execution produces the
+ordinary certified Attempts and a deterministic Scorecard over the full paired
+matrix. This supports repeated provider/model comparisons without giving
+Dvergr a second scheduler or allowing evaluated SCI code to own trusted
+verifiers. Initially the Scorecard is a portable returned value; durable Runs
+and Attempts remain the evidence of record. A leaderboard can later be a
+Datahike projection over admitted Scorecards rather than mutable benchmark
+state.
+
+The first provider-free room-REPL probe on 2026-09-04 executed two echo
+candidates against two environments with two repetitions and parallelism two.
+It produced eight distinct durable Runs, eight certified Attempts, two 4/4
+candidate summaries, one content-addressed Scorecard, and zero active Runs at
+completion. This validates the experiment composition itself; it is not model
+quality evidence. The existing Codex/Claude live environments still use a
+bespoke trusted setup path. Migrating one of them is the acceptance criterion
+for the next setup-capability slice.
+
 ## Port order driven by failures
 
 1. Complete scoped observation and expose it in the REPL/UI.
-2. Add DatasetDef/ExperimentDef/Scorecard projections and repeated paired runs.
+2. Use DatasetDef/ExperimentDef/Scorecard repeated paired runs in the live REPL.
 3. Build a forkable business-state simulator and import an AutomationBench
    smoke subset.
 4. Add scheduled trigger/execution/delivery receipts using ordinary Runs.

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -113,12 +113,15 @@ trusted model-backed verifier establish the recursive boundary before real CRM,
 support, scheduling, or delivery effects are added.
 
 The comparison unit is now explicit. A DatasetDef fixes a non-empty ordered set
-of exact environments; an ExperimentDef fixes exact candidate AgentDef content,
-repetitions, and bounded parallelism. Its lazy Spindel execution produces the
+of exact environments; an ExperimentDef fixes exact candidate AgentDef content
+and repetitions. Host-owned admission policy caps total attempts and
+parallelism. Its lazy Spindel execution produces the
 ordinary certified Attempts and a deterministic Scorecard over the full paired
 matrix. This supports repeated provider/model comparisons without giving
 Dvergr a second scheduler or allowing evaluated SCI code to own trusted
-verifiers. Initially the Scorecard is a portable returned value; durable Runs
+verifiers. Jobs are realized only one bounded batch at a time, and batch
+environments initially require discard settlement until partial experiments
+have durable recoverable identity. Initially the Scorecard is a portable returned value; durable Runs
 and Attempts remain the evidence of record. A leaderboard can later be a
 Datahike projection over admitted Scorecards rather than mutable benchmark
 state.

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -1,0 +1,461 @@
+(ns dvergr.agent.experiment
+  "Portable experiment definitions and pure scorecard projections.
+
+   A DatasetDef contains exact EnvironmentDefs. An ExperimentDef pairs every
+   environment with exact AgentDef identities and a repetition count. Running
+   an experiment merely composes ordinary evaluation Spins; Runs, worlds,
+   certified Attempts, and settlement retain their existing authority."
+  (:require [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.roster :as roster]
+            [hasch.core :as hasch]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.spin.combinators :as comb]))
+
+(defn- invalid! [message type data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn- positive-int! [label value]
+  (when-not (and (integer? value) (pos? value))
+    (invalid! (str label " must be a positive integer")
+              ::invalid-positive-integer {:label label :value value}))
+  value)
+
+(defn- portable-map! [label value]
+  (when-not (and (map? value) (roster/data-value? value))
+    (invalid! (str label " must be a portable map")
+              ::invalid-portable-map {:label label :value value}))
+  value)
+
+(def ^:private dataset-spec-keys #{:id :version :environments :metadata})
+(def ^:private dataset-keys
+  #{:dataset/id :dataset/version :dataset/environments :dataset/metadata
+    :dataset/content-id})
+(def ^:private required-dataset-keys
+  (disj dataset-keys :dataset/metadata))
+
+(defn make-dataset
+  "Construct a portable, content-addressed DatasetDef from a non-empty vector
+   of exact EnvironmentDefs. Environment content identities must be unique."
+  [{:keys [id version environments metadata]
+    :or {version 1}
+    :as opts}]
+  (when-let [unknown (seq (remove dataset-spec-keys (keys opts)))]
+    (invalid! "Dataset contains unknown keys" ::unknown-dataset-keys
+              {:unknown (set unknown) :allowed dataset-spec-keys}))
+  (when-not (keyword? id)
+    (invalid! "Dataset :id must be a keyword" ::invalid-dataset-id {:id id}))
+  (positive-int! "Dataset :version" version)
+  (when-not (and (vector? environments) (seq environments))
+    (invalid! "Dataset :environments must be a non-empty vector"
+              ::invalid-environments {:environments environments}))
+  (doseq [definition environments]
+    (environment/validate-environment definition))
+  (let [ids (mapv :environment/content-id environments)]
+    (when-not (= (count ids) (count (set ids)))
+      (invalid! "Dataset contains duplicate EnvironmentDefs"
+                ::duplicate-environments {:content-ids ids})))
+  (when (some? metadata) (portable-map! "Dataset :metadata" metadata))
+  (let [definition (cond-> {:dataset/id id
+                            :dataset/version version
+                            :dataset/environments environments}
+                     (some? metadata) (assoc :dataset/metadata metadata))]
+    (assoc definition :dataset/content-id
+           (hasch/uuid [:dvergr/dataset-definition definition]))))
+
+(defn validate-dataset
+  "Validate canonical DatasetDef data and its claimed content identity."
+  [dataset]
+  (when-not (map? dataset)
+    (invalid! "DatasetDef must be a map" ::invalid-dataset {:value dataset}))
+  (when-let [unknown (seq (remove dataset-keys (keys dataset)))]
+    (invalid! "DatasetDef contains unknown canonical keys"
+              ::unknown-dataset-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? dataset %)
+                                  required-dataset-keys))]
+    (invalid! "DatasetDef is missing canonical keys"
+              ::missing-dataset-keys {:missing (set missing)}))
+  (let [spec (cond-> {:id (:dataset/id dataset)
+                      :version (:dataset/version dataset)
+                      :environments (:dataset/environments dataset)}
+               (contains? dataset :dataset/metadata)
+               (assoc :metadata (:dataset/metadata dataset)))]
+    (when-not (= dataset (make-dataset spec))
+      (invalid! "DatasetDef is not canonical or its content ID is stale"
+                ::non-canonical-dataset {:dataset/id (:dataset/id dataset)})))
+  dataset)
+
+(defn dataset-ref
+  "Return the stable logical/version/content reference for a DatasetDef."
+  [dataset]
+  (select-keys (validate-dataset dataset)
+               [:dataset/id :dataset/version :dataset/content-id]))
+
+(defn- candidate [agent]
+  (when-not (and (map? agent)
+                 (keyword? (:agent/id agent))
+                 (integer? (:agent/version agent))
+                 (pos? (:agent/version agent))
+                 (roster/data-value? agent))
+    (invalid! "Experiment candidates must be portable AgentDefs"
+              ::invalid-candidate {:candidate agent}))
+  {:candidate/id (:agent/id agent)
+   :candidate/agent (roster/agent-ref agent)
+   :candidate/agent-content-id (hasch/uuid agent)})
+
+(def ^:private experiment-spec-keys
+  #{:id :version :dataset :candidates :repetitions :parallelism :metadata})
+(def ^:private experiment-keys
+  #{:experiment/id :experiment/version :experiment/dataset
+    :experiment/candidates :experiment/repetitions :experiment/parallelism
+    :experiment/metadata :experiment/content-id})
+(def ^:private required-experiment-keys
+  (disj experiment-keys :experiment/metadata))
+
+(defn make-experiment
+  "Construct a content-addressed full-factorial ExperimentDef.
+
+   `:candidates` is a non-empty vector of AgentDefs. Each stored candidate binds
+   its lightweight AgentRef to the hash of the complete definition. Every
+   candidate is evaluated in every DatasetDef environment `:repetitions` times.
+   `:parallelism` is an explicit bounded execution policy and defaults to one."
+  [{:keys [id version dataset candidates repetitions parallelism metadata]
+    :or {version 1 repetitions 1 parallelism 1}
+    :as opts}]
+  (when-let [unknown (seq (remove experiment-spec-keys (keys opts)))]
+    (invalid! "Experiment contains unknown keys" ::unknown-experiment-keys
+              {:unknown (set unknown) :allowed experiment-spec-keys}))
+  (when-not (keyword? id)
+    (invalid! "Experiment :id must be a keyword"
+              ::invalid-experiment-id {:id id}))
+  (positive-int! "Experiment :version" version)
+  (validate-dataset dataset)
+  (when-not (and (vector? candidates) (seq candidates))
+    (invalid! "Experiment :candidates must be a non-empty vector"
+              ::invalid-candidates {:candidates candidates}))
+  (let [candidates (mapv candidate candidates)
+        ids (mapv :candidate/id candidates)]
+    (when-not (= (count ids) (count (set ids)))
+      (invalid! "Experiment candidate ids must be unique"
+                ::duplicate-candidates {:candidate-ids ids}))
+    (positive-int! "Experiment :repetitions" repetitions)
+    (positive-int! "Experiment :parallelism" parallelism)
+    (when (some? metadata) (portable-map! "Experiment :metadata" metadata))
+    (let [definition
+          (cond-> {:experiment/id id
+                   :experiment/version version
+                   :experiment/dataset dataset
+                   :experiment/candidates candidates
+                   :experiment/repetitions repetitions
+                   :experiment/parallelism parallelism}
+            (some? metadata) (assoc :experiment/metadata metadata))]
+      (assoc definition :experiment/content-id
+             (hasch/uuid [:dvergr/experiment-definition definition])))))
+
+(defn validate-experiment
+  "Validate canonical ExperimentDef data and all embedded definitions."
+  [experiment]
+  (when-not (map? experiment)
+    (invalid! "ExperimentDef must be a map"
+              ::invalid-experiment {:value experiment}))
+  (when-let [unknown (seq (remove experiment-keys (keys experiment)))]
+    (invalid! "ExperimentDef contains unknown canonical keys"
+              ::unknown-experiment-keys {:unknown (set unknown)}))
+  (when-let [missing (seq (remove #(contains? experiment %)
+                                  required-experiment-keys))]
+    (invalid! "ExperimentDef is missing canonical keys"
+              ::missing-experiment-keys {:missing (set missing)}))
+  (validate-dataset (:experiment/dataset experiment))
+  (let [candidates (:experiment/candidates experiment)]
+    (when-not (and (vector? candidates) (seq candidates))
+      (invalid! "Experiment candidates must be a non-empty vector"
+                ::invalid-candidates {:candidates candidates}))
+    (doseq [c candidates]
+      (when-not (and (= #{:candidate/id :candidate/agent
+                          :candidate/agent-content-id}
+                        (set (keys c)))
+                     (keyword? (:candidate/id c))
+                     (= (:candidate/id c) (get-in c [:candidate/agent :agent/id]))
+                     (uuid? (:candidate/agent-content-id c))
+                     (= #{:agent/id :agent/version}
+                        (set (keys (:candidate/agent c))))
+                     (integer? (get-in c [:candidate/agent :agent/version]))
+                     (pos? (get-in c [:candidate/agent :agent/version])))
+        (invalid! "Experiment contains an invalid canonical candidate"
+                  ::invalid-candidate {:candidate c})))
+    (when-not (= (count candidates) (count (set (map :candidate/id candidates))))
+      (invalid! "Experiment candidate ids must be unique"
+                ::duplicate-candidates
+                {:candidate-ids (mapv :candidate/id candidates)})))
+  (positive-int! "Experiment :version" (:experiment/version experiment))
+  (positive-int! "Experiment :repetitions" (:experiment/repetitions experiment))
+  (positive-int! "Experiment :parallelism" (:experiment/parallelism experiment))
+  (when (contains? experiment :experiment/metadata)
+    (portable-map! "Experiment :metadata" (:experiment/metadata experiment)))
+  (when-not (and (keyword? (:experiment/id experiment))
+                 (roster/data-value? experiment))
+    (invalid! "ExperimentDef must contain portable data"
+              ::non-portable-experiment {:experiment experiment}))
+  (let [claimed (:experiment/content-id experiment)
+        actual (hasch/uuid [:dvergr/experiment-definition
+                            (dissoc experiment :experiment/content-id)])]
+    (when-not (= claimed actual)
+      (invalid! "ExperimentDef content ID does not match its content"
+                ::experiment-content-id-mismatch
+                {:claimed claimed :actual actual})))
+  experiment)
+
+(defn experiment-ref
+  "Return the stable logical/version/content reference for an ExperimentDef."
+  [experiment]
+  (select-keys (validate-experiment experiment)
+               [:experiment/id :experiment/version :experiment/content-id]))
+
+(defn- exact-agent! [team candidate]
+  (let [ref (:candidate/agent candidate)
+        agent (or (roster/agent team ref)
+                  (invalid! "Experiment candidate is absent from the Roster"
+                            ::unknown-candidate {:candidate candidate}))
+        actual (hasch/uuid agent)]
+    (when-not (= (:candidate/agent-content-id candidate) actual)
+      (invalid! "Roster AgentDef does not match the ExperimentDef candidate"
+                ::candidate-content-mismatch
+                {:candidate/id (:candidate/id candidate)
+                 :expected (:candidate/agent-content-id candidate)
+                 :actual actual}))
+    agent))
+
+(defn- evaluator! [evaluators definition]
+  (let [ref (:environment/verifier definition)
+        evaluator (get evaluators ref)]
+    (or evaluator
+        (invalid! "Experiment has no exact host Evaluator for an environment"
+                  ::missing-evaluator {:verifier ref
+                                       :environment
+                                       (environment/environment-ref definition)}))))
+
+(defn- jobs [experiment]
+  (vec
+   (for [candidate (:experiment/candidates experiment)
+         definition (get-in experiment
+                            [:experiment/dataset :dataset/environments])
+         repetition (range (:experiment/repetitions experiment))]
+     {:candidate candidate
+      :environment definition
+      :repetition repetition})))
+
+(defn- result-spin [room team evaluators opts job]
+  (let [definition (:environment job)
+        candidate (:candidate job)
+        ;; Construct every evaluation Spin during experiment preflight. This
+        ;; validates evaluator capability identity and environment policy before
+        ;; the first batch can admit a Run.
+        evaluation-spin
+        (evaluation/evaluate room team (:candidate/agent candidate)
+                             definition (evaluator! evaluators definition) opts)]
+    (sp/spin
+     (let [result (sp/await evaluation-spin)]
+       (assoc result :experiment/job
+              {:candidate/id (:candidate/id candidate)
+               :candidate/agent (:candidate/agent candidate)
+               :candidate/agent-content-id
+               (:candidate/agent-content-id candidate)
+               :environment (environment/environment-ref definition)
+               :repetition (:repetition job)})))))
+
+(defn- run-batches [spins parallelism]
+  (if (seq spins)
+    (let [batch (vec (take parallelism spins))
+          rest-spins (drop parallelism spins)]
+      (sp/spin
+       (let [head (if (= 1 (count batch))
+                    [(sp/await (first batch))]
+                    (sp/await (apply comb/parallel batch)))
+             tail (sp/await (run-batches rest-spins parallelism))]
+         (into head tail))))
+    (sp/spin [])))
+
+(defn- passed? [receipt]
+  (every? true? (vals (:attempt/checks receipt))))
+
+(defn- score-entry [{:keys [experiment/job attempt]}]
+  (attempt/validate-attempt attempt)
+  (let [receipt (:attempt/receipt attempt)]
+    (when-not (= [(:candidate/agent-content-id job) (:environment job)]
+                 [(:attempt/agent-def-hash attempt)
+                  (:attempt/environment receipt)])
+      (invalid! "Certified Attempt does not match its experiment cell"
+                ::attempt-cell-mismatch {:job job :attempt/id (:attempt/id attempt)}))
+    {:candidate/id (:candidate/id job)
+     :candidate/agent (:candidate/agent job)
+     :candidate/agent-content-id (:candidate/agent-content-id job)
+     :environment (:environment job)
+     :repetition (:repetition job)
+     :attempt/id (:attempt/id attempt)
+     :attempt/content-id (:attempt/content-id attempt)
+     :reward (:attempt/reward receipt)
+     :passed? (passed? receipt)}))
+
+(defn- summarize [entries]
+  (->> entries
+       (group-by :candidate/id)
+       (map (fn [[candidate-id xs]]
+              (let [rewards (map :reward xs)
+                    n (count xs)]
+                {:candidate/id candidate-id
+                 :attempt-count n
+                 :passed-count (count (filter :passed? xs))
+                 :reward-sum (reduce + 0 rewards)
+                 :reward-mean (double (/ (reduce + 0 rewards) n))})))
+       (sort-by (comp str :candidate/id))
+       vec))
+
+(defn- entry-sort-key [entry]
+  [(str (:candidate/id entry))
+   (str (get-in entry [:environment :environment/id]))
+   (:repetition entry)])
+
+(declare validate-scorecard)
+
+(defn make-scorecard
+  "Create a content-addressed Scorecard from successful evaluation results.
+   Every result must contain the certified Attempt produced for its exact cell."
+  [experiment results]
+  (validate-experiment experiment)
+  (let [entries (->> results (map score-entry)
+                     (sort-by entry-sort-key)
+                     vec)
+        expected (* (count (:experiment/candidates experiment))
+                    (count (get-in experiment
+                                   [:experiment/dataset :dataset/environments]))
+                    (:experiment/repetitions experiment))]
+    (when-not (= expected (count entries))
+      (invalid! "Scorecard requires exactly one Attempt per experiment cell"
+                ::incomplete-scorecard {:expected expected
+                                        :actual (count entries)}))
+    (when-not (= (count entries)
+                 (count (set (map (juxt :candidate/agent-content-id
+                                        (comp :environment/content-id
+                                              :environment)
+                                        :repetition)
+                                  entries))))
+      (invalid! "Scorecard contains duplicate experiment cells"
+                ::duplicate-scorecard-cells {}))
+    (let [scorecard {:scorecard/experiment experiment
+                     :scorecard/entries entries
+                     :scorecard/summary (summarize entries)}]
+      (validate-scorecard
+       (assoc scorecard :scorecard/content-id
+              (hasch/uuid [:dvergr/experiment-scorecard scorecard]))))))
+
+(defn validate-scorecard
+  "Validate a canonical Scorecard, its experiment-cell matrix, deterministic
+   aggregates, and claimed content identity."
+  [scorecard]
+  (when-not (and (map? scorecard)
+                 (= #{:scorecard/experiment :scorecard/entries
+                      :scorecard/summary :scorecard/content-id}
+                    (set (keys scorecard)))
+                 (roster/data-value? scorecard))
+    (invalid! "Scorecard must be canonical portable data"
+              ::invalid-scorecard {:scorecard scorecard}))
+  (validate-experiment (:scorecard/experiment scorecard))
+  (let [experiment (:scorecard/experiment scorecard)
+        entries (:scorecard/entries scorecard)
+        candidates (into {} (map (juxt :candidate/id identity)
+                                 (:experiment/candidates experiment)))
+        environments (into {}
+                           (map (juxt :environment/content-id identity)
+                                (get-in experiment
+                                        [:experiment/dataset
+                                         :dataset/environments])))
+        expected (* (count candidates) (count environments)
+                    (:experiment/repetitions experiment))]
+    (when-not (and (vector? entries) (= expected (count entries)))
+      (invalid! "Scorecard has an incomplete entry set"
+                ::incomplete-scorecard {:expected expected
+                                        :actual (count entries)}))
+    (when-not (= entries (vec (sort-by entry-sort-key entries)))
+      (invalid! "Scorecard entries are not in canonical cell order"
+                ::non-canonical-scorecard-order {}))
+    (doseq [entry entries]
+      (let [candidate (get candidates (:candidate/id entry))
+            environment-ref (:environment entry)
+            definition (get environments (:environment/content-id
+                                          environment-ref))]
+        (when-not (and
+                   (= #{:candidate/id :candidate/agent
+                        :candidate/agent-content-id :environment :repetition
+                        :attempt/id :attempt/content-id :reward :passed?}
+                      (set (keys entry)))
+                   (= (select-keys candidate
+                                   [:candidate/id :candidate/agent
+                                    :candidate/agent-content-id])
+                      (select-keys entry
+                                   [:candidate/id :candidate/agent
+                                    :candidate/agent-content-id]))
+                   definition
+                   (= environment-ref (environment/environment-ref definition))
+                   (integer? (:repetition entry))
+                   (<= 0 (:repetition entry))
+                   (< (:repetition entry)
+                      (:experiment/repetitions experiment))
+                   (uuid? (:attempt/id entry))
+                   (uuid? (:attempt/content-id entry))
+                   (number? (:reward entry))
+                   (Double/isFinite (double (:reward entry)))
+                   (boolean? (:passed? entry)))
+          (invalid! "Scorecard contains an invalid experiment-cell entry"
+                    ::invalid-scorecard-entry {:entry entry}))))
+    (when-not (= (count entries)
+                 (count (set (map (juxt :candidate/agent-content-id
+                                        (comp :environment/content-id
+                                              :environment)
+                                        :repetition)
+                                  entries))))
+      (invalid! "Scorecard contains duplicate experiment cells"
+                ::duplicate-scorecard-cells {}))
+    (when-not (= (:scorecard/summary scorecard) (summarize entries))
+      (invalid! "Scorecard summary does not match its entries"
+                ::scorecard-summary-mismatch {})))
+  (let [claimed (:scorecard/content-id scorecard)
+        actual (hasch/uuid [:dvergr/experiment-scorecard
+                            (dissoc scorecard :scorecard/content-id)])]
+    (when-not (= claimed actual)
+      (invalid! "Scorecard content ID does not match its content"
+                ::scorecard-content-id-mismatch
+                {:claimed claimed :actual actual})))
+  scorecard)
+
+(defn run
+  "Return a lazy Spin for one complete ExperimentDef.
+
+   `evaluators` is a host-owned map from exact verifier refs to Evaluator
+   capabilities. All candidates and evaluators are preflighted before the Spin
+   can admit a Run. Work is executed in bounded batches using Spindel. Options
+   are the ordinary evaluation options `:from` and `:parent-run`."
+  ([room team experiment evaluators]
+   (run room team experiment evaluators {}))
+  ([room team experiment evaluators opts]
+   (validate-experiment experiment)
+   (when-not (map? evaluators)
+     (invalid! "Experiment evaluators must be a host capability map"
+               ::invalid-evaluators {:evaluators evaluators}))
+   (doseq [candidate (:experiment/candidates experiment)]
+     (exact-agent! team candidate))
+   (doseq [definition (get-in experiment
+                              [:experiment/dataset :dataset/environments])]
+     (evaluator! evaluators definition))
+   (when-let [unknown (seq (remove #{:from :parent-run} (keys opts)))]
+     (invalid! "Experiment contains unknown run options"
+               ::unknown-run-options {:unknown (set unknown)}))
+   (let [spins (mapv #(result-spin room team evaluators opts %)
+                     (jobs experiment))]
+     (sp/spin
+      (let [results (sp/await
+                     (run-batches spins (:experiment/parallelism experiment)))]
+        {:experiment experiment
+         :results results
+         :attempts (mapv :attempt results)
+         :scorecard (make-scorecard experiment results)})))))

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -342,6 +342,9 @@
                                   entries))))
       (invalid! "Scorecard contains duplicate experiment cells"
                 ::duplicate-scorecard-cells {}))
+    (when-not (= (count entries) (count (set (map :attempt/id entries))))
+      (invalid! "Scorecard repetitions must name distinct Attempts"
+                ::duplicate-scorecard-attempts {}))
     (let [scorecard {:scorecard/experiment experiment
                      :scorecard/entries entries
                      :scorecard/summary (summarize entries)}]
@@ -416,6 +419,9 @@
                                   entries))))
       (invalid! "Scorecard contains duplicate experiment cells"
                 ::duplicate-scorecard-cells {}))
+    (when-not (= (count entries) (count (set (map :attempt/id entries))))
+      (invalid! "Scorecard repetitions must name distinct Attempts"
+                ::duplicate-scorecard-attempts {}))
     (when-not (= (:scorecard/summary scorecard) (summarize entries))
       (invalid! "Scorecard summary does not match its entries"
                 ::scorecard-summary-mismatch {})))

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -105,11 +105,11 @@
    :candidate/agent-content-id (hasch/uuid agent)})
 
 (def ^:private experiment-spec-keys
-  #{:id :version :dataset :candidates :repetitions :parallelism :metadata})
+  #{:id :version :dataset :candidates :repetitions :metadata})
 (def ^:private experiment-keys
   #{:experiment/id :experiment/version :experiment/dataset
-    :experiment/candidates :experiment/repetitions :experiment/parallelism
-    :experiment/metadata :experiment/content-id})
+    :experiment/candidates :experiment/repetitions :experiment/metadata
+    :experiment/content-id})
 (def ^:private required-experiment-keys
   (disj experiment-keys :experiment/metadata))
 
@@ -119,9 +119,10 @@
    `:candidates` is a non-empty vector of AgentDefs. Each stored candidate binds
    its lightweight AgentRef to the hash of the complete definition. Every
    candidate is evaluated in every DatasetDef environment `:repetitions` times.
-   `:parallelism` is an explicit bounded execution policy and defaults to one."
-  [{:keys [id version dataset candidates repetitions parallelism metadata]
-    :or {version 1 repetitions 1 parallelism 1}
+   Concurrency and admission ceilings belong to host execution policy, not to
+   this agent-authorable definition."
+  [{:keys [id version dataset candidates repetitions metadata]
+    :or {version 1 repetitions 1}
     :as opts}]
   (when-let [unknown (seq (remove experiment-spec-keys (keys opts)))]
     (invalid! "Experiment contains unknown keys" ::unknown-experiment-keys
@@ -140,15 +141,13 @@
       (invalid! "Experiment candidate ids must be unique"
                 ::duplicate-candidates {:candidate-ids ids}))
     (positive-int! "Experiment :repetitions" repetitions)
-    (positive-int! "Experiment :parallelism" parallelism)
     (when (some? metadata) (portable-map! "Experiment :metadata" metadata))
     (let [definition
           (cond-> {:experiment/id id
                    :experiment/version version
                    :experiment/dataset dataset
                    :experiment/candidates candidates
-                   :experiment/repetitions repetitions
-                   :experiment/parallelism parallelism}
+                   :experiment/repetitions repetitions}
             (some? metadata) (assoc :experiment/metadata metadata))]
       (assoc definition :experiment/content-id
              (hasch/uuid [:dvergr/experiment-definition definition])))))
@@ -190,7 +189,6 @@
                 {:candidate-ids (mapv :candidate/id candidates)})))
   (positive-int! "Experiment :version" (:experiment/version experiment))
   (positive-int! "Experiment :repetitions" (:experiment/repetitions experiment))
-  (positive-int! "Experiment :parallelism" (:experiment/parallelism experiment))
   (when (contains? experiment :experiment/metadata)
     (portable-map! "Experiment :metadata" (:experiment/metadata experiment)))
   (when-not (and (keyword? (:experiment/id experiment))
@@ -236,21 +234,17 @@
                                        (environment/environment-ref definition)}))))
 
 (defn- jobs [experiment]
-  (vec
-   (for [candidate (:experiment/candidates experiment)
-         definition (get-in experiment
-                            [:experiment/dataset :dataset/environments])
-         repetition (range (:experiment/repetitions experiment))]
-     {:candidate candidate
-      :environment definition
-      :repetition repetition})))
+  (for [candidate (:experiment/candidates experiment)
+        definition (get-in experiment
+                           [:experiment/dataset :dataset/environments])
+        repetition (range (:experiment/repetitions experiment))]
+    {:candidate candidate
+     :environment definition
+     :repetition repetition}))
 
 (defn- result-spin [room team evaluators opts job]
   (let [definition (:environment job)
         candidate (:candidate job)
-        ;; Construct every evaluation Spin during experiment preflight. This
-        ;; validates evaluator capability identity and environment policy before
-        ;; the first batch can admit a Run.
         evaluation-spin
         (evaluation/evaluate room team (:candidate/agent candidate)
                              definition (evaluator! evaluators definition) opts)]
@@ -314,6 +308,8 @@
 (defn- entry-sort-key [entry]
   [(str (:candidate/id entry))
    (str (get-in entry [:environment :environment/id]))
+   (get-in entry [:environment :environment/version])
+   (str (get-in entry [:environment :environment/content-id]))
    (:repetition entry)])
 
 (declare validate-scorecard)
@@ -438,12 +434,19 @@
   "Return a lazy Spin for one complete ExperimentDef.
 
    `evaluators` is a host-owned map from exact verifier refs to Evaluator
-   capabilities. All candidates and evaluators are preflighted before the Spin
-   can admit a Run. Work is executed in bounded batches using Spindel. Options
-   are the ordinary evaluation options `:from` and `:parent-run`."
+   capabilities. All candidates, evaluators, environment policies, and host
+   admission ceilings are preflighted before the Spin can admit a Run. Jobs and
+   evaluation Spins are realized one bounded batch at a time. Options include
+   ordinary evaluation `:from`/`:parent-run` plus host-owned `:parallelism`,
+   `:max-parallelism`, and `:max-attempts`. Experiment batches initially require
+   discard settlement; retained partial experiments need durable execution
+   identity and recovery first."
   ([room team experiment evaluators]
    (run room team experiment evaluators {}))
-  ([room team experiment evaluators opts]
+  ([room team experiment evaluators
+    {:keys [parallelism max-parallelism max-attempts]
+     :or {parallelism 1 max-parallelism 16 max-attempts 256}
+     :as opts}]
    (validate-experiment experiment)
    (when-not (map? evaluators)
      (invalid! "Experiment evaluators must be a host capability map"
@@ -452,16 +455,54 @@
      (exact-agent! team candidate))
    (doseq [definition (get-in experiment
                               [:experiment/dataset :dataset/environments])]
-     (evaluator! evaluators definition))
-   (when-let [unknown (seq (remove #{:from :parent-run} (keys opts)))]
+     (evaluator! evaluators definition)
+     (when-not (= :discard (get-in definition
+                                   [:environment/world :settlement]))
+       (invalid! "Experiment batches currently require :discard settlement"
+                 ::retained-experiment-unsupported
+                 {:environment (environment/environment-ref definition)
+                  :settlement (get-in definition
+                                      [:environment/world :settlement])})))
+   (when-let [unknown (seq (remove #{:from :parent-run :parallelism
+                                     :max-parallelism :max-attempts}
+                                   (keys opts)))]
      (invalid! "Experiment contains unknown run options"
                ::unknown-run-options {:unknown (set unknown)}))
-   (let [spins (mapv #(result-spin room team evaluators opts %)
-                     (jobs experiment))]
+   (doseq [[label value] [["Experiment :parallelism" parallelism]
+                          ["Experiment :max-parallelism" max-parallelism]
+                          ["Experiment :max-attempts" max-attempts]]]
+     (positive-int! label value))
+   (when (> parallelism max-parallelism)
+     (invalid! "Experiment parallelism exceeds the host admission ceiling"
+               ::parallelism-exceeds-ceiling
+               {:parallelism parallelism :max-parallelism max-parallelism}))
+   (let [attempt-count (* (count (:experiment/candidates experiment))
+                          (count (get-in experiment
+                                         [:experiment/dataset
+                                          :dataset/environments]))
+                          (:experiment/repetitions experiment))
+         _ (when (> attempt-count max-attempts)
+             (invalid! "Experiment size exceeds the host admission ceiling"
+                       ::attempts-exceed-ceiling
+                       {:attempt-count attempt-count
+                        :max-attempts max-attempts}))
+         evaluation-opts (select-keys opts [:from :parent-run])
+         ;; Validate every distinct candidate/environment pairing once before
+         ;; execution. Repetitions are constructed lazily per bounded batch.
+         _ (doseq [candidate (:experiment/candidates experiment)
+                   definition (get-in experiment
+                                      [:experiment/dataset
+                                       :dataset/environments])]
+             (evaluation/evaluate room team (:candidate/agent candidate)
+                                  definition (evaluator! evaluators definition)
+                                  evaluation-opts))
+         spins (map #(result-spin room team evaluators evaluation-opts %)
+                    (jobs experiment))]
      (sp/spin
-      (let [results (sp/await
-                     (run-batches spins (:experiment/parallelism experiment)))]
+      (let [results (sp/await (run-batches spins parallelism))]
         {:experiment experiment
+         :execution {:parallelism parallelism
+                     :attempt-count attempt-count}
          :results results
          :attempts (mapv :attempt results)
          :scorecard (make-scorecard experiment results)})))))

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -238,7 +238,7 @@
          environment-ref [([environment]) "Return the stable logical/version/content reference for one exact EnvironmentDef. Individual execution Run IDs remain unique."]
          dataset      [([spec]) "Create a portable DatasetDef from a non-empty vector of exact EnvironmentDefs. Dataset construction is pure and content-addressed."]
          dataset-ref  [([dataset]) "Return the stable logical/version/content reference for one exact DatasetDef."]
-         experiment   [([spec]) "Create a portable full-factorial ExperimentDef. Requires a DatasetDef and a non-empty vector of AgentDefs; repetitions and bounded parallelism default to one. Candidates bind the exact AgentDef content, not only id/version."]
+         experiment   [([spec]) "Create a portable full-factorial ExperimentDef. Requires a DatasetDef and a non-empty vector of AgentDefs; repetitions default to one. Candidates bind exact AgentDef content. Concurrency and admission ceilings remain host policy."]
          experiment-ref [([experiment]) "Return the stable logical/version/content reference for one exact ExperimentDef. Running and trusted scoring remain host-owned capabilities."]
          room-id      [([]) "Return the live identity of the current Room/world. In an isolated fork this is the child Room, not its parent."]
          hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]

--- a/src/dvergr/sandbox/ns/agent.clj
+++ b/src/dvergr/sandbox/ns/agent.clj
@@ -60,6 +60,10 @@
         select-agents* (requiring-resolve 'dvergr.agent.roster/select-agents)
         make-environment* (requiring-resolve 'dvergr.agent.environment/make-environment)
         environment-ref* (requiring-resolve 'dvergr.agent.environment/environment-ref)
+        make-dataset*   (requiring-resolve 'dvergr.agent.experiment/make-dataset)
+        dataset-ref*    (requiring-resolve 'dvergr.agent.experiment/dataset-ref)
+        make-experiment* (requiring-resolve 'dvergr.agent.experiment/make-experiment)
+        experiment-ref* (requiring-resolve 'dvergr.agent.experiment/experiment-ref)
         hire-in*       (requiring-resolve 'dvergr.agent.program/hire-in!)
         observe*       (requiring-resolve 'dvergr.agent.program/observe)
         snapshot*      (requiring-resolve 'dvergr.agent.observation/snapshot)
@@ -210,6 +214,10 @@
         'select       select-agents*
         'environment  make-environment*
         'environment-ref environment-ref*
+        'dataset      make-dataset*
+        'dataset-ref  dataset-ref*
+        'experiment   make-experiment*
+        'experiment-ref experiment-ref*
         'room-id      (fn [] (:id (room!)))
         'hire!        hire-fn
         'observe      observe-fn
@@ -228,6 +236,10 @@
          select       [([roster selector]) "Select AgentDefs by :id, :status, :skill/:skills, and exact portable :where data."]
          environment  [([spec]) "Create a portable, content-addressed EnvironmentDef. Requires :id, :task, and trusted verifier ref {:id keyword :version n}; optional :limits/:world/:metadata stay data, never live functions or handles."]
          environment-ref [([environment]) "Return the stable logical/version/content reference for one exact EnvironmentDef. Individual execution Run IDs remain unique."]
+         dataset      [([spec]) "Create a portable DatasetDef from a non-empty vector of exact EnvironmentDefs. Dataset construction is pure and content-addressed."]
+         dataset-ref  [([dataset]) "Return the stable logical/version/content reference for one exact DatasetDef."]
+         experiment   [([spec]) "Create a portable full-factorial ExperimentDef. Requires a DatasetDef and a non-empty vector of AgentDefs; repetitions and bounded parallelism default to one. Candidates bind the exact AgentDef content, not only id/version."]
+         experiment-ref [([experiment]) "Return the stable logical/version/content reference for one exact ExperimentDef. Running and trusted scoring remain host-owned capabilities."]
          room-id      [([]) "Return the live identity of the current Room/world. In an isolated fork this is the child Room, not its parent."]
          hire!        [([roster agent-ref opts]) "Durably start one owned AgentDef in the current Room: (hire! team :a {:task value :resources {\"microUSD\" 1000}}). Returns a RunHandle. The current Run remains responsible for the child even if the handle is ignored; opts may also include :from, :settlement, and a positive conserved :resources vector split from the current Run/Room."]
          observe      [([handle-or-run-id]) "Read the current Room's durable Run projection for a RunHandle or UUID."]

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -141,6 +141,15 @@
                      clojure.lang.ExceptionInfo #"content ID"
                      (experiment/validate-scorecard
                       (assoc scorecard :scorecard/content-id (random-uuid))))))
+              (testing "one certified attempt cannot fill two repetitions"
+                (let [same-cell-results
+                      (-> results
+                          vec
+                          (assoc-in [1 :attempt] (:attempt (first results))))]
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo #"distinct Attempts"
+                       (experiment/make-scorecard definition
+                                                  same-cell-results)))))
               (finally
                 (doseq [result results]
                   (when-let [fork (some-> result :run/result :run/world

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -1,5 +1,6 @@
 (ns dvergr.agent.experiment-test
   (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.environment :as environment-def]
             [dvergr.agent.evaluation :as evaluation]
             [dvergr.agent.experiment :as experiment]
             [dvergr.agent.roster :as roster]
@@ -8,15 +9,19 @@
             [dvergr.room.registry :as registry]
             [dvergr.room.store :as store]
             [dvergr.room.store.memory :as memory]
+            [hasch.core :as hasch]
             [org.replikativ.spindel.engine.core :as ec]))
 
-(defn- environment [id task]
-  ((requiring-resolve 'dvergr.agent.environment/make-environment)
-   {:id id
-    :task task
-    :verifier {:id :test/exact :version 1 :basis "experiment-test:v1"}
-    :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
-    :world {:isolation :ctx :settlement :review}}))
+(defn- environment
+  ([id task] (environment id 1 task))
+  ([id version task]
+   (environment-def/make-environment
+    {:id id
+     :version version
+     :task task
+     :verifier {:id :test/exact :version 1 :basis "experiment-test:v1"}
+     :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+     :world {:isolation :ctx :settlement :discard}})))
 
 (def exact-evaluator
   (evaluation/make-evaluator
@@ -35,8 +40,9 @@
                  (roster/make-agent {:id :beta :program {:kind :echo}}))
         dataset (experiment/make-dataset
                  {:id :experiment/tasks
-                  :environments [(environment :task/one {:value 1})
-                                 (environment :task/two {:value 2})]})]
+                  ;; Logical IDs may recur across exact environment versions.
+                  :environments [(environment :task/versioned 1 {:value 1})
+                                 (environment :task/versioned 2 {:value 2})]})]
     {:team team
      :dataset dataset
      :definition
@@ -44,8 +50,7 @@
       {:id :experiment/paired
        :dataset dataset
        :candidates [(roster/agent team :alpha) (roster/agent team :beta)]
-       :repetitions 2
-       :parallelism 2})}))
+       :repetitions 2})}))
 
 (deftest definitions-are-canonical-portable-values
   (let [{:keys [team dataset definition]} (fixture)
@@ -102,6 +107,40 @@
              clojure.lang.ExceptionInfo #"does not match"
              (experiment/run room team definition
                              {(:ref exact-evaluator) wrong}))))
+      (let [retained-env
+            (environment-def/make-environment
+             {:id :test/retained
+              :task :retained
+              :verifier {:id :test/exact :version 1
+                         :basis "experiment-test:v1"}
+              :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+              :world {:isolation :ctx :settlement :review}})
+            retained-dataset (experiment/make-dataset
+                              {:id :test/retained
+                               :environments [retained-env]})
+            retained-experiment
+            (experiment/make-experiment
+             {:id :test/retained
+              :dataset retained-dataset
+              :candidates [(roster/agent team :alpha)]})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"require :discard"
+             (experiment/run room team retained-experiment
+                             {(:ref exact-evaluator) exact-evaluator}))))
+      (let [oversized (experiment/make-experiment
+                       {:id :test/oversized
+                        :dataset (:experiment/dataset definition)
+                        :candidates [(roster/agent team :alpha)]
+                        :repetitions 1000000000})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"host admission ceiling"
+             (experiment/run room team oversized
+                             {(:ref exact-evaluator) exact-evaluator}))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"parallelism exceeds"
+           (experiment/run room team definition
+                           {(:ref exact-evaluator) exact-evaluator}
+                           {:parallelism 3 :max-parallelism 2})))
       (is (empty? (run/active-runs (:id room))))
       (finally
         (d/close-room! room)))))
@@ -113,12 +152,14 @@
     (try
       (binding [ec/*execution-context* (:ctx room)]
         (let [spin (experiment/run room team definition
-                                   {evaluator-ref exact-evaluator})]
+                                   {evaluator-ref exact-evaluator}
+                                   {:parallelism 2})]
           (is (empty? (run/active-runs (:id room)))
               "constructing the Experiment Spin admits no Runs")
-          (let [{:keys [results attempts scorecard]} @spin]
+          (let [{:keys [results attempts scorecard execution]} @spin]
             (try
               (is (= 8 (count results) (count attempts)))
+              (is (= {:parallelism 2 :attempt-count 8} execution))
               (is (= 8 (count (set (map :attempt/id attempts)))))
               (is (= 8 (count (:scorecard/entries scorecard))))
               (is (= [{:candidate/id :alpha :attempt-count 4
@@ -150,10 +191,58 @@
                        clojure.lang.ExceptionInfo #"distinct Attempts"
                        (experiment/make-scorecard definition
                                                   same-cell-results)))))
+              (testing "exact environment identity determines canonical order"
+                (let [entries (:scorecard/entries scorecard)
+                      ;; This order is canonical under the old
+                      ;; [candidate logical-environment-id repetition] key:
+                      ;; versions compare equal within each repetition. It is
+                      ;; not canonical under exact environment identity.
+                      alternate-entries
+                      (into [(nth entries 2) (nth entries 0)
+                             (nth entries 3) (nth entries 1)]
+                            (drop 4 entries))
+                      swapped (-> scorecard
+                                  (assoc :scorecard/entries alternate-entries)
+                                  (dissoc :scorecard/content-id))
+                      swapped (assoc swapped :scorecard/content-id
+                                     (hasch/uuid
+                                      [:dvergr/experiment-scorecard swapped]))]
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo #"canonical cell order"
+                       (experiment/validate-scorecard swapped)))))
               (finally
                 (doseq [result results]
                   (when-let [fork (some-> result :run/result :run/world
                                           registry/lookup)]
                     (d/discard fork))))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest later-cell-failure-leaves-no-retained-run-worlds
+  (let [{:keys [team definition]} (fixture)
+        room (d/make-room {:id :experiment-partial-failure
+                           :store (memory/make)})
+        failing-evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact
+          :version 1
+          :basis "experiment-test:v1"
+          :observe (fn [{:keys [default]}] default)
+          :verify (fn [definition _]
+                    (if (= 2 (:environment/version definition))
+                      (throw (ex-info "deliberate verifier failure" {}))
+                      {:checks {:first-cell? true} :reward 1.0}))})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"certification failed"
+             @(experiment/run room team definition
+                              {(:ref failing-evaluator) failing-evaluator}
+                              {:parallelism 1})))
+        (is (empty? (run/active-runs (:id room))))
+        (let [runs (run/runs room {:limit 20})]
+          (is (seq runs))
+          (is (every? #(= :discarded (:run/settlement-status %)) runs))
+          (is (every? #(nil? (registry/lookup (:run/world %))) runs))))
       (finally
         (d/close-room! room)))))

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -1,0 +1,150 @@
+(ns dvergr.agent.experiment-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(defn- environment [id task]
+  ((requiring-resolve 'dvergr.agent.environment/make-environment)
+   {:id id
+    :task task
+    :verifier {:id :test/exact :version 1 :basis "experiment-test:v1"}
+    :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+    :world {:isolation :ctx :settlement :review}}))
+
+(def exact-evaluator
+  (evaluation/make-evaluator
+   {:id :test/exact
+    :version 1
+    :basis "experiment-test:v1"
+    :observe (fn [{:keys [default]}] default)
+    :verify (fn [definition evidence]
+              (let [ok? (= (:environment/task definition) (:result evidence))]
+                {:checks {:exact? ok?}
+                 :reward (if ok? 1.0 0.0)}))}))
+
+(defn- fixture []
+  (let [team (-> (roster/make-roster {:id :experiment/team})
+                 (roster/make-agent {:id :alpha :program {:kind :echo}})
+                 (roster/make-agent {:id :beta :program {:kind :echo}}))
+        dataset (experiment/make-dataset
+                 {:id :experiment/tasks
+                  :environments [(environment :task/one {:value 1})
+                                 (environment :task/two {:value 2})]})]
+    {:team team
+     :dataset dataset
+     :definition
+     (experiment/make-experiment
+      {:id :experiment/paired
+       :dataset dataset
+       :candidates [(roster/agent team :alpha) (roster/agent team :beta)]
+       :repetitions 2
+       :parallelism 2})}))
+
+(deftest definitions-are-canonical-portable-values
+  (let [{:keys [team dataset definition]} (fixture)
+        reordered (experiment/make-dataset
+                   {:environments (:dataset/environments dataset)
+                    :id :experiment/tasks})]
+    (is (= dataset reordered))
+    (is (= dataset (experiment/validate-dataset dataset)))
+    (is (= definition (experiment/validate-experiment definition)))
+    (is (uuid? (:dataset/content-id dataset)))
+    (is (uuid? (:experiment/content-id definition)))
+    (is (= #{:alpha :beta}
+           (set (map :candidate/id (:experiment/candidates definition)))))
+    (is (every? uuid?
+                (map :candidate/agent-content-id
+                     (:experiment/candidates definition))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"content ID"
+                          (experiment/validate-dataset
+                           (assoc dataset :dataset/version 2))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"content ID"
+                          (experiment/validate-experiment
+                           (assoc definition :experiment/repetitions 3))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"duplicate"
+         (experiment/make-dataset
+          {:id :duplicate
+           :environments [(first (:dataset/environments dataset))
+                          (first (:dataset/environments dataset))]})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"portable"
+         (experiment/make-experiment
+          {:id :non-portable :dataset dataset
+           :candidates [(assoc (roster/agent team :alpha)
+                               :agent/metadata {:live (atom 1)})]})))))
+
+(deftest exact-candidates-and-evaluators-fail-before-run-admission
+  (let [{:keys [team definition]} (fixture)
+        room (d/make-room {:id :experiment-preflight :store (memory/make)})]
+    (try
+      (let [changed-team (roster/revise-agent team :alpha
+                                              {:prompt "different definition"})]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"version"
+                              (experiment/run room changed-team definition
+                                              {(:ref exact-evaluator)
+                                               exact-evaluator})))
+        (is (empty? (run/active-runs (:id room)))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no exact host Evaluator"
+                            (experiment/run room team definition {})))
+      (let [wrong (evaluation/make-evaluator
+                   {:id :test/wrong
+                    :observe (constantly {})
+                    :verify (fn [_ _] {:checks {} :reward 0.0})})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"does not match"
+             (experiment/run room team definition
+                             {(:ref exact-evaluator) wrong}))))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest repeated-paired-experiment-composes-ordinary-certified-evaluations
+  (let [{:keys [team definition]} (fixture)
+        room (d/make-room {:id :experiment-run :store (memory/make)})
+        evaluator-ref (:ref exact-evaluator)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [spin (experiment/run room team definition
+                                   {evaluator-ref exact-evaluator})]
+          (is (empty? (run/active-runs (:id room)))
+              "constructing the Experiment Spin admits no Runs")
+          (let [{:keys [results attempts scorecard]} @spin]
+            (try
+              (is (= 8 (count results) (count attempts)))
+              (is (= 8 (count (set (map :attempt/id attempts)))))
+              (is (= 8 (count (:scorecard/entries scorecard))))
+              (is (= [{:candidate/id :alpha :attempt-count 4
+                       :passed-count 4 :reward-sum 4.0 :reward-mean 1.0}
+                      {:candidate/id :beta :attempt-count 4
+                       :passed-count 4 :reward-sum 4.0 :reward-mean 1.0}]
+                     (:scorecard/summary scorecard)))
+              (is (= scorecard (experiment/validate-scorecard scorecard)))
+              (is (every? #(= % (store/-load-attempt
+                                 (:store room) (:id room) (:attempt/id %)))
+                          attempts))
+              (is (empty? (run/active-runs (:id room))))
+              (testing "entry and aggregate tampering are rejected"
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo #"summary"
+                     (experiment/validate-scorecard
+                      (assoc-in scorecard [:scorecard/summary 0 :reward-mean]
+                                0.5))))
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo #"content ID"
+                     (experiment/validate-scorecard
+                      (assoc scorecard :scorecard/content-id (random-uuid))))))
+              (finally
+                (doseq [result results]
+                  (when-let [fork (some-> result :run/result :run/world
+                                          registry/lookup)]
+                    (d/discard fork))))))))
+      (finally
+        (d/close-room! room)))))

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -99,7 +99,7 @@
                     "{:same? (= a b) :ref (agent/environment-ref a) "
                     ":dataset-ref (agent/dataset-ref dataset) "
                     ":experiment-ref (agent/experiment-ref experiment) "
-                    ":parallelism (:experiment/parallelism experiment)})"))]
+                    ":repetitions (:experiment/repetitions experiment)})"))]
           (is (:success result) (pr-str (:error result)))
           (is (true? (get-in result [:value :same?])))
           (is (uuid? (get-in result [:value :ref :environment/content-id])))
@@ -107,7 +107,7 @@
                              [:value :dataset-ref :dataset/content-id])))
           (is (uuid? (get-in result
                              [:value :experiment-ref :experiment/content-id])))
-          (is (= 1 (get-in result [:value :parallelism]))))
+          (is (= 2 (get-in result [:value :repetitions]))))
         (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.comb)]
           (is (re-find #"cancel losing branches" guide))
           (is (re-find #"owned-result-spin" guide)))

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -87,11 +87,27 @@
                     "b (agent/environment "
                     "{:limits {:timeout-ms 1000} "
                     ":verifier {:version 1 :id :checks/example} "
-                    ":task {:input 42} :id :training/example})] "
-                    "{:same? (= a b) :ref (agent/environment-ref a)})"))]
+                    ":task {:input 42} :id :training/example}) "
+                    "team (agent/make-agent (agent/roster) "
+                    "{:id :candidate :program {:kind :echo}}) "
+                    "dataset (agent/dataset "
+                    "{:id :training/smoke :environments [a]}) "
+                    "experiment (agent/experiment "
+                    "{:id :training/paired :dataset dataset "
+                    ":candidates [(agent/lookup team :candidate)] "
+                    ":repetitions 2})] "
+                    "{:same? (= a b) :ref (agent/environment-ref a) "
+                    ":dataset-ref (agent/dataset-ref dataset) "
+                    ":experiment-ref (agent/experiment-ref experiment) "
+                    ":parallelism (:experiment/parallelism experiment)})"))]
           (is (:success result) (pr-str (:error result)))
           (is (true? (get-in result [:value :same?])))
-          (is (uuid? (get-in result [:value :ref :environment/content-id]))))
+          (is (uuid? (get-in result [:value :ref :environment/content-id])))
+          (is (uuid? (get-in result
+                             [:value :dataset-ref :dataset/content-id])))
+          (is (uuid? (get-in result
+                             [:value :experiment-ref :experiment/content-id])))
+          (is (= 1 (get-in result [:value :parallelism]))))
         (let [guide (sandbox/ns-doc-md sci-ctx 'spindel.comb)]
           (is (re-find #"cancel losing branches" guide))
           (is (re-find #"owned-result-spin" guide)))


### PR DESCRIPTION
## Summary

- add portable content-addressed DatasetDef and ExperimentDef values with exact AgentDef content binding
- compose repeated paired evaluations as lazy bounded Spindel batches over ordinary Runs and certified Attempts
- keep concurrency and max-attempt admission as host-owned execution policy, outside agent-authored definitions
- require discard settlement until partial experiments have durable recoverable identity
- return canonical content-addressed Scorecards without adding a scheduler or settlement authority
- expose pure definition construction in SCI while keeping evaluator capabilities and certification host-owned

## Verification

- focused experiment suite: 4 tests, 37 assertions, green
- focused experiment plus SCI suites: 24 tests, 147 assertions, green before final targeted additions
- full suite before review fixes: 661 tests, 3011 assertions; only missing-doc coverage failed, then fixed and exact regression passed
- format check passed
- standalone harness built: target/dvergr-0.1.68-harness.jar
- interactive room nREPL probe: 2 candidates x 2 environments x 2 repetitions produced 8 durable Runs, 8 certified Attempts, 4/4 per candidate, zero active Runs
- independent review found three medium issues; current head fixes all, re-review found no medium-or-higher findings

## Stack

This PR is intentionally based on #89, the independent Fireworks URL normalization fix.