### PR TITLE
Supervise affine live-resource cleanup stacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,10 @@ jobs:
       - run:
           name: Run tests (kaocha)
           command: clojure -M:test
+          # The dots reporter may produce no newline while a compilation-heavy
+          # namespace runs. Keep CircleCI's inactivity watchdog above the
+          # suite's bounded test waits; assertion failures still exit normally.
+          no_output_timeout: 20m
 
   build-harness:
     executor: clojure-java22

--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
         ;; restart.
         ;; 0.1.44 includes structured work admission, cancellation hand-back,
         ;; canonical inference worlds, and forkable SCI world components.
-        org.replikativ/spindel     {:mvn/version "0.1.45"}
+        org.replikativ/spindel     {:mvn/version "0.1.47"}
 
         ;; muschel — bash → AST → safely runnable shell.
         ;; muschel.session.spindel is fork-aware via spindel/fork-context

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -361,6 +361,18 @@ during experiment preflight. Each attempt still receives a fresh Run ID, so
 content identity never collapses distinct executions. The current REPL
 benchmark reports retain both the exact definition and its compact reference.
 
+Trusted preparation also receives a process-local `:register-cleanup!`
+capability. Every acquired database, browser, process, session, or other live
+lease must register its release immediately. The Run supervisor unwinds all
+registrations in reverse acquisition order after candidate work quiesces and
+before world settlement; one failing release does not skip the remaining
+releases. A cleanup callback must complete—or internally await—the physical
+release before it returns; launching detached asynchronous cleanup does not
+extend the supervisor's quiescence fence. This is the common affine lifecycle
+for later resource arenas, not a second world/fork mechanism. The registrar and
+live resources are never part of portable EnvironmentDefs, SCI bindings, or
+mergeable world state.
+
 Every opt-in REPL attempt returns a content-addressed `:attempt-receipt`. It binds the
 unique root Run to the exact EnvironmentDef, provider/model, exact assembled
 system-prompt ID, per-resource usage, timing, trusted checks/reward, Run/tool

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -83,6 +83,11 @@
                   :workers {}
                   :children {}
                   :cleanups []
+                  ;; Cleanup registration remains open while a cancelled but
+                  ;; still-live setup worker hands back resources. The first
+                  ;; physical cleanup claim closes it monotonically; unlike
+                  ;; :cleanup-phase, it never reopens between stack entries.
+                  :cleanup-admission-open? true
                   :cleanup-phase :pending
                   :cleanup-error nil
                   :llm-metrics nil
@@ -115,12 +120,16 @@
               (let [cleanup (peek cleanups)]
                 (swap! (:state supervisor)
                        #(-> %
-                            (assoc :cleanup-phase :running)
+                            (assoc :cleanup-admission-open? false
+                                   :cleanup-phase :running)
                             (update :cleanups pop)))
                 [:cleanup cleanup])
 
               (and sealed? cleanup-safe? (not normal-live?) (= :pending cleanup-phase))
-              (do (swap! (:state supervisor) assoc :cleanup-phase :done)
+              (do (swap! (:state supervisor)
+                         assoc
+                         :cleanup-admission-open? false
+                         :cleanup-phase :done)
                   :advance)
 
               (and sealed? (= :done cleanup-phase) (empty? workers) (not quiesced?))
@@ -259,7 +268,7 @@
     (throw (ex-info "Run cleanup must be a function"
                     {:type ::invalid-cleanup})))
   (locking supervisor
-    (when-not (= :pending (:cleanup-phase @(:state supervisor)))
+    (when-not (:cleanup-admission-open? @(:state supervisor))
       (throw (ex-info "Cleanup registered after supervisor cleanup began"
                       {:type ::late-cleanup-registration})))
     ;; Stack order is intentional: resources unwind in reverse acquisition

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -76,9 +76,13 @@
     :worker-ctx worker-ctx
     :state (atom {:cancelled? false
                   :sealed? false
+                  ;; Sealing closes admission. It does not prove that the
+                  ;; orchestration body has stopped using resources acquired
+                  ;; by a completed worker. Cleanup needs this separate gate.
+                  :cleanup-safe? false
                   :workers {}
                   :children {}
-                  :cleanup nil
+                  :cleanups []
                   :cleanup-phase :pending
                   :cleanup-error nil
                   :llm-metrics nil
@@ -99,17 +103,23 @@
   [supervisor]
   (let [action
         (locking supervisor
-          (let [{:keys [sealed? workers children cleanup cleanup-phase quiesced?]
+          (let [{:keys [sealed? cleanup-safe? workers children cleanups
+                        cleanup-phase quiesced?]
                  :as state}
                 @(:state supervisor)
                 normal-live? (or (seq children)
                                  (some #(= :normal (:kind %)) (vals workers)))]
             (cond
-              (and sealed? (not normal-live?) (= :pending cleanup-phase) cleanup)
-              (do (swap! (:state supervisor) assoc :cleanup-phase :running)
-                  [:cleanup cleanup])
+              (and sealed? cleanup-safe? (not normal-live?) (= :pending cleanup-phase)
+                   (seq cleanups))
+              (let [cleanup (peek cleanups)]
+                (swap! (:state supervisor)
+                       #(-> %
+                            (assoc :cleanup-phase :running)
+                            (update :cleanups pop)))
+                [:cleanup cleanup])
 
-              (and sealed? (not normal-live?) (= :pending cleanup-phase))
+              (and sealed? cleanup-safe? (not normal-live?) (= :pending cleanup-phase))
               (do (swap! (:state supervisor) assoc :cleanup-phase :done)
                   :advance)
 
@@ -142,10 +152,12 @@
            (fn [state]
              (cond-> (update state :workers dissoc worker-id)
                (= :cleanup kind)
-               (assoc :cleanup-phase :done
-                      :cleanup-error (when (and (map? result)
-                                                (contains? result ::worker-error))
-                                       (::worker-error result)))))))
+               (assoc :cleanup-phase :pending)
+
+               (and (= :cleanup kind)
+                    (map? result)
+                    (contains? result ::worker-error))
+               (update :cleanup-error #(or % (::worker-error result)))))))
   (advance-supervisor! supervisor))
 
 (defn- start-worker!
@@ -243,11 +255,29 @@
   nil)
 
 (defn- register-cleanup! [supervisor cleanup]
+  (when-not (fn? cleanup)
+    (throw (ex-info "Run cleanup must be a function"
+                    {:type ::invalid-cleanup})))
   (locking supervisor
     (when-not (= :pending (:cleanup-phase @(:state supervisor)))
       (throw (ex-info "Cleanup registered after supervisor cleanup began"
                       {:type ::late-cleanup-registration})))
-    (swap! (:state supervisor) assoc :cleanup cleanup))
+    ;; Stack order is intentional: resources unwind in reverse acquisition
+    ;; order, as with lexical `finally` scopes. Every registered cleanup runs
+    ;; even when an earlier cleanup fails; the first error determines the Run
+    ;; outcome after physical quiescence.
+    (swap! (:state supervisor) update :cleanups conj cleanup))
+  nil)
+
+(defn- mark-cleanup-safe!
+  "Acknowledge that the orchestration body can no longer touch acquired live
+   resources. Cancellation alone must never make cleanup eligible: a setup
+   worker can finish while the enclosing Spin is still allocating resources or
+   transitioning into candidate execution."
+  [supervisor]
+  (locking supervisor
+    (swap! (:state supervisor) assoc :cleanup-safe? true))
+  (advance-supervisor! supervisor)
   nil)
 
 (defn- seal-supervisor! [supervisor]
@@ -998,6 +1028,10 @@
                                    (cond-> agent
                                      (seq limits) (assoc ::limits limits))
                                    task trigger supervisor))
+                 ;; Candidate execution has returned and can no longer touch
+                 ;; setup-owned resources. This is distinct from sealing:
+                 ;; cancellation may seal admission while this body is live.
+                 _ (mark-cleanup-safe! supervisor)
                  ;; Seal admits no further provider work, runs owned cleanup
                  ;; after all workers terminate, and publishes one stable
                  ;; quiescence acknowledgement.
@@ -1037,6 +1071,11 @@
            (catch Throwable t
              (let [cancelled? (cancelled-error? t id)
                    graph-cancelled? (graph-cancelled-error? t)
+                   ;; A graph cancellation is only cleanup-safe once the
+                   ;; terminal spawn callback runs. Other failures are handled
+                   ;; by this still-live body after candidate work unwound.
+                   _ (when-not graph-cancelled?
+                       (mark-cleanup-safe! supervisor))
                    quiesced (seal-supervisor! supervisor)]
                (if graph-cancelled?
                  ;; Cancellation is sticky on a Spin. Awaiting `quiesced` from
@@ -1088,8 +1127,16 @@
    supervisor allocation-state limits outcome-promise prepare-world!]
   (sp/spin
    (let [_ (swap! (:state supervisor) assoc :execution-phase :world-setup)
-         worker (start-worker! supervisor
-                               #(prepare-world! {:room work-room :run/id id}))
+         worker (start-worker!
+                 supervisor
+                 #(prepare-world!
+                   {:room work-room
+                    :run/id id
+                    ;; Host-only affine registrar. WorldSetup code may acquire
+                    ;; several live resources, but cannot transfer this
+                    ;; process-local authority to SCI or durable definitions.
+                    :register-cleanup!
+                    (fn [cleanup] (register-cleanup! supervisor cleanup))}))
          prepared (sp/await (worker-result-spin worker))]
      (cond
        (run/cancel-requested? id)
@@ -1294,6 +1341,11 @@
               (when (= :cancelled (:run/status result))
                 (run/cancel-room-run! (:id control-room) id))
               (cancel-supervisor! supervisor)
+              ;; The spawned orchestration graph is terminal here. In
+              ;; particular, a cancellation during the gap after setup cannot
+              ;; release its resources before this callback acknowledges that
+              ;; the enclosing body has stopped using them.
+              (mark-cleanup-safe! supervisor)
               (seal-supervisor! supervisor)
               (deliver outcome-promise
                        {:result result

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -1096,27 +1096,35 @@
       (finally
         (d/close-room! room)))))
 
-(deftest cancellation-does-not-clean-up-before-the-orchestration-body-is-terminal
+(deftest cancellation-awaits-physical-allocation-exit-before-cleanup
   (let [room (test-room :program-preparation-cleanup-body-fence)
         team (test-roster)
         allocation-entered (promise)
-        release-allocation (promise)
+        release-allocation (java.util.concurrent.CountDownLatch. 1)
         allocation-returned (promise)
         cleanup-entered (promise)]
     (try
       (with-redefs [resource/allocate-run!
                     (fn [& _]
-                      ;; Reproduce the post-setup gap: the setup worker has
-                      ;; terminated, but its enclosing orchestration body is
-                      ;; still using the acquired resource during allocation.
+                      ;; Allocation is now a supervised worker. Model an I/O
+                      ;; operation that cannot physically stop on interruption:
+                      ;; graph cancellation must not release its resources yet.
                       (deliver allocation-entered true)
-                      @release-allocation
-                      (deliver allocation-returned true))]
+                      (loop []
+                        (let [released?
+                              (try
+                                (.await release-allocation)
+                                true
+                                (catch InterruptedException _ false))]
+                          (when-not released? (recur))))
+                      (deliver allocation-returned true))
+                    resource/run-balance (fn [& _] {})]
         (binding [ec/*execution-context* (:ctx room)]
           (let [handle
                 (program/hire-prepared-in!
                  room room team :analyst
-                 {:task :work :settlement :discard}
+                 {:task :work :settlement :discard
+                  :resources {resource/microdollars 1M}}
                  (fn [{register! :register-cleanup!}]
                    (register! #(deliver cleanup-entered true))))]
             ;; These positive waits tolerate a loaded randomized suite. The
@@ -1126,7 +1134,7 @@
             (is (= ::timeout (deref cleanup-entered 500 ::timeout))
                 "sealing cancellation is not permission to release a resource")
             (is (not (realized? allocation-returned)))
-            (deliver release-allocation true)
+            (.countDown release-allocation)
             (is (= true (deref allocation-returned 15000 ::timeout)))
             (let [result (deref handle 15000 ::timeout)]
               (is (= :cancelled (:run/status result)))
@@ -1134,7 +1142,7 @@
               (is (= :discarded (:run/settlement-status result)))))))
       (finally
         ;; Never strand the Room executor if an earlier assertion fails.
-        (deliver release-allocation true)
+        (.countDown release-allocation)
         (d/close-room! room)))))
 
 (deftest llm-program-uses-one-normalized-tool-contract

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -989,6 +989,88 @@
       (finally
         (d/close-room! room)))))
 
+(deftest cleanup-admission-does-not-reopen-between-stack-entries
+  (let [room (test-room :program-cleanup-admission)
+        supervisor (binding [ec/*execution-context* (:ctx room)]
+                     (#'program/make-supervisor (:ctx room)))
+        claimed-cleanup (promise)]
+    (try
+      (#'program/register-cleanup! supervisor (constantly :older))
+      (#'program/register-cleanup! supervisor (constantly :newer))
+      ;; Claim the first physical cleanup without starting its worker so the
+      ;; transition into the between-callback :pending phase is deterministic.
+      (with-redefs-fn
+        {#'program/start-worker!
+         (fn [_ cleanup kind]
+           (is (= :cleanup kind))
+           (deliver claimed-cleanup cleanup))}
+        #(do
+           (#'program/mark-cleanup-safe! supervisor)
+           (#'program/seal-supervisor! supervisor)))
+      (is (fn? (deref claimed-cleanup 5000 ::timeout)))
+      (is (false? (:cleanup-admission-open? @(:state supervisor))))
+      (with-redefs-fn
+        {#'program/advance-supervisor! (constantly nil)}
+        (fn []
+          (#'program/worker-finished! supervisor ::claimed-cleanup :cleanup nil)))
+      (is (= :pending (:cleanup-phase @(:state supervisor))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Cleanup registered after supervisor cleanup began"
+           (#'program/register-cleanup! supervisor (constantly :late))))
+      (is (= 1 (count (:cleanups @(:state supervisor))))
+          "the older cleanup remains without admitting a late stack entry")
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancelled-live-setup-worker-can-register-before-first-cleanup-claim
+  (let [room (test-room :program-cleanup-live-handback)
+        supervisor (binding [ec/*execution-context* (:ctx room)]
+                     (#'program/make-supervisor (:ctx room)))
+        entered (promise)
+        registered (promise)
+        cleaned (promise)
+        waiter (atom nil)
+        release-worker (java.util.concurrent.CountDownLatch. 1)]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (#'program/start-worker!
+         supervisor
+         (fn []
+           (deliver entered true)
+           ;; Model non-interruptible teardown/acquisition hand-back: targeted
+           ;; cancellation interrupts the wait, but the worker remains live until
+           ;; its owner releases it and must still be allowed to register.
+           (loop []
+             (when (pos? (.getCount release-worker))
+               (let [released?
+                     (try
+                       (.await release-worker)
+                       true
+                       (catch InterruptedException _ false))]
+                 (when-not released? (recur)))))
+           (#'program/register-cleanup! supervisor #(deliver cleaned true))
+           (deliver registered true))))
+      (is (= true (deref entered 5000 ::timeout)))
+      (#'program/cancel-supervisor! supervisor)
+      (#'program/mark-cleanup-safe! supervisor)
+      (#'program/seal-supervisor! supervisor)
+      (is (true? (:cleanup-admission-open? @(:state supervisor)))
+          "cleanup admission remains open while the cancelled worker is live")
+      (is (= ::pending (deref cleaned 100 ::pending)))
+      (.countDown release-worker)
+      (is (= true (deref registered 5000 ::timeout)))
+      (reset! waiter (future (#'program/await-supervisor! supervisor)))
+      (is (nil? (deref @waiter 5000 ::timeout)))
+      (is (= true (deref cleaned 5000 ::timeout)))
+      (is (false? (:cleanup-admission-open? @(:state supervisor))))
+      (is (= :done (:cleanup-phase @(:state supervisor))))
+      (finally
+        (.countDown release-worker)
+        (when-let [waiter @waiter]
+          (future-cancel waiter))
+        (d/close-room! room)))))
+
 (deftest cancellation-unwinds-every-resource-acquired-during-preparation
   (let [room (test-room :program-preparation-cleanup-cancel)
         team (test-roster)

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -944,6 +944,117 @@
       (finally
         (d/close-room! room)))))
 
+(deftest trusted-preparation-registers-an-affine-cleanup-stack
+  (let [room (test-room :program-preparation-cleanup-stack)
+        team (test-roster)
+        cleaned (atom [])]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle
+              (program/hire-prepared-in!
+               room room team :analyst
+               {:task :work :settlement :discard}
+               (fn [{register! :register-cleanup!}]
+                 (register! #(swap! cleaned conj :first))
+                 (register! #(swap! cleaned conj :second))))
+              result @handle]
+          (is (= :completed (:run/status result)))
+          (is (= [:second :first] @cleaned)
+              "live resources unwind in reverse acquisition order")
+          (is (= :discarded (:run/settlement-status result)))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest one-cleanup-failure-does-not-leak-the-rest-of-the-stack
+  (let [room (test-room :program-preparation-cleanup-failure)
+        team (test-roster)
+        cleaned (atom [])]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle
+              (program/hire-prepared-in!
+               room room team :analyst
+               {:task :work :settlement :discard}
+               (fn [{register! :register-cleanup!}]
+                 (register! #(swap! cleaned conj :first))
+                 (register!
+                  #(do (swap! cleaned conj :second)
+                       (throw (ex-info "second cleanup failed" {}))))))
+              result @handle]
+          (is (= :failed (:run/status result)))
+          (is (= "second cleanup failed" (:run/error result)))
+          (is (= [:second :first] @cleaned)
+              "cleanup errors are collected only after every lease unwinds")
+          (is (= :discarded (:run/settlement-status result)))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-unwinds-every-resource-acquired-during-preparation
+  (let [room (test-room :program-preparation-cleanup-cancel)
+        team (test-roster)
+        entered (promise)
+        cleaned (atom [])]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [handle
+              (program/hire-prepared-in!
+               room room team :analyst
+               {:task :work :settlement :discard}
+               (fn [{register! :register-cleanup!}]
+                 (register! #(swap! cleaned conj :first))
+                 (register! #(swap! cleaned conj :second))
+                 (deliver entered true)
+                 (Thread/sleep 10000)))]
+          (is (= true (deref entered 2000 ::timeout)))
+          (is (true? (program/cancel! handle)))
+          (let [result (deref handle 2000 ::timeout)]
+            (is (= :cancelled (:run/status result)))
+            (is (= [:second :first] @cleaned))
+            (is (= :discarded (:run/settlement-status result))))))
+      (finally
+        (d/close-room! room)))))
+
+(deftest cancellation-does-not-clean-up-before-the-orchestration-body-is-terminal
+  (let [room (test-room :program-preparation-cleanup-body-fence)
+        team (test-roster)
+        allocation-entered (promise)
+        release-allocation (promise)
+        allocation-returned (promise)
+        cleanup-entered (promise)]
+    (try
+      (with-redefs [resource/allocate-run!
+                    (fn [& _]
+                      ;; Reproduce the post-setup gap: the setup worker has
+                      ;; terminated, but its enclosing orchestration body is
+                      ;; still using the acquired resource during allocation.
+                      (deliver allocation-entered true)
+                      @release-allocation
+                      (deliver allocation-returned true))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [handle
+                (program/hire-prepared-in!
+                 room room team :analyst
+                 {:task :work :settlement :discard}
+                 (fn [{register! :register-cleanup!}]
+                   (register! #(deliver cleanup-entered true))))]
+            ;; These positive waits tolerate a loaded randomized suite. The
+            ;; bounded negative wait below is the actual ordering assertion.
+            (is (= true (deref allocation-entered 15000 ::timeout)))
+            (is (true? (program/cancel! handle)))
+            (is (= ::timeout (deref cleanup-entered 500 ::timeout))
+                "sealing cancellation is not permission to release a resource")
+            (is (not (realized? allocation-returned)))
+            (deliver release-allocation true)
+            (is (= true (deref allocation-returned 15000 ::timeout)))
+            (let [result (deref handle 15000 ::timeout)]
+              (is (= :cancelled (:run/status result)))
+              (is (= true (deref cleanup-entered 15000 ::timeout)))
+              (is (= :discarded (:run/settlement-status result)))))))
+      (finally
+        ;; Never strand the Room executor if an earlier assertion fails.
+        (deliver release-allocation true)
+        (d/close-room! room)))))
+
 (deftest llm-program-uses-one-normalized-tool-contract
   (let [room (test-room :program-llm-tools)
         team (-> (roster/make-roster)

--- a/test/dvergr/sandbox/agent_programming_test.clj
+++ b/test/dvergr/sandbox/agent_programming_test.clj
@@ -574,6 +574,10 @@
         (try
           (binding [ec/*execution-context* (:ctx room)]
             (#'program/cancel-supervisor! supervisor)
+            ;; This test owns the private supervisor directly rather than via
+            ;; execution-spin, so it must acknowledge that its orchestration
+            ;; body is terminal before cleanup/quiescence becomes eligible.
+            (#'program/mark-cleanup-safe! supervisor)
             (#'program/seal-supervisor! supervisor)
             (let [waiter (future (#'program/await-supervisor! supervisor))]
               (when (= ::cleanup-timeout


### PR DESCRIPTION
## Summary

- replace the Run supervisor's single cleanup slot with a LIFO cleanup stack
- expose a host-only cleanup registrar to trusted fork-local preparation
- distinguish sealed admission from an orchestration-body-terminal cleanup gate
- run cleanup only after the body is terminal and normal workers/children quiesce
- continue unwinding after a cleanup failure while retaining the first failure as the Run outcome
- unwind resources acquired before cancellation, even when setup is interrupted
- document this as the shared affine lifecycle for databases, browsers, processes, sessions, and later ExperimentArena capabilities—not another fork model
- allow compilation-heavy test namespaces twenty minutes without a newline before CircleCI's inactivity watchdog fires

## Lifecycle invariant

Cancellation closes work admission and requests worker/child cancellation. It does not itself permit resource release. Cleanup begins only after all three conditions hold:

1. admission is sealed;
2. the orchestration body is terminal and cannot use acquired resources;
3. normal workers and owned child Runs have acknowledged termination.

## Verification

- `clojure -M:format`
- focused post-setup cancellation/allocation race: 1 test, 8 assertions, green
- full agent-program namespace: 41 tests, 254 assertions, green
- both affected namespaces together: 62 tests, 369 assertions, green
- `clojure -T:build harness`
- `git diff --check`

The first full CI run was terminated by CircleCI's default ten-minute no-output watchdog, not by a test assertion. The next randomized run exposed two load-sensitive test-contract issues: positive waits in the new body-fence regression were too short, and the one test that directly owns a private supervisor did not mark its orchestration body terminal. Both are corrected and pass together with their complete namespaces; CI uses an explicit twenty-minute inactivity bound.

Stacked on #92.
