### PR TITLE
fix(chat): install late-bound tool schemas safely

### DIFF
--- a/src/dvergr/chat/context.clj
+++ b/src/dvergr/chat/context.clj
@@ -171,8 +171,10 @@
      chat-ctx - ChatContext
      message - Map with :role, :content, :tokens, etc."
   [chat-ctx message]
-  (let [msg-entity (schema/create-message-entity
-                    (assoc message :chat-id (:chat-id chat-ctx)))]
+  (let [opts (assoc message :chat-id (:chat-id chat-ctx))
+        msg-entity (if-let [conn (:db-conn chat-ctx)]
+                     (schema/create-message-entity! conn opts)
+                     (schema/create-message-entity opts))]
     ;; Update spindel signal (reactive)
     (binding [rtc/*execution-context* (selected-execution-context chat-ctx)]
       (swap! (:messages-signal chat-ctx) conj msg-entity))

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -1500,6 +1500,36 @@
   (java.util.Collections/synchronizedSet
    (java.util.Collections/newSetFromMap (java.util.IdentityHashMap.))))
 
+(defonce ^:private ensured-dynamic-tool-schemas
+  ;; Run-world connections are deliberately short lived. Weak keys prevent
+  ;; late-registered semantic tools from retaining discarded branches.
+  (java.util.Collections/synchronizedMap (java.util.WeakHashMap.)))
+
+(defn ensure-tool-use-schemas!
+  "Ensure schemas for registered tools appearing in `tool-uses` exist on
+   `conn`. Rooms install the registry known at provisioning time, but trusted
+   hosts may register semantic tools later; their first durable use must remain
+   transactable. Unknown tool calls still use the raw-EDN fallback schema."
+  ([conn tool-uses]
+   (ensure-tool-use-schemas! conn tool-uses (get-tool-registry)))
+  ([conn tool-uses registry]
+   (doseq [tool-name (into #{} (keep :tool-use/name) tool-uses)
+           :let [tool (get registry tool-name)]
+           :when tool]
+     (let [fingerprint (select-keys tool [:name :parameters])]
+        ;; Keep schema installation and publication under the same lock. If the
+        ;; cache were marked first, a concurrent message could transact typed
+        ;; tool input while the schema transaction was still in flight. Cache
+        ;; the definition fingerprint rather than only its name so a trusted
+        ;; host can add fields to a late-bound tool before its next use.
+       (locking ensured-dynamic-tool-schemas
+         (let [installed (or (.get ensured-dynamic-tool-schemas conn) {})]
+           (when-not (= fingerprint (get installed tool-name))
+             (tool-schema/install-tool-schema! conn tool)
+             (.put ensured-dynamic-tool-schemas conn
+                   (assoc installed tool-name fingerprint)))))))
+   conn))
+
 (defn ensure-full-schema!
   "Ensure the full schema is installed on `conn` — exactly once per process
    per connection. Subsequent calls are a cheap no-op.
@@ -1539,15 +1569,20 @@
            :chat/updated-at (java.util.Date.)}
     description (assoc :chat/description description)))
 
+(defn- get-tool-registry-atom
+  "Dynamically resolve the registry atom without introducing a schema/tools
+   namespace cycle."
+  []
+  (try
+    (require 'dvergr.tools)
+    @(ns-resolve 'dvergr.tools 'registry)
+    (catch Exception _ nil)))
+
 (defn- get-tool-registry
   "Dynamically get the tool registry to avoid circular deps.
    Returns the registry map (not the atom)."
   []
-  (try
-    (require 'dvergr.tools)
-    ;; ns-resolve returns the var, @ gets the atom, @@ gets the map
-    @@(ns-resolve 'dvergr.tools 'registry)
-    (catch Exception _ nil)))
+  (some-> (get-tool-registry-atom) deref))
 
 (defn- serialize-tool-use
   "Serialize a tool-use for Datahike storage.
@@ -1563,10 +1598,9 @@
    is always transactable. Persisting an agent's turn must not crash on a bad
    tool call — tool EXECUTION returns the \"unknown tool\" / validation error the
    model then recovers from."
-  [tool-use]
+  [registry tool-use]
   (let [tool-name (:tool-use/name tool-use)
         input     (:tool-use/input tool-use)
-        registry  (get-tool-registry)
         tool-def  (get registry tool-name)
         entity    (when (and tool-def (map? input))
                     (try (tool-schema/tool-input->entity tool-def input)
@@ -1595,7 +1629,7 @@
       :else
       (dissoc tool-use :tool-use/input))))
 
-(defn create-message-entity
+(defn- create-message-entity*
   "Create a message entity map for transacting.
 
    Args:
@@ -1603,7 +1637,7 @@
 
    Tool-uses are stored as component entities with input serialized to EDN.
    The :message/tool-uses key references the tool-use entities."
-  [{:keys [chat-id role content reasoning tokens important? compacted? reply-to-id tool-uses tool-use-id turn-number]}]
+  [registry {:keys [chat-id role content reasoning tokens important? compacted? reply-to-id tool-uses tool-use-id turn-number]}]
   (cond-> {:message/id (random-uuid)
            :message/chat [:chat/id chat-id]
            :message/role (or role :user)
@@ -1615,9 +1649,28 @@
     important? (assoc :message/important? true)
     compacted? (assoc :message/compacted? true)
     reply-to-id (assoc :message/reply-to [:message/id reply-to-id])
-    (seq tool-uses) (assoc :message/tool-uses (mapv serialize-tool-use tool-uses))
+    (seq tool-uses) (assoc :message/tool-uses
+                           (mapv (partial serialize-tool-use registry) tool-uses))
     tool-use-id (assoc :message/tool-use-id tool-use-id)
     turn-number (assoc :message/turn-number (long turn-number))))
+
+(defn create-message-entity
+  "Create a message entity using one coherent snapshot of the tool registry."
+  [opts]
+  (if-let [registry-atom (get-tool-registry-atom)]
+    (locking registry-atom
+      (create-message-entity* @registry-atom opts))
+    (create-message-entity* {} opts)))
+
+(defn create-message-entity!
+  "Ensure and serialize a message's tool inputs from one registry revision."
+  [conn opts]
+  (if-let [registry-atom (get-tool-registry-atom)]
+    (locking registry-atom
+      (let [registry @registry-atom]
+        (ensure-tool-use-schemas! conn (:tool-uses opts) registry)
+        (create-message-entity* registry opts)))
+    (create-message-entity* {} opts)))
 
 ;; ============================================================================
 ;; Tool Call Queries (for UI rendering)

--- a/src/dvergr/chat/tool_schema.clj
+++ b/src/dvergr/chat/tool_schema.clj
@@ -185,6 +185,28 @@
   (when (and name parameters (= "object" (:type parameters)))
     (generate-object-schema name [] parameters)))
 
+(defn compatible-evolution?
+  "True when `new-tool` is a monotonic durable-schema evolution of `old-tool`.
+
+   A tool name owns its generated Datahike attribute namespace. Once those
+   attributes contain data, their value type/cardinality cannot safely change
+   and an old attribute cannot disappear. Descriptions, handlers and
+   non-storage JSON-Schema constraints may change; new properties may be added."
+  [old-tool new-tool]
+  (let [durable-shape (fn [tool]
+                        (into {}
+                              (map (juxt :db/ident
+                                         #(select-keys % [:db/valueType
+                                                          :db/cardinality
+                                                          :db/isComponent
+                                                          :db/unique])))
+                              (or (generate-tool-schema tool) [])))
+        old-shape (durable-shape old-tool)
+        new-shape (durable-shape new-tool)]
+    (every? (fn [[ident shape]]
+              (= shape (get new-shape ident)))
+            old-shape)))
+
 ;; ============================================================================
 ;; Schema Installation
 ;; ============================================================================

--- a/src/dvergr/chat/tool_schema.clj
+++ b/src/dvergr/chat/tool_schema.clj
@@ -211,6 +211,45 @@
 ;; Schema Installation
 ;; ============================================================================
 
+(def ^:private durable-schema-keys
+  [:db/valueType :db/cardinality :db/isComponent :db/unique])
+
+(defn- durable-attr-shape [attr]
+  (select-keys attr durable-schema-keys))
+
+(defn- install-compatible-attrs
+  "Datahike transaction function for an atomic schema claim.
+
+   Writer serialization makes the current DB schema authoritative even when
+   different processes race the first use of one late-bound tool. Existing
+   attributes must have the same durable shape; only absent attributes are
+   returned for installation. In particular, do not rely on Datahike rejecting
+   a redeclaration: under `:schema-flexibility :write` it may legally rewrite
+   an unused attribute before an older serialized message reaches the writer."
+  [db attrs]
+  (let [installed (d/schema db)]
+    (reduce
+     (fn [missing attr]
+       (let [ident (:db/ident attr)]
+         (if-let [current (get installed ident)]
+           (let [current-shape (durable-attr-shape current)
+                 proposed-shape (durable-attr-shape attr)]
+             (when-not (= current-shape proposed-shape)
+               (throw
+                (ex-info
+                 "Incompatible durable tool schema is already installed"
+                 {:type ::incompatible-installed-tool-schema
+                  :attribute ident
+                  :installed current-shape
+                  :proposed proposed-shape})))
+             missing)
+           (conj missing attr))))
+     []
+     attrs)))
+
+(defn- install-compatible-schema! [conn schema]
+  (d/transact conn [[:db.fn/call install-compatible-attrs schema]]))
+
 (defn install-tool-schema!
   "Install schema for a tool into a Datahike connection.
 
@@ -227,14 +266,8 @@
   [conn tool-def]
   (when-let [schema (generate-tool-schema tool-def)]
     (when (seq schema)
-      (try
-        (d/transact conn schema)
-        (count schema)
-        (catch Exception e
-          ;; Schema might already exist - that's fine
-          (when-not (re-find #"already exists|already defined" (.getMessage e))
-            (throw e))
-          (count schema))))))
+      (install-compatible-schema! conn schema)
+      (count schema))))
 
 ;; Defined below; referenced by install-all-tool-schemas! (resolved at call time).
 (declare raw-input-schema)
@@ -253,11 +286,7 @@
   ;; Always install the raw-EDN fallback attributes. serialize-tool-use degrades
   ;; a tool input it cannot type into :tool-input.raw/*, so persistence stays
   ;; total — these MUST exist before any such write can land.
-  (try
-    (d/transact conn raw-input-schema)
-    (catch Exception e
-      (when-not (re-find #"already exists|already defined" (.getMessage e))
-        (throw e))))
+  (install-compatible-schema! conn raw-input-schema)
   (->> registry
        (map (fn [[tool-name tool-def]]
               [tool-name (install-tool-schema! conn tool-def)]))

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -803,24 +803,32 @@
   (-store-message! [_ room-id msg]
     (let [slug (store/room-id->slug room-id)]
       (if-let [ent (room-by-slug conn slug)]
-        (let [chat-id (:chat/id ent)
-              entity  (message->entity chat-id msg)]
+        ;; An exact retry cannot need schema work: its durable entity already
+        ;; exists. Decide this first so registry drift cannot turn an otherwise
+        ;; idempotent retry into an unrelated schema failure. The transaction
+        ;; function below remains the authority for concurrent first writers.
+        (if (dh/entity @conn [:message/id (:id msg)])
+          :duplicate
+          (let [_ (schema/ensure-tool-use-schemas!
+                   conn (get-in msg [:metadata :tool-uses]))
+                chat-id (:chat/id ent)
+                entity  (message->entity chat-id msg)]
           ;; One durability policy (surface + retry-once + dead-letter) instead
           ;; of the old catch-and-silently-drop — a lost message is now visible
           ;; and recoverable, not swallowed at :warn. The transaction function
           ;; makes the idempotence decision inside Datahike's write serialization.
-          (let [report
-                (persist/persist-tx-result!
-                 conn
-                 [[:db.fn/call store-message-if-absent
-                   entity
-                   {:db/id [:chat/id chat-id]
-                    :chat/updated-at (java.util.Date.)}]]
-                 {:op :store-message :room-id room-id :msg-id (:id msg)})]
-            (cond
-              (false? report) :failed
-              (seq (:tx-data report)) :inserted
-              :else :duplicate)))
+            (let [report
+                  (persist/persist-tx-result!
+                   conn
+                   [[:db.fn/call store-message-if-absent
+                     entity
+                     {:db/id [:chat/id chat-id]
+                      :chat/updated-at (java.util.Date.)}]]
+                   {:op :store-message :room-id room-id :msg-id (:id msg)})]
+              (cond
+                (false? report) :failed
+                (seq (:tx-data report)) :inserted
+                :else :duplicate))))
         (do
           (tel/log! {:level :error :id :room-store/datahike-missing-room
                      :data {:room-id room-id :msg-id (:id msg)}}

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -10,6 +10,7 @@
             [dvergr.code.index :as idx]
             [dvergr.tools.structural :as structural]
             [dvergr.chat.compaction :as compaction]
+            [dvergr.chat.tool-schema :as tool-schema]
             [muschel.fs :as mfs]
             [org.replikativ.spindel.engine.core :as rtc])
   (:import [java.util.concurrent TimeUnit]))
@@ -45,9 +46,21 @@
     (->> xs (map clojure.string/trim) (remove clojure.string/blank?) set not-empty)))
 
 (defn register!
-  "Register a tool in the registry."
+  "Register a tool in the registry.
+
+   A tool name also owns a durable Datahike attribute namespace. Re-registering
+   may add input properties, but cannot remove or change an existing durable
+   property. Use a new tool/schema version for an incompatible contract."
   [tool-def]
-  (swap! registry assoc (:name tool-def) tool-def))
+  (locking registry
+    (when-let [previous (get @registry (:name tool-def))]
+      (when-not (tool-schema/compatible-evolution? previous tool-def)
+        (throw (ex-info "Incompatible durable tool schema evolution; use a new tool name/version"
+                        {:type ::incompatible-tool-schema
+                         :tool-name (:name tool-def)
+                         :previous (:parameters previous)
+                         :proposed (:parameters tool-def)}))))
+    (swap! registry assoc (:name tool-def) tool-def)))
 
 (defn get-tool [name]
   (get @registry name))

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -1215,10 +1215,12 @@
                      {:task :work :settlement :discard}
                      (fn [{register! :register-cleanup!}]
                        (register! #(deliver cleaned true)))))
-                  result (deref handle 5000 ::timeout)]
+                  ;; Keep a finite envelope while testing executor independence
+                  ;; rather than scheduler latency under the full suite.
+                  result (deref handle 20000 ::timeout)]
               (is (= :completed (:run/status result)))
               (is (= :discarded (:run/settlement-status result)))
-              (is (= true (deref cleaned 5000 ::timeout)))
+              (is (= true (deref cleaned 20000 ::timeout)))
               (is (false? (deref finalizer-in-drain? 5000 ::timeout))
                   "the detached finalizer does not inherit an engine drain")
               (is (empty? (run/active-runs (:id room))))))))

--- a/test/dvergr/chat/tool_schema_test.clj
+++ b/test/dvergr/chat/tool_schema_test.clj
@@ -1,6 +1,7 @@
 (ns dvergr.chat.tool-schema-test
   "Tests for critical tool schema generation features."
   (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
             [dvergr.chat.tool-schema :as ts]))
 
 ;; NOTE: Removed reset-installed-schemas! fixture - no longer needed
@@ -21,6 +22,18 @@
                                                    :port {:type "integer"}}}
                              :enabled {:type "boolean"}}
                 :required ["server"]}})
+
+(defn- test-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write}]
+    (d/create-database cfg)
+    {:cfg cfg :conn (d/connect cfg)}))
+
+(defn- error-type [error]
+  (loop [error error]
+    (when error
+      (or (:type (ex-data error))
+          (recur (ex-cause error))))))
 
 (deftest generate-tool-schema-test
   (testing "Simple tool schema generation"
@@ -62,3 +75,73 @@
                                                   :items {:type "string"}}}}}
           entity (ts/tool-input->entity tool {:items ["a" "b" "c"]})]
       (is (= ["a" "b" "c"] (:tool-input.batch/items entity))))))
+
+(deftest incompatible-concurrent-first-installs-have-one-durable-winner
+  (let [{:keys [cfg conn]} (test-conn)
+        ready (java.util.concurrent.CountDownLatch. 2)
+        start (java.util.concurrent.CountDownLatch. 1)
+        tool (fn [type]
+               {:name "schema_race"
+                :parameters {:type "object"
+                             :properties {:value {:type type}}}})
+        attempt
+        (fn [type]
+          (future
+            (.countDown ready)
+            (.await start)
+            (try
+              (ts/install-tool-schema! conn (tool type))
+              {:status :installed :type type}
+              (catch Throwable error
+                {:status :rejected :type type :error error}))))
+        string-attempt (attempt "string")
+        integer-attempt (attempt "integer")]
+    (try
+      (is (.await ready 5 java.util.concurrent.TimeUnit/SECONDS))
+      (.countDown start)
+      (let [string-outcome (deref string-attempt 5000 ::timeout)
+            integer-outcome (deref integer-attempt 5000 ::timeout)
+            outcomes [string-outcome integer-outcome]
+            installed (filter #(= :installed (:status %)) outcomes)
+            rejected (filter #(= :rejected (:status %)) outcomes)
+            installed-value-type
+            (get {"string" :db.type/string "integer" :db.type/long}
+                 (:type (first installed)))]
+        (is (not= ::timeout string-outcome))
+        (is (not= ::timeout integer-outcome))
+        (is (= 1 (count installed)) outcomes)
+        (is (= 1 (count rejected)) outcomes)
+        (is (= ::ts/incompatible-installed-tool-schema
+               (error-type (:error (first rejected)))))
+        (is (= installed-value-type
+               (:db/valueType (d/entity @conn :tool-input.schema-race/value)))
+            "the losing first use cannot rewrite an unused durable attribute"))
+      (finally
+        (.countDown start)
+        (future-cancel string-attempt)
+        (future-cancel integer-attempt)
+        (d/release conn)
+        (d/delete-database cfg)))))
+
+(deftest compatible-schema-extension-installs-only-new-attributes
+  (let [{:keys [cfg conn]} (test-conn)
+        base {:name "schema_extension"
+              :parameters {:type "object"
+                           :properties {:value {:type "string"}}}}
+        extended (assoc-in base [:parameters :properties :revision]
+                           {:type "integer"})]
+    (try
+      (is (= 1 (ts/install-tool-schema! conn base)))
+      (is (= 2 (ts/install-tool-schema! conn extended)))
+      ;; An older compatible process may race after the extension. Its subset
+      ;; must neither fail nor retract the already-installed field.
+      (is (= 1 (ts/install-tool-schema! conn base)))
+      (is (= :db.type/string
+             (:db/valueType
+              (d/entity @conn :tool-input.schema-extension/value))))
+      (is (= :db.type/long
+             (:db/valueType
+              (d/entity @conn :tool-input.schema-extension/revision))))
+      (finally
+        (d/release conn)
+        (d/delete-database cfg)))))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -15,6 +15,7 @@
             [dvergr.room.store :as store]
             [dvergr.room.store.contract :as contract]
             [dvergr.room.store.datahike :as dhs]
+            [dvergr.tools :as tools]
             [hasch.core :as hasch]
             [kontor.resource :as kontor]))
 
@@ -550,6 +551,83 @@
         (is (= #{"grep" "read_file"}
                (set (map :tool-use/name (:tool-uses m))))
             "structured tool-uses round-trip through the store")))))
+
+(deftest late-registered-tool-input-schema-is-installed-on-first-use
+  (testing "a trusted semantic tool registered after Room provisioning remains durable"
+    (let [[conn st] (mem-store)
+          room-id :late-tool-schema
+          tool-name "late_bound_probe"
+          previous (tools/get-tool tool-name)
+          tool {:name tool-name
+                :description "late-bound test tool"
+                :parameters {:type "object"
+                             :properties {:value {:type "string"}}
+                             :required ["value"]}}]
+      (try
+        (store/-store-room! st room-id {:slug (name room-id) :title "T"})
+        (tools/register! tool)
+        (let [message-id (random-uuid)
+              tool-uses
+              (:message/tool-uses
+               (schema/create-message-entity
+                {:chat-id (random-uuid) :role :assistant :content ""
+                 :tool-uses [{:tool-use/id "late-1"
+                              :tool-use/name tool-name
+                              :tool-use/input {:value "durable"}}]}))]
+          (is (= :inserted
+                 (store/-store-message!
+                  st room-id
+                  {:id message-id :from :agent :content "late tool"
+                   :metadata {:role :assistant :tool-uses tool-uses}})))
+          (is (some? (dh/entity @conn :tool-input.late-bound-probe/value)))
+          (is (= "durable"
+                 (-> (store/-list-messages st room-id {}) first
+                     :metadata :tool-uses first :tool-use/input
+                     :tool-input.late-bound-probe/value)))
+          (tools/register!
+           (assoc-in tool [:parameters :properties :revision]
+                     {:type "integer"}))
+          (let [revised-tool-uses
+                (:message/tool-uses
+                 (schema/create-message-entity
+                  {:chat-id (random-uuid) :role :assistant :content ""
+                   :tool-uses [{:tool-use/id "late-2"
+                                :tool-use/name tool-name
+                                :tool-use/input {:value "again"
+                                                 :revision 2}}]}))]
+            (is (= :inserted
+                   (store/-store-message!
+                    st room-id
+                    {:id (random-uuid) :from :agent :content "revised tool"
+                     :metadata {:role :assistant
+                                :tool-uses revised-tool-uses}})))
+            (is (some? (dh/entity @conn
+                                  :tool-input.late-bound-probe/revision))
+                "a revised late-bound definition installs its added field")
+            (let [incompatible (assoc-in tool [:parameters :properties :value]
+                                         {:type "integer"})]
+              (is (= ::tools/incompatible-tool-schema
+                     (try
+                       (tools/register! incompatible)
+                       ::not-rejected
+                       (catch clojure.lang.ExceptionInfo e
+                         (:type (ex-data e)))))
+                  "a populated durable attribute cannot change type")
+              ;; Simulate registry drift from another process/version. An exact
+              ;; durable retry is still a duplicate and must not attempt the
+              ;; now-incompatible schema transaction first.
+              (locking tools/registry
+                (swap! tools/registry assoc tool-name incompatible))
+              (is (= :duplicate
+                     (store/-store-message!
+                      st room-id
+                      {:id message-id :from :agent :content "late tool"
+                       :metadata {:role :assistant :tool-uses tool-uses}}))))))
+        (finally
+          (locking tools/registry
+            (if previous
+              (swap! tools/registry assoc tool-name previous)
+              (swap! tools/registry dissoc tool-name))))))))
 
 (deftest plain-message-has-no-tool-uses-key
   (testing "a message without tool activity carries no :tool-uses key"


### PR DESCRIPTION
## Summary
- install schemas for trusted tools registered after Room provisioning
- make same-name durable tool schemas monotonic and reject incompatible evolution
- capture one registry revision across schema installation and serialization
- preserve exact duplicate message retry semantics before schema work

## Verification
- late-bound schema regression: 1 test, 7 assertions
- chat-context suite: 9 tests, 50 assertions
- nested additive/removal/type-change probes
- independent re-review: no credible medium-or-higher findings

Stacked on #97.