### PR TITLE
Validate live paired agent benchmarks

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
         ;; restart.
         ;; 0.1.44 includes structured work admission, cancellation hand-back,
         ;; canonical inference worlds, and forkable SCI world components.
-        org.replikativ/spindel     {:mvn/version "0.1.44"}
+        org.replikativ/spindel     {:mvn/version "0.1.45"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -10,6 +10,8 @@
             [datahike.api :as dh]
             [dvergr.activity :as activity]
             [dvergr.agent.environment :as environment]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.experiment :as experiment]
             [dvergr.agent.observation :as observation]
             [dvergr.agent.program :as program]
             [dvergr.agent.roster :as roster]
@@ -35,6 +37,9 @@
        "Do not merely describe the code; execute it."))
 
 (def expected-v1 {:analyst "evidence" :reviewer {:claim 42}})
+
+(def effect-safe-repl-prompt-v1
+  "Exercise Dvergr through clojure_eval and complete the requested computation before answering. Treat calls ending in ! as durable effects: inspect or validate their complete call shape before executing them, execute each requested effect exactly once, and never run documentation examples as probes. agent/hire! takes an options map; put every task value, including a map-valued task, under the :task key. If a later pure composition fails, reuse the handles already created instead of hiring again.")
 
 (def race-task-v1
   (str "Use clojure_eval to solve this task. Construct an immutable roster with "
@@ -130,11 +135,12 @@
         (catch Throwable _ nil)))))
 
 (defn- common-checks
-  [{:keys [result parsed-value durable-status active-after]} expected]
-  {:root-completed? (= :completed (:run/status result))
-   :durably-completed? (= :completed durable-status)
-   :exact-result? (= expected parsed-value)
-   :quiescent? (zero? active-after)})
+  [{:keys [result run-result parsed-value durable-status active-after]} expected]
+  (let [execution-result (or run-result result)]
+    {:root-completed? (= :completed (:run/status execution-result))
+     :durably-completed? (= :completed durable-status)
+     :exact-result? (= expected parsed-value)
+     :quiescent? (zero? active-after)}))
 
 (defn- join-checks [{:keys [root-run-id child-runs] :as observation}]
   (let [by-actor (group-by :run/actor child-runs)]
@@ -171,13 +177,14 @@
                                    child-runs)})))
 
 (defn- renewal-risk-checks
-  [{:keys [result parsed-value durable-status active-after root-run-id
+  [{:keys [result run-result parsed-value durable-status active-after root-run-id
            root-causes child-runs inspection-receipts]}]
-  (let [owned (filterv #(= root-run-id (:run/parent %)) child-runs)
+  (let [execution-result (or run-result result)
+        owned (filterv #(= root-run-id (:run/parent %)) child-runs)
         outside (remove #(= root-run-id (:run/parent %)) child-runs)
         owned-ids (into #{} (map :run/id) owned)
         reported (dissoc parsed-value :scope :inspection)]
-    {:root-completed? (= :completed (:run/status result))
+    {:root-completed? (= :completed (:run/status execution-result))
      :durably-completed? (= :completed durable-status)
      :quiescent? (zero? active-after)
      :business-result? (= expected-renewal-risk-v1 reported)
@@ -414,6 +421,209 @@
   "Return the exact portable definition for a named benchmark environment."
   [environment-id]
   (some-> (get environments environment-id) :definition))
+
+(def ^:private paired-environment-ids
+  #{:programming/join-v1
+    :programming/race-v1
+    :programming/self-programming-v1})
+
+(defn- paired-environment [environment-id]
+  (when-not (contains? paired-environment-ids environment-id)
+    (throw (ex-info
+            "Environment requires trusted setup not yet supported by paired runs"
+            {:environment-id environment-id
+             :supported paired-environment-ids})))
+  (let [definition (environment-definition environment-id)
+        verifier (:environment/verifier definition)
+        world (:environment/world definition)]
+    (when-not (= memory-setup-ref (:setup world))
+      (throw (ex-info "Paired environment does not use the memory baseline"
+                      {:environment-id environment-id
+                       :setup (:setup world)})))
+    (environment/make-environment
+     (cond-> {:id (:environment/id definition)
+              :version (:environment/version definition)
+              :task (:environment/task definition)
+              :verifier
+              (cond-> {:id (:verifier/id verifier)
+                       :version (:verifier/version verifier)}
+                (contains? verifier :verifier/basis)
+                (assoc :basis (:verifier/basis verifier)))
+              :limits (:environment/limits definition)
+              :world (-> world (dissoc :setup) (assoc :settlement :discard))}
+       (contains? definition :environment/metadata)
+       (assoc :metadata (:environment/metadata definition))))))
+
+(defn- scoped-observation
+  [{:keys [room run-id result durable]}]
+  (let [all-runs (run/runs room {:root-run-id run-id :limit 200})
+        run-ids (into #{} (map :run/id) all-runs)
+        trigger-ids (into #{} (keep :run/trigger) all-runs)
+        messages (d/messages room {:limit 500
+                                   :run-ids run-ids
+                                   :message-ids trigger-ids})
+        projection (observation/snapshot
+                    room run-id
+                    {:run-limit 200 :message-limit 500
+                     :content-limit 1000 :content-budget 64000
+                     :detail-limit 500})
+        activity-messages (filter #(= :_activity (:to %)) messages)
+        tool-trace (mapv activity/tool-trace-entry activity-messages)
+        parsed (parse-edn (:run/value result))
+        run-trace (mapv #(select-keys % [:run/id :run/parent :run/caused-by
+                                         :run/actor :run/status :run/error
+                                         :run/settlement-status])
+                        all-runs)
+        child-runs (filterv #(not= run-id (:run/id %)) run-trace)]
+    (let [evidence
+          {:run-result (select-keys result
+                                    [:run/id :run/status :run/value :run/error
+                                     :run/metrics :run/world
+                                     :run/settlement-status])
+           :result parsed
+           :parsed-value parsed
+           :durable-status (:run/status durable)
+           :root-causes (set (:run/caused-by durable))
+           :room-id (:id room)
+           :root-run-id run-id
+           :child-runs child-runs
+           :tool-calls tool-trace
+           :inspection-receipts
+           (into #{}
+                 (comp
+                  (mapcat activity/message-activities)
+                  (filter #(and (= run-id (:activity/run-id %))
+                                (= :observation (:activity/kind %))
+                                (= :inspect (:activity/verb %))))
+                  (map :activity/id))
+                 messages)
+           :active-after (count (filter #(contains? #{:running :cancelling}
+                                                    (:run/status %))
+                                        run-trace))
+           :trace {:runs run-trace
+                   :messages (:observation/messages projection)
+                   :tool-calls tool-trace}}]
+      (when-not (roster/data-value? evidence)
+        (throw (ex-info
+                "Paired verifier produced non-portable evidence"
+                {:non-portable
+                 (into {}
+                       (keep (fn [[k value]]
+                               (when-not (roster/data-value? value)
+                                 [k (some-> value class str)])))
+                       evidence)})))
+      evidence)))
+
+(defn- paired-evaluator [definition]
+  (let [verifier-ref (:environment/verifier definition)
+        verify (or (get trusted-verifiers verifier-ref)
+                   (throw (ex-info "Environment names an untrusted verifier"
+                                   {:environment
+                                    (environment/environment-ref definition)
+                                    :verifier verifier-ref})))]
+    (evaluation/make-evaluator
+     (cond-> {:id (:verifier/id verifier-ref)
+              :version (:verifier/version verifier-ref)
+              :observe scoped-observation
+              :verify (fn [_ evidence]
+                        (let [checks (verify evidence)]
+                          {:checks checks
+                           :reward (if (every? true? (vals checks)) 1.0 0.0)}))}
+       (contains? verifier-ref :verifier/basis)
+       (assoc :basis (:verifier/basis verifier-ref))))))
+
+(defn- candidate-agent [team {:keys [id provider model prompt] :as candidate}]
+  (when-not (and (keyword? id) (keyword? provider) (string? model))
+    (throw (ex-info "Candidate requires keyword :id/:provider and string :model"
+                    {:candidate candidate})))
+  (when-not (or (nil? prompt) (string? prompt))
+    (throw (ex-info "Candidate :prompt must be a string when present"
+                    {:candidate candidate})))
+  (roster/make-agent
+   team
+   {:id id
+    :prompt (or prompt
+                (str "Exercise Dvergr through clojure_eval. Complete the "
+                     "requested computation before answering."))
+    :tools #{:clojure_eval}
+    :model-policy {:provider provider :model model}
+    :program {:kind :llm :max-model-steps 16
+              :budget-dollars 1.0 :auto-compact? false}}))
+
+(defn paired-experiment-spin
+  "Build a repeated paired live-model experiment and return its lazy Spin.
+
+   The caller owns `room`, so durable Runs and Attempts remain inspectable after
+   completion. Candidates are maps with keyword `:id`/`:provider`, string
+   `:model`, and an optional string `:prompt`; this makes prompt policy an exact
+   content-addressed experimental variable. Supported environments currently
+   need no setup beyond the shared memory baseline: join, race, and
+   self-programming v1. Host execution options are `:parallelism`,
+   `:max-parallelism`, and `:max-attempts`."
+  [room {:keys [environment-ids candidates repetitions id]
+         :or {repetitions 1 id :live/paired-v1}
+         :as opts}]
+  (when-not (and (vector? environment-ids) (seq environment-ids))
+    (throw (ex-info ":environment-ids must be a non-empty vector"
+                    {:environment-ids environment-ids})))
+  (when-not (and (vector? candidates) (seq candidates))
+    (throw (ex-info ":candidates must be a non-empty vector"
+                    {:candidates candidates})))
+  (let [definitions (mapv paired-environment environment-ids)
+        team (reduce candidate-agent
+                     (roster/make-roster {:id :live/paired-candidates})
+                     candidates)
+        dataset (experiment/make-dataset
+                 {:id (keyword (namespace id) (str (name id) "-dataset"))
+                  :environments definitions
+                  :metadata {:source :dvergr.agent.program-bench}})
+        experiment-definition
+        (experiment/make-experiment
+         {:id id
+          :dataset dataset
+          :candidates (roster/agents team)
+          :repetitions repetitions
+          :metadata {:kind :live-model-comparison}})
+        evaluators (into {}
+                         (map (fn [definition]
+                                (let [evaluator (paired-evaluator definition)]
+                                  [(evaluation/evaluator-ref evaluator)
+                                   evaluator])))
+                         definitions)]
+    (experiment/run room team experiment-definition evaluators
+                    (select-keys opts [:parallelism :max-parallelism
+                                       :max-attempts]))))
+
+(defn run-paired-experiment!
+  "Convenience REPL entry point for a live paired experiment.
+
+   Creates and closes an ephemeral in-memory Room, returning the portable
+   ExperimentDef, execution summary, certified Attempts, and Scorecard. Use
+   `paired-experiment-spin` with a caller-owned Room when interactive durable
+   inspection is more important than convenience."
+  [opts]
+  (let [room-id (keyword (str "paired-bench-" (random-uuid)))
+        room (d/make-room {:id room-id :store (memory/make)})]
+    (try
+      (let [result (binding [ec/*execution-context* (:ctx room)]
+                     @(paired-experiment-spin room opts))]
+        (select-keys result [:experiment :execution :attempts :scorecard]))
+      (finally
+        ;; Parallel failure cancels sibling evaluations immediately, while
+        ;; their world discard runs off-drain. Join that physical cleanup
+        ;; before invalidating the ephemeral Room context/store.
+        (try
+          (evaluation/await-cleanups! room)
+          (catch Throwable error
+            ;; The caller can recover/inspect this process-local Room from
+            ;; ex-data. Closing here would destroy the fork authority whose
+            ;; cleanup just failed.
+            (throw (ex-info "Benchmark Room retained for cleanup recovery"
+                            {:type ::cleanup-recovery-required
+                             :room/id (:id room)
+                             :room room}
+                            error))))
+        (d/close-room! room)))))
 
 (defn run-environment!
   "Run a named programming environment through `provider`/`model`.

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -466,7 +466,8 @@ levels:
    result plus durable Room/Run facts; model prose is never the reward source.
    Reports retain individual checks, binary reward, generated SCI, leaked
    Runs/resources, model steps, token/cost usage, wall time, task version,
-   model, and a stable ID of the exact assembled system prompt. Durable receipt
+   model, typed allowlisted tool diagnostics, and a stable ID of the exact assembled system
+   prompt. Durable receipt
    persistence, trusted-writer authorization, and settlement against a retained
    benchmark world remain follow-ups.
 
@@ -498,6 +499,23 @@ their reports:
 ;; The generic entry point makes the task/version explicit.
 (bench/run-environment! :programming/race-v1
                         :codex-subscription "codex-subscription-sol")
+
+;; Generic, repeated full-factorial comparison. The prompt is exact AgentDef
+;; content, so prompt policy can vary without changing the environment/verifier.
+(bench/run-paired-experiment!
+ {:environment-ids [:programming/join-v1]
+  :candidates
+  [{:id :codex-safe
+    :provider :codex-subscription
+    :model "codex-subscription-sol"
+    :prompt bench/effect-safe-repl-prompt-v1}
+   {:id :claude-safe
+    :provider :claude-code
+    :model "claude-code-sonnet"
+    :prompt bench/effect-safe-repl-prompt-v1}]
+  :repetitions 3
+  :parallelism 2
+  :max-attempts 20})
 ```
 
 It is an explicit REPL benchmark rather than a CI test because it is

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -131,14 +131,27 @@ candidates against two environments with two repetitions and parallelism two.
 It produced eight distinct durable Runs, eight certified Attempts, two 4/4
 candidate summaries, one content-addressed Scorecard, and zero active Runs at
 completion. This validates the experiment composition itself; it is not model
-quality evidence. The existing Codex/Claude live environments still use a
-bespoke trusted setup path. Migrating one of them is the acceptance criterion
-for the next setup-capability slice.
+quality evidence.
+
+The first generic live migration used the same `:programming/join-v1`
+EnvironmentDef to compare Claude Code and Codex subscription AgentDefs. It
+immediately found two observable failures: retries left duplicate child Runs,
+and the REPL's process worker inherited Spindel's drain marker, so the documented
+`@(spin (await ...))` bridge rejected valid composition as a deadlock. Tool
+activities now retain typed status and allowlisted diagnostic codes—but never
+raw result content—making that class of failure visible in certified evidence
+after an ephemeral Room closes. Clearing the drain marker and ambient Spin
+identity at the real worker boundary restored the advertised algebra. With the same concise,
+content-addressed effect-safety prompt, both providers then passed independently
+in three model steps, with exactly two completed children, an exact result, and
+zero active Runs. This is one smoke result, not a quality ranking; repetitions
+and held-out environments are required for comparative claims.
 
 ## Port order driven by failures
 
 1. Complete scoped observation and expose it in the REPL/UI.
-2. Use DatasetDef/ExperimentDef/Scorecard repeated paired runs in the live REPL.
+2. Extend DatasetDef/ExperimentDef/Scorecard live runs beyond the migrated
+   setup-free join/race/self-programming environments.
 3. Build a forkable business-state simulator and import an AutomationBench
    smoke subset.
 4. Add scheduled trigger/execution/delivery receipts using ordinary Runs.

--- a/src/dvergr/activity.clj
+++ b/src/dvergr/activity.clj
@@ -12,25 +12,62 @@
   [parts]
   (hasch/uuid [:dvergr/activity parts]))
 
+(defn- tool-result-fact [tool-name value]
+  ;; Tool results belong to the private ChatContext/tool-call trace. Room
+  ;; activities may reveal only a typed status and an allowlisted diagnostic —
+  ;; never a prefix, hash, or derivative of arbitrary user/tool content.
+  (when (and (= "clojure_eval" (str tool-name)) (string? value))
+    (cond
+      (str/starts-with? value "Evaluation cancelled:")
+      {:activity/status :cancelled
+       :activity/outcome "clojure-eval/cancelled"}
+
+      (str/starts-with? value "Evaluation error:")
+      {:activity/status :failed
+       :activity/outcome
+       (cond
+         (str/includes?
+          value "Cannot deref @(spin ...) from inside a drain context")
+         "spindel/deref-in-drain"
+
+         (str/includes? value "Unknown hire! options")
+         "dvergr.agent/unknown-hire-options"
+
+         (str/includes? value "await called outside of asynchronous scope")
+         "spindel/await-outside-async-scope"
+
+         :else "clojure-eval/error")}
+
+      (str/starts-with? value "=> ")
+      {:activity/status :completed}
+
+      :else nil)))
+
 (defn tool-activities
   "Project the tool requests in an assistant message into compact semantic
-   observations. Raw arguments and results remain in the existing tool trace.
+   observations. Raw arguments and results remain in the private tool trace;
+   an optional result map adds only typed, allowlisted diagnostics.
 
    `source-id` should identify the source assistant message when available.
    The ordinal keeps repeated provider tool-use ids distinct."
-  [run-id source-id tool-uses]
-  (mapv (fn [ordinal tool-use]
-          (let [tool-id (or (:tool-use/id tool-use) (:id tool-use))
-                name    (or (:tool-use/name tool-use) (:name tool-use))]
-            (cond-> {:activity/id (stable-id [run-id source-id tool-id ordinal])
-                     :activity/kind :tool
-                     :activity/verb :invoke
-                     :activity/at (Date.)}
-              run-id (assoc :activity/run-id run-id)
-              tool-id (assoc :activity/tool-use-id (str tool-id))
-              name (assoc :activity/tool-name (str name)))))
-        (range)
-        tool-uses))
+  ([run-id source-id tool-uses]
+   (tool-activities run-id source-id tool-uses {}))
+  ([run-id source-id tool-uses outcomes]
+   (mapv (fn [ordinal tool-use]
+           (let [tool-id (or (:tool-use/id tool-use) (:id tool-use))
+                 name    (or (:tool-use/name tool-use) (:name tool-use))
+                 result-fact (tool-result-fact name (get outcomes tool-id))]
+             (cond-> (merge
+                      {:activity/id (stable-id [run-id source-id tool-id ordinal])
+                       :activity/kind :tool
+                       :activity/verb :invoke
+                       :activity/at (Date.)}
+                      result-fact)
+               run-id (assoc :activity/run-id run-id)
+               tool-id (assoc :activity/tool-use-id (str tool-id))
+               name (assoc :activity/tool-name (str name)))))
+         (range)
+         tool-uses)))
 
 (defn lifecycle-activity
   "Create a semantic Run lifecycle observation for a visible activity message."

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -21,6 +21,97 @@
 
 (defrecord Evaluator [ref observe verify])
 
+(defonce ^:private pending-tasks (atom {}))
+
+(declare positive-timeout!)
+
+(defn- cleanup-scope [room]
+  [(:id room) (:incarnation room)])
+
+(defn- start-task! [room task-fn]
+  (let [scope (cleanup-scope room)
+        token (random-uuid)
+        gate (promise)
+        started (promise)]
+    ;; Registration happens before the Future can start. A caller that regains
+    ;; control after evaluation cancellation can therefore never miss the
+    ;; cleanup it must join before closing the Room.
+    (swap! pending-tasks update scope (fnil assoc {}) token gate)
+    (let [worker
+          (future
+            (deliver started true)
+            (let [outcome
+                  (try
+                    (let [result (task-fn)]
+                      (if (and (map? result) (false? (:ok? result)))
+                        {:error (ex-info "Evaluation task failed"
+                                         {:type ::cleanup-failed
+                                          :result result})}
+                        {:ok result}))
+                    (catch Throwable error {:error error}))]
+              (deliver gate outcome)
+              ;; Successful work no longer needs a barrier entry. Failures stay
+              ;; until a teardown owner observes them rather than being silently
+              ;; forgotten.
+              (when (contains? outcome :ok)
+                (swap! pending-tasks update scope dissoc token))))]
+      {:token token :gate gate :started started :future worker})))
+
+(defn await-cleanups!
+  "Block a host teardown boundary until detached evaluation cleanup completes.
+
+   Evaluation cancellation itself stays non-blocking for the Spindel drain.
+   Ephemeral Room owners must call this outside a Spin before closing the Room.
+   Throws on timeout or a cleanup failure."
+  ([room] (await-cleanups! room 30000))
+  ([room timeout-ms]
+   (positive-timeout! "Cleanup timeout" timeout-ms)
+   (let [scope (cleanup-scope room)
+         deadline (+ (System/nanoTime) (* 1000000 timeout-ms))]
+     (loop [observed #{} failures []]
+       (let [entries (remove (comp observed key)
+                             (get @pending-tasks scope))]
+         (if (seq entries)
+           (let [outcomes
+                 (mapv
+                  (fn [[token gate]]
+                    (let [remaining-ms
+                          (max 1 (long (/ (- deadline (System/nanoTime))
+                                          1000000)))
+                          outcome (deref gate remaining-ms ::timeout)]
+                      [token outcome]))
+                  entries)
+                 failures'
+                 (into failures
+                       (keep (fn [[token outcome]]
+                               (cond
+                                 (= ::timeout outcome)
+                                 {:token token :type ::cleanup-timeout}
+
+                                 (:error outcome)
+                                 {:token token :type ::cleanup-failed
+                                  :error (:error outcome)}
+
+                                 :else nil)))
+                       outcomes)]
+             ;; Every completed gate has now been handed to this teardown
+             ;; owner. Timed-out gates remain registered and keep the Room
+             ;; non-closeable; completed failures are removed but reported
+             ;; together after all siblings have been joined.
+             (doseq [[token outcome] outcomes
+                     :when (not= ::timeout outcome)]
+               (swap! pending-tasks update scope dissoc token))
+             (recur (into observed (map first outcomes)) failures'))
+           (if (seq failures)
+             (throw (ex-info "Evaluation work did not quiesce before Room close"
+                             {:type ::cleanup-incomplete
+                              :room/id (:id room)
+                              :timeout-ms timeout-ms
+                              :failures failures}))
+             (do
+               (swap! pending-tasks dissoc scope)
+               true))))))))
+
 (defn make-evaluator
   "Create a process-local trusted evaluator capability.
 
@@ -308,7 +399,8 @@
                               :run/id run-id
                               :run/world (:run/world result)
                               :cleanup cleanup}
-                             error)})))
+                             error)})
+                  cleanup))
               settlement-failure!
               (fn [error]
                 (sync/deliver!
@@ -321,79 +413,86 @@
                             :attempt @persisted-attempt
                             :run/settlement-status
                             (:run/settlement-status result)}
-                           error)}))
+                           error)})
+                {:ok? false
+                 :run/id run-id
+                 :run/world (:run/world result)
+                 :reason :settlement-recovery-required})
               worker
-              (future
-                (binding [ec/*execution-context* (:ctx room)
-                          ec/*spin-id* nil]
-                  (try
-                    (let [{:keys [evidence receipt]}
-                          (certification-candidate
-                           {:room room :definition definition
-                            :evaluator evaluator :agent agent :run-id run-id
-                            :result result :durable durable
-                            :started-at started-at :started-nanos started-nanos
-                            :timeout? timeout?})
-                          certified-attempt
-                          (attempt/make-attempt definition agent receipt evidence
-                                                settlement)]
-                      (let [deferred? (= :deferred
-                                         (:run/settlement-status result))
-                            claim!
-                            #(if (cancelled-externally?)
-                               (do
-                                 (compare-and-set! state :scoring :cancelled)
-                                 false)
-                               (when (compare-and-set! state :scoring
-                                                       :certifying)
+              (start-task!
+               room
+               (fn []
+                 (binding [ec/*execution-context* (:ctx room)
+                           ec/*spin-id* nil]
+                   (try
+                     (let [{:keys [evidence receipt]}
+                           (certification-candidate
+                            {:room room :definition definition
+                             :evaluator evaluator :agent agent :run-id run-id
+                             :result result :durable durable
+                             :started-at started-at :started-nanos started-nanos
+                             :timeout? timeout?})
+                           certified-attempt
+                           (attempt/make-attempt definition agent receipt evidence
+                                                 settlement)]
+                       (let [deferred? (= :deferred
+                                          (:run/settlement-status result))
+                             claim!
+                             #(if (cancelled-externally?)
+                                (do
+                                  (compare-and-set! state :scoring :cancelled)
+                                  false)
+                                (when (compare-and-set! state :scoring
+                                                        :certifying)
                                  ;; This write occurs inside the fork's affine
                                  ;; settlement lock. The world cannot become
                                  ;; reviewable or disappear before its trusted
                                  ;; certification is durable.
-                                 (reset! persisted-attempt
-                                         (attempt/persist! room
-                                                           certified-attempt))
-                                 true))]
-                        (when (cancelled-externally?)
-                          (compare-and-set! state :scoring :cancelled))
-                        (if (or deferred? (claim!))
-                          (let [final-settlement
-                                (if deferred?
-                                  (settle-certified! fork settlement claim!)
-                                  (:run/settlement-status result))
-                                result (assoc result
-                                              :run/settlement-status
-                                              (case final-settlement
-                                                :discard :discarded
-                                                :review :review
-                                                final-settlement))]
-                            (reset! state :certified)
-                            (sync/deliver!
-                             done
-                             {:ok {:environment definition
-                                   :attempt @persisted-attempt
-                                   :attempt-receipt receipt
-                                   :evidence evidence
-                                   :run/id run-id
-                                   :run/result result
-                                   :run/handle handle}}))
-                          (cleanup-once! :evaluation-cancelled))))
-                    (catch Throwable error
-                      (if @persisted-attempt
-                        (settlement-failure! error)
-                        (certification-failure! error))))))]
+                                  (reset! persisted-attempt
+                                          (attempt/persist! room
+                                                            certified-attempt))
+                                  true))]
+                         (when (cancelled-externally?)
+                           (compare-and-set! state :scoring :cancelled))
+                         (if (or deferred? (claim!))
+                           (let [final-settlement
+                                 (if deferred?
+                                   (settle-certified! fork settlement claim!)
+                                   (:run/settlement-status result))
+                                 result (assoc result
+                                               :run/settlement-status
+                                               (case final-settlement
+                                                 :discard :discarded
+                                                 :review :review
+                                                 final-settlement))]
+                             (reset! state :certified)
+                             (sync/deliver!
+                              done
+                              {:ok {:environment definition
+                                    :attempt @persisted-attempt
+                                    :attempt-receipt receipt
+                                    :evidence evidence
+                                    :run/id run-id
+                                    :run/result result
+                                    :run/handle handle}}))
+                           (cleanup-once! :evaluation-cancelled))))
+                     (catch Throwable error
+                       (if @persisted-attempt
+                         (settlement-failure! error)
+                         (certification-failure! error)))))))]
           (try
             (let [{:keys [ok error]} (sp/await done)]
               (if error (throw error) ok))
             (catch Throwable error
               (when (and (spin-cancelled? error)
                          (compare-and-set! state :scoring :cancelled))
-                (future-cancel worker)
-                ;; Cancellation remains non-blocking for the Spindel drain
-                ;; path. The gate is already closed by `state`; cleanup runs
-                ;; externally and the interrupted worker can never certify.
-                (future
-                  (binding [ec/*execution-context* (:ctx room)
-                            ec/*spin-id* nil]
-                    (cleanup-once! :evaluation-cancelled))))
+                ;; Interrupt an evaluator already executing on its worker. A
+                ;; not-yet-started worker is left scheduled: it will observe the
+                ;; closed state and cannot certify, while its registered gate
+                ;; prevents teardown from racing it.
+                ;; Cancellation remains non-blocking for the Spindel drain.
+                ;; The scorer owns cleanup and stays registered until it
+                ;; physically exits; the closed gate prevents certification.
+                (when (realized? (:started worker))
+                  (future-cancel (:future worker))))
               (throw error)))))))))

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -15,6 +15,7 @@
             [hasch.core :as hasch]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.spin.combinators :as comb]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]))
@@ -42,7 +43,11 @@
             (deliver started true)
             (let [outcome
                   (try
-                    (let [result (task-fn)]
+                    ;; Futures convey dynamic bindings, but this worker is no
+                    ;; longer executing on the originating engine drain.
+                    (let [result (binding [simple/*in-drain?* false
+                                           ec/*spin-id* nil]
+                                   (task-fn))]
                       (if (and (map? result) (false? (:ok? result)))
                         {:error (ex-info "Evaluation task failed"
                                          {:type ::cleanup-failed

--- a/src/dvergr/agent/observation.clj
+++ b/src/dvergr/agent/observation.clj
@@ -95,15 +95,22 @@
   (when (some? value)
     (content-preview value 80)))
 
+(defn- portable-time [value]
+  (if (instance? java.util.Date value)
+    (.getTime ^java.util.Date value)
+    value))
+
 (defn- run-summary [candidate cause-limit]
   (let [all-causes (vec (:run/caused-by candidate))
         causes (take cause-limit all-causes)]
     (cond->
-     (select-keys candidate
-                  [:run/id :run/kind :run/room :run/actor :run/trigger
-                   :run/parent :run/status :run/started-at
-                   :run/ended-at :run/world-id :run/settlement-status
-                   :run/settlement-reason])
+     (-> (select-keys candidate
+                      [:run/id :run/kind :run/room :run/actor :run/trigger
+                       :run/parent :run/status :run/started-at
+                       :run/ended-at :run/world-id :run/settlement-status
+                       :run/settlement-reason])
+         (update :run/started-at portable-time)
+         (update :run/ended-at portable-time))
       (seq causes)
       (assoc :run/caused-by (set causes)
              :run/caused-by-count (count all-causes)
@@ -139,10 +146,11 @@
 
 (defn- activity-summary [fact]
   (cond->
-   (select-keys fact
-                [:activity/id :activity/kind :activity/verb :activity/at
-                 :activity/run-id :activity/tool-use-id :activity/status
-                 :activity/critical?])
+   (update (select-keys fact
+                        [:activity/id :activity/kind :activity/verb :activity/at
+                         :activity/run-id :activity/tool-use-id :activity/status
+                         :activity/critical?])
+           :activity/at portable-time)
     (:activity/tool-name fact)
     (assoc :activity/tool-name (compact-value (:activity/tool-name fact)))
     (:activity/outcome fact)
@@ -158,7 +166,7 @@
     (cond-> {:message/id (:id message)
              :message/from (:from message)
              :message/to (:to message)
-             :message/at (:ts message)
+             :message/at (portable-time (:ts message))
              :message/in-reply-to (:in-reply-to message)
              :message/thread-root-id (discourse/thread-root-id message)
              :message/run-id (activity/message-run-id message)}

--- a/src/dvergr/agent/process.clj
+++ b/src/dvergr/agent/process.clj
@@ -18,6 +18,7 @@
    Effects are applied by `run-effect!`, a multimethod against
    chat-ctx — unknown ops are logged and skipped, never crash."
   (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.signal :as sig]
             [dvergr.chat.context :as chat-ctx]
             [dvergr.chat.accounting :as acct]
@@ -428,7 +429,14 @@
     (swap-registry! process-chat-ctx assoc pid process)
     (future
       (binding [*current-process*    process
-                ec/*execution-context* world]
+                ec/*execution-context* world
+                ;; Clojure futures convey dynamic bindings from their creator.
+                ;; ->process is often called by a Spindel drain slice, but its
+                ;; body runs on a genuinely separate worker and may safely
+                ;; deref a Spin. Do not leak the creator's re-entrancy guard or
+                ;; structural Spin identity across this detached boundary.
+                simple/*in-drain?* false
+                ec/*spin-id* nil]
         (try
           (let [result (body-fn)]
             (reset! (:status-signal process) :completed)

--- a/src/dvergr/agent/turn.clj
+++ b/src/dvergr/agent/turn.clj
@@ -230,10 +230,21 @@
   ([room agent-id chat-ctx posted]
    (post-turn-activity! room agent-id chat-ctx posted nil nil))
   ([room agent-id chat-ctx posted run-id trigger]
-   (let [tool-msgs (->> (chat-ctx/get-messages chat-ctx)
+   (let [messages (chat-ctx/get-messages chat-ctx)
+         tool-msgs (->> messages
                         (filter #(= :assistant (or (:role %) (:message/role %))))
                         (filter #(seq (or (:message/tool-uses %) (:tool-uses %))))
-                        vec)]
+                        vec)
+         outcomes (into {}
+                        (keep (fn [message]
+                                (when (= :tool-result
+                                         (or (:role message)
+                                             (:message/role message)))
+                                  [(or (:tool-use-id message)
+                                       (:message/tool-use-id message))
+                                   (or (:content message)
+                                       (:message/content message))])))
+                        messages)]
      (when (> (count tool-msgs) @posted)
        (binding [rtc/*execution-context* (:ctx room)]
          (doseq [m (subvec tool-msgs @posted)]
@@ -247,7 +258,7 @@
                             (cond-> {:role :tool
                                      :tool-uses uses
                                      :activities (activity/tool-activities
-                                                  run-id source-id uses)}
+                                                  run-id source-id uses outcomes)}
                               (seq reason) (assoc :reasoning reason)))))))
        (reset! posted (count tool-msgs)))
      nil)))

--- a/test/dvergr/activity_test.clj
+++ b/test/dvergr/activity_test.clj
@@ -1,5 +1,6 @@
 (ns dvergr.activity-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [dvergr.activity :as activity]
             [dvergr.agent.environment :as environment]))
 
@@ -19,6 +20,29 @@
       (is (uuid? first-id))
       (is (= first-id replay-id))
       (is (not= first-id other-id)))))
+
+(deftest tool-activities-carry-only-typed-allowlisted-diagnostics
+  (let [run-id (random-uuid)
+        source-id (random-uuid)
+        uses [{:tool-use/id "call-1" :tool-use/name "clojure_eval"}
+              {:tool-use/id "call-2" :tool-use/name "clojure_eval"}
+              {:tool-use/id "call-3" :tool-use/name "read_file"}]
+        activities (activity/tool-activities
+                    run-id source-id uses
+                    {"call-1" "=> \"secret-token\""
+                     "call-2" "Evaluation error: private@example.test"
+                     "call-3" "secret file contents"})]
+    (is (= :completed (:activity/status (first activities))))
+    (is (nil? (:activity/outcome (first activities))))
+    (is (= {:activity/status :failed
+            :activity/outcome "clojure-eval/error"}
+           (select-keys (second activities)
+                        [:activity/status :activity/outcome])))
+    (is (nil? (:activity/status (nth activities 2))))
+    (is (nil? (:activity/outcome (nth activities 2))))
+    (is (not (str/includes? (pr-str activities) "secret")))
+    (is (not (str/includes? (pr-str activities)
+                            "private@example.test")))))
 
 (deftest tool-traces-preserve-correlation-across-interleaved-runs
   (let [run-a (random-uuid)

--- a/test/dvergr/agent/evaluation_test.clj
+++ b/test/dvergr/agent/evaluation_test.clj
@@ -140,6 +140,39 @@
       (finally
         (d/close-room! room)))))
 
+(deftest host-evaluator-workers-can-compose-and-deref-spins
+  (let [room (test-room :evaluation-worker-spin)
+        team (roster/make-agent
+              (roster/make-roster)
+              {:id :candidate
+               :program {:kind :echo}})
+        env (definition :test/worker-spin {})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact
+          :version 1
+          :basis "test:v1"
+          :observe (fn [{:keys [default]}]
+                     @(sp/spin default))
+          :verify (fn [environment evidence]
+                    @(sp/spin
+                      (let [exact? (= (:environment/task environment)
+                                      (:result evidence))]
+                        {:checks {:exact? exact?}
+                         :reward (if exact? 1.0 0.0)})))})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result @(evaluation/evaluate room team :candidate env evaluator)]
+          (try
+            (is (= {:exact? true}
+                   (get-in result [:attempt-receipt :attempt/checks])))
+            (is (= 1.0 (get-in result [:attempt-receipt :attempt/reward])))
+            (finally
+              (discard-retained! result)))))
+      (finally
+        (evaluation/await-cleanups! room 5000)
+        (d/close-room! room)))))
+
 (deftest evaluation-fails-closed-when-attempt-certification-is-not-durable
   (let [delegate (memory/make)
         room (d/make-room {:id :evaluation-attempt-durability

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -9,8 +9,10 @@
             [dvergr.room.registry :as registry]
             [dvergr.room.store :as store]
             [dvergr.room.store.memory :as memory]
+            [dvergr.rooms.forks :as forks]
             [hasch.core :as hasch]
-            [org.replikativ.spindel.engine.core :as ec]))
+            [org.replikativ.spindel.engine.core :as ec])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (defn- environment
   ([id task] (environment id 1 task))
@@ -245,4 +247,82 @@
           (is (every? #(= :discarded (:run/settlement-status %)) runs))
           (is (every? #(nil? (registry/lookup (:run/world %))) runs))))
       (finally
+        (d/close-room! room)))))
+
+(deftest parallel-cell-failure-has-a-host-cleanup-barrier
+  (let [team (-> (roster/make-roster {:id :experiment/cleanup-team})
+                 (roster/make-agent {:id :alpha :program {:kind :echo}}))
+        dataset (experiment/make-dataset
+                 {:id :experiment/cleanup-tasks
+                  :environments [(environment :cleanup/slow-a 1 :slow-a)
+                                 (environment :cleanup/slow-b 1 :slow-b)
+                                 (environment :cleanup/fail 1 :fail)]})
+        definition (experiment/make-experiment
+                    {:id :experiment/parallel-cleanup
+                     :dataset dataset
+                     :candidates [(roster/agent team :alpha)]})
+        slow-started (CountDownLatch. 2)
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact
+          :version 1
+          :basis "experiment-test:v1"
+          :observe (fn [{:keys [default]}] default)
+          :verify
+          (fn [environment _]
+            (if (contains? #{:slow-a :slow-b}
+                           (:environment/task environment))
+              (do
+                (.countDown slow-started)
+                (Thread/sleep 10000)
+                {:checks {:unexpected? true} :reward 0.0})
+              (do
+                (when-not (.await slow-started 5 TimeUnit/SECONDS)
+                  (throw (ex-info "slow verifiers did not start" {})))
+                (throw (ex-info "deliberate parallel verifier failure" {})))))})
+        room (d/make-room {:id :experiment-parallel-cleanup
+                           :store (memory/make)})
+        discard! forks/discard-deferred!
+        discard-count (atom 0)
+        failing-discard
+        (fn failing-discard
+          ([fork reason]
+           (failing-discard fork reason (constantly true)))
+          ([fork reason claim!]
+           (if (= 2 (swap! discard-count inc))
+             {:ok? false
+              :fork/id (:id fork)
+              :error :deliberate-discard-failure}
+             (discard! fork reason claim!))))]
+    (try
+      (with-redefs [forks/discard-deferred! failing-discard]
+        (binding [ec/*execution-context* (:ctx room)]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"certification failed"
+               @(experiment/run room team definition
+                                {(:ref evaluator) evaluator}
+                                {:parallelism 3}))))
+        (let [error (try
+                      (evaluation/await-cleanups! room 5000)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= :dvergr.agent.evaluation/cleanup-incomplete
+                 (:type (ex-data error))))
+          (is (= 1 (count (:failures (ex-data error))))))
+        (is (= 3 @discard-count)
+            "the barrier joins every sibling despite one cleanup failure"))
+      (is (empty? (run/active-runs (:id room))))
+      (let [runs (run/runs room {:limit 10})]
+        (is (= 3 (count runs)))
+        (is (= 2 (count (filter #(= :discarded
+                                    (:run/settlement-status %))
+                                runs))))
+        ;; Recover the one retained affine world before closing the fixture.
+        (binding [ec/*execution-context* (:ctx room)]
+          (doseq [run runs
+                  :let [fork (registry/lookup (:run/world run))]
+                  :when fork]
+            (is (:ok? (discard! fork :test-recovery))))))
+      (finally
+        (evaluation/await-cleanups! room 5000)
         (d/close-room! room)))))

--- a/test/dvergr/agent/observation_test.clj
+++ b/test/dvergr/agent/observation_test.clj
@@ -3,6 +3,7 @@
             [datahike.api :as dh]
             [dvergr.activity :as activity]
             [dvergr.agent.observation :as observation]
+            [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
             [dvergr.chat.schema :as schema]
             [dvergr.discourse :as d]
@@ -65,7 +66,13 @@
                      :activity/run-id)))
           (is (= (activity/message-run-id
                   {:metadata {:run-id (:run/id child)}})
-                 (:run/id child)))))
+                 (:run/id child))))
+        (testing "the complete projection is portable workflow/evidence data"
+          (is (roster/data-value? scoped))
+          (is (integer? (-> scoped :observation/runs first :run/started-at)))
+          (is (integer? (:message/at tool-message)))
+          (is (integer? (-> scoped :observation/activities first
+                            :activity/at)))))
       (testing "a foreign or stale scope fails closed"
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"not a Run in this Room"

--- a/test/dvergr/agent/process_test.clj
+++ b/test/dvergr/agent/process_test.clj
@@ -1,0 +1,35 @@
+(ns dvergr.agent.process-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.agent.process :as process]
+            [dvergr.agent.turn :as turn]
+            [dvergr.chat.context :as chat-context]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]))
+
+(deftest process-worker-does-not-inherit-the-callers-drain-marker
+  (let [execution-ctx (context/create-execution-context)
+        chat-ctx (turn/new-working-ctx
+                  {:execution-ctx execution-ctx
+                   :title "process drain-boundary"
+                   :durable? false})
+        completed (promise)
+        caller-spin-id (random-uuid)]
+    (try
+      (binding [ec/*execution-context* execution-ctx
+                ;; A real tool call is initiated by an engine drain slice.
+                simple/*in-drain?* true
+                ec/*spin-id* caller-spin-id]
+        (process/->process
+         chat-ctx
+         {:description "deref a Spin on the process worker"
+          :on-complete #(deliver completed {:value %})
+          :on-abort #(deliver completed {:error %})}
+         #(hash-map :inherited-spin-id ec/*spin-id*
+                    :result (deref (sp/spin :completed)))))
+      (is (= {:value {:inherited-spin-id nil :result :completed}}
+             (deref completed 5000 ::timeout)))
+      (finally
+        (chat-context/close-chat! chat-ctx)
+        (context/close-context! execution-ctx)))))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -464,7 +464,7 @@
                            chat-ctx
                            {:role :tool-result
                             :tool-use-id "call-1"
-                            :content "2"})
+                            :content "=> 2"})
                           :continue)
                         (do
                           (chat-context/add-message!
@@ -501,6 +501,9 @@
           (is (= ["clojure_eval"]
                  (mapv :tool-use/name
                        (get-in activity [:metadata :tool-uses]))))
+          (is (= [:completed]
+                 (mapv :activity/status
+                       (get-in activity [:metadata :activities]))))
           (is (= [{:activity/kind :tool
                    :activity/verb :invoke
                    :activity/run-id (program/run-id handle)


### PR DESCRIPTION
## Summary

- migrate setup-free Codex/Claude programming probes onto DatasetDef/ExperimentDef/Scorecard execution
- preserve portable, scoped tool status and allowlisted diagnostics without copying private result content into Room history
- fix process workers inheriting Spindel's drain marker and Spin identity, restoring the documented REPL `@(spin (await ...))` bridge
- join every detached scorer/cleanup task before closing ephemeral benchmark rooms, aggregate sibling failures, and retain failed Rooms for explicit recovery
- make prompt policy exact candidate content and document the first paired smoke findings

## Verification

- `clojure -M:format`
- `clojure -M:test` (665 tests, 3043 assertions)
- `clojure -T:build harness`
- live Claude Code Sonnet join: reward 1.0, 3 model steps, exactly 2 child Runs
- live Codex subscription Sol join: reward 1.0, 3 model steps, exactly 2 child Runs

Stacked on #90.
