### PR TITLE
fix(resource): preserve idempotent retry semantics

### DIFF
--- a/src/dvergr/resource.clj
+++ b/src/dvergr/resource.clj
@@ -9,7 +9,7 @@
             [dvergr.room.store :as store]
             [kontor.resource :as kontor])
   (:import [java.nio.charset StandardCharsets]
-           [java.util Date UUID]))
+           [java.util UUID]))
 
 (def microdollars
   "The initial numeraire coordinate. Other coordinates remain ordinary data and
@@ -43,6 +43,10 @@
                       {:type ::resource-store-unavailable
                        :room-id (:id room)})))
     resource-store))
+
+(defn- store-room-id [room]
+  (or (some-> room :meta deref :conversation-id)
+      (:id room)))
 
 (defn install-connection!
   "Install the minimal Kontor kernel and the Room's root wallet on `conn`.
@@ -88,8 +92,8 @@
             :kind :mint
             :source kontor/source-account
             :destination (kontor/account-ref (room-wallet-id (:id room)))
-            :resources resources
-            :effective-date (or effective-date (Date.))}
+            :resources resources}
+     effective-date (assoc :effective-date effective-date)
      posted-at (assoc :posted-at posted-at)
      actor (assoc :actor actor))))
 
@@ -102,12 +106,17 @@
           parent-wallet (if parent-run
                           (run-wallet-id parent-run)
                           (room-wallet-id (:id room)))
+          started-at (:run/started-at
+                      (store/-load-run resource-store (store-room-id room) run-id))
+          _ (when-not started-at
+              (throw (ex-info "Run resource allocation requires a durable Run"
+                              {:type ::run-not-durable :run/id run-id})))
           transfer {:id (allocation-id run-id)
                     :kind :grant
                     :source (kontor/account-ref parent-wallet)
                     :destination (kontor/account-ref (run-wallet-id run-id))
                     :resources resources
-                    :effective-date (Date.)}]
+                    :effective-date started-at}]
       {:wallet (kontor/account-ref (run-wallet-id run-id))
        :receipt (store/-allocate-resource-wallet!
                  resource-store
@@ -126,8 +135,8 @@
             :kind :consume
             :source (kontor/account-ref (run-wallet-id run-id))
             :destination kontor/sink-account
-            :resources resources
-            :effective-date (or effective-date (Date.))}
+            :resources resources}
+     effective-date (assoc :effective-date effective-date)
      posted-at (assoc :posted-at posted-at)
      actor (assoc :actor actor))))
 
@@ -143,5 +152,4 @@
                   (if parent-run
                     (run-wallet-id parent-run)
                     (room-wallet-id (:id room))))
-    :resources resources
-    :effective-date (Date.)}))
+    :resources resources}))

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -324,6 +324,49 @@
                              :attempt/id (:attempt/id attempt-entity)})))))
       [entity])))
 
+(defn- assert-run-allocation-live
+  "Transaction guard coupling a Run's first grant to its durable lifecycle.
+
+   A receipt which appeared after the caller's optimistic read deliberately
+   aborts this transaction. The adapter then re-enters Kontor's complete
+   replay check, so a colliding command can never masquerade as a duplicate.
+   Existing receipts take that replay path before this function is invoked and
+   therefore remain replayable after the Run has terminated. The account and
+   transfer datoms remain adjacent top-level operations, so Kontor's complete
+   validation machinery still sees them before this guard and those operations
+   commit as one transaction.
+
+   This establishes the terminal-first boundary: a first grant cannot serialize
+   after terminal state. If the grant commits first, ordinary Run lifecycle code
+   remains responsible for returning or consuming it before finishing."
+  [db wallet-spec transfer-spec]
+  (let [transfer-id (:id transfer-spec)
+        owner       (:owner wallet-spec)
+        run-id      (when (and (vector? owner)
+                               (= :run/id (first owner)))
+                      (second owner))
+        run         (and run-id (dh/entity db owner))]
+    (when (dh/entity db [:kontor.resource-transfer/id transfer-id])
+      (throw (ex-info "Run allocation receipt appeared concurrently"
+                      {:type :room-store/concurrent-resource-allocation
+                       :run/id run-id
+                       :transfer/id transfer-id})))
+    (when-not (and run
+                   (= :grant (:kind transfer-spec))
+                   (= [:kontor.resource-account/id (:id wallet-spec)]
+                      (:destination transfer-spec)))
+      (throw (ex-info "Run allocation does not identify its durable Run"
+                      {:type :room-store/invalid-run-resource-allocation
+                       :run/id run-id
+                       :transfer/id transfer-id})))
+    (when (contains? store/terminal-run-statuses (:run/status run))
+      (throw (ex-info "A terminal Run cannot receive its first resource grant"
+                      {:type :room-store/terminal-run-resource-allocation
+                       :run/id run-id
+                       :run/status (:run/status run)
+                       :transfer/id transfer-id})))
+    []))
+
 (def ^:private message-pull-pattern
   '[:message/id :message/role :message/content
     :message/created-at :message/source-user
@@ -1413,10 +1456,13 @@
       ;; never mistaken for a successful replay.
       (resource/transfer! conn transfer-spec)
       (try
-        (kontor-gate/transact-with-validation
-         conn
-         (into (vec (resource/open-account-tx-data wallet-spec))
-               (resource/transfer-tx-data transfer-spec)))
+        (let [guard [[:db.fn/call assert-run-allocation-live
+                      wallet-spec transfer-spec]]
+              tx-data (into guard
+                            (concat
+                             (resource/open-account-tx-data wallet-spec)
+                             (resource/transfer-tx-data transfer-spec)))]
+          (kontor-gate/transact-with-validation conn tx-data))
         (assoc (resource/receipt conn (:id transfer-spec)) :status :committed)
         (catch Throwable error
           ;; Resolve the only benign race: another identical allocator may

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -19,6 +19,7 @@
             [dvergr.room.store.memory :as memory]
             [dvergr.room.store.datahike :as datahike-store]
             [dvergr.tools :as tools]
+            [kontor.gate :as kontor-gate]
             [kontor.governance :as kontor-governance]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.effects.await :refer [await]]
@@ -209,6 +210,67 @@
       (is (= {} (resource/run-balance room run-id)))
       (is (= {resource/microdollars 8M} (resource/balance room)))
       (run/finish! run-id :completed)
+      (let [replay (resource/allocate-run!
+                    room run-id nil {resource/microdollars 6M})]
+        (is (= :duplicate (get-in replay [:receipt :status]))
+            "the stable first grant remains replayable after termination")
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (resource/allocate-run!
+                      room run-id nil {resource/microdollars 5M}))
+            "terminal replay still checks the complete command"))
+      (finally
+        (when (some #(= run-id (:run/id %)) (run/active-runs))
+          (run/finish! run-id :cancelled {:reason :test-cleanup}))
+        (close-resource-test-room! room conn)))))
+
+(deftest terminal-run-cannot-receive-a-first-resource-grant
+  (let [[room conn] (resource-test-room :program-terminal-first-grant)
+        run-id (random-uuid)
+        trigger (d/message :test :_runs "late allocation" nil {:role :user})]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 10M}})
+      (d/post! room trigger)
+      (run/start! room :resource-test trigger nil {:id run-id})
+      (run/finish! run-id :completed)
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"terminal Run cannot receive"
+           (resource/allocate-run!
+            room run-id nil {resource/microdollars 4M})))
+      (is (nil? (room-store/-resource-receipt
+                 (:store room) (resource/allocation-id run-id))))
+      (is (= {resource/microdollars 10M} (resource/balance room)))
+      (finally
+        (close-resource-test-room! room conn)))))
+
+(deftest terminalization-between-allocation-setup-and-commit-wins-atomically
+  (let [[room conn] (resource-test-room :program-allocation-terminal-race)
+        run-id (random-uuid)
+        trigger (d/message :test :_runs "racing allocation" nil {:role :user})
+        original-transact kontor-gate/transact-with-validation
+        terminalized? (atom false)]
+    (try
+      (resource/mint! room {:id (random-uuid)
+                            :resources {resource/microdollars 10M}})
+      (d/post! room trigger)
+      (run/start! room :resource-test trigger nil {:id run-id})
+      ;; Force terminal persistence after allocate-run!'s optimistic Run read,
+      ;; but before Datahike serializes the wallet/grant transaction.
+      (with-redefs [kontor-gate/transact-with-validation
+                    (fn [conn tx-data]
+                      (when (compare-and-set! terminalized? false true)
+                        (run/finish! run-id :completed))
+                      (original-transact conn tx-data))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"terminal Run cannot receive"
+             (resource/allocate-run!
+              room run-id nil {resource/microdollars 4M}))))
+      (is @terminalized?)
+      (is (nil? (room-store/-resource-receipt
+                 (:store room) (resource/allocation-id run-id))))
+      (is (= {resource/microdollars 10M} (resource/balance room)))
       (finally
         (when (some #(= run-id (:run/id %)) (run/active-runs))
           (run/finish! run-id :cancelled {:reason :test-cleanup}))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -166,6 +166,54 @@
       (finally
         (close-resource-test-room! room conn)))))
 
+(deftest stable-resource-effects-retry-without-clock-drift
+  (let [[room conn] (resource-test-room :program-resource-retry)
+        mint-id (random-uuid)
+        consume-id (random-uuid)
+        run-id (random-uuid)
+        trigger (d/message :test :_runs "retry resources" nil {:role :user})
+        same-receipt? #(= (dissoc %1 :status) (dissoc %2 :status))]
+    (try
+      (let [mint-a (resource/mint! room {:id mint-id
+                                         :resources {resource/microdollars 10M}})
+            mint-b (resource/mint! room {:id mint-id
+                                         :resources {resource/microdollars 10M}})]
+        (is (same-receipt? mint-a mint-b)
+            "mint retry returns the original durable receipt")
+        (is (= :duplicate (:status mint-b))))
+      (d/post! room trigger)
+      (run/start! room :resource-test trigger nil {:id run-id})
+      (let [grant-a (resource/allocate-run!
+                     room run-id nil {resource/microdollars 6M})
+            grant-b (resource/allocate-run!
+                     room run-id nil {resource/microdollars 6M})]
+        (is (same-receipt? (:receipt grant-a) (:receipt grant-b))
+            "allocation uses the durable Run start instant")
+        (is (= :duplicate (get-in grant-b [:receipt :status]))))
+      (let [consume-a (resource/consume!
+                       room run-id {:id consume-id
+                                    :resources {resource/microdollars 2M}})
+            consume-b (resource/consume!
+                       room run-id {:id consume-id
+                                    :resources {resource/microdollars 2M}})]
+        (is (same-receipt? consume-a consume-b)
+            "consume retry does not acquire a new timestamp")
+        (is (= :duplicate (:status consume-b))))
+      (let [return-a (resource/return!
+                      room run-id nil {resource/microdollars 4M})
+            return-b (resource/return!
+                      room run-id nil {resource/microdollars 4M})]
+        (is (same-receipt? return-a return-b)
+            "return retry is one semantic transfer")
+        (is (= :duplicate (:status return-b))))
+      (is (= {} (resource/run-balance room run-id)))
+      (is (= {resource/microdollars 8M} (resource/balance room)))
+      (run/finish! run-id :completed)
+      (finally
+        (when (some #(= run-id (:run/id %)) (run/active-runs))
+          (run/finish! run-id :cancelled {:reason :test-cleanup}))
+        (close-resource-test-room! room conn)))))
+
 (deftest ignored-owned-child-delays-parent-resource-settlement
   (let [[room conn] (resource-test-room :program-owned-child-resources)
         team (-> (roster/make-roster {:id :nested-resource-team})


### PR DESCRIPTION
## Summary
- preserve stable Kontor command identity when callers omit timestamps
- derive Run allocation time from the durable Run start
- address forked resource stores through their stable control-room identity
- cover retry behavior without wall-clock drift

## Verification
- focused resource regression: 1 test, 10 assertions
- full renewal arena against Yggdrasil PR #20: 3 tests, 33 assertions
- independent review: no credible medium-or-higher findings

Stacked on #96.