### PR TITLE
Prepare exact trusted evaluation worlds

### DIFF
--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -350,6 +350,20 @@
    resource-setup-ref resource-environment
    renewal-risk-setup-ref renewal-risk-environment})
 
+(def ^:private trusted-world-setups
+  (into {}
+        (map (fn [ref]
+               [ref (evaluation/make-world-setup
+                     {:id (:setup/id ref)
+                      :version (:setup/version ref)
+                      :basis (:setup/basis ref)
+                      ;; The current Room factories establish their shared
+                      ;; baseline before the experiment. This exact per-Run
+                      ;; hook still closes the semantic setup gate and is where
+                      ;; fork-local scenario transactions compose next.
+                      :prepare (fn [_] {:setup/ref ref})})]))
+        [memory-setup-ref resource-setup-ref renewal-risk-setup-ref]))
+
 (def ^:private trusted-verifiers
   {#:verifier{:id :programming/join-checks-v1 :version 1} join-checks
    #:verifier{:id :programming/race-checks-v1 :version 1} race-checks
@@ -450,7 +464,7 @@
                 (contains? verifier :verifier/basis)
                 (assoc :basis (:verifier/basis verifier)))
               :limits (:environment/limits definition)
-              :world (-> world (dissoc :setup) (assoc :settlement :discard))}
+              :world (assoc world :settlement :discard)}
        (contains? definition :environment/metadata)
        (assoc :metadata (:environment/metadata definition))))))
 
@@ -591,8 +605,9 @@
                                    evaluator])))
                          definitions)]
     (experiment/run room team experiment-definition evaluators
-                    (select-keys opts [:parallelism :max-parallelism
-                                       :max-attempts]))))
+                    (assoc (select-keys opts [:parallelism :max-parallelism
+                                              :max-attempts])
+                           :world-setups trusted-world-setups))))
 
 (defn run-paired-experiment!
   "Convenience REPL entry point for a live paired experiment.

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -242,10 +242,11 @@ authority:
 Coordinates are extensible strings; `"microUSD"` is merely the first installed
 unit. Kontor records the allocation and return as balanced, idempotent receipts,
 and its Datahike writer predicate rejects overdrafts or unreceipted changes.
-Allocation happens after durable Run admission but before the trigger or any
-program effect. If it fails, the Run is durably failed and no agent effect
-starts. After all owned work quiesces, unused resources return to the structural
-parent; recursive vectors therefore remain conserved across fork/join.
+Allocation happens after durable Run admission and persistence of its private
+causal trigger, but before any agent effect. If it fails, the Run is durably
+failed and no agent effect starts. After all owned work quiesces, unused
+resources return to the structural parent; recursive vectors therefore remain
+conserved across fork/join.
 
 SCI exposes only `agent/balance` and the `:resources` argument to `hire!`. It
 does not expose connections, minting, arbitrary transfers, or a way to redirect
@@ -349,11 +350,16 @@ runner resolves exact verifier and world-setup references and computes reward.
 The benchmark interpreter derives its timeout, cancellation grace, restrictive
 model-step and dollar limits, settlement policy, and resource grants from that
 validated definition. It rejects unsupported policy keys instead of silently
-certifying a different scenario. In particular, world `:setup` remains closed
-until the host supplies a versioned trusted setup resolver. Each attempt still
-receives a fresh Run ID, so content identity never collapses distinct
-executions. The current REPL benchmark reports retain both the exact definition
-and its compact reference.
+certifying a different scenario. A world `:setup` is an exact portable
+reference resolved to a process-local trusted `WorldSetup`; the preparer runs
+as supervised, cancellable host work against the already-forked candidate world
+after durable Run admission and its private causal trigger, but before resource
+allocation or model work. Setup failure/cancellation is audited on the Run but
+never scored as a candidate Attempt. Setup evidence is portable and visible
+only to the trusted observer. Missing or mismatched setup capabilities fail
+during experiment preflight. Each attempt still receives a fresh Run ID, so
+content identity never collapses distinct executions. The current REPL
+benchmark reports retain both the exact definition and its compact reference.
 
 Every opt-in REPL attempt returns a content-addressed `:attempt-receipt`. It binds the
 unique root Run to the exact EnvironmentDef, provider/model, exact assembled
@@ -467,8 +473,8 @@ levels:
    Reports retain individual checks, binary reward, generated SCI, leaked
    Runs/resources, model steps, token/cost usage, wall time, task version,
    model, typed allowlisted tool diagnostics, and a stable ID of the exact assembled system
-   prompt. Durable receipt
-   persistence, trusted-writer authorization, and settlement against a retained
+   prompt. Exact trusted world setup and durable receipt persistence now guard
+   the attempt; trusted-writer authorization and settlement against a retained
    benchmark world remain follow-ups.
 
 The initial model-facing task set should include pure roster specialization,

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -126,6 +126,14 @@ and Attempts remain the evidence of record. A leaderboard can later be a
 Datahike projection over admitted Scorecards rather than mutable benchmark
 state.
 
+An EnvironmentDef may also name an exact WorldSetup reference. The host
+resolves that reference before admitting any experiment cell, while the actual
+preparer runs separately for every cell inside its already-forked Run world.
+This makes fixture construction part of the reproducible environment identity
+without exposing live preparers or verifier authority to SCI. Shared substrate
+provisioning—such as opening a Datahike/Kontor arena or a managed browser—stays
+an outer resource lifecycle; fork-local scenario state belongs to WorldSetup.
+
 The first provider-free room-REPL probe on 2026-09-04 executed two echo
 candidates against two environments with two repetitions and parallelism two.
 It produced eight distinct durable Runs, eight certified Attempts, two 4/4

--- a/src/dvergr/agent/environment.clj
+++ b/src/dvergr/agent/environment.clj
@@ -50,6 +50,27 @@
              :verifier/version (or version 1)}
       basis (assoc :verifier/basis basis))))
 
+(def ^:private setup-ref-keys #{:setup/id :setup/version :setup/basis})
+
+(defn- setup-ref! [setup]
+  (when-not (map? setup)
+    (invalid! "Environment world :setup must be an exact reference map"
+              ::invalid-setup {:setup setup}))
+  (when-let [unknown (seq (remove setup-ref-keys (keys setup)))]
+    (invalid! "Environment world :setup contains unknown keys"
+              ::unknown-setup-keys {:unknown (set unknown)}))
+  (when-not (keyword? (:setup/id setup))
+    (invalid! "World setup :setup/id must be a keyword"
+              ::invalid-setup-id {:id (:setup/id setup)}))
+  (positive-version! "World setup :setup/version" (:setup/version setup))
+  (when-not (roster/data-value? (:setup/basis setup))
+    (invalid! "World setup :setup/basis must contain only portable data"
+              ::non-portable-setup-basis {:basis (:setup/basis setup)}))
+  (cond-> {:setup/id (:setup/id setup)
+           :setup/version (:setup/version setup)}
+    (some? (:setup/basis setup))
+    (assoc :setup/basis (:setup/basis setup))))
+
 (defn make-environment
   "Construct a portable, content-addressed EnvironmentDef.
 
@@ -82,19 +103,22 @@
   (when-not (map? world)
     (invalid! "Environment :world must be a map"
               ::invalid-world {:world world}))
-  (when (and metadata (not (map? metadata)))
-    (invalid! "Environment :metadata must be a map"
-              ::invalid-metadata {:metadata metadata}))
-  (let [definition (cond-> {:environment/id id
-                            :environment/version version
-                            :environment/task task
-                            :environment/verifier (verifier-ref! verifier)
-                            :environment/limits limits
-                            :environment/world world}
-                     metadata (assoc :environment/metadata metadata))]
-    (assoc definition
-           :environment/content-id
-           (hasch/uuid [:dvergr/environment-definition definition]))))
+  (let [world (if (contains? world :setup)
+                (assoc world :setup (setup-ref! (:setup world)))
+                world)]
+    (when (and metadata (not (map? metadata)))
+      (invalid! "Environment :metadata must be a map"
+                ::invalid-metadata {:metadata metadata}))
+    (let [definition (cond-> {:environment/id id
+                              :environment/version version
+                              :environment/task task
+                              :environment/verifier (verifier-ref! verifier)
+                              :environment/limits limits
+                              :environment/world world}
+                       metadata (assoc :environment/metadata metadata))]
+      (assoc definition
+             :environment/content-id
+             (hasch/uuid [:dvergr/environment-definition definition])))))
 
 (defn validate-environment
   "Validate that `environment` is canonical portable data and that its content

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -21,6 +21,7 @@
             [org.replikativ.spindel.spin.sync :as sync]))
 
 (defrecord Evaluator [ref observe verify])
+(defrecord WorldSetup [ref prepare])
 
 (defonce ^:private pending-tasks (atom {}))
 
@@ -146,10 +147,43 @@
                  (some? basis) (assoc :verifier/basis basis))
                observe verify))
 
+(defn make-world-setup
+  "Create a process-local trusted preparer for one exact world setup.
+
+   `prepare` runs after the candidate Run and its isolated world exist, but
+   before resource allocation or candidate work. Its private causal trigger is
+   already durable. It receives
+   `{:room isolated-work-room :run/id uuid :environment EnvironmentDef}` and may
+   transact only against that fork-local world. Its optional return value must
+   be portable data and is supplied to the trusted Evaluator observer as
+   `:setup/evidence`. The capability itself is never portable or exposed to SCI."
+  [{:keys [id version basis prepare]
+    :or {version 1}}]
+  (when-not (keyword? id)
+    (throw (ex-info "World setup :id must be a keyword"
+                    {:type ::invalid-setup-id :id id})))
+  (when-not (and (integer? version) (pos? version))
+    (throw (ex-info "World setup :version must be a positive integer"
+                    {:type ::invalid-setup-version :version version})))
+  (when-not (roster/data-value? basis)
+    (throw (ex-info "World setup :basis must contain only portable data"
+                    {:type ::invalid-setup-basis :basis basis})))
+  (when-not (fn? prepare)
+    (throw (ex-info "World setup :prepare must be a function"
+                    {:type ::invalid-setup-preparer})))
+  (->WorldSetup (cond-> {:setup/id id :setup/version version}
+                  (some? basis) (assoc :setup/basis basis))
+                prepare))
+
 (defn evaluator-ref
   "Return the portable verifier reference named by an Evaluator capability."
   [evaluator]
   (:ref evaluator))
+
+(defn world-setup-ref
+  "Return the portable exact reference named by a WorldSetup capability."
+  [setup]
+  (:ref setup))
 
 (defn- require-matching-evaluator! [definition evaluator]
   (when-not (instance? Evaluator evaluator)
@@ -163,6 +197,26 @@
                        :expected expected
                        :actual actual}))))
   evaluator)
+
+(defn- require-matching-setup! [definition setup]
+  (let [expected (get-in definition [:environment/world :setup])]
+    (cond
+      (nil? expected)
+      (when setup
+        (throw (ex-info "Environment without :setup received a WorldSetup"
+                        {:type ::unexpected-world-setup
+                         :actual (when (instance? WorldSetup setup)
+                                   (:ref setup))})))
+
+      (not (instance? WorldSetup setup))
+      (throw (ex-info "Environment requires an exact host WorldSetup"
+                      {:type ::missing-world-setup :expected expected}))
+
+      (not= expected (:ref setup))
+      (throw (ex-info "WorldSetup does not match EnvironmentDef"
+                      {:type ::world-setup-mismatch
+                       :expected expected :actual (:ref setup)})))
+    setup))
 
 (defn- default-evidence [{:keys [result durable]}]
   {:result (:run/value result)
@@ -213,7 +267,7 @@
       (throw (ex-info "Evaluation environment contains unsupported limits"
                       {:type ::unsupported-evaluation-limits
                        :unknown (set unknown)})))
-    (when-let [unknown (seq (remove #{:isolation :settlement :resources}
+    (when-let [unknown (seq (remove #{:isolation :settlement :resources :setup}
                                     (keys world)))]
       (throw (ex-info
               "Evaluation environment contains unsupported world policy; setup requires a trusted resolver"
@@ -257,10 +311,12 @@
           (recur (ex-cause error))))))
 
 (defn- certification-candidate
-  [{:keys [room definition evaluator agent run-id result durable
-           started-at started-nanos timeout?]}]
+  [{:keys [room world-room setup-evidence definition evaluator agent run-id
+           result durable started-at started-nanos timeout?]}]
   (let [evidence ((:observe evaluator)
                   {:room room
+                   :world/room world-room
+                   :setup/evidence setup-evidence
                    :environment definition
                    :run-id run-id
                    :result result
@@ -306,10 +362,12 @@
   ([room team agent-ref definition evaluator]
    (evaluate room team agent-ref definition evaluator {}))
   ([room team agent-ref definition evaluator
-    {:keys [from parent-run] :or {from :environment} :as opts}]
+    {:keys [from parent-run world-setup]
+     :or {from :environment} :as opts}]
    (environment/validate-environment definition)
    (require-matching-evaluator! definition evaluator)
-   (let [agent (roster/agent team agent-ref)
+   (let [world-setup (require-matching-setup! definition world-setup)
+         agent (roster/agent team agent-ref)
          {:keys [timeout-ms cancel-timeout-ms]
           :or {timeout-ms 120000 cancel-timeout-ms 10000}}
          (:environment/limits definition)
@@ -317,7 +375,8 @@
           :or {settlement :review}}
          (:environment/world definition)
          model-limits (when agent (require-supported-policy! definition agent))]
-     (when-let [unknown (seq (remove #{:from :parent-run} (keys opts)))]
+     (when-let [unknown (seq (remove #{:from :parent-run :world-setup}
+                                     (keys opts)))]
        (throw (ex-info "Evaluation contains unknown options"
                        {:type ::unknown-evaluation-options
                         :unknown (set unknown)})))
@@ -350,7 +409,19 @@
                         parent-run (assoc :parent-run parent-run)
                         (seq resources) (assoc :resources resources)
                         (seq model-limits) (assoc :limits model-limits))
-            handle (program/hire! room team agent-ref hire-opts)
+            setup-evidence (atom nil)
+            prepare-world!
+            (when world-setup
+              (fn [context]
+                (let [evidence ((:prepare world-setup)
+                                (assoc context :environment definition))]
+                  (when-not (roster/data-value? evidence)
+                    (throw (ex-info "World setup evidence must be portable"
+                                    {:type ::non-portable-setup-evidence
+                                     :setup (:ref world-setup)})))
+                  (reset! setup-evidence evidence))))
+            handle (program/hire-prepared-in! room room team agent-ref hire-opts
+                                              prepare-world!)
             timed-out ::timed-out
             initial (sp/await
                      (comb/timeout (program/owned-result-spin handle)
@@ -370,6 +441,21 @@
         (let [run-id (program/run-id handle)
               durable (program/observe room handle)
               fork (some-> (:run/world result) registry/lookup)
+              _ (when (contains? #{:world-setup-failed
+                                   :world-setup-cancelled}
+                                 (:run/reason durable))
+                  ;; Setup is trusted environment construction, not candidate
+                  ;; work. It has an auditable Run and settled world but must
+                  ;; never produce a reward-bearing Attempt or enter the
+                  ;; evaluator.
+                  (throw
+                   (ex-info (or (:run/error durable)
+                                "Environment world setup did not complete")
+                            {:type ::world-setup-failed
+                             :run/id run-id
+                             :run/world (:run/world result)
+                             :run/status (:run/status durable)
+                             :run/reason (:run/reason durable)})))
               evaluation-spin-id ec/*spin-id*
               cancelled-externally?
               #(and evaluation-spin-id
@@ -434,6 +520,8 @@
                            (certification-candidate
                             {:room room :definition definition
                              :evaluator evaluator :agent agent :run-id run-id
+                             :world-room fork
+                             :setup-evidence @setup-evidence
                              :result result :durable durable
                              :started-at started-at :started-nanos started-nanos
                              :timeout? timeout?})

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -233,6 +233,19 @@
                                        :environment
                                        (environment/environment-ref definition)}))))
 
+(defn- world-setup! [world-setups definition]
+  (when-let [ref (get-in definition [:environment/world :setup])]
+    (or (get world-setups ref)
+        (invalid! "Experiment has no exact host WorldSetup for an environment"
+                  ::missing-world-setup
+                  {:setup ref
+                   :environment (environment/environment-ref definition)}))))
+
+(defn- cell-evaluation-opts [world-setups opts definition]
+  (if-let [setup (world-setup! world-setups definition)]
+    (assoc opts :world-setup setup)
+    opts))
+
 (defn- jobs [experiment]
   (for [candidate (:experiment/candidates experiment)
         definition (get-in experiment
@@ -242,12 +255,13 @@
      :environment definition
      :repetition repetition}))
 
-(defn- result-spin [room team evaluators opts job]
+(defn- result-spin [room team evaluators world-setups opts job]
   (let [definition (:environment job)
         candidate (:candidate job)
         evaluation-spin
         (evaluation/evaluate room team (:candidate/agent candidate)
-                             definition (evaluator! evaluators definition) opts)]
+                             definition (evaluator! evaluators definition)
+                             (cell-evaluation-opts world-setups opts definition))]
     (sp/spin
      (let [result (sp/await evaluation-spin)]
        (assoc result :experiment/job
@@ -438,24 +452,29 @@
    admission ceilings are preflighted before the Spin can admit a Run. Jobs and
    evaluation Spins are realized one bounded batch at a time. Options include
    ordinary evaluation `:from`/`:parent-run` plus host-owned `:parallelism`,
-   `:max-parallelism`, and `:max-attempts`. Experiment batches initially require
-   discard settlement; retained partial experiments need durable execution
-   identity and recovery first."
+   `:max-parallelism`, `:max-attempts`, and an exact `:world-setups` capability
+   map for environments that name setup references. Experiment batches
+   initially require discard settlement; retained partial experiments need
+   durable execution identity and recovery first."
   ([room team experiment evaluators]
    (run room team experiment evaluators {}))
   ([room team experiment evaluators
-    {:keys [parallelism max-parallelism max-attempts]
-     :or {parallelism 1 max-parallelism 16 max-attempts 256}
+    {:keys [parallelism max-parallelism max-attempts world-setups]
+     :or {parallelism 1 max-parallelism 16 max-attempts 256 world-setups {}}
      :as opts}]
    (validate-experiment experiment)
    (when-not (map? evaluators)
      (invalid! "Experiment evaluators must be a host capability map"
                ::invalid-evaluators {:evaluators evaluators}))
+   (when-not (map? world-setups)
+     (invalid! "Experiment WorldSetups must be a host capability map"
+               ::invalid-world-setups {:world-setups world-setups}))
    (doseq [candidate (:experiment/candidates experiment)]
      (exact-agent! team candidate))
    (doseq [definition (get-in experiment
                               [:experiment/dataset :dataset/environments])]
      (evaluator! evaluators definition)
+     (world-setup! world-setups definition)
      (when-not (= :discard (get-in definition
                                    [:environment/world :settlement]))
        (invalid! "Experiment batches currently require :discard settlement"
@@ -464,7 +483,8 @@
                   :settlement (get-in definition
                                       [:environment/world :settlement])})))
    (when-let [unknown (seq (remove #{:from :parent-run :parallelism
-                                     :max-parallelism :max-attempts}
+                                     :max-parallelism :max-attempts
+                                     :world-setups}
                                    (keys opts)))]
      (invalid! "Experiment contains unknown run options"
                ::unknown-run-options {:unknown (set unknown)}))
@@ -486,17 +506,20 @@
                        ::attempts-exceed-ceiling
                        {:attempt-count attempt-count
                         :max-attempts max-attempts}))
-         evaluation-opts (select-keys opts [:from :parent-run])
+         base-evaluation-opts (select-keys opts [:from :parent-run])
          ;; Validate every distinct candidate/environment pairing once before
          ;; execution. Repetitions are constructed lazily per bounded batch.
          _ (doseq [candidate (:experiment/candidates experiment)
                    definition (get-in experiment
                                       [:experiment/dataset
                                        :dataset/environments])]
-             (evaluation/evaluate room team (:candidate/agent candidate)
-                                  definition (evaluator! evaluators definition)
-                                  evaluation-opts))
-         spins (map #(result-spin room team evaluators evaluation-opts %)
+             (evaluation/evaluate
+              room team (:candidate/agent candidate)
+              definition (evaluator! evaluators definition)
+              (cell-evaluation-opts world-setups base-evaluation-opts
+                                    definition)))
+         spins (map #(result-spin room team evaluators world-setups
+                                  base-evaluation-opts %)
                     (jobs experiment))]
      (sp/spin
       (let [results (sp/await (run-batches spins parallelism))]

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -81,6 +81,7 @@
                   :cleanup-phase :pending
                   :cleanup-error nil
                   :llm-metrics nil
+                  :execution-phase :admitted
                   :quiesced? false})
     :quiesced (sync/deferred)
     :quiesced-latch (CountDownLatch. 1)}))
@@ -159,7 +160,13 @@
          callable   (reify Callable
                       (call [_]
                         (when (compare-and-set! phase :new :running)
-                          (binding [ec/*execution-context* (:worker-ctx supervisor)]
+                          (binding [ec/*execution-context* (:worker-ctx supervisor)
+                                    ;; A native worker is an effect boundary,
+                                    ;; not another node in the caller's Spin.
+                                    ;; In particular trusted world setup must
+                                    ;; not inherit the drain/graph identity
+                                    ;; which admitted the Run.
+                                    ec/*spin-id* nil]
                             (try
                               (reset! result (f))
                               (catch Throwable t
@@ -1048,30 +1055,75 @@
      (deliver outcome-promise outcome)
      result)))
 
-(defn hire-in!
-  "Start one AgentDef execution with separate control and work parents.
+(defn- prepared-execution-spin
+  "Run trusted fork-local preparation off the drain before candidate effects.
+
+   The setup worker is owned by the same supervisor as model/native work, so
+   targeted cancellation interrupts it and physical quiescence waits for its
+   actual exit. Resource allocation and candidate execution remain behind the
+   successful setup gate; the private causal trigger is already durable."
+  [control-room work-room agent task trigger id chat-id parent-run resources
+   supervisor limits outcome-promise prepare-world!]
+  (sp/spin
+   (let [_ (swap! (:state supervisor) assoc :execution-phase :world-setup)
+         worker (start-worker! supervisor
+                               #(prepare-world! {:room work-room :run/id id}))
+         prepared (sp/await (worker-result-spin worker))]
+     (cond
+       (run/cancel-requested? id)
+       (throw (ex-info "Run cancelled during world setup"
+                       {:type ::world-setup-cancelled :run/id id}))
+
+       (worker-error? prepared)
+       (let [cause (::worker-error prepared)]
+         (throw (ex-info (str "Run world setup failed: " (ex-message cause))
+                         {:type ::world-setup-failed :run/id id}
+                         cause))))
+     (try
+       (resource/allocate-run! control-room id parent-run resources)
+       (catch Throwable t
+         (throw (ex-info "Run resource allocation failed"
+                         {:type ::resource-allocation-failed :run/id id}
+                         t))))
+     (when (run/cancel-requested? id)
+       (throw (ex-info "Run cancelled after world setup"
+                       {:type ::world-setup-cancelled :run/id id})))
+     (swap! (:state supervisor) assoc :execution-phase :candidate)
+     (sp/await
+      (execution-spin control-room work-room agent task trigger id chat-id
+                      supervisor limits outcome-promise)))))
+
+(defn- execution-failure-reason [error]
+  (loop [error error]
+    (if error
+      (case (:type (ex-data error))
+        ::world-setup-failed :world-setup-failed
+        ::world-setup-cancelled :world-setup-cancelled
+        ::resource-allocation-failed :resource-allocation-failed
+        ::trigger-emission-failed :trigger-emission-failed
+        (recur (ex-cause error)))
+      :execution-error)))
+
+(defn ^:no-doc hire-prepared-in!
+  "Host-only Run admission with a trusted fork-local world preparer.
 
    `control-room` owns durable Run/message facts. `world-parent` is the
    immediate Spindel/Yggdrasil world that the child forks and later settles
    into. They are identical for a top-level hire and intentionally differ for
    recursive hires inside an already-isolated Run world.
 
-   `agent-ref` is a keyword id or versioned ref resolved against immutable
-   `roster`. Options:
-
-   - `:task`       portable task value (required)
-   - `:from`       triggering actor, default `:repl`
-   - `:parent-run` explicit structural parent Run UUID
-   - `:settlement`  `:automatic` (default), `:review`, `:discard`, or host-owned `:deferred`
-   - `:resources`   positive conserved vector split from the parent Run/Room
-   - `:limits`      restrictive LLM `:max-model-steps` / `:budget-dollars`
-   Built-in program kinds are deterministic `:scripted` / `:echo` and the
-   bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
-   interpreters implement the same boundary."
+   The preparer runs against the isolated work Room after durable admission and
+   before resource allocation or candidate-visible work. The private trigger
+   is already durable at that point so a setup failure remains causally valid.
+   This entry point is deliberately absent from the SCI surface."
   [control-room world-parent roster agent-ref
    {:keys [task from parent-run settlement resources limits]
     :or {from :repl settlement :automatic}
-    :as raw-opts}]
+    :as raw-opts}
+   prepare-world!]
+  (when-not (or (nil? prepare-world!) (fn? prepare-world!))
+    (throw (ex-info "Run world preparer must be a function"
+                    {:type ::invalid-world-preparer})))
   (let [opts      (assoc raw-opts :from from)
         agent     (validate-hire! roster agent-ref opts)
         actor     (:agent/id agent)
@@ -1105,35 +1157,48 @@
       (catch Throwable t
         (d/discard work-room)
         (throw t)))
-    (try
-      (resource/allocate-run! control-room id parent-run resources)
-      (catch Throwable t
-        (let [{:keys [status reason]} (world/settle! run-world :failed)]
-          (run/finish! id :failed {:reason :resource-allocation-failed
-                                   :error t
-                                   :settlement-status status
-                                   :settlement-reason reason}))
-        (throw t)))
     (run/register-cancel-hook! id ::native-worker
                                #(cancel-supervisor! supervisor))
+    ;; The trigger is the Run's durable causal input, not candidate execution.
+    ;; Persist it for every admitted Run—including setup failures—before any
+    ;; asynchronous phase starts. The private run sink prevents participant
+    ;; routing, while the exact message remains available to thread/audit
+    ;; projections.
     (try
-      ;; The precise trigger must exist before execution begins. A failed post
-      ;; terminalizes the already-admitted Run instead of leaving a :running
-      ;; record or an unowned message behind.
       (d/post! control-room trigger)
       (catch Throwable t
-        (return-unused-resources! control-room id parent-run (boolean (seq resources)))
-        (let [{:keys [status reason]} (world/settle! run-world :failed)]
-          (run/finish! id :failed {:reason :trigger-emission-failed
-                                   :error t
-                                   :settlement-status status
-                                   :settlement-reason reason}))
+        (let [{:keys [result finish-opts]}
+              (settlement-result
+               run-world
+               {:run/id id :run/status :failed
+                :run/error (ex-message t)})]
+          (run/finish! id (:run/status result)
+                       (merge {:reason :trigger-emission-failed :error t}
+                              finish-opts)))
         (throw t)))
+    ;; The ordinary path retains its fail-fast admission semantics. Trusted
+    ;; setup runs through `prepared-execution-spin` instead so setup, allocation,
+    ;; and candidate execution are all behind one timed/cancellable gate.
+    (when-not prepare-world!
+      (try
+        (resource/allocate-run! control-room id parent-run resources)
+        (catch Throwable t
+          (let [{:keys [status reason]} (world/settle! run-world :failed)]
+            (run/finish! id :failed {:reason :resource-allocation-failed
+                                     :error t
+                                     :settlement-status status
+                                     :settlement-reason reason}))
+          (throw t))))
     (try
       (let [completion (sync/deferred)
             outcome-promise (promise)
-            worker-execution (execution-spin control-room work-room agent task trigger id chat-id
-                                             supervisor limits outcome-promise)
+            worker-execution
+            (if prepare-world!
+              (prepared-execution-spin control-room work-room agent task trigger
+                                       id chat-id parent-run resources supervisor
+                                       limits outcome-promise prepare-world!)
+              (execution-spin control-room work-room agent task trigger id chat-id
+                              supervisor limits outcome-promise))
             execution (sp/spin (sp/await completion))
             owner-fork-id (:fork-id (ec/current-execution-context))
             handle    (RunHandle. id (:id control-room) owner-fork-id execution completion
@@ -1159,7 +1224,16 @@
             ;; this callback may safely block on stable supervisor quiescence,
             ;; while the cancelled body may not cross another await breakpoint.
             ;; finish! is idempotent if another terminal path already won.
-            (let [result (if (cancelled-error? t id)
+            (let [cancelled? (cancelled-error? t id)
+                  setup-cancelled?
+                  (and cancelled?
+                       prepare-world!
+                       (not= :candidate
+                             (:execution-phase @(:state supervisor))))
+                  failure-reason (if setup-cancelled?
+                                   :world-setup-cancelled
+                                   (execution-failure-reason t))
+                  result (if cancelled?
                            {:run/id id :run/status :cancelled}
                            {:run/id id :run/status :failed
                             :run/error (ex-message t)})]
@@ -1171,8 +1245,11 @@
                        {:result result
                         :finish-opts
                         (if (= :cancelled (:run/status result))
-                          {:reason :structured-cancellation}
-                          {:reason :execution-error :error t})})))})
+                          {:reason (if (= :world-setup-cancelled failure-reason)
+                                     failure-reason
+                                     :structured-cancellation)}
+                          {:reason failure-reason
+                           :error t})})))})
         (finalize-execution-external! world-parent control-room run-world id parent-run
                                       (boolean (seq resources)) supervisor worker-execution
                                       completion outcome-promise)
@@ -1184,6 +1261,29 @@
                                    :settlement-status status
                                    :settlement-reason reason}))
         (throw t)))))
+
+(defn hire-in!
+  "Start one AgentDef execution with separate control and work parents.
+
+   `control-room` owns durable Run/message facts. `world-parent` is the
+   immediate Spindel/Yggdrasil world that the child forks and later settles
+   into. They are identical for a top-level hire and intentionally differ for
+   recursive hires inside an already-isolated Run world.
+
+   `agent-ref` is a keyword id or versioned ref resolved against immutable
+   `roster`. Options:
+
+   - `:task`       portable task value (required)
+   - `:from`       triggering actor, default `:repl`
+   - `:parent-run` explicit structural parent Run UUID
+   - `:settlement` `:automatic` (default), `:review`, `:discard`, or host-owned `:deferred`
+   - `:resources`  positive conserved vector split from the parent Run/Room
+   - `:limits`     restrictive LLM `:max-model-steps` / `:budget-dollars`
+   Built-in program kinds are deterministic `:scripted` / `:echo` and the
+   bounded Dvergr-native `:llm` model/tool loop. Simulation and replay
+   interpreters implement the same boundary."
+  [control-room world-parent roster agent-ref opts]
+  (hire-prepared-in! control-room world-parent roster agent-ref opts nil))
 
 (defn hire!
   "Start a top-level AgentDef execution in `room` and return an opaque

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -16,6 +16,7 @@
             [dvergr.discourse :as d]
             [dvergr.model.providers :as providers]
             [dvergr.resource :as resource]
+            [dvergr.room.store :as room-store]
             [dvergr.system.rooms :as system-rooms]
             [dvergr.tools :as tools]
             [hasch.core :as hasch]
@@ -911,25 +912,46 @@
    idempotent. A configured resource allocation is never silently abandoned:
    transient store failures retain the live Run and retry behind the same
    physical-quiescence fence as durable terminal persistence."
-  [room id parent-run allocated?]
-  (when allocated?
-    (loop []
-      (let [outcome (try
-                      (let [remaining (resource/run-balance room id)]
-                        (when (seq remaining)
-                          (resource/return! room id parent-run remaining))
-                        :returned)
-                      (catch Throwable t t))]
-        (when (instance? Throwable outcome)
-          (Thread/sleep 25)
-          (recur))))))
+  [room id parent-run allocation-state]
+  (let [allocated?
+        (loop []
+          (case @allocation-state
+            (:not-requested :not-started) false
+            :allocated true
+            ;; The allocating worker exited through an exception. Reconcile its
+            ;; stable transfer identity after physical quiescence: a receipt is
+            ;; authoritative evidence that the wallet/grant committed, while an
+            ;; authoritative nil proves there is nothing to return.
+            (:attempting :uncertain)
+            (let [outcome
+                  (try
+                    (if (satisfies? room-store/PResourceStore (:store room))
+                      (boolean
+                       (room-store/-resource-receipt
+                        (:store room) (resource/allocation-id id)))
+                      false)
+                    (catch Throwable t t))]
+              (if (instance? Throwable outcome)
+                (do (Thread/sleep 25) (recur))
+                outcome))))]
+    (when allocated?
+      (loop []
+        (let [outcome (try
+                        (let [remaining (resource/run-balance room id)]
+                          (when (seq remaining)
+                            (resource/return! room id parent-run remaining))
+                          :returned)
+                        (catch Throwable t t))]
+          (when (instance? Throwable outcome)
+            (Thread/sleep 25)
+            (recur)))))))
 
 (defn- finalize-execution-external!
   "Finalize from a process-local watcher only after the orchestration Spin has a
    cached terminal result and the stable supervisor reports every native worker
    and owned cleanup quiescent. World settlement happens behind the same
    physical-quiescence fence."
-  [room control-room run-world id parent-run allocated? supervisor execution completion outcome]
+  [room control-room run-world id parent-run allocation-state supervisor execution completion outcome]
   (future
     ;; `future` conveys dynamic bindings. A cancellation hook normally launches
     ;; this watcher from the losing observer Spin, so retaining its *spin-id*
@@ -950,7 +972,7 @@
               (Thread/sleep 5)
               (recur))))
         (await-supervisor! supervisor)
-        (return-unused-resources! control-room id parent-run allocated?)
+        (return-unused-resources! control-room id parent-run allocation-state)
         (let [{:keys [cleanup-error llm-metrics]} @(:state supervisor)
               result (cond-> (if cleanup-error
                                {:run/id id :run/status :failed
@@ -1063,7 +1085,7 @@
    actual exit. Resource allocation and candidate execution remain behind the
    successful setup gate; the private causal trigger is already durable."
   [control-room work-room agent task trigger id chat-id parent-run resources
-   supervisor limits outcome-promise prepare-world!]
+   supervisor allocation-state limits outcome-promise prepare-world!]
   (sp/spin
    (let [_ (swap! (:state supervisor) assoc :execution-phase :world-setup)
          worker (start-worker! supervisor
@@ -1079,12 +1101,33 @@
          (throw (ex-info (str "Run world setup failed: " (ex-message cause))
                          {:type ::world-setup-failed :run/id id}
                          cause))))
-     (try
-       (resource/allocate-run! control-room id parent-run resources)
-       (catch Throwable t
-         (throw (ex-info "Run resource allocation failed"
-                         {:type ::resource-allocation-failed :run/id id}
-                         t))))
+     ;; Durable resource admission can block on Datahike. Keep it off the
+     ;; execution-context drain and under the same cancellation/quiescence fence
+     ;; as setup and provider work.
+     (when (seq resources)
+       (swap! (:state supervisor) assoc :execution-phase :resource-allocation)
+       (let [allocation-worker
+             (start-worker!
+              supervisor
+              (fn []
+                (reset! allocation-state :attempting)
+                (try
+                  (let [allocation
+                        (resource/allocate-run! control-room id parent-run resources)]
+                    (reset! allocation-state :allocated)
+                    allocation)
+                  (catch Throwable t
+                    (reset! allocation-state :uncertain)
+                    (throw t)))))
+             allocation (sp/await (worker-result-spin allocation-worker))]
+         (when (or (= ::worker-cancelled allocation)
+                   (run/cancel-requested? id))
+           (throw (ex-info "Run cancelled during resource allocation"
+                           {:type ::world-setup-cancelled :run/id id})))
+         (when (worker-error? allocation)
+           (throw (ex-info "Run resource allocation failed"
+                           {:type ::resource-allocation-failed :run/id id}
+                           (::worker-error allocation))))))
      (when (run/cancel-requested? id)
        (throw (ex-info "Run cancelled after world setup"
                        {:type ::world-setup-cancelled :run/id id})))
@@ -1132,6 +1175,8 @@
         run-world (world/open! world-parent id settlement)
         work-room (:work run-world)
         supervisor (make-supervisor (:ctx world-parent) (:ctx work-room))
+        allocation-state
+        (atom (if (seq resources) :not-started :not-requested))
         ;; Private Run facts are still Room messages, but never addressed to an
         ;; installed Participant: direct interpretation and participant routing
         ;; must not execute the same task twice.
@@ -1180,9 +1225,17 @@
     ;; setup runs through `prepared-execution-spin` instead so setup, allocation,
     ;; and candidate execution are all behind one timed/cancellable gate.
     (when-not prepare-world!
+      (when (seq resources) (reset! allocation-state :attempting))
       (try
         (resource/allocate-run! control-room id parent-run resources)
+        (when (seq resources) (reset! allocation-state :allocated))
         (catch Throwable t
+          ;; The durable transfer may have committed even when its caller saw an
+          ;; exception. Reconcile its stable receipt and return any authority
+          ;; before publishing the failed Run; hire! retains its synchronous
+          ;; admission-failure contract without leaking a committed grant.
+          (when (seq resources) (reset! allocation-state :uncertain))
+          (return-unused-resources! control-room id parent-run allocation-state)
           (let [{:keys [status reason]} (world/settle! run-world :failed)]
             (run/finish! id :failed {:reason :resource-allocation-failed
                                      :error t
@@ -1196,7 +1249,8 @@
             (if prepare-world!
               (prepared-execution-spin control-room work-room agent task trigger
                                        id chat-id parent-run resources supervisor
-                                       limits outcome-promise prepare-world!)
+                                       allocation-state limits outcome-promise
+                                       prepare-world!)
               (execution-spin control-room work-room agent task trigger id chat-id
                               supervisor limits outcome-promise))
             execution (sp/spin (sp/await completion))
@@ -1251,11 +1305,11 @@
                           {:reason failure-reason
                            :error t})})))})
         (finalize-execution-external! world-parent control-room run-world id parent-run
-                                      (boolean (seq resources)) supervisor worker-execution
+                                      allocation-state supervisor worker-execution
                                       completion outcome-promise)
         handle)
       (catch Throwable t
-        (return-unused-resources! control-room id parent-run (boolean (seq resources)))
+        (return-unused-resources! control-room id parent-run allocation-state)
         (let [{:keys [status reason]} (world/settle! run-world :failed)]
           (run/finish! id :failed {:reason :spawn-failed :error t
                                    :settlement-status status

--- a/test/dvergr/agent/environment_test.clj
+++ b/test/dvergr/agent/environment_test.clj
@@ -23,7 +23,9 @@
            (environment/environment-ref a)))
     (doseq [changed [(assoc base-spec :task "Different task")
                      (assoc-in base-spec [:verifier :version] 2)
-                     (assoc-in base-spec [:limits :max-model-steps] 9)]]
+                     (assoc-in base-spec [:limits :max-model-steps] 9)
+                     (assoc-in base-spec [:world :setup]
+                               {:setup/id :fixture :setup/version 1})]]
       (is (not= (:environment/content-id a)
                 (:environment/content-id
                  (environment/make-environment changed)))))))
@@ -39,6 +41,30 @@
                           #"portable data"
                           (environment/make-environment
                            (assoc base-spec :metadata {:state (atom 0)})))))
+  (testing "world setup is an exact portable reference"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"exact reference map"
+                          (environment/make-environment
+                           (assoc-in base-spec [:world :setup] :fixture))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"positive integer"
+                          (environment/make-environment
+                           (assoc-in base-spec [:world :setup]
+                                     {:setup/id :fixture :setup/version 0}))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"unknown keys"
+                          (environment/make-environment
+                           (assoc-in base-spec [:world :setup]
+                                     {:setup/id :fixture :setup/version 1
+                                      :prepare :not-a-capability}))))
+    (is (= {:setup/id :fixture :setup/version 1}
+           (get-in
+            (environment/make-environment
+             (assoc-in base-spec [:world :setup]
+                       {:setup/id :fixture :setup/version 1
+                        :setup/basis nil}))
+            [:environment/world :setup]))
+        "an absent and explicit nil setup basis have one canonical form"))
   (testing "unknown keys fail rather than silently changing hash semantics"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"unknown keys"

--- a/test/dvergr/agent/evaluation_test.clj
+++ b/test/dvergr/agent/evaluation_test.clj
@@ -13,6 +13,7 @@
             [dvergr.rooms.forks :as forks]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.spin.combinators :as comb]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.yggdrasil :as ygg]))
@@ -384,18 +385,206 @@
       (finally
         (d/close-room! room)))))
 
-(deftest unsupported-world-setup-is-rejected-before-admission
-  (let [room (test-room :evaluation-unsupported-setup)
+(deftest exact-world-setup-prepares-only-the-candidate-fork
+  (let [room (test-room :evaluation-world-setup)
         team (roster/make-agent (roster/make-roster)
                                 {:id :candidate :program {:kind :echo}})
-        env (definition :test/setup {:world {:isolation :ctx
-                                             :settlement :review
-                                             :setup {:fixture :v1}}})]
+        setup-ref {:setup/id :test/fixture :setup/version 1
+                   :setup/basis "fixture:v1"}
+        env (definition :test/setup
+              {:world {:isolation :ctx :settlement :discard
+                       :setup setup-ref}})
+        setup
+        (evaluation/make-world-setup
+         {:id :test/fixture :version 1 :basis "fixture:v1"
+          :prepare
+          (fn [{work-room :room run-id :run/id}]
+            ;; Exercise the ordinary ambient Spindel state API, not only an
+            ;; explicit Room operation. This state must land in the candidate
+            ;; fork and disappear with its discard, never touch the parent.
+            (ec/swap-state! [:test :world-setup] (constantly run-id))
+            (d/post! work-room
+                     (d/message :fixture :_fixture {:run/id run-id}))
+            {:fixture/run-id run-id
+             :ambient-is-work-context?
+             (identical? (ec/current-execution-context) (:ctx work-room))
+             :ambient-spin-detached? (nil? ec/*spin-id*)
+             :work-state (ec/get-state [:test :world-setup])
+             :parent-state (rtp/get-state (:ctx room)
+                                          [:test :world-setup])})})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact :version 1 :basis "test:v1"
+          :observe
+          (fn [{control-room :room work-room :world/room
+                setup-evidence :setup/evidence default :default}]
+            (let [fixture? #(= :fixture (:from %))]
+              (assoc default
+                     :setup-evidence setup-evidence
+                     :work-fixtures (count (filter fixture?
+                                                   (d/messages work-room)))
+                     :control-fixtures (count (filter fixture?
+                                                      (d/messages control-room))))))
+          :verify
+          (fn [_ evidence]
+            (let [exact? (= {:claim 42} (:result evidence))
+                  isolated? (= [1 0] [(:work-fixtures evidence)
+                                      (:control-fixtures evidence)])
+                  same-run? (= (get-in evidence [:trace :runs 0 :run/id])
+                               (get-in evidence [:setup-evidence
+                                                 :fixture/run-id]))
+                  ambient-isolated?
+                  (let [{:keys [fixture/run-id ambient-is-work-context?
+                                ambient-spin-detached? work-state parent-state]}
+                        (:setup-evidence evidence)]
+                    (and ambient-is-work-context?
+                         ambient-spin-detached?
+                         (= run-id work-state)
+                         (nil? parent-state)))]
+              {:checks {:exact? exact? :isolated? isolated?
+                        :same-run? same-run?
+                        :ambient-isolated? ambient-isolated?}
+               :reward (if (and exact? isolated? same-run? ambient-isolated?)
+                         1.0
+                         0.0)}))})]
     (try
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"trusted resolver"
+      (is (= setup-ref (evaluation/world-setup-ref setup)))
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result @(evaluation/evaluate room team :candidate env evaluator
+                                           {:world-setup setup})]
+          (is (= {:exact? true :isolated? true :same-run? true
+                  :ambient-isolated? true}
+                 (get-in result [:attempt-receipt :attempt/checks])))
+          (is (= :discarded
+                 (get-in result [:run/result :run/settlement-status])))
+          (is (nil? (registry/lookup
+                     (get-in result [:run/result :run/world]))))))
+      (is (empty? (filter #(= :fixture (:from %)) (d/messages room))))
+      (is (nil? (rtp/get-state (:ctx room) [:test :world-setup])))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest world-setup-mismatch-and-failure-are-closed-before-candidate-work
+  (let [room (test-room :evaluation-world-setup-failure)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        setup-ref {:setup/id :test/fixture :setup/version 1}
+        env (definition :test/setup-failure
+              {:world {:isolation :ctx :settlement :discard
+                       :setup setup-ref}})
+        wrong (evaluation/make-world-setup
+               {:id :test/wrong :prepare (constantly nil)})
+        failing (evaluation/make-world-setup
+                 {:id :test/fixture
+                  :prepare
+                  (fn [{work-room :room}]
+                    (d/post! work-room (d/message :fixture :_fixture :partial))
+                    (throw (ex-info "deliberate setup failure" {})))})]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires an exact"
                             (evaluation/evaluate room team :candidate env
                                                  exact-evaluator)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not match"
+                            (evaluation/evaluate room team :candidate env
+                                                 exact-evaluator
+                                                 {:world-setup wrong})))
+      (is (empty? (run/runs room)))
+      (binding [ec/*execution-context* (:ctx room)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"deliberate setup failure"
+                              @(evaluation/evaluate room team :candidate env
+                                                    exact-evaluator
+                                                    {:world-setup failing}))))
+      (let [[failed] (run/runs room)]
+        (is (= :failed (:run/status failed)))
+        (is (= :world-setup-failed (:run/reason failed)))
+        (is (= :discarded (:run/settlement-status failed)))
+        (is (some #(= (:run/trigger failed) (:id %)) (d/messages room))
+            "the failed Run retains a real causal trigger")
+        (binding [ec/*execution-context* (:ctx room)]
+          (is (nil? (registry/lookup (:run/world failed))))))
+      (is (empty? (filter #(= :fixture (:from %)) (d/messages room))))
       (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest world-setup-timeout-is-supervised-and-never-scored
+  (let [room (test-room :evaluation-world-setup-timeout)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/setup-timeout
+              {:limits {:timeout-ms 20 :cancel-timeout-ms 2000}
+               :world {:isolation :ctx :settlement :discard
+                       :setup {:setup/id :test/slow :setup/version 1}}})
+        entered (promise)
+        interrupted (promise)
+        setup (evaluation/make-world-setup
+               {:id :test/slow
+                :prepare
+                (fn [_]
+                  (deliver entered true)
+                  (try
+                    (Thread/sleep 10000)
+                    (catch InterruptedException error
+                      (deliver interrupted true)
+                      (throw error))))})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [started (System/currentTimeMillis)
+              error (try
+                      @(evaluation/evaluate room team :candidate env
+                                            exact-evaluator
+                                            {:world-setup setup})
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= true (deref entered 1000 ::timeout)))
+          (is (= true (deref interrupted 1000 ::timeout)))
+          (is (= ::evaluation/world-setup-failed
+                 (:type (ex-data error))))
+          (is (< (- (System/currentTimeMillis) started) 2000))))
+      (let [[cancelled] (run/runs room)]
+        (is (= :cancelled (:run/status cancelled)))
+        (is (= :world-setup-cancelled (:run/reason cancelled)))
+        (is (= :discarded (:run/settlement-status cancelled)))
+        (is (some #(= (:run/trigger cancelled) (:id %)) (d/messages room))))
+      (is (empty? (filter #(= :candidate (:from %)) (d/messages room))))
+      (is (empty? (episode/attempts room)))
+      (is (empty? (run/active-runs (:id room))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest world-setup-failure-retains-recovery-when-discard-fails
+  (let [room (test-room :evaluation-world-setup-discard-failure)
+        team (roster/make-agent (roster/make-roster)
+                                {:id :candidate :program {:kind :echo}})
+        env (definition :test/setup-discard-failure
+              {:world {:isolation :ctx :settlement :discard
+                       :setup {:setup/id :test/failing :setup/version 1}}})
+        setup (evaluation/make-world-setup
+               {:id :test/failing
+                :prepare #(throw (ex-info "broken fixture" %))})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (with-redefs [d/discard-deferred
+                      (fn [& _] (throw (ex-info "discard unavailable" {})))]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"broken fixture"
+                                @(evaluation/evaluate room team :candidate env
+                                                      exact-evaluator
+                                                      {:world-setup setup})))))
+      (let [[failed] (run/runs room)
+            retained (binding [ec/*execution-context* (:ctx room)]
+                       (registry/lookup (:run/world failed)))]
+        (is (= :failed (:run/status failed)))
+        (is (= :world-setup-failed (:run/reason failed)))
+        (is (= :review (:run/settlement-status failed)))
+        (is (= :settlement-failed (:run/settlement-reason failed)))
+        (is (some? retained) "the failed world remains available for recovery")
+        (is (empty? (episode/attempts room)))
+        (is (empty? (run/active-runs (:id room))))
+        (when retained
+          (binding [ec/*execution-context* (:ctx room)]
+            (d/discard-deferred retained))))
       (finally
         (d/close-room! room)))))
 

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -138,6 +138,26 @@
              clojure.lang.ExceptionInfo #"host admission ceiling"
              (experiment/run room team oversized
                              {(:ref exact-evaluator) exact-evaluator}))))
+      (let [setup-ref {:setup/id :test/experiment-fixture :setup/version 1}
+            setup-env
+            (environment-def/make-environment
+             {:id :test/setup
+              :task :setup
+              :verifier {:id :test/exact :version 1
+                         :basis "experiment-test:v1"}
+              :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+              :world {:isolation :ctx :settlement :discard
+                      :setup setup-ref}})
+            setup-experiment
+            (experiment/make-experiment
+             {:id :test/setup
+              :dataset (experiment/make-dataset
+                        {:id :test/setup :environments [setup-env]})
+              :candidates [(roster/agent team :alpha)]})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"no exact host WorldSetup"
+             (experiment/run room team setup-experiment
+                             {(:ref exact-evaluator) exact-evaluator}))))
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"parallelism exceeds"
            (experiment/run room team definition
@@ -145,6 +165,49 @@
                            {:parallelism 3 :max-parallelism 2})))
       (is (empty? (run/active-runs (:id room))))
       (finally
+        (d/close-room! room)))))
+
+(deftest experiment-applies-an-exact-world-setup-to-every-cell
+  (let [{:keys [team]} (fixture)
+        setup-ref {:setup/id :test/experiment-fixture :setup/version 1}
+        setup-env
+        (environment-def/make-environment
+         {:id :test/setup-cells
+          :task :setup-cells
+          :verifier {:id :test/exact :version 1
+                     :basis "experiment-test:v1"}
+          :limits {:timeout-ms 2000 :cancel-timeout-ms 1000}
+          :world {:isolation :ctx :settlement :discard :setup setup-ref}})
+        definition
+        (experiment/make-experiment
+         {:id :test/setup-cells
+          :dataset (experiment/make-dataset
+                    {:id :test/setup-cells :environments [setup-env]})
+          :candidates [(roster/agent team :alpha) (roster/agent team :beta)]
+          :repetitions 2})
+        prepared (atom [])
+        setup (evaluation/make-world-setup
+               {:id :test/experiment-fixture
+                :prepare (fn [{run-id :run/id}]
+                           (swap! prepared conj run-id)
+                           {:prepared run-id})})
+        room (d/make-room {:id :experiment-world-setups
+                           :store (memory/make)})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [{:keys [attempts scorecard]}
+              @(experiment/run room team definition
+                               {(:ref exact-evaluator) exact-evaluator}
+                               {:parallelism 2
+                                :world-setups {setup-ref setup}})]
+          (is (= 4 (count attempts)))
+          (is (= 4 (count @prepared)))
+          (is (= (set (map :attempt/run-id attempts)) (set @prepared)))
+          (is (= 4 (count (:scorecard/entries scorecard))))
+          (is (every? #(= :discarded (:run/settlement-status %))
+                      (run/runs room {:limit 10})))))
+      (finally
+        (evaluation/await-cleanups! room 5000)
         (d/close-room! room)))))
 
 (deftest repeated-paired-experiment-composes-ordinary-certified-evaluations

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -311,12 +311,19 @@
                                     {:task :too-expensive
                                      :resources {resource/microdollars 4M}}))))
       (is (= {resource/microdollars 3M} (resource/balance room)))
-      (is (empty? (d/messages room {:limit 10})))
+      (let [[trigger :as messages] (d/messages room {:limit 10})]
+        (is (= 1 (count messages)))
+        (is (= [:repl :_runs]
+               ((juxt :from :to) trigger)))
+        (is (empty? (filter #(= :analyst (:from %)) messages))
+            "resource refusal starts no candidate effect"))
       (is (empty? (run/active-runs :program-resource-refusal)))
-      (is (= :failed
-             (:run/status
-              (first (room-store/-list-runs (:store room) (:id room)
-                                            {:limit 1})))))
+      (let [failed (first (room-store/-list-runs (:store room) (:id room)
+                                                 {:limit 1}))]
+        (is (= :failed (:run/status failed)))
+        (is (= :resource-allocation-failed (:run/reason failed)))
+        (is (= (:run/trigger failed)
+               (:id (first (d/messages room {:limit 1}))))))
       (finally
         (close-resource-test-room! room conn)))))
 

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -327,6 +327,127 @@
       (finally
         (close-resource-test-room! room conn)))))
 
+(deftest committed-resource-admission-error-returns-the-stable-grant
+  (let [[room conn] (resource-test-room :program-resource-uncertain-commit)
+        team (test-roster)
+        allocate! resource/allocate-run!]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 3M}})
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"lost allocation acknowledgement"
+           (with-redefs
+            [resource/allocate-run!
+             (fn [& args]
+               (apply allocate! args)
+               ;; Simulate transport/process acknowledgement loss after the
+               ;; PResourceStore transaction and stable receipt committed.
+               (throw (ex-info "lost allocation acknowledgement" {})))]
+             (binding [ec/*execution-context* (:ctx room)]
+               (program/hire! room team :analyst
+                              {:task :uncertain-allocation
+                               :resources {resource/microdollars 2M}})))))
+      (let [[failed] (run/runs room)
+            run-id (:run/id failed)]
+        (is (= :failed (:run/status failed)))
+        (is (= :resource-allocation-failed (:run/reason failed)))
+        (is (some? (room-store/-resource-receipt
+                    (:store room) (resource/allocation-id run-id)))
+            "the simulated failure happened after a durable allocation")
+        (is (= {} (resource/run-balance room run-id)))
+        (is (= {resource/microdollars 3M} (resource/balance room)))
+        (is (empty? (filter #(= :analyst (:from %))
+                            (d/messages room {:limit 10})))
+            "candidate execution never starts after admission failure")
+        (is (empty? (run/active-runs (:id room)))))
+      (finally
+        (close-resource-test-room! room conn)))))
+
+(deftest prepared-run-setup-failure-with-resources-terminalizes-without-a-wallet
+  (let [[room conn] (resource-test-room :program-setup-resource-failure)
+        team (test-roster)]
+    (try
+      (let [handle
+            (binding [ec/*execution-context* (:ctx room)]
+              (program/hire-prepared-in!
+               room room team :analyst
+               {:task :fixture-fails
+                :resources {resource/microdollars 1M}}
+               (fn [_]
+                 (throw (ex-info "fixture failed" {})))))
+            result (binding [ec/*execution-context* (:ctx room)]
+                     (deref handle 5000 ::timeout))
+            durable (program/observe room handle)]
+        (is (not= ::timeout result))
+        (is (= :failed (:run/status result)))
+        (is (= :world-setup-failed (:run/reason durable)))
+        (is (= :discarded (:run/settlement-status durable)))
+        (is (= {} (resource/balance room)))
+        (is (empty? (run/active-runs (:id room)))))
+      (finally
+        (close-resource-test-room! room conn)))))
+
+(deftest prepared-run-resource-refusal-terminalizes-without-candidate-effects
+  (let [[room conn] (resource-test-room :program-prepared-resource-refusal)
+        team (test-roster)]
+    (try
+      (let [handle
+            (binding [ec/*execution-context* (:ctx room)]
+              (program/hire-prepared-in!
+               room room team :analyst
+               {:task :too-expensive
+                :resources {resource/microdollars 1M}}
+               (constantly nil)))
+            result (binding [ec/*execution-context* (:ctx room)]
+                     (deref handle 5000 ::timeout))
+            durable (program/observe room handle)]
+        (is (not= ::timeout result))
+        (is (= :failed (:run/status result)))
+        (is (= :resource-allocation-failed (:run/reason durable)))
+        (is (= :discarded (:run/settlement-status durable)))
+        (is (= {} (resource/balance room)))
+        (is (empty? (filter #(= :analyst (:from %))
+                            (d/messages room {:limit 10})))
+            "resource refusal starts no candidate program")
+        (is (empty? (run/active-runs (:id room)))))
+      (finally
+        (close-resource-test-room! room conn)))))
+
+(deftest prepared-resource-allocation-does-not-block-the-spindel-drain
+  (let [room (test-room :program-prepared-resource-drain)
+        team (test-roster)
+        allocation-entered (promise)
+        release-allocation (promise)
+        drain-progress (promise)]
+    (try
+      (with-redefs
+       [resource/allocate-run!
+        (fn [& _]
+          (deliver allocation-entered true)
+          @release-allocation
+          {:receipt :committed})
+        resource/run-balance (fn [& _] {})]
+        (let [handle
+              (binding [ec/*execution-context* (:ctx room)]
+                (program/hire-prepared-in!
+                 room room team :analyst
+                 {:task :allocated-off-drain
+                  :resources {resource/microdollars 1M}}
+                 (constantly nil)))]
+          (is (= true (deref allocation-entered 2000 ::timeout)))
+          (binding [ec/*execution-context* (:ctx room)]
+            (sp/spawn! (sp/spin (deliver drain-progress true))))
+          (is (= true (deref drain-progress 500 ::timeout))
+              "the Room execution context remains reactive during allocation")
+          (deliver release-allocation true)
+          (is (= :completed
+                 (:run/status
+                  (binding [ec/*execution-context* (:ctx room)]
+                    (deref handle 5000 ::timeout)))))))
+      (finally
+        (deliver release-allocation true)
+        (d/close-room! room)))))
+
 (deftest settlement-policy-controls-the-isolated-run-world
   (let [room (test-room :program-settlement)
         team (test-roster)]


### PR DESCRIPTION
## Summary

- add exact portable WorldSetup references and process-local trusted preparer capabilities
- persist each admitted Run causal trigger before preparation so setup failures remain valid thread/audit records
- run setup as supervised, cancellable host work bound to the candidate fork context with no inherited Spin identity
- gate resource allocation and candidate/model execution on successful setup
- classify setup failure/cancellation separately and never certify it as a candidate Attempt
- preserve failed worlds for recovery if physical discard fails
- pass only portable setup evidence to trusted observers and keep preparers outside SCI
- preflight every experiment cell setup registry before Run admission
- canonicalize absent and explicit-nil setup basis identically
- retain setup references in paired live benchmarks instead of stripping them
- document the boundary between fork-local semantic setup and outer heavyweight arena provisioning

## Verification

- CircleCI setup, format, test, and harness build: green
- affected environment/evaluation/experiment/program suites: 64 tests, 425 assertions
- setup isolation/cancellation/discard-failure regressions: green
- `clojure -T:build harness` (`target/dvergr-0.1.73-harness.jar`)
- full local suite reached 669 tests / 3093 assertions; the known memory-pressure SMC watchdog was the only failing test and passed immediately in isolation (1 test / 12 assertions)
- independent re-review after fixes found no credible medium-or-higher issue

Stacked on #91.