### PR TITLE
ci: restore dependencies in downstream jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "deps.edn" }}
+            - v1-deps-
       - install-clojure
       - run:
           name: Check formatting (cljfmt)
@@ -73,6 +77,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "deps.edn" }}
+            - v1-deps-
       - install-clojure
       - run:
           name: Run tests (kaocha)
@@ -87,6 +95,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "deps.edn" }}
+            - v1-deps-
       - install-clojure
       - run:
           name: Build standalone harness uberjar
@@ -103,6 +115,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "deps.edn" }}
+            - v1-deps-
       - install-clojure
       - run:
           name: Deploy library jar to Clojars


### PR DESCRIPTION
## Summary

- restore the exact dependency cache prepared by the setup job in every downstream Clojure job
- retain the prefix fallback for dependency-compatible revisions
- leave the release-only job unchanged because it does not invoke Clojure

## Why

The setup job downloads and caches Maven/gitlib dependencies, but format, test, harness-build, and deploy currently attach only the repository workspace. They consequently redownload the full dependency graph. Restoring the cache makes the setup contract effective and reduces avoidable network, memory, and timeout pressure across the remaining benchmark campaign.

## Verification

- git diff --check
- CircleCI validates the complete config and exercises every affected job