### PR TITLE
test(agent): certify recursive harness path

### DIFF
--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -158,6 +158,20 @@ in three model steps, with exactly two completed children, an exact result, and
 zero active Runs. This is one smoke result, not a quality ranking; repetitions
 and held-out environments are required for comparative claims.
 
+The first repeated Codex subscription probe then ran
+`:programming/self-programming-v1` twice through the Experiment API. Each root
+used `clojure_eval` to author a Roster, hired three simulated specialists in
+isolated worlds, observed their results through Spindel, and computed the exact
+answer. Both Attempts passed all ten trusted checks in four model steps; the two
+root Runs and six child Runs quiesced, and the resulting 2/2 Scorecard
+round-tripped through the Room store. A deterministic model simulator now
+exercises that same complete path in CI—from the native LLM/tool loop through
+SCI-authored recursive hires, world settlement, trusted verification, Attempt
+certification, and durable Scorecard. Building that contract exposed and fixed
+an observation projection typo that had hidden `:run/world` identities, which
+is precisely the kind of harness failure these paired probes are intended to
+find.
+
 ## Port order driven by failures
 
 1. Complete scoped observation and expose it in the REPL/UI.

--- a/src/dvergr/agent/observation.clj
+++ b/src/dvergr/agent/observation.clj
@@ -107,7 +107,7 @@
      (-> (select-keys candidate
                       [:run/id :run/kind :run/room :run/actor :run/trigger
                        :run/parent :run/status :run/started-at
-                       :run/ended-at :run/world-id :run/settlement-status
+                       :run/ended-at :run/world :run/settlement-status
                        :run/settlement-reason])
          (update :run/started-at portable-time)
          (update :run/ended-at portable-time))

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -22,6 +22,7 @@
             [hasch.core :as hasch]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.atom :as ratom]
             [org.replikativ.spindel.spin.combinators :as comb]
             [org.replikativ.spindel.spin.core :as spin-core]
@@ -29,7 +30,9 @@
             [taoensso.telemere :as tel])
   (:import [java.nio.charset StandardCharsets]
            [java.util UUID]
-           [java.util.concurrent Callable CountDownLatch FutureTask]))
+           [java.util.concurrent Callable CountDownLatch Executors FutureTask
+            ThreadFactory]
+           [java.util.concurrent.atomic AtomicLong]))
 
 (def run-sink
   "Reserved non-subscribed Room address for private Run inputs and outputs.
@@ -40,6 +43,23 @@
 (def interpreter-version 5)
 
 (def ^:private default-max-model-steps 32)
+
+(defonce ^:private native-thread-counter (AtomicLong.))
+
+(defonce ^:private native-executor
+  ;; Clojure futures and send-off share Agent/soloExecutor. A finalization watcher
+  ;; blocks until its orchestration publishes an outcome, so using that same
+  ;; executor for the native worker which produces the outcome creates a
+  ;; scheduler-dependent deadlock when an embedder bounds or replaces the Agent
+  ;; executor. Dvergr owns this cached daemon pool as part of its process-local
+  ;; Run supervisor instead.
+  (Executors/newCachedThreadPool
+   (reify ThreadFactory
+     (newThread [_ runnable]
+       (doto (Thread. ^Runnable runnable)
+         (.setName (str "dvergr-agent-native-"
+                        (.incrementAndGet native-thread-counter)))
+         (.setDaemon true))))))
 
 (declare with-owned-child! cancel!)
 
@@ -232,7 +252,7 @@
       ;; Do not even enqueue work when cancellation preceded registration.
        (.cancel task false)
        (try
-         (.execute clojure.lang.Agent/soloExecutor task)
+         (.execute native-executor task)
          (catch Throwable t
           ;; Make executor rejection flow through the same acknowledgement path.
            (reset! result {::worker-error t})
@@ -990,41 +1010,42 @@
    cached terminal result and the stable supervisor reports every native worker
    and owned cleanup quiescent. World settlement happens behind the same
    physical-quiescence fence."
-  [room control-room run-world id parent-run allocation-state supervisor execution completion outcome]
-  (future
-    ;; `future` conveys dynamic bindings. A cancellation hook normally launches
-    ;; this watcher from the losing observer Spin, so retaining its *spin-id*
-    ;; would make the supposedly external durability path a child of the very
-    ;; graph being reaped. Keep the Room memory context but detach graph identity.
-    (binding [ec/*execution-context* (:ctx room)
-              ec/*spin-id* nil]
-      ;; Wait until the executor has published either its ordinary outcome or
-      ;; its graph-level cancellation/failure through the process-local bridge.
-      (let [outcome @outcome]
-        ;; Keep the durable cancellation token/live lease until the executor has
-      ;; acknowledged termination. Direct cancellation relies on that token at
-      ;; its next cooperative checkpoint; releasing it merely because a pure
-      ;; program has no native workers would let the body continue to effects.
-        (let [execution-id (spin-core/spin-id execution)]
-          (loop []
-            (when-not (ec/spin-current-result execution-id)
-              (Thread/sleep 5)
-              (recur))))
-        (await-supervisor! supervisor)
-        (return-unused-resources! control-room id parent-run allocation-state)
-        (let [{:keys [cleanup-error llm-metrics]} @(:state supervisor)
-              result (cond-> (if cleanup-error
-                               {:run/id id :run/status :failed
-                                :run/error (ex-message cleanup-error)}
-                               (:result outcome))
-                       llm-metrics (assoc :run/metrics llm-metrics))
-              execution-opts (merge
-                              (:finish-opts outcome)
-                              (when cleanup-error
-                                {:reason :cleanup-error :error cleanup-error}))
-              {:keys [result finish-opts]} (settlement-result run-world result)]
-          (publish-result-and-release! id completion result
-                                       (merge execution-opts finish-opts)))))))
+  [room control-room run-world id parent-run allocation-state supervisor execution-terminal
+   completion outcome]
+  (.execute
+   native-executor
+   ^Runnable
+   (bound-fn []
+     ;; `bound-fn` conveys dynamic bindings. A cancellation hook normally
+     ;; launches this watcher from the losing observer Spin, so retaining its
+     ;; *spin-id* would make the supposedly external durability path a child of
+     ;; the very graph being reaped. Keep the Room memory context but detach
+     ;; graph identity.
+     (binding [simple/*in-drain?* false
+               ec/*execution-context* (:ctx room)
+               ec/*spin-id* nil]
+       ;; Wait until the executor has published either its ordinary outcome or
+       ;; its graph-level cancellation/failure through the process-local bridge.
+       (let [outcome @outcome]
+         ;; Keep the durable cancellation token/live lease until the supervising
+         ;; Spin explicitly acknowledges terminality. Polling context state is
+         ;; racy with graph cleanup and is not a compositional completion edge.
+         @execution-terminal
+         (await-supervisor! supervisor)
+         (return-unused-resources! control-room id parent-run allocation-state)
+         (let [{:keys [cleanup-error llm-metrics]} @(:state supervisor)
+               result (cond-> (if cleanup-error
+                                {:run/id id :run/status :failed
+                                 :run/error (ex-message cleanup-error)}
+                                (:result outcome))
+                        llm-metrics (assoc :run/metrics llm-metrics))
+               execution-opts (merge
+                               (:finish-opts outcome)
+                               (when cleanup-error
+                                 {:reason :cleanup-error :error cleanup-error}))
+               {:keys [result finish-opts]} (settlement-result run-world result)]
+           (publish-result-and-release! id completion result
+                                        (merge execution-opts finish-opts))))))))
 
 (defn- execution-spin
   [control-room work-room agent task trigger id chat-id supervisor limits outcome-promise]
@@ -1309,6 +1330,7 @@
                                        prepare-world!)
               (execution-spin control-room work-room agent task trigger id chat-id
                               supervisor limits outcome-promise))
+            execution-terminal (promise)
             execution (sp/spin (sp/await completion))
             owner-fork-id (:fork-id (ec/current-execution-context))
             handle    (RunHandle. id (:id control-room) owner-fork-id execution completion
@@ -1326,10 +1348,18 @@
         ;; boundary. register-cancel-hook! immediately invokes it if cancellation
         ;; won between durable admission and construction of this execution.
         (run/register-cancel-hook! id ::native-worker cancel!)
-        (sp/spawn!
+        ;; Use Spindel's fire-and-forget GC pin together with exact terminal
+        ;; callbacks instead of polling internal context state.
+        (sync/spawn!
          worker-execution
-         {:on-error
+         {:on-success
+          (fn [_]
+            (deliver execution-terminal true))
+          :on-error
           (fn [t]
+            ;; This callback is invoked only after the Spin rejects, including
+            ;; cancellation before its body begins.
+            (deliver execution-terminal true)
             ;; Graph-level cancellation is settled outside the cancelled Spin:
             ;; this callback may safely block on stable supervisor quiescence,
             ;; while the cancelled body may not cross another await breakpoint.
@@ -1366,7 +1396,7 @@
                           {:reason failure-reason
                            :error t})})))})
         (finalize-execution-external! world-parent control-room run-world id parent-run
-                                      allocation-state supervisor worker-execution
+                                      allocation-state supervisor execution-terminal
                                       completion outcome-promise)
         handle)
       (catch Throwable t

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -1,11 +1,18 @@
 (ns dvergr.agent.experiment-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [dvergr.activity :as activity]
             [dvergr.agent.environment :as environment-def]
             [dvergr.agent.evaluation :as evaluation]
             [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.observation :as observation]
             [dvergr.agent.roster :as roster]
             [dvergr.agent.run :as run]
+            [dvergr.chat.agent :as chat-agent]
             [dvergr.discourse :as d]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.providers :as providers]
             [dvergr.room.registry :as registry]
             [dvergr.room.store :as store]
             [dvergr.room.store.memory :as memory]
@@ -455,6 +462,186 @@
                   :let [fork (registry/lookup (:run/world run))]
                   :when fork]
             (is (:ok? (discard! fork :test-recovery))))))
+      (finally
+        (evaluation/await-cleanups! room 5000)
+        (d/close-room! room)))))
+
+(def ^:private recursive-program-result
+  {:answer 23 :particles 2 :verified true})
+
+(def ^:private recursive-program-code
+  (str
+   "(require '[dvergr.agent :as agent] "
+   "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+   "         '[org.replikativ.spindel.effects.await :refer [await]] "
+   "         '[spindel.comb :as comb]) "
+   "(let [team (-> (agent/roster {:id :particle-eval}) "
+   "               (agent/make-agent {:id :mod-five "
+   "                 :program {:kind :scripted "
+   "                           :reply [8 23 38 53 68 83 98]}}) "
+   "               (agent/make-agent {:id :mod-seven "
+   "                 :program {:kind :scripted "
+   "                           :reply [2 9 16 23 30 37 44 51 58 65 72 79 86 93]}}) "
+   "               (agent/make-agent {:id :verifier "
+   "                 :program {:kind :scripted "
+   "                           :reply {:moduli [[3 2] [5 3] [7 2]] "
+   "                                   :upper-bound 100}}})) "
+   "      a (agent/hire! team :mod-five {:task :candidates}) "
+   "      b (agent/hire! team :mod-seven {:task :candidates}) "
+   "      v (agent/hire! team :verifier {:task :constraints}) "
+   "      [ra rb rv] @(spin (await (comb/parallel "
+   "                                  (agent/result-spin a) "
+   "                                  (agent/result-spin b) "
+   "                                  (agent/result-spin v)))) "
+   "      [xs ys spec] (mapv :run/value [ra rb rv]) "
+   "      candidates (filter (set ys) xs) "
+   "      valid? (fn [n] (and (pos? n) (< n (:upper-bound spec)) "
+   "                            (every? (fn [[m r]] (= r (mod n m))) "
+   "                                    (:moduli spec)))) "
+   "      answers (vec (filter valid? candidates))] "
+   "  {:answer (first answers) :particles 2 :verified (= [23] answers)})"))
+
+(defn- read-one-edn [value]
+  (when (string? value)
+    (try
+      (edn/read-string value)
+      (catch Throwable _ nil))))
+
+(deftest deterministic-model-certifies-the-complete-recursive-harness-path
+  (let [verifier-ref {:verifier/id :test/recursive-harness
+                      :verifier/version 1
+                      :verifier/basis "recursive-harness-test:v1"}
+        definition
+        (environment-def/make-environment
+         {:id :test/recursive-harness
+          :task :author-and-run-particle-program
+          :verifier {:id :test/recursive-harness :version 1
+                     :basis "recursive-harness-test:v1"}
+          :limits {:timeout-ms 10000 :cancel-timeout-ms 2000
+                   :max-model-steps 2 :budget-dollars 1.0}
+          :world {:isolation :ctx :settlement :discard}})
+        team (-> (roster/make-roster {:id :test/recursive-candidates})
+                 (roster/make-agent
+                  {:id :simulated-model
+                   :tools #{:clojure_eval}
+                   :model-policy {:provider :test :model "deterministic"}
+                   :program {:kind :llm :max-model-steps 2
+                             :budget-dollars 1.0 :auto-compact? false}}))
+        experiment-def
+        (experiment/make-experiment
+         {:id :test/recursive-harness
+          :dataset
+          (experiment/make-dataset
+           {:id :test/recursive-harness
+            :environments [definition]})
+          :candidates [(roster/agent team :simulated-model)]})
+        evaluator
+        (evaluation/make-evaluator
+         {:id :test/recursive-harness
+          :version 1
+          :basis "recursive-harness-test:v1"
+          :observe
+          (fn [{:keys [room run-id result durable]}]
+            (let [snapshot (observation/snapshot
+                            room run-id
+                            {:run-limit 20 :message-limit 100
+                             :content-limit 1000 :content-budget 32000
+                             :detail-limit 100})]
+              {:result (read-one-edn (:run/value result))
+               :durable-status (:run/status durable)
+               :root-run-id run-id
+               :runs (:observation/runs snapshot)
+               :activities (:observation/activities snapshot)}))
+          :verify
+          (fn [_ {:keys [result durable-status root-run-id runs activities]}]
+            (let [root (some #(when (= root-run-id (:run/id %)) %) runs)
+                  children (remove #(= root-run-id (:run/id %)) runs)
+                  child-ids (into #{} (map :run/id) children)
+                  root-evals
+                  (filter #(and (= root-run-id (:activity/run-id %))
+                                (= :tool (:activity/kind %))
+                                (= :invoke (:activity/verb %))
+                                (= "clojure_eval" (:activity/tool-name %))
+                                (= :completed (:activity/status %)))
+                          activities)
+                  checks
+                  {:exact-result? (= recursive-program-result result)
+                   :durably-completed? (= :completed durable-status)
+                   :four-run-tree? (= 4 (count runs))
+                   :three-specialists? (= #{:mod-five :mod-seven :verifier}
+                                          (set (map :run/actor children)))
+                   :structural-parentage?
+                   (every? #(= root-run-id (:run/parent %)) children)
+                   :all-results-observed?
+                   (= child-ids (set (:run/caused-by root)))
+                   :specialists-completed?
+                   (every? #(= :completed (:run/status %)) children)
+                   :specialists-merged?
+                   (every? #(= :merged (:run/settlement-status %)) children)
+                   :distinct-worlds?
+                   (= 4 (count (set (map :run/world runs))))
+                   :one-real-clojure-eval? (= 1 (count root-evals))}]
+              {:checks checks
+               :reward (if (every? true? (vals checks)) 1.0 0.0)}))})
+        room (d/make-room {:id :experiment-recursive-harness
+                           :store (memory/make)})
+        calls (atom 0)
+        forwarded-tool-result (atom nil)]
+    (try
+      (with-redefs
+       [providers/ensure-initialized! (constantly nil)
+        chat-agent/messages->api-format (fn [messages _ _] messages)
+        model-chat/chat
+        (fn [messages _]
+          (case (swap! calls inc)
+            1 {:content ""
+               :tool-calls [{:id "recursive-program"
+                             :name "clojure_eval"
+                             :input {:code recursive-program-code}}]
+               :usage {:input-tokens 10 :output-tokens 20}
+               :stop-reason :tool-use}
+            2 (let [content
+                    (some (fn [message]
+                            (when (and (= :tool-result (:message/role message))
+                                       (= "recursive-program"
+                                          (:message/tool-use-id message)))
+                              (:message/content message)))
+                          messages)
+                    _ (when-not (and (string? content)
+                                     (str/starts-with? content "=> "))
+                        (throw (ex-info "missing recursive tool result"
+                                        {:messages messages})))
+                    value (edn/read-string (subs content 3))]
+                (reset! forwarded-tool-result value)
+                {:content (pr-str value)
+                 :tool-calls nil
+                 :usage {:input-tokens 30 :output-tokens 10}
+                 :stop-reason :end-turn})
+            (throw (ex-info "deterministic model called too often"
+                            {:calls @calls}))))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [{:keys [attempts scorecard]}
+                @(experiment/run room team experiment-def
+                                 {verifier-ref evaluator}
+                                 {:parallelism 1})
+                attempt (first attempts)
+                checks (get-in attempt [:attempt/receipt :attempt/checks])
+                runs (run/runs room {:limit 20})]
+            (is (= 2 @calls))
+            (is (= recursive-program-result @forwarded-tool-result)
+                "the simulated model forwards the actual tool result")
+            (is (= 1 (count attempts)))
+            (is (every? true? (vals checks)) (pr-str checks))
+            (is (= 1.0 (get-in attempt [:attempt/receipt :attempt/reward])))
+            (is (= scorecard
+                   (experiment/scorecard room (:scorecard/content-id scorecard))))
+            (is (= [{:candidate/id :simulated-model
+                     :attempt-count 1 :passed-count 1
+                     :reward-sum 1.0 :reward-mean 1.0}]
+                   (:scorecard/summary scorecard)))
+            (is (empty? (run/active-runs (:id room))))
+            (is (every? #(nil? (registry/lookup (:run/world %))) runs)
+                "all discarded/merged Run worlds release their registry handles"))))
       (finally
         (evaluation/await-cleanups! room 5000)
         (d/close-room! room)))))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -24,8 +24,10 @@
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.engine.context :as context]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.spin.combinators :as comb]
-            [org.replikativ.spindel.yggdrasil :as ygg]))
+            [org.replikativ.spindel.yggdrasil :as ygg])
+  (:import [java.util.concurrent ExecutorService Executors]))
 
 (defn- test-roster []
   (-> (roster/make-roster {:id :test-team})
@@ -1069,6 +1071,50 @@
         (.countDown release-worker)
         (when-let [waiter @waiter]
           (future-cancel waiter))
+        (d/close-room! room)))))
+
+(deftest native-run-supervision-does-not-depend-on-clojure-send-off
+  (let [room (test-room :program-native-executor-isolation)
+        team (test-roster)
+        cleaned (promise)
+        finalizer-in-drain? (promise)
+        publish! @#'program/publish-result-and-release!
+        original-executor clojure.lang.Agent/soloExecutor
+        ^ExecutorService rejecting-executor (Executors/newSingleThreadExecutor)]
+    ;; An already-shut-down executor rejects every future/send-off submission.
+    ;; Before Dvergr owned its native supervision executor, either prepared work
+    ;; or the blocking finalizer passed through Agent/soloExecutor and this Run
+    ;; could not reach a durable terminal result.
+    (.shutdownNow rejecting-executor)
+    (try
+      (set-agent-send-off-executor! rejecting-executor)
+      (with-redefs-fn
+        {#'program/publish-result-and-release!
+         (fn [& args]
+           (deliver finalizer-in-drain? simple/*in-drain?*)
+           (apply publish! args))}
+        (fn []
+          (binding [ec/*execution-context* (:ctx room)]
+            (let [handle
+                  ;; Model scheduling from an engine drain without blocking in
+                  ;; it. The detached finalizer's bound-fn would otherwise carry
+                  ;; this marker onto the native executor.
+                  (binding [simple/*in-drain?* true]
+                    (program/hire-prepared-in!
+                     room room team :analyst
+                     {:task :work :settlement :discard}
+                     (fn [{register! :register-cleanup!}]
+                       (register! #(deliver cleaned true)))))
+                  result (deref handle 5000 ::timeout)]
+              (is (= :completed (:run/status result)))
+              (is (= :discarded (:run/settlement-status result)))
+              (is (= true (deref cleaned 5000 ::timeout)))
+              (is (false? (deref finalizer-in-drain? 5000 ::timeout))
+                  "the detached finalizer does not inherit an engine drain")
+              (is (empty? (run/active-runs (:id room))))))))
+      (finally
+        (set-agent-send-off-executor! original-executor)
+        (.shutdownNow rejecting-executor)
         (d/close-room! room)))))
 
 (deftest cancellation-unwinds-every-resource-acquired-during-preparation


### PR DESCRIPTION
## Summary

- add a deterministic model simulation that exercises the complete certified recursive harness path in CI
- run the native LLM/tool loop, execute `clojure_eval`, author a Roster in SCI, hire three isolated specialists, compose their result Spins, and certify the resulting Run tree
- verify structural parentage, causal observation, merged child worlds, physical quiescence, tool activity, immutable Attempt evidence, and durable Scorecard round-trip
- fix scoped observations to expose the actual durable `:run/world` identity instead of the nonexistent `:run/world-id`
- isolate blocking native work and finalization from Clojure's shared `Agent/soloExecutor`, closing the cancellation/finalization scheduler cycle exposed by the first CI run
- replace finalizer polling of internal Spin state with a GC-pinned resolve/reject terminal edge, closing the slower-runner race exposed by the second CI run
- record the successful two-repetition live Codex subscription probe and the defects this paired validation found

## Why this is a test

The existing provider-free SCI test bypassed the native model/tool loop, RunWorld verification gate, Attempt certification, and Scorecard persistence. Existing Experiment tests used simple echo agents. This contract connects both halves while stubbing only the nondeterministic model response, so CI exercises the actual Dvergr/SCI/Spindel/world/evaluation stack without network or subscription use.

The scheduler regression replaces Clojure's send-off executor with an already-rejecting executor and requires a prepared Run to execute setup, unwind cleanup, discard its world, publish a durable terminal result, and leave no active Run. It deterministically fails the former implementation, where both native workers and the blocking finalizer submitted through that shared executor.

Final settlement now waits for the orchestration Spin's actual resolve/reject callback while retaining the same `:engine/spawned` GC root as Spindel's fire-and-forget `spawn!`. It no longer polls a context projection whose lifecycle may race graph cleanup.

## Verification

- live REPL probe: Codex subscription Sol, two repetitions, 2/2 passed, ten trusted checks per Attempt, four model steps each, zero active Runs, durable Scorecard round-trip
- deterministic recursive contract: 1 test, 9 assertions, zero failures; the simulated model's final answer is derived from the exact tool-result message
- shared-executor independence regression: 1 test, 4 assertions, zero failures
- terminal/cleanup/cancellation regression group: 4 tests, 19 assertions, zero failures
- exact former CI seed `327275112`: 678 tests, 3157 assertions, zero failures
- standalone harness uberjar build passes
- formatting and `git diff --check` pass
- independent review: no remaining credible medium-or-higher finding
