### PR TITLE
feat(agent): persist certified experiment scorecards

### DIFF
--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -452,7 +452,21 @@ experiment identity.
 The result contains every certified Attempt plus a content-addressed Scorecard
 with one entry per candidate/environment/repetition cell and deterministic
 per-candidate aggregates. Scorecards are immutable projections, not a mutable
-leaderboard or scheduler.
+leaderboard or scheduler. When the Room has a store, completion durably writes
+the exact Scorecard only after all referenced Attempts are certified. The
+Datahike projection joins those same-Room Attempts and indexes experiment,
+dataset, and candidate identities; its mandatory writer predicate rejects raw
+creation or later mutation. Host code can use `experiment/scorecard` and
+`experiment/scorecards` to reconstruct exact comparisons without replaying
+model work. A failed partial batch still leaves its individual Attempts but no
+misleading complete Scorecard.
+
+Attempts and Scorecards are certified control-plane facts, not candidate-world
+state. They are written through the trusted Room store after effects settle and
+are never admitted merely because a Datahike branch was merged. Fork/proposal
+settlement may carry the work that an Attempt evaluated, while certification is
+re-established through its one-use host writer capability in the authoritative
+Room. Every Scorecard identity consequently has one Room owner.
 
 Pure policy can rank/select the scorecards. Existing room-fork
 merge/discard/adoption remains the only settlement authority. SMC, MCTS,

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -121,10 +121,13 @@ matrix. This supports repeated provider/model comparisons without giving
 Dvergr a second scheduler or allowing evaluated SCI code to own trusted
 verifiers. Jobs are realized only one bounded batch at a time, and batch
 environments initially require discard settlement until partial experiments
-have durable recoverable identity. Initially the Scorecard is a portable returned value; durable Runs
-and Attempts remain the evidence of record. A leaderboard can later be a
-Datahike projection over admitted Scorecards rather than mutable benchmark
-state.
+have durable recoverable identity. Completed Scorecards are immutable durable
+Room projections over the already-certified Attempts: the exact value lives in
+the content-addressed artifact store, while Datahike indexes exact experiment,
+dataset, candidate, and Attempt joins. Mandatory writer validation rejects
+forged or mutable leaderboard rows. Incomplete batches leave their individual
+Attempts but never publish a complete Scorecard; durable resumption of the
+partial matrix remains a later execution policy.
 
 An EnvironmentDef may also name an exact WorldSetup reference. The host
 resolves that reference before admitting any experiment cell, while the actual

--- a/src/dvergr/agent/attempt/governance.clj
+++ b/src/dvergr/agent/attempt/governance.clj
@@ -1,5 +1,5 @@
 (ns dvergr.agent.attempt.governance
-  "Mandatory Datahike writer predicate for certified Attempt projections.
+  "Mandatory Datahike writer predicate for certified evaluation projections.
 
    This composes with an existing store predicate (notably Kontor) and validates
    fully-resolved datoms. It prevents raw transactions, imports, and remote
@@ -18,9 +18,25 @@
     :attempt/evidence-content-id :attempt/evidence-runs
     :attempt/settlement-intent :attempt/checks})
 
+(def ^:private scorecard-required
+  #{:scorecard/id :scorecard/chat :scorecard/payload-blob
+    :scorecard/payload-codec :scorecard/experiment-id
+    :scorecard/experiment-version :scorecard/experiment-content-id
+    :scorecard/dataset-id :scorecard/dataset-version
+    :scorecard/dataset-content-id :scorecard/stored-at
+    :scorecard/attempts :scorecard/summaries})
+
+(def ^:private summary-required
+  #{:scorecard.summary/id :scorecard.summary/candidate-id
+    :scorecard.summary/candidate-content-id
+    :scorecard.summary/attempt-count :scorecard.summary/passed-count
+    :scorecard.summary/reward-sum :scorecard.summary/reward-mean})
+
 (defn- protected-ident? [ident]
   (and (keyword? ident)
-       (contains? #{"attempt" "attempt.check"} (namespace ident))))
+       (contains? #{"attempt" "attempt.check"
+                    "scorecard" "scorecard.summary"}
+                  (namespace ident))))
 
 (defn- datom-ident [db datom]
   (let [attr (nth datom 1)]
@@ -38,16 +54,25 @@
     {:attempt/run [* {:run/chat [:db/id :chat/id]}]}
     {:attempt/evidence-runs [* {:run/chat [:db/id :chat/id]}]}
     {:attempt/evidence-messages [* {:message/chat [:db/id :chat/id]}]}
-    {:attempt/checks [*]}])
+    {:attempt/checks [*]}
+    {:scorecard/chat [:db/id :chat/id]}
+    {:scorecard/attempts [* {:attempt/chat [:db/id :chat/id]}]}
+    {:scorecard/summaries [*]}])
 
 (defn- entity-map [db eid]
   (d/pull db entity-pattern eid))
 
 (defn- attempt? [entity] (uuid? (:attempt/id entity)))
 (defn- check? [entity] (uuid? (:attempt.check/id entity)))
+(defn- scorecard? [entity] (uuid? (:scorecard/id entity)))
+(defn- summary? [entity] (uuid? (:scorecard.summary/id entity)))
 
 (defn- same-chat? [attempt run]
   (= (:db/id (:attempt/chat attempt)) (:db/id (:run/chat run))))
+
+(defn- same-scorecard-chat? [scorecard attempt]
+  (= (:db/id (:scorecard/chat scorecard))
+     (:db/id (:attempt/chat attempt))))
 
 (defn- validate-new-attempt! [db entity]
   (let [missing (remove #(contains? entity %) attempt-required)
@@ -94,6 +119,43 @@
                          :attempt/id (:attempt/id entity)}))))
     db))
 
+(defn- validate-new-scorecard! [db entity]
+  (let [missing (remove #(contains? entity %) scorecard-required)]
+    (when (seq missing)
+      (throw (ex-info "Certified Scorecard row is incomplete"
+                      {:type ::incomplete-scorecard :missing (set missing)})))
+    (when-not (seq (:scorecard/attempts entity))
+      (throw (ex-info "Certified Scorecard requires Attempts"
+                      {:type ::scorecard-without-attempts
+                       :scorecard/id (:scorecard/id entity)})))
+    (doseq [attempt (:scorecard/attempts entity)]
+      (when-not (and (attempt? attempt)
+                     (same-scorecard-chat? entity attempt))
+        (throw (ex-info "Certified Scorecard has a missing or cross-Room Attempt"
+                        {:type ::invalid-scorecard-attempt
+                         :scorecard/id (:scorecard/id entity)}))))
+    (doseq [summary (:scorecard/summaries entity)]
+      (let [missing-summary (remove #(contains? summary %) summary-required)]
+        (when (seq missing-summary)
+          (throw (ex-info "Certified Scorecard summary is incomplete"
+                          {:type ::incomplete-scorecard-summary
+                           :scorecard/id (:scorecard/id entity)
+                           :missing (set missing-summary)})))
+        (when-not (and (keyword? (:scorecard.summary/candidate-id summary))
+                       (uuid? (:scorecard.summary/candidate-content-id summary))
+                       (pos-int? (:scorecard.summary/attempt-count summary))
+                       (nat-int? (:scorecard.summary/passed-count summary))
+                       (<= (:scorecard.summary/passed-count summary)
+                           (:scorecard.summary/attempt-count summary))
+                       (Double/isFinite
+                        (double (:scorecard.summary/reward-sum summary)))
+                       (Double/isFinite
+                        (double (:scorecard.summary/reward-mean summary))))
+          (throw (ex-info "Certified Scorecard summary is malformed"
+                          {:type ::invalid-scorecard-summary
+                           :scorecard/id (:scorecard/id entity)})))))
+    db))
+
 (defonce ^:private authorized-writes (atom {}))
 
 (defn- store-id [conn-or-db]
@@ -106,24 +168,44 @@
   [conn attempt-id f]
   (let [token (random-uuid)
         key [(store-id conn) token]]
-    (swap! authorized-writes assoc key attempt-id)
+    (swap! authorized-writes assoc key {:kind :attempt :id attempt-id})
     (try
-      (f {:attempt.writer/token token})
+      (f {:evaluation.writer/token token})
       (finally
         (swap! authorized-writes dissoc key)))))
 
 (defn- authorized-attempt-id [report]
-  (when-let [token (get-in report [:tx-meta :attempt.writer/token])]
-    (get @authorized-writes
-         [(get-in report [:db-after :config :store :id]) token])))
+  (when-let [token (get-in report [:tx-meta :evaluation.writer/token])]
+    (let [authorization
+          (get @authorized-writes
+               [(get-in report [:db-after :config :store :id]) token])]
+      (when (= :attempt (:kind authorization)) (:id authorization)))))
+
+(defn with-authorized-scorecard-write
+  "Invoke `f` with a one-use capability for one certified Scorecard identity."
+  [conn scorecard-id f]
+  (let [token (random-uuid)
+        key [(store-id conn) token]]
+    (swap! authorized-writes assoc key {:kind :scorecard :id scorecard-id})
+    (try
+      (f {:evaluation.writer/token token})
+      (finally
+        (swap! authorized-writes dissoc key)))))
+
+(defn- authorized-scorecard-id [report]
+  (when-let [token (get-in report [:tx-meta :evaluation.writer/token])]
+    (let [authorization
+          (get @authorized-writes
+               [(get-in report [:db-after :config :store :id]) token])]
+      (when (= :scorecard (:kind authorization)) (:id authorization)))))
 
 (defn validate-report
-  "Reject unauthorized creation and every mutation of certified Attempt facts."
+  "Reject unauthorized creation and mutation of certified evaluation facts."
   [{:keys [db-before db-after tx-data] :as report}]
   (let [changed (vec (touched report))
         eids (into #{} (map #(nth % 0)) changed)
-        merge? (seq (get-in db-after [:meta :datahike/merge-parents]))
-        authorized-id (authorized-attempt-id report)]
+        authorized-id (authorized-attempt-id report)
+        authorized-scorecard-id (authorized-scorecard-id report)]
     (doseq [eid eids]
       (let [before (entity-map db-before eid)
             after (entity-map db-after eid)
@@ -131,11 +213,15 @@
             after-attempt? (attempt? after)
             before-check? (check? before)
             after-check? (check? after)
+            before-scorecard? (scorecard? before)
+            after-scorecard? (scorecard? after)
+            before-summary? (summary? before)
+            after-summary? (summary? after)
             entity-datoms (filter #(= eid (nth % 0)) changed)]
         (cond
           (and (not before-attempt?) after-attempt?)
           (do
-            (when-not (or merge? (= authorized-id (:attempt/id after)))
+            (when-not (= authorized-id (:attempt/id after))
               (throw (ex-info "Certified Attempts require the trusted writer"
                               {:type ::unauthorized-attempt-create
                                :attempt/id (:attempt/id after)})))
@@ -156,7 +242,7 @@
                              :attempt/id (:attempt/id before)})))
 
           (and (not before-check?) after-check?)
-          (when-not (or merge? authorized-id)
+          (when-not authorized-id
             (throw (ex-info "Attempt checks require the trusted writer"
                             {:type ::unauthorized-check-create})))
 
@@ -174,7 +260,51 @@
             (when (attempt? (entity-map db-after owner))
               (throw (ex-info "Attempt check deletion requires Attempt deletion"
                               {:type ::check-deletion
-                               :check/id (:attempt.check/id before)})))))))
+                               :check/id (:attempt.check/id before)}))))
+
+          (and (not before-scorecard?) after-scorecard?)
+          (do
+            (when-not (= authorized-scorecard-id (:scorecard/id after))
+              (throw (ex-info "Certified Scorecards require the trusted writer"
+                              {:type ::unauthorized-scorecard-create
+                               :scorecard/id (:scorecard/id after)})))
+            (validate-new-scorecard! db-after after))
+
+          (and before-scorecard? after-scorecard?)
+          (when (seq entity-datoms)
+            (throw (ex-info "Certified Scorecard rows are immutable"
+                            {:type ::scorecard-mutation
+                             :scorecard/id (:scorecard/id before)})))
+
+          (and before-scorecard? (not after-scorecard?))
+          (when (:chat/id
+                 (d/pull db-after [:chat/id]
+                         (get-in before [:scorecard/chat :db/id])))
+            (throw (ex-info "Certified Scorecard deletion requires Room deletion"
+                            {:type ::scorecard-deletion
+                             :scorecard/id (:scorecard/id before)})))
+
+          (and (not before-summary?) after-summary?)
+          (when-not authorized-scorecard-id
+            (throw (ex-info "Scorecard summaries require the trusted writer"
+                            {:type ::unauthorized-scorecard-summary-create})))
+
+          (and before-summary? after-summary?)
+          (when (seq entity-datoms)
+            (throw (ex-info "Scorecard summaries are immutable"
+                            {:type ::scorecard-summary-mutation
+                             :summary/id (:scorecard.summary/id before)})))
+
+          (and before-summary? (not after-summary?))
+          (when-let [owner
+                     (d/q '[:find ?s . :in $ ?summary
+                            :where [?s :scorecard/summaries ?summary]]
+                          db-before eid)]
+            (when (scorecard? (entity-map db-after owner))
+              (throw
+               (ex-info "Scorecard summary deletion requires Scorecard deletion"
+                        {:type ::scorecard-summary-deletion
+                         :summary/id (:scorecard.summary/id before)})))))))
     ;; A newly-created check must be owned by an Attempt component edge.
     (doseq [eid eids
             :let [before (entity-map db-before eid)
@@ -184,12 +314,28 @@
                        :where [?a :attempt/checks ?check]] db-after eid)
         (throw (ex-info "Attempt check is not owned by a certified Attempt"
                         {:type ::orphan-check :check/id (:attempt.check/id after)}))))
+    ;; A newly-created summary must be a component of the authorized Scorecard.
+    (doseq [eid eids
+            :let [before (entity-map db-before eid)
+                  after (entity-map db-after eid)]
+            :when (and (not (summary? before)) (summary? after))]
+      (let [owner (d/q '[:find ?s . :in $ ?summary
+                         :where [?s :scorecard/summaries ?summary]]
+                       db-after eid)
+            owner-scorecard (when owner (entity-map db-after owner))]
+        (when-not (and (scorecard? owner-scorecard)
+                       (= authorized-scorecard-id
+                          (:scorecard/id owner-scorecard)))
+          (throw
+           (ex-info "Scorecard summary is not owned by its certified Scorecard"
+                    {:type ::orphan-scorecard-summary
+                     :summary/id (:scorecard.summary/id after)})))))
     report))
 
 (defonce ^:private installed (atom {}))
 
 (defn govern!
-  "Compose Attempt validation with the store's current mandatory predicate."
+  "Compose certified Attempt/Scorecard validation with the store predicate."
   [conn]
   (let [store-id (get-in @conn [:config :store :id])
         tx-pred-for (requiring-resolve 'datahike.tx-preds/tx-pred-for)

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -9,6 +9,7 @@
             [dvergr.agent.environment :as environment]
             [dvergr.agent.evaluation :as evaluation]
             [dvergr.agent.roster :as roster]
+            [dvergr.room.store :as store]
             [hasch.core :as hasch]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.spin.combinators :as comb]))
@@ -444,6 +445,90 @@
                 {:claimed claimed :actual actual})))
   scorecard)
 
+(defn validate-scorecard-attempts
+  "Verify that every Scorecard entry is an exact projection of its certified
+   Attempt, then return `scorecard` unchanged.
+
+   `attempts` is a map keyed by Attempt UUID. Repetition is intentionally the
+   Experiment cell coordinate: repeated Attempts for one exact candidate and
+   environment are exchangeable, but their identities must remain distinct."
+  [scorecard attempts]
+  (validate-scorecard scorecard)
+  (when-not (map? attempts)
+    (invalid! "Scorecard Attempts must be keyed by UUID"
+              ::invalid-scorecard-attempts {:attempts attempts}))
+  (let [entries (:scorecard/entries scorecard)
+        entry-ids (set (map :attempt/id entries))]
+    (when-not (= entry-ids (set (keys attempts)))
+      (invalid! "Scorecard Attempt set differs from its certifications"
+                ::scorecard-attempt-set-mismatch
+                {:expected entry-ids :actual (set (keys attempts))}))
+    (doseq [entry entries]
+      (let [certified
+            (or (some-> (get attempts (:attempt/id entry))
+                        attempt/validate-attempt)
+                (invalid! "Scorecard references an uncertified Attempt"
+                          ::uncertified-scorecard-attempt
+                          {:scorecard/id (:scorecard/content-id scorecard)
+                           :attempt/id (:attempt/id entry)}))
+            receipt (:attempt/receipt certified)
+            expected {:attempt/content-id (:attempt/content-id certified)
+                      :candidate/agent (roster/agent-ref
+                                        (:attempt/agent certified))
+                      :candidate/agent-content-id
+                      (:attempt/agent-def-hash certified)
+                      :environment (:attempt/environment receipt)
+                      :reward (:attempt/reward receipt)
+                      :passed? (passed? receipt)}
+            actual (select-keys entry (keys expected))]
+        (when-not (= expected actual)
+          (invalid! "Scorecard entry differs from its certified Attempt"
+                    ::scorecard-attempt-mismatch
+                    {:scorecard/id (:scorecard/content-id scorecard)
+                     :attempt/id (:attempt/id entry)
+                     :expected expected :actual actual})))))
+  scorecard)
+
+(defn persist-scorecard!
+  "Persist a completed canonical Scorecard through its Room store.
+
+   Rooms without a store intentionally return an ephemeral value. A configured
+   store must support certified Scorecards; returning a leaderboard projection
+   that cannot be reconstructed from the Room would violate the evaluation
+   boundary."
+  [room scorecard]
+  (validate-scorecard scorecard)
+  (if-let [room-store (:store room)]
+    (if (satisfies? store/PScorecardStore room-store)
+      (or (store/-store-scorecard! room-store (:id room) scorecard)
+          (invalid! "Scorecard was not durable"
+                    ::scorecard-not-durable
+                    {:scorecard/id (:scorecard/content-id scorecard)}))
+      (invalid! "Configured Room store does not support durable Scorecards"
+                ::unsupported-scorecard-store {:store (class room-store)}))
+    scorecard))
+
+(defn scorecard
+  "Load one completed certified Scorecard from `room` by content UUID."
+  [room scorecard-id]
+  (if-let [room-store (:store room)]
+    (if (satisfies? store/PScorecardStore room-store)
+      (store/-load-scorecard room-store (:id room) scorecard-id)
+      (invalid! "Configured Room store does not support durable Scorecards"
+                ::unsupported-scorecard-store {:store (class room-store)}))
+    nil))
+
+(defn scorecards
+  "List completed certified Scorecards in `room` using indexed exact filters."
+  ([room] (scorecards room {}))
+  ([room opts]
+   (if-let [room-store (:store room)]
+     (if (satisfies? store/PScorecardStore room-store)
+       (store/-list-scorecards room-store (:id room) opts)
+       (invalid! "Configured Room store does not support durable Scorecards"
+                 ::unsupported-scorecard-store {:store (class room-store)}))
+     [])))
+
 (defn run
   "Return a lazy Spin for one complete ExperimentDef.
 
@@ -523,9 +608,12 @@
                     (jobs experiment))]
      (sp/spin
       (let [results (sp/await (run-batches spins parallelism))]
-        {:experiment experiment
-         :execution {:parallelism parallelism
-                     :attempt-count attempt-count}
-         :results results
-         :attempts (mapv :attempt results)
-         :scorecard (make-scorecard experiment results)})))))
+        (let [scorecard (->> results
+                             (make-scorecard experiment)
+                             (persist-scorecard! room))]
+          {:experiment experiment
+           :execution {:parallelism parallelism
+                       :attempt-count attempt-count}
+           :results results
+           :attempts (mapv :attempt results)
+           :scorecard scorecard}))))))

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -435,7 +435,16 @@
                 ::duplicate-scorecard-attempts {}))
     (when-not (= (:scorecard/summary scorecard) (summarize entries))
       (invalid! "Scorecard summary does not match its entries"
-                ::scorecard-summary-mismatch {})))
+                ::scorecard-summary-mismatch {}))
+    (doseq [summary (:scorecard/summary scorecard)
+            key [:reward-sum :reward-mean]
+            :let [value (get summary key)]]
+      (when-not (and (number? value)
+                     (Double/isFinite (double value)))
+        (invalid! "Scorecard reward aggregates must be finite"
+                  ::non-finite-scorecard-summary
+                  {:candidate/id (:candidate/id summary)
+                   :key key :value value}))))
   (let [claimed (:scorecard/content-id scorecard)
         actual (hasch/uuid [:dvergr/experiment-scorecard
                             (dissoc scorecard :scorecard/content-id)])]

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -712,10 +712,10 @@
    Exact EnvironmentDef, AgentDef, receipt, and evidence values live in the
    content-addressed payload. Runs, messages, and checks remain typed joins so
    benchmark and UI queries never need to scan opaque payloads."
-  [{:db/ident :attempt.writer/token
+  [{:db/ident :evaluation.writer/token
     :db/valueType :db.type/uuid
     :db/cardinality :db.cardinality/one
-    :db/doc "One-use process-local capability attached to a trusted certification transaction"}
+    :db/doc "One-use process-local capability attached to a trusted evaluation projection transaction"}
 
    {:db/ident :attempt/id
     :db/valueType :db.type/uuid
@@ -867,6 +867,109 @@
 
    {:db/ident :attempt.check/passed?
     :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one
+    :db/index true}])
+
+;; ============================================================================
+;; Certified Experiment Scorecard Schema
+;; ============================================================================
+
+(def scorecard-schema
+  "Immutable typed index for one complete certified Experiment scorecard.
+
+   The canonical ExperimentDef, entries, and summaries live in the immutable
+   payload. Typed Attempt joins and candidate summaries make provenance and
+   leaderboard queries available without scanning that payload."
+  [{:db/ident :scorecard/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard/chat
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard/payload-blob
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard/payload-codec
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard/experiment-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard/experiment-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard/experiment-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard/dataset-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard/dataset-version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard/dataset-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard/stored-at
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard/attempts
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/index true}
+
+   {:db/ident :scorecard/summaries
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/isComponent true}
+
+   {:db/ident :scorecard.summary/id
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard.summary/candidate-id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard.summary/candidate-content-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+
+   {:db/ident :scorecard.summary/attempt-count
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard.summary/passed-count
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard.summary/reward-sum
+    :db/valueType :db.type/double
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard.summary/reward-mean
+    :db/valueType :db.type/double
     :db/cardinality :db.cardinality/one
     :db/index true}])
 
@@ -1339,6 +1442,7 @@
                message-schema
                run-schema
                attempt-schema
+               scorecard-schema
                attention-schema
                tool-call-schema
                ledger-schema

--- a/src/dvergr/room/store.clj
+++ b/src/dvergr/room/store.clj
@@ -151,6 +151,28 @@
      :environment-id, :environment-content-id, :provider, :model, and :status;
      :limit is applied after filtering."))
 
+(defprotocol PScorecardStore
+  "Durable immutable projection of completed certified Experiments.
+
+   A Scorecard contains the exact ExperimentDef and full cell matrix, while its
+   Attempt references must resolve to already-certified Attempts in the same
+   Room. It is a query/index projection, not another execution lifecycle."
+
+  (-store-scorecard! [this room-id scorecard]
+    "Persist one canonical completed Scorecard. Repeating identical content is
+     idempotent. Its content identity has one authoritative Room owner across
+     the store; claiming it from another Room or with different content is an
+     error.")
+
+  (-load-scorecard [this room-id scorecard-id]
+    "Return one exact Scorecard by content UUID in `room-id`, else nil.")
+
+  (-list-scorecards [this room-id opts]
+    "Return recently stored Scorecards newest first. Optional exact filters are
+     :experiment-id, :experiment-content-id, :dataset-id,
+     :dataset-content-id, :candidate-id, and :candidate-content-id; :limit is
+     applied after filtering."))
+
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -20,6 +20,17 @@
             [hasch.core :as hasch]
             [taoensso.telemere :as tel]))
 
+(defn- validate-scorecard [value]
+  ;; DatahikeStore is loaded below discourse, which the Experiment interpreter
+  ;; itself uses. Resolve the pure validator at the store call boundary rather
+  ;; than introducing that namespace cycle at load time.
+  ((requiring-resolve 'dvergr.agent.experiment/validate-scorecard) value))
+
+(defn- validate-scorecard-attempts [value attempts]
+  ((requiring-resolve
+    'dvergr.agent.experiment/validate-scorecard-attempts)
+   value attempts))
+
 ;; =============================================================================
 ;; Helpers
 ;; =============================================================================
@@ -288,6 +299,31 @@
                              :message/ref ref})))))
       [entity])))
 
+(defn- store-scorecard-if-absent
+  "Transaction function for one immutable Scorecard over same-Room Attempts."
+  [db entity]
+  (if-let [existing (dh/entity db [:scorecard/id (:scorecard/id entity)])]
+    (if (= (second (:scorecard/chat entity))
+           (:chat/id (:scorecard/chat existing)))
+      []
+      (throw (ex-info "Scorecard identity belongs to another Room"
+                      {:type :room-store/scorecard-room-mismatch
+                       :scorecard/id (:scorecard/id entity)})))
+    (let [chat-id (second (:scorecard/chat entity))]
+      (doseq [ref (:scorecard/attempts entity)]
+        (let [attempt-entity (dh/entity db ref)]
+          (when-not attempt-entity
+            (throw (ex-info "Scorecard references an uncertified Attempt"
+                            {:type :room-store/invalid-scorecard-attempt
+                             :scorecard/id (:scorecard/id entity)
+                             :attempt/ref ref})))
+          (when-not (= chat-id (:chat/id (:attempt/chat attempt-entity)))
+            (throw (ex-info "Scorecard Attempt crosses Room stores"
+                            {:type :room-store/scorecard-room-mismatch
+                             :scorecard/id (:scorecard/id entity)
+                             :attempt/id (:attempt/id attempt-entity)})))))
+      [entity])))
+
 (def ^:private message-pull-pattern
   '[:message/id :message/role :message/content
     :message/created-at :message/source-user
@@ -344,6 +380,19 @@
     {:attempt/evidence-messages [:message/id]}
     {:attempt/checks [:attempt.check/id :attempt.check/key
                       :attempt.check/passed?]}])
+
+(def ^:private scorecard-pull-pattern
+  '[:scorecard/id :scorecard/payload-blob :scorecard/payload-codec
+    :scorecard/experiment-id :scorecard/experiment-version
+    :scorecard/experiment-content-id :scorecard/dataset-id
+    :scorecard/dataset-version :scorecard/dataset-content-id
+    :scorecard/stored-at
+    {:scorecard/attempts [:attempt/id :attempt/content-id]}
+    {:scorecard/summaries
+     [:scorecard.summary/id :scorecard.summary/candidate-id
+      :scorecard.summary/candidate-content-id
+      :scorecard.summary/attempt-count :scorecard.summary/passed-count
+      :scorecard.summary/reward-sum :scorecard.summary/reward-mean]}])
 
 (def ^:private attention-pull-pattern
   '[:attention/id :attention/participant :attention/message-id
@@ -506,6 +555,105 @@
                              :key k :expected expected :actual (get actual k)}))))
         value))))
 
+(defn- scorecard-summary-id [scorecard-id candidate-id]
+  (hasch/uuid [:dvergr/scorecard-summary scorecard-id candidate-id]))
+
+(defn- scorecard->entity [chat-id value payload-ref stored-at]
+  (let [definition (:scorecard/experiment value)
+        dataset (:experiment/dataset definition)
+        candidates (into {} (map (juxt :candidate/id identity)
+                                 (:experiment/candidates definition)))
+        scorecard-id (:scorecard/content-id value)]
+    {:scorecard/id scorecard-id
+     :scorecard/chat [:chat/id chat-id]
+     :scorecard/payload-blob payload-ref
+     :scorecard/payload-codec :edn-v1
+     :scorecard/experiment-id (:experiment/id definition)
+     :scorecard/experiment-version (long (:experiment/version definition))
+     :scorecard/experiment-content-id (:experiment/content-id definition)
+     :scorecard/dataset-id (:dataset/id dataset)
+     :scorecard/dataset-version (long (:dataset/version dataset))
+     :scorecard/dataset-content-id (:dataset/content-id dataset)
+     :scorecard/stored-at stored-at
+     :scorecard/attempts
+     (mapv (fn [entry] [:attempt/id (:attempt/id entry)])
+           (:scorecard/entries value))
+     :scorecard/summaries
+     (mapv
+      (fn [summary]
+        (let [candidate (get candidates (:candidate/id summary))]
+          {:scorecard.summary/id
+           (scorecard-summary-id scorecard-id (:candidate/id summary))
+           :scorecard.summary/candidate-id (:candidate/id summary)
+           :scorecard.summary/candidate-content-id
+           (:candidate/agent-content-id candidate)
+           :scorecard.summary/attempt-count (long (:attempt-count summary))
+           :scorecard.summary/passed-count (long (:passed-count summary))
+           :scorecard.summary/reward-sum (double (:reward-sum summary))
+           :scorecard.summary/reward-mean (double (:reward-mean summary))}))
+      (:scorecard/summary value))}))
+
+(defn- entity->scorecard [entity artifacts]
+  (when entity
+    (when-not (= :edn-v1 (:scorecard/payload-codec entity))
+      (throw (ex-info "Unsupported Scorecard payload codec"
+                      {:type :room-store/unsupported-scorecard-payload
+                       :codec (:scorecard/payload-codec entity)})))
+    (let [value (artifact/get-value artifacts (:scorecard/payload-blob entity))]
+      (when-not value
+        (throw (ex-info "Scorecard payload artifact is unavailable"
+                        {:type :room-store/missing-scorecard-payload
+                         :scorecard/id (:scorecard/id entity)
+                         :artifact/ref (:scorecard/payload-blob entity)})))
+      (validate-scorecard value)
+      (let [definition (:scorecard/experiment value)
+            dataset (:experiment/dataset definition)
+            candidates (into {} (map (juxt :candidate/id identity)
+                                     (:experiment/candidates definition)))
+            expected-summaries
+            (set
+             (map
+              (fn [summary]
+                (let [candidate (get candidates (:candidate/id summary))]
+                  {:scorecard.summary/id
+                   (scorecard-summary-id (:scorecard/content-id value)
+                                         (:candidate/id summary))
+                   :scorecard.summary/candidate-id (:candidate/id summary)
+                   :scorecard.summary/candidate-content-id
+                   (:candidate/agent-content-id candidate)
+                   :scorecard.summary/attempt-count (:attempt-count summary)
+                   :scorecard.summary/passed-count (:passed-count summary)
+                   :scorecard.summary/reward-sum (double (:reward-sum summary))
+                   :scorecard.summary/reward-mean
+                   (double (:reward-mean summary))}))
+              (:scorecard/summary value)))
+            expected {:scorecard/id (:scorecard/content-id value)
+                      :scorecard/experiment-id (:experiment/id definition)
+                      :scorecard/experiment-version (:experiment/version definition)
+                      :scorecard/experiment-content-id
+                      (:experiment/content-id definition)
+                      :scorecard/dataset-id (:dataset/id dataset)
+                      :scorecard/dataset-version (:dataset/version dataset)
+                      :scorecard/dataset-content-id (:dataset/content-id dataset)
+                      :scorecard/attempts
+                      (set (map (juxt :attempt/id :attempt/content-id)
+                                (:scorecard/entries value)))
+                      :scorecard/summaries expected-summaries}
+            actual (assoc entity
+                          :scorecard/attempts
+                          (set (map (juxt :attempt/id :attempt/content-id)
+                                    (:scorecard/attempts entity)))
+                          :scorecard/summaries
+                          (set (:scorecard/summaries entity)))]
+        (doseq [[k expected-value] expected]
+          (when-not (= expected-value (get actual k))
+            (throw
+             (ex-info "Scorecard typed projection differs from exact payload"
+                      {:type :room-store/corrupt-scorecard-projection
+                       :scorecard/id (:scorecard/content-id value)
+                       :key k :expected expected-value :actual (get actual k)}))))
+        value))))
+
 (defn- attention->entity [chat-id fact]
   (cond-> (-> fact
               (dissoc :attention/metadata)
@@ -571,6 +719,13 @@
                                   [?a :attempt/chat ?c]
                                   [?a :attempt/id ?aid]]
                                 @conn chat-id)
+              scorecard-ids (dh/q '[:find [?sid ...]
+                                    :in $ ?cid
+                                    :where
+                                    [?c :chat/id ?cid]
+                                    [?s :scorecard/chat ?c]
+                                    [?s :scorecard/id ?sid]]
+                                  @conn chat-id)
               attention-ids (dh/q '[:find [?aid ...]
                                     :in $ ?cid
                                     :where
@@ -578,9 +733,12 @@
                                     [?a :attention/chat ?c]
                                     [?a :attention/id ?aid]]
                                   @conn chat-id)]
-          (dh/transact conn (-> (mapv (fn [aid]
-                                        [:db/retractEntity [:attempt/id aid]])
-                                      attempt-ids)
+          (dh/transact conn (-> (mapv (fn [sid]
+                                        [:db/retractEntity [:scorecard/id sid]])
+                                      scorecard-ids)
+                                (into (map (fn [aid]
+                                             [:db/retractEntity [:attempt/id aid]])
+                                           attempt-ids))
                                 (into (map (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids))
                                 (into (map (fn [rid] [:db/retractEntity [:run/id rid]]) run-ids))
                                 (into (map (fn [aid]
@@ -1016,6 +1174,128 @@
                         #(compare %2 %1))
                (take (or limit 100))
                (mapv #(entity->attempt % artifacts))))
+        [])))
+
+  store/PScorecardStore
+
+  (-store-scorecard! [this room-id value]
+    (let [value (validate-scorecard value)
+          scorecard-id (:scorecard/content-id value)
+          slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        (let [payload-ref (artifact/put-value! artifacts value)
+              entity (scorecard->entity (:chat/id ent) value payload-ref
+                                        (java.util.Date.))]
+          (locking conn
+            (if-let [existing (store/-load-scorecard this room-id scorecard-id)]
+              (if (= existing value)
+                existing
+                (throw (ex-info "Scorecard identity is immutable"
+                                {:type :room-store/scorecard-identity-collision
+                                 :existing existing :scorecard value})))
+              (let [existing-chat-id
+                    (dh/q '[:find ?chat-id .
+                            :in $ ?scorecard-id
+                            :where
+                            [?s :scorecard/id ?scorecard-id]
+                            [?s :scorecard/chat ?c]
+                            [?c :chat/id ?chat-id]]
+                          @conn scorecard-id)
+                    _ (when (and existing-chat-id
+                                 (not= existing-chat-id (:chat/id ent)))
+                        (throw
+                         (ex-info "Scorecard identity belongs to another Room"
+                                  {:type :room-store/scorecard-room-mismatch
+                                   :scorecard/id scorecard-id})))
+                    _ (validate-scorecard-attempts
+                       value
+                       (into {}
+                             (keep
+                              (fn [entry]
+                                (when-let [stored
+                                           (store/-load-attempt
+                                            this room-id (:attempt/id entry))]
+                                  [(:attempt/id entry) stored])))
+                             (:scorecard/entries value)))
+                    report
+                    (attempt-governance/with-authorized-scorecard-write
+                      conn scorecard-id
+                      (fn [tx-meta]
+                        (persist/persist-tx-result!
+                         conn
+                         [[:db.fn/call store-scorecard-if-absent entity]]
+                         {:op :store-scorecard :room-id room-id
+                          :scorecard-id scorecard-id :tx-meta tx-meta})))]
+                (when report
+                  (let [stored (store/-load-scorecard this room-id scorecard-id)]
+                    (when-not (= stored value)
+                      (throw
+                       (ex-info "Concurrent Scorecard identity collision"
+                                {:type :room-store/scorecard-identity-collision
+                                 :stored stored :scorecard value})))
+                    stored)))))))))
+
+  (-load-scorecard [_ room-id scorecard-id]
+    (let [slug (store/room-id->slug room-id)]
+      (when-let [ent (room-by-slug conn slug)]
+        (some-> (dh/q '[:find (pull ?s pattern) .
+                        :in $ ?chat-id ?scorecard-id pattern
+                        :where
+                        [?c :chat/id ?chat-id]
+                        [?s :scorecard/chat ?c]
+                        [?s :scorecard/id ?scorecard-id]]
+                      @conn (:chat/id ent) scorecard-id
+                      scorecard-pull-pattern)
+                (entity->scorecard artifacts)))))
+
+  (-list-scorecards [_ room-id {:keys [limit experiment-id
+                                       experiment-content-id dataset-id
+                                       dataset-content-id candidate-id
+                                       candidate-content-id]}]
+    (let [slug (store/room-id->slug room-id)]
+      (if-let [ent (room-by-slug conn slug)]
+        (let [where
+              (cond-> '[[?c :chat/id ?chat-id]
+                        [?s :scorecard/chat ?c]]
+                experiment-id
+                (conj '[?s :scorecard/experiment-id ?experiment-id])
+                experiment-content-id
+                (conj '[?s :scorecard/experiment-content-id
+                        ?experiment-content-id])
+                dataset-id (conj '[?s :scorecard/dataset-id ?dataset-id])
+                dataset-content-id
+                (conj '[?s :scorecard/dataset-content-id ?dataset-content-id])
+                candidate-id
+                (into '[[?s :scorecard/summaries ?summary]
+                        [?summary :scorecard.summary/candidate-id ?candidate-id]])
+                candidate-content-id
+                (into '[[?s :scorecard/summaries ?summary]
+                        [?summary :scorecard.summary/candidate-content-id
+                         ?candidate-content-id]]))
+              inputs (cond-> '[$ ?chat-id pattern]
+                       experiment-id (conj '?experiment-id)
+                       experiment-content-id (conj '?experiment-content-id)
+                       dataset-id (conj '?dataset-id)
+                       dataset-content-id (conj '?dataset-content-id)
+                       candidate-id (conj '?candidate-id)
+                       candidate-content-id (conj '?candidate-content-id))
+              args (cond-> [@conn (:chat/id ent) scorecard-pull-pattern]
+                     experiment-id (conj experiment-id)
+                     experiment-content-id (conj experiment-content-id)
+                     dataset-id (conj dataset-id)
+                     dataset-content-id (conj dataset-content-id)
+                     candidate-id (conj candidate-id)
+                     candidate-content-id (conj candidate-content-id))
+              query {:find '[(pull ?s pattern)] :in inputs :where where}]
+          (->> (apply dh/q query args)
+               (map first)
+               distinct
+               (sort-by (juxt #(some-> ^java.util.Date
+                                (:scorecard/stored-at %) .getTime)
+                              #(str (:scorecard/id %)))
+                        #(compare %2 %1))
+               (take (or limit 100))
+               (mapv #(entity->scorecard % artifacts))))
         [])))
 
   store/PAttentionStore

--- a/src/dvergr/room/store/memory.clj
+++ b/src/dvergr/room/store/memory.clj
@@ -5,12 +5,24 @@
   (:require [dvergr.agent.attempt :as attempt]
             [dvergr.room.store :as store]))
 
+(defn- validate-scorecard [value]
+  ;; Keep the generic Room store below the Experiment execution layer. The
+  ;; validator is resolved only at this protocol boundary to avoid making Room
+  ;; construction depend cyclically on agent/program/discourse namespaces.
+  ((requiring-resolve 'dvergr.agent.experiment/validate-scorecard) value))
+
+(defn- validate-scorecard-attempts [value attempts]
+  ((requiring-resolve
+    'dvergr.agent.experiment/validate-scorecard-attempts)
+   value attempts))
+
 (defrecord MemoryStore [state]
   ;; state atom shape:
   ;;   {:rooms     {room-id metadata}
   ;;    :messages  {room-id [msg ...] (chronological)}
   ;;    :runs      {room-id {run-id run}}
-  ;;    :attempts  {room-id {attempt-id attempt}}}
+  ;;    :attempts  {room-id {attempt-id attempt}}
+  ;;    :scorecards {room-id {scorecard-id {:value scorecard :stored-at date}}}}
   store/PRoomStore
 
   (-store-room! [_ room-id metadata]
@@ -25,12 +37,16 @@
   (-delete-room! [_ room-id]
     (swap! state
            (fn [s]
-             (let [attention-ids (keys (get-in s [:attention room-id] {}))]
+             (let [attention-ids (keys (get-in s [:attention room-id] {}))
+                   scorecard-ids (keys (get-in s [:scorecards room-id] {}))]
                (-> s
                    (update :rooms    dissoc room-id)
                    (update :messages dissoc room-id)
                    (update :runs     dissoc room-id)
                    (update :attempts dissoc room-id)
+                   (update :scorecards dissoc room-id)
+                   (update :scorecard-index
+                           #(apply dissoc % scorecard-ids))
                    (update :attention dissoc room-id)
                    (update :attention-index
                            #(apply dissoc % attention-ids)))))))
@@ -264,6 +280,89 @@
          (take (or limit 100))
          vec))
 
+  store/PScorecardStore
+
+  (-store-scorecard! [_ room-id value]
+    (let [value (validate-scorecard value)
+          scorecard-id (:scorecard/content-id value)]
+      (swap! state
+             (fn [snapshot]
+               (let [global (get-in snapshot [:scorecard-index scorecard-id])
+                     _ (when (and global (not= room-id (:room-id global)))
+                         (throw
+                          (ex-info "Scorecard identity belongs to another Room"
+                                   {:type :room-store/scorecard-room-mismatch
+                                    :scorecard/id scorecard-id})))
+                     _ (validate-scorecard-attempts
+                        value
+                        (into {}
+                              (keep (fn [entry]
+                                      (when-let [stored
+                                                 (get-in
+                                                  snapshot
+                                                  [:attempts room-id
+                                                   (:attempt/id entry)])]
+                                        [(:attempt/id entry) stored])))
+                              (:scorecard/entries value)))
+                     existing (get-in snapshot
+                                      [:scorecards room-id scorecard-id :value])]
+                 (when (and existing (not= existing value))
+                   (throw (ex-info "Scorecard identity is immutable"
+                                   {:type :room-store/scorecard-identity-collision
+                                    :existing existing :scorecard value})))
+                 (if existing
+                   snapshot
+                   (let [entry {:value value :stored-at (java.util.Date.)}]
+                     (-> snapshot
+                         (assoc-in [:scorecards room-id scorecard-id] entry)
+                         (assoc-in [:scorecard-index scorecard-id]
+                                   {:room-id room-id :value value})))))))
+      value))
+
+  (-load-scorecard [_ room-id scorecard-id]
+    (get-in @state [:scorecards room-id scorecard-id :value]))
+
+  (-list-scorecards [_ room-id {:keys [limit experiment-id
+                                       experiment-content-id dataset-id
+                                       dataset-content-id candidate-id
+                                       candidate-content-id]}]
+    (->> (vals (get-in @state [:scorecards room-id] {}))
+         (filter
+          (fn [{:keys [value]}]
+            (and
+             (if experiment-id
+               (= experiment-id (get-in value [:scorecard/experiment
+                                               :experiment/id]))
+               true)
+             (if experiment-content-id
+               (= experiment-content-id
+                  (get-in value [:scorecard/experiment
+                                 :experiment/content-id]))
+               true)
+             (if dataset-id
+               (= dataset-id (get-in value [:scorecard/experiment
+                                            :experiment/dataset :dataset/id]))
+               true)
+             (if dataset-content-id
+               (= dataset-content-id
+                  (get-in value [:scorecard/experiment
+                                 :experiment/dataset :dataset/content-id]))
+               true)
+             (if candidate-id
+               (some #(= candidate-id (:candidate/id %))
+                     (:scorecard/summary value))
+               true)
+             (if candidate-content-id
+               (some #(= candidate-content-id
+                         (:candidate/agent-content-id %))
+                     (:scorecard/entries value))
+               true))))
+         (sort-by (juxt #(some-> ^java.util.Date (:stored-at %) .getTime)
+                        #(str (get-in % [:value :scorecard/content-id])))
+                  #(compare %2 %1))
+         (take (or limit 100))
+         (mapv :value)))
+
   store/PAttentionStore
 
   (-store-attention! [_ room-id fact]
@@ -308,4 +407,5 @@
   "Create a fresh in-memory store."
   []
   (->MemoryStore (atom {:rooms {} :messages {} :runs {} :attempts {}
+                        :scorecards {} :scorecard-index {}
                         :attention {} :attention-index {}})))

--- a/src/dvergr/sandbox/ns/datahike.clj
+++ b/src/dvergr/sandbox/ns/datahike.clj
@@ -64,36 +64,41 @@
     schema reverse-schema metrics db history as-of since filter
     transact transact! with])
 
-(defn- attempt-attr? [x]
+(defn- certified-evaluation-attr? [x]
   (and (keyword? x)
-       (contains? #{"attempt" "attempt.check"} (namespace x))))
+       (contains? #{"attempt" "attempt.check"
+                    "scorecard" "scorecard.summary"}
+                  (namespace x))))
 
-(defn- attempt-entity? [conn eid]
+(defn- certified-evaluation-entity? [conn eid]
   (try
     (let [entity (d/entity @conn eid)]
-      (boolean (or (:attempt/id entity) (:attempt.check/id entity))))
+      (boolean (or (:attempt/id entity) (:attempt.check/id entity)
+                   (:scorecard/id entity) (:scorecard.summary/id entity))))
     (catch Throwable _ false)))
 
-(defn- assert-no-attempt-write! [conn tx-data]
+(defn- assert-no-certified-evaluation-write! [conn tx-data]
   (doseq [form tx-data]
     (let [protected?
           (cond
             (map? form)
-            (or (some attempt-attr? (keys form))
-                (attempt-entity? conn (:db/id form)))
+            (or (some certified-evaluation-attr? (keys form))
+                (certified-evaluation-entity? conn (:db/id form)))
 
             (vector? form)
             (let [[op eid attr] form]
               (or (= :db.fn/call op)
-                  (attempt-attr? attr)
-                  (and (vector? eid) (attempt-attr? (first eid)))
+                  (certified-evaluation-attr? attr)
+                  (and (vector? eid)
+                       (certified-evaluation-attr? (first eid)))
                   (and (#{:db/retractEntity :db.fn/retractEntity} op)
-                       (attempt-entity? conn eid))))
+                       (certified-evaluation-entity? conn eid))))
 
             :else false)]
       (when protected?
-        (throw (ex-info "Verified Attempt projections are host-certified and read-only in SCI"
-                        {:type ::protected-attempt-write :tx-form form})))))
+        (throw
+         (ex-info "Certified evaluation projections are host-owned and read-only in SCI"
+                  {:type ::protected-evaluation-write :tx-form form})))))
   tx-data)
 
 (defn- cfg-name
@@ -173,12 +178,14 @@
                          (fn [conn tx-data]
                            (let [conn (resolve-connection conn)]
                              (d/transact conn
-                                         (assert-no-attempt-write! conn tx-data))))
+                                         (assert-no-certified-evaluation-write!
+                                          conn tx-data))))
                          'transact!
                          (fn [conn tx-data]
                            (let [conn (resolve-connection conn)]
                              (d/transact! conn
-                                          (assert-no-attempt-write! conn tx-data)))))
+                                          (assert-no-certified-evaluation-write!
+                                           conn tx-data)))))
         ;; per-sandbox ephemeral (:mem) databases, keyed by logical name
         ephemeral (atom {})
         ephemeral-map #(if binding-resolver

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -210,6 +210,43 @@
         (evaluation/await-cleanups! room 5000)
         (d/close-room! room)))))
 
+(deftest finite-cell-rewards-cannot-overflow-scorecard-aggregates
+  (let [team (-> (roster/make-roster {:id :experiment/overflow-team})
+                 (roster/make-agent {:id :candidate :program {:kind :echo}}))
+        definition
+        (experiment/make-experiment
+         {:id :experiment/overflow
+          :dataset
+          (experiment/make-dataset
+           {:id :experiment/overflow
+            :environments [(environment :experiment/overflow :ok)]})
+          :candidates [(roster/agent team :candidate)]
+          :repetitions 2})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/exact
+          :version 1
+          :basis "experiment-test:v1"
+          :observe (fn [{:keys [default]}] default)
+          :verify (fn [_ _]
+                    {:checks {:finite-cell? true}
+                     :reward Double/MAX_VALUE})})
+        room (d/make-room {:id :experiment-overflow
+                           :store (memory/make)})]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"aggregates must be finite"
+             @(experiment/run room team definition
+                              {(:ref evaluator) evaluator}))))
+      (is (= 2 (count (store/-list-attempts (:store room) (:id room) {})))
+          "every finite cell Attempt remains certified for diagnosis")
+      (is (empty? (store/-list-scorecards (:store room) (:id room) {}))
+          "the constructor never exposes or persists an invalid Scorecard")
+      (finally
+        (evaluation/await-cleanups! room 5000)
+        (d/close-room! room)))))
+
 (deftest repeated-paired-experiment-composes-ordinary-certified-evaluations
   (let [{:keys [team definition]} (fixture)
         room (d/make-room {:id :experiment-run :store (memory/make)})

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -233,6 +233,38 @@
                        :passed-count 4 :reward-sum 4.0 :reward-mean 1.0}]
                      (:scorecard/summary scorecard)))
               (is (= scorecard (experiment/validate-scorecard scorecard)))
+              (is (= scorecard
+                     (experiment/scorecard room
+                                           (:scorecard/content-id scorecard))))
+              (is (= [scorecard]
+                     (experiment/scorecards
+                      room {:experiment-content-id
+                            (:experiment/content-id definition)
+                            :dataset-content-id
+                            (get-in definition [:experiment/dataset
+                                                :dataset/content-id])
+                            :candidate-id :alpha
+                            :candidate-content-id
+                            (get-in definition [:experiment/candidates 0
+                                                :candidate/agent-content-id])})))
+              (is (= scorecard (experiment/persist-scorecard! room scorecard))
+                  "repeating the same immutable projection is idempotent")
+              (testing "a new content hash cannot forge certified rewards"
+                (let [forged (-> scorecard
+                                 (assoc-in [:scorecard/entries 0 :reward] 99.0)
+                                 (assoc-in [:scorecard/summary 0 :reward-sum]
+                                           102.0)
+                                 (assoc-in [:scorecard/summary 0 :reward-mean]
+                                           25.5)
+                                 (dissoc :scorecard/content-id))
+                      forged
+                      (assoc forged :scorecard/content-id
+                             (hasch/uuid
+                              [:dvergr/experiment-scorecard forged]))]
+                  (is (= forged (experiment/validate-scorecard forged)))
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo #"certified Attempt"
+                       (experiment/persist-scorecard! room forged)))))
               (is (every? #(= % (store/-load-attempt
                                  (:store room) (:id room) (:attempt/id %)))
                           attempts))

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -75,6 +75,82 @@
                             (store/-store-scorecard! st room-b scorecard)))
       (is (empty? (store/-list-scorecards st room-b {}))))))
 
+(defn- finite-reward-overflow-scorecard []
+  (let [agent (-> (roster/make-roster)
+                  (roster/make-agent {:id :overflow-candidate
+                                      :program {:kind :echo}})
+                  (roster/agent :overflow-candidate))
+        definition
+        (environment/make-environment
+         {:id :contract/overflow :task :ok
+          :verifier {:id :contract/overflow :version 1}
+          :world {:isolation :ctx :settlement :review}})
+        experiment-def
+        (experiment/make-experiment
+         {:id :contract/overflow
+          :dataset (experiment/make-dataset
+                    {:id :contract/overflow
+                     :environments [definition]})
+          :candidates [agent]
+          :repetitions 2})
+        candidate (first (:experiment/candidates experiment-def))
+        result
+        (fn [repetition]
+          (let [run-id (random-uuid)
+                receipt
+                (environment/make-attempt-receipt
+                 definition
+                 {:run-id run-id :provider :dvergr :model "echo"
+                  :status :completed :started-at 1000 :elapsed-ms 10
+                  :metrics {:program-kind :echo
+                            :model-resolution :not-applicable
+                            :agent-version 1
+                            :agent-def-hash (hasch/uuid agent)
+                            :interpreter-version 5}
+                  :checks {:exact? true} :reward 1.0
+                  :trace {:runs [{:run/id run-id
+                                  :run/status :completed}]}})
+                certified
+                (attempt/make-attempt
+                 definition agent receipt
+                 {:trace {:runs [{:run/id run-id :run/status :completed}]}}
+                 :review)]
+            {:experiment/job
+             {:candidate/id (:candidate/id candidate)
+              :candidate/agent (:candidate/agent candidate)
+              :candidate/agent-content-id
+              (:candidate/agent-content-id candidate)
+              :environment (environment/environment-ref definition)
+              :repetition repetition}
+             :attempt certified}))
+        valid (experiment/make-scorecard experiment-def [(result 0) (result 1)])
+        overflow (-> valid
+                     (update :scorecard/entries
+                             #(mapv (fn [entry]
+                                      (assoc entry :reward Double/MAX_VALUE))
+                                    %))
+                     (assoc :scorecard/summary
+                            [{:candidate/id :overflow-candidate
+                              :attempt-count 2
+                              :passed-count 2
+                              :reward-sum ##Inf
+                              :reward-mean ##Inf}])
+                     (dissoc :scorecard/content-id))]
+    (assoc overflow :scorecard/content-id
+           (hasch/uuid [:dvergr/experiment-scorecard overflow]))))
+
+(defn assert-non-finite-scorecard-aggregates-rejected!
+  "Canonical and store validation reject overflow from finite cell rewards."
+  [st room-id]
+  (testing "non-finite derived Scorecard aggregates are rejected consistently"
+    (let [scorecard (finite-reward-overflow-scorecard)]
+      (store/-store-room! st room-id {:slug (name room-id)})
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be finite"
+                            (experiment/validate-scorecard scorecard)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be finite"
+                            (store/-store-scorecard! st room-id scorecard)))
+      (is (empty? (store/-list-scorecards st room-id {}))))))
+
 (defn assert-message-envelope!
   "Exercise lossless envelope replay and first-write-wins idempotence."
   [st room-id]

--- a/test/dvergr/room/store/contract.clj
+++ b/test/dvergr/room/store/contract.clj
@@ -1,7 +1,79 @@
 (ns dvergr.room.store.contract
   "Behavioral contract shared by every PRoomStore implementation."
   (:require [clojure.test :refer [is testing]]
-            [dvergr.room.store :as store]))
+            [dvergr.agent.attempt :as attempt]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.room.store :as store]
+            [hasch.core :as hasch]))
+
+(defn assert-cross-room-scorecard-identity!
+  "One certified Scorecard content identity has exactly one control Room owner."
+  [st]
+  (testing "Scorecard identity cannot be claimed by another Room"
+    (let [room-a :scorecard-room-a
+          room-b :scorecard-room-b
+          run-id (random-uuid)
+          now (java.util.Date. 1000)
+          agent (-> (roster/make-roster)
+                    (roster/make-agent {:id :candidate
+                                        :program {:kind :echo}})
+                    (roster/agent :candidate))
+          definition
+          (environment/make-environment
+           {:id :contract/exact :task :ok
+            :verifier {:id :contract/exact :version 1}
+            :world {:isolation :ctx :settlement :review}})
+          receipt
+          (environment/make-attempt-receipt
+           definition
+           {:run-id run-id :provider :dvergr :model "echo"
+            :status :completed :started-at 1000 :elapsed-ms 10
+            :metrics {:program-kind :echo :model-resolution :not-applicable
+                      :agent-version 1 :agent-def-hash (hasch/uuid agent)
+                      :interpreter-version 5}
+            :checks {:exact? true} :reward 1.0
+            :trace {:runs [{:run/id run-id :run/status :completed}]}})
+          certified
+          (attempt/make-attempt
+           definition agent receipt
+           {:trace {:runs [{:run/id run-id :run/status :completed}]}}
+           :review)
+          experiment-def
+          (experiment/make-experiment
+           {:id :contract/scorecard
+            :dataset (experiment/make-dataset
+                      {:id :contract/scorecard
+                       :environments [definition]})
+            :candidates [agent]})
+          candidate (first (:experiment/candidates experiment-def))
+          scorecard
+          (experiment/make-scorecard
+           experiment-def
+           [{:experiment/job
+             {:candidate/id (:candidate/id candidate)
+              :candidate/agent (:candidate/agent candidate)
+              :candidate/agent-content-id
+              (:candidate/agent-content-id candidate)
+              :environment (environment/environment-ref definition)
+              :repetition 0}
+             :attempt certified}])]
+      (doseq [room-id [room-a room-b]]
+        (store/-store-room! st room-id {:slug (name room-id)}))
+      (store/-store-run!
+       st room-a
+       {:run/id run-id :run/kind :agent-task :run/room room-a
+        :run/actor :candidate :run/trigger (random-uuid)
+        :run/status :completed :run/created-at now :run/started-at now
+        :run/updated-at now :run/ended-at (java.util.Date. 1010)
+        :run/agent-version 1 :run/program-kind :echo
+        :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)})
+      (store/-store-attempt! st room-a certified)
+      (is (= scorecard (store/-store-scorecard! st room-a scorecard)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"another Room"
+                            (store/-store-scorecard! st room-b scorecard)))
+      (is (empty? (store/-list-scorecards st room-b {}))))))
 
 (defn assert-message-envelope!
   "Exercise lossless envelope replay and first-write-wins idempotence."

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -8,6 +8,7 @@
             [dvergr.agent.attempt :as attempt]
             [dvergr.agent.attempt.governance :as attempt-governance]
             [dvergr.agent.environment :as environment]
+            [dvergr.agent.experiment :as experiment]
             [dvergr.agent.roster :as roster]
             [dvergr.artifact :as artifact]
             [dvergr.chat.schema :as schema]
@@ -60,6 +61,134 @@
                           {:trace {:runs [{:run/id run-id
                                            :run/status :completed}]}}
                           :review)))
+
+(defn- certified-scorecard [value agent]
+  (let [definition
+        (experiment/make-experiment
+         {:id :datahike/scorecard
+          :dataset
+          (experiment/make-dataset
+           {:id :datahike/scorecard
+            :environments [(:attempt/environment value)]})
+          :candidates [agent]})
+        candidate (first (:experiment/candidates definition))]
+    (experiment/make-scorecard
+     definition
+     [{:experiment/job
+       {:candidate/id (:candidate/id candidate)
+        :candidate/agent (:candidate/agent candidate)
+        :candidate/agent-content-id (:candidate/agent-content-id candidate)
+        :environment
+        (environment/environment-ref (:attempt/environment value))
+        :repetition 0}
+       :attempt value}])))
+
+(deftest certified-scorecard-round-trips-through-indexed-attempt-joins
+  (let [[conn _] (mem-store)
+        artifacts (artifact/memory-store)
+        st (dhs/make conn artifacts)
+        room-id :datahike-scorecard
+        other-room-id :other-scorecard-room
+        run-id (random-uuid)
+        agent (-> (roster/make-roster)
+                  (roster/make-agent {:id :candidate
+                                      :program {:kind :echo}})
+                  (roster/agent :candidate))
+        value (certified-attempt run-id agent)
+        scorecard (certified-scorecard value agent)
+        scorecard-id (:scorecard/content-id scorecard)
+        now (java.util.Date. 1000)]
+    (doseq [id [room-id other-room-id]]
+      (store/-store-room! st id {:slug (name id)}))
+    (store/-store-run!
+     st room-id
+     {:run/id run-id :run/kind :agent-task :run/room room-id
+      :run/actor :candidate :run/trigger (random-uuid)
+      :run/status :completed :run/created-at now :run/started-at now
+      :run/updated-at now :run/ended-at (java.util.Date. 1010)
+      :run/agent-version 1 :run/program-kind :echo
+      :run/interpreter-version 5 :run/agent-def-hash (hasch/uuid agent)})
+    (store/-store-attempt! st room-id value)
+    (is (= scorecard (store/-store-scorecard! st room-id scorecard)))
+    (is (= scorecard (store/-store-scorecard! st room-id scorecard)))
+    (is (= scorecard (store/-load-scorecard st room-id scorecard-id)))
+    (is (= [scorecard]
+           (store/-list-scorecards
+            st room-id
+            {:experiment-id :datahike/scorecard
+             :experiment-content-id
+             (get-in scorecard [:scorecard/experiment :experiment/content-id])
+             :dataset-id :datahike/scorecard
+             :candidate-id :candidate
+             :candidate-content-id (hasch/uuid agent)})))
+    (is (empty? (store/-list-scorecards st room-id
+                                        {:candidate-id :absent})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"another Room"
+         (store/-store-scorecard! st other-room-id scorecard)))
+    (let [unbacked (-> scorecard
+                       (assoc-in [:scorecard/entries 0 :attempt/id]
+                                 (random-uuid))
+                       (dissoc :scorecard/content-id))
+          unbacked (assoc unbacked :scorecard/content-id
+                          (hasch/uuid [:dvergr/experiment-scorecard unbacked]))]
+      (is (= unbacked (experiment/validate-scorecard unbacked)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Attempt set differs"
+           (store/-store-scorecard! st other-room-id unbacked))))
+    (let [mismatched (-> scorecard
+                         (assoc-in [:scorecard/entries 0 :attempt/content-id]
+                                   (random-uuid))
+                         (dissoc :scorecard/content-id))
+          mismatched
+          (assoc mismatched :scorecard/content-id
+                 (hasch/uuid [:dvergr/experiment-scorecard mismatched]))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"certified Attempt"
+           (store/-store-scorecard! st room-id mismatched))))
+    (let [forged (-> scorecard
+                     (assoc-in [:scorecard/entries 0 :reward] 99.0)
+                     (assoc-in [:scorecard/summary 0 :reward-sum] 99.0)
+                     (assoc-in [:scorecard/summary 0 :reward-mean] 99.0)
+                     (dissoc :scorecard/content-id))
+          forged (assoc forged :scorecard/content-id
+                        (hasch/uuid [:dvergr/experiment-scorecard forged]))]
+      (is (= forged (experiment/validate-scorecard forged)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"certified Attempt"
+           (store/-store-scorecard! st room-id forged))))
+    (testing "typed joins and summaries are queryable"
+      (is (= [run-id]
+             (dh/q '[:find [?attempt-id ...]
+                     :where
+                     [?s :scorecard/id _]
+                     [?s :scorecard/attempts ?a]
+                     [?a :attempt/id ?attempt-id]] @conn)))
+      (is (= #{[:candidate 1 1 1.0]}
+             (dh/q '[:find ?candidate ?attempts ?passed ?reward
+                     :where
+                     [?s :scorecard/id _]
+                     [?s :scorecard/summaries ?summary]
+                     [?summary :scorecard.summary/candidate-id ?candidate]
+                     [?summary :scorecard.summary/attempt-count ?attempts]
+                     [?summary :scorecard.summary/passed-count ?passed]
+                     [?summary :scorecard.summary/reward-mean ?reward]] @conn))))
+    (testing "the mandatory writer predicate guards scorecards and summaries"
+      (is (thrown-with-msg?
+           Throwable #"trusted writer"
+           (dh/transact conn [{:scorecard/id (random-uuid)}])))
+      (is (thrown-with-msg?
+           Throwable #"trusted writer"
+           (dh/transact conn [{:scorecard.summary/id (random-uuid)}])))
+      (is (thrown-with-msg?
+           Throwable #"immutable"
+           (dh/transact conn [[:db/add [:scorecard/id scorecard-id]
+                               :scorecard/experiment-id :forged]]))))
+    (store/-delete-room! st room-id)
+    (is (nil? (store/-load-scorecard st room-id scorecard-id)))
+    (is (zero? (or (dh/q '[:find (count ?summary) .
+                           :where [?s :scorecard/summaries ?summary]] @conn)
+                   0)))))
 
 (deftest certified-attempt-round-trips-through-typed-index-and-cas
   (let [[conn _] (mem-store)
@@ -148,6 +277,10 @@
 (deftest message-envelope-contract
   (let [[_conn st] (mem-store)]
     (contract/assert-message-envelope! st :envelope-datahike)))
+
+(deftest cross-room-scorecard-identity-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-cross-room-scorecard-identity! st)))
 
 (deftest concurrent-message-writes-are-atomically-first-write-wins
   (testing "the first committed immutable envelope cannot be overwritten"

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -282,6 +282,11 @@
   (let [[_conn st] (mem-store)]
     (contract/assert-cross-room-scorecard-identity! st)))
 
+(deftest finite-scorecard-aggregate-contract
+  (let [[_conn st] (mem-store)]
+    (contract/assert-non-finite-scorecard-aggregates-rejected!
+     st :scorecard-overflow-datahike)))
+
 (deftest concurrent-message-writes-are-atomically-first-write-wins
   (testing "the first committed immutable envelope cannot be overwritten"
     (let [[_conn st] (mem-store)

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -23,6 +23,9 @@
 (deftest cross-room-attention-identity-contract
   (contract/assert-cross-room-attention-identity! (memory/make)))
 
+(deftest cross-room-scorecard-identity-contract
+  (contract/assert-cross-room-scorecard-identity! (memory/make)))
+
 (deftest attention-metadata-validation-contract
   (contract/assert-attention-metadata-validation!
    (memory/make) :attention-metadata-memory))

--- a/test/dvergr/room/store/memory_test.clj
+++ b/test/dvergr/room/store/memory_test.clj
@@ -26,6 +26,10 @@
 (deftest cross-room-scorecard-identity-contract
   (contract/assert-cross-room-scorecard-identity! (memory/make)))
 
+(deftest finite-scorecard-aggregate-contract
+  (contract/assert-non-finite-scorecard-aggregates-rejected!
+   (memory/make) :scorecard-overflow-memory))
+
 (deftest attention-metadata-validation-contract
   (contract/assert-attention-metadata-validation!
    (memory/make) :attention-metadata-memory))

--- a/test/dvergr/sandbox/datahike_attempt_guard_test.clj
+++ b/test/dvergr/sandbox/datahike_attempt_guard_test.clj
@@ -12,19 +12,26 @@
       (schema/ensure-full-schema! conn)
       conn)))
 
-(deftest sci-datahike-surface-rejects-certified-attempt-writes-and-retractions
+(deftest sci-datahike-surface-rejects-certified-evaluation-writes-and-retractions
   (let [conn (conn)
         attempt-id (random-uuid)
-        guard @#'sandbox-datahike/assert-no-attempt-write!]
+        scorecard-id (random-uuid)
+        guard @#'sandbox-datahike/assert-no-certified-evaluation-write!]
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"host-certified"
+         clojure.lang.ExceptionInfo #"host-owned"
          (guard conn [{:attempt/id attempt-id}])))
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"host-certified"
+         clojure.lang.ExceptionInfo #"host-owned"
          (guard conn [[:db/add -1 :attempt/reward 1.0]])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"host-owned"
+         (guard conn [{:scorecard/id scorecard-id}])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"host-owned"
+         (guard conn [[:db/add -1 :scorecard.summary/reward-mean 1.0]])))
     ;; Host setup proves numeric retractEntity cannot bypass the namespace check.
     (d/transact conn [{:attempt/id attempt-id}])
     (let [eid (:db/id (d/entity @conn [:attempt/id attempt-id]))]
       (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"host-certified"
+           clojure.lang.ExceptionInfo #"host-owned"
            (guard conn [[:db/retractEntity eid]]))))))


### PR DESCRIPTION
## Summary

- persist every complete Experiment Scorecard as an immutable Room projection after all exact Attempts are certified
- store the exact canonical value in the artifact CAS and index experiment, dataset, candidate, summary, and same-Room Attempt joins in Datahike
- expose scorecard and scorecards host query functions with exact indexed filters
- bind every Scorecard cell to the exact certified Attempt content, actor, environment, reward, and pass state before admission
- enforce one-Room ownership of a Scorecard content ID atomically in both memory and Datahike stores
- protect all certified evaluation entities from raw SCI/Datahike writes; certification is authoritative control-plane state and cannot be authorized through world merge
- leave incomplete experiment batches as ordinary durable Attempts without publishing a misleading complete Scorecard

## Semantics

This is a durable query projection, not a second Run lifecycle or scheduler. Runs remain execution identity, Attempts remain trusted cell evidence, and the Scorecard is the immutable aggregate over that exact matrix. The store verifies every referenced Attempt and all result-bearing fields against the certified record before admission.

## Verification

- independent review: no remaining medium-or-higher findings
- formatting and git diff checks pass
- focused review-fix suite: 44 tests, 239 assertions, zero failures
- full suite: 676 tests, 3144 assertions, zero failures
- standalone harness built successfully as dvergr 0.1.76
