### PR TITLE
Scope detached evaluation cleanup by operation

### DIFF
--- a/dev/dvergr/agent/program_bench.clj
+++ b/dev/dvergr/agent/program_bench.clj
@@ -573,7 +573,8 @@
    content-addressed experimental variable. Supported environments currently
    need no setup beyond the shared memory baseline: join, race, and
    self-programming v1. Host execution options are `:parallelism`,
-   `:max-parallelism`, and `:max-attempts`."
+   `:max-parallelism`, `:max-attempts`, and an optional caller-owned
+   `:cleanup-group` for operation-scoped cleanup."
   [room {:keys [environment-ids candidates repetitions id]
          :or {repetitions 1 id :live/paired-v1}
          :as opts}]
@@ -606,7 +607,7 @@
                          definitions)]
     (experiment/run room team experiment-definition evaluators
                     (assoc (select-keys opts [:parallelism :max-parallelism
-                                              :max-attempts])
+                                              :max-attempts :cleanup-group])
                            :world-setups trusted-world-setups))))
 
 (defn run-paired-experiment!
@@ -618,17 +619,19 @@
    inspection is more important than convenience."
   [opts]
   (let [room-id (keyword (str "paired-bench-" (random-uuid)))
-        room (d/make-room {:id room-id :store (memory/make)})]
+        room (d/make-room {:id room-id :store (memory/make)})
+        cleanup-group (evaluation/cleanup-group)]
     (try
       (let [result (binding [ec/*execution-context* (:ctx room)]
-                     @(paired-experiment-spin room opts))]
+                     @(paired-experiment-spin
+                       room (assoc opts :cleanup-group cleanup-group)))]
         (select-keys result [:experiment :execution :attempts :scorecard]))
       (finally
         ;; Parallel failure cancels sibling evaluations immediately, while
         ;; their world discard runs off-drain. Join that physical cleanup
         ;; before invalidating the ephemeral Room context/store.
         (try
-          (evaluation/await-cleanups! room)
+          (evaluation/await-cleanups-for! room cleanup-group)
           (catch Throwable error
             ;; The caller can recover/inspect this process-local Room from
             ;; ex-data. Closing here would destroy the fork authority whose

--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -434,11 +434,24 @@ repetition count:
                    :dataset dataset
                    :candidates [(agent/lookup team :codex)
                                 (agent/lookup team :claude)]
-                   :repetitions 5})]
-  ;; Host code supplies exact trusted Evaluator capabilities.
-  @(experiment/run room team experiment evaluator-map
-                   {:parallelism 2 :max-attempts 100}))
+                   :repetitions 5})
+      ;; Allocate operation-scoped cleanup authority before realization so it
+      ;; remains available when the Experiment fails or is cancelled.
+      cleanup-group (evaluation/cleanup-group)]
+  (try
+    ;; Host code supplies exact trusted Evaluator capabilities.
+    @(experiment/run room team experiment evaluator-map
+                     {:parallelism 2 :max-attempts 100
+                      :cleanup-group cleanup-group})
+    (finally
+      (evaluation/await-cleanups-for! room cleanup-group))))
 ```
+
+Omitting `:cleanup-group` deliberately makes detached evaluation cleanup
+Room-owned. This is convenient for a single-operation ephemeral Room, whose
+owner joins all work with `evaluation/await-cleanups!` before teardown. Shared
+Rooms should allocate a group before starting each operation and join that exact
+group in `finally`, so another operation's work or failure is never consumed.
 
 Dataset and experiment construction is pure and available inside SCI. Execution
 and reward certification are host-only: an agent can propose the benchmark it

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -30,7 +30,28 @@
 (defn- cleanup-scope [room]
   [(:id room) (:incarnation room)])
 
-(defn- start-task! [room task-fn]
+(defn cleanup-group
+  "Create a process-local identity for cleanup tasks owned by one host
+   operation. Pass it through evaluation/experiment options and join it with
+   `await-cleanups-for!`; it is coordination authority, not durable evidence."
+  []
+  (random-uuid))
+
+(defn- require-cleanup-group! [group]
+  (when-not (uuid? group)
+    (throw (ex-info "Cleanup group must be a UUID"
+                    {:type ::invalid-cleanup-group :cleanup/group group})))
+  group)
+
+(defn- remove-task! [scope token]
+  (swap! pending-tasks
+         (fn [tasks]
+           (let [remaining (dissoc (get tasks scope) token)]
+             (if (seq remaining)
+               (assoc tasks scope remaining)
+               (dissoc tasks scope))))))
+
+(defn- start-task! [room group task-fn]
   (let [scope (cleanup-scope room)
         token (random-uuid)
         gate (promise)
@@ -38,7 +59,8 @@
     ;; Registration happens before the Future can start. A caller that regains
     ;; control after evaluation cancellation can therefore never miss the
     ;; cleanup it must join before closing the Room.
-    (swap! pending-tasks update scope (fnil assoc {}) token gate)
+    (swap! pending-tasks update scope (fnil assoc {}) token
+           {:gate gate :group group})
     (let [worker
           (future
             (deliver started true)
@@ -60,63 +82,77 @@
               ;; until a teardown owner observes them rather than being silently
               ;; forgotten.
               (when (contains? outcome :ok)
-                (swap! pending-tasks update scope dissoc token))))]
+                (remove-task! scope token))))]
       {:token token :gate gate :started started :future worker})))
 
+(defn- await-cleanups* [room group timeout-ms]
+  (positive-timeout! "Cleanup timeout" timeout-ms)
+  (let [scope (cleanup-scope room)
+        deadline (+ (System/nanoTime) (* 1000000 timeout-ms))]
+    (loop [observed #{} failures []]
+      (let [entries (->> (get @pending-tasks scope)
+                         (remove (comp observed key))
+                         (filter (fn [[_ entry]]
+                                   (or (nil? group)
+                                       (= group (:group entry))))))]
+        (if (seq entries)
+          (let [outcomes
+                (mapv
+                 (fn [[token {:keys [gate]}]]
+                   (let [remaining-ms
+                         (max 1 (long (/ (- deadline (System/nanoTime))
+                                         1000000)))
+                         outcome (deref gate remaining-ms ::timeout)]
+                     [token outcome]))
+                 entries)
+                failures'
+                (into failures
+                      (keep (fn [[token outcome]]
+                              (cond
+                                (= ::timeout outcome)
+                                {:token token :type ::cleanup-timeout}
+
+                                (:error outcome)
+                                {:token token :type ::cleanup-failed
+                                 :error (:error outcome)}
+
+                                :else nil)))
+                      outcomes)]
+            ;; Every completed gate has now been handed to this owner. A timed
+            ;; out task remains registered so a later join or Room teardown can
+            ;; still recover it.
+            (doseq [[token outcome] outcomes
+                    :when (not= ::timeout outcome)]
+              (remove-task! scope token))
+            (recur (into observed (map first outcomes)) failures'))
+          (if (seq failures)
+            (throw (ex-info "Evaluation work did not quiesce before cleanup boundary"
+                            {:type ::cleanup-incomplete
+                             :room/id (:id room)
+                             :cleanup/group group
+                             :timeout-ms timeout-ms
+                             :failures failures}))
+            true))))))
+
 (defn await-cleanups!
-  "Block a host teardown boundary until detached evaluation cleanup completes.
+  "Block a Room teardown boundary until all detached evaluation cleanup completes.
 
    Evaluation cancellation itself stays non-blocking for the Spindel drain.
    Ephemeral Room owners must call this outside a Spin before closing the Room.
    Throws on timeout or a cleanup failure."
   ([room] (await-cleanups! room 30000))
   ([room timeout-ms]
-   (positive-timeout! "Cleanup timeout" timeout-ms)
-   (let [scope (cleanup-scope room)
-         deadline (+ (System/nanoTime) (* 1000000 timeout-ms))]
-     (loop [observed #{} failures []]
-       (let [entries (remove (comp observed key)
-                             (get @pending-tasks scope))]
-         (if (seq entries)
-           (let [outcomes
-                 (mapv
-                  (fn [[token gate]]
-                    (let [remaining-ms
-                          (max 1 (long (/ (- deadline (System/nanoTime))
-                                          1000000)))
-                          outcome (deref gate remaining-ms ::timeout)]
-                      [token outcome]))
-                  entries)
-                 failures'
-                 (into failures
-                       (keep (fn [[token outcome]]
-                               (cond
-                                 (= ::timeout outcome)
-                                 {:token token :type ::cleanup-timeout}
+   (await-cleanups* room nil timeout-ms)))
 
-                                 (:error outcome)
-                                 {:token token :type ::cleanup-failed
-                                  :error (:error outcome)}
+(defn await-cleanups-for!
+  "Join only detached evaluation cleanup owned by `group` in `room`.
 
-                                 :else nil)))
-                       outcomes)]
-             ;; Every completed gate has now been handed to this teardown
-             ;; owner. Timed-out gates remain registered and keep the Room
-             ;; non-closeable; completed failures are removed but reported
-             ;; together after all siblings have been joined.
-             (doseq [[token outcome] outcomes
-                     :when (not= ::timeout outcome)]
-               (swap! pending-tasks update scope dissoc token))
-             (recur (into observed (map first outcomes)) failures'))
-           (if (seq failures)
-             (throw (ex-info "Evaluation work did not quiesce before Room close"
-                             {:type ::cleanup-incomplete
-                              :room/id (:id room)
-                              :timeout-ms timeout-ms
-                              :failures failures}))
-             (do
-               (swap! pending-tasks dissoc scope)
-               true))))))))
+   This is the operation boundary for experiments in a shared Room. It never
+   waits on or consumes failures from another cleanup group. Room owners must
+   still use `await-cleanups!` before teardown."
+  ([room group] (await-cleanups-for! room group 30000))
+  ([room group timeout-ms]
+   (await-cleanups* room (require-cleanup-group! group) timeout-ms)))
 
 (defn make-evaluator
   "Create a process-local trusted evaluator capability.
@@ -362,7 +398,7 @@
   ([room team agent-ref definition evaluator]
    (evaluate room team agent-ref definition evaluator {}))
   ([room team agent-ref definition evaluator
-    {:keys [from parent-run world-setup]
+    {:keys [from parent-run world-setup cleanup-group]
      :or {from :environment} :as opts}]
    (environment/validate-environment definition)
    (require-matching-evaluator! definition evaluator)
@@ -375,7 +411,8 @@
           :or {settlement :review}}
          (:environment/world definition)
          model-limits (when agent (require-supported-policy! definition agent))]
-     (when-let [unknown (seq (remove #{:from :parent-run :world-setup}
+     (when-let [unknown (seq (remove #{:from :parent-run :world-setup
+                                       :cleanup-group}
                                      (keys opts)))]
        (throw (ex-info "Evaluation contains unknown options"
                        {:type ::unknown-evaluation-options
@@ -383,6 +420,7 @@
      (when-not agent
        (throw (ex-info "Evaluation AgentDef does not exist in the Roster"
                        {:type ::unknown-agent :agent-ref agent-ref})))
+     (when (some? cleanup-group) (require-cleanup-group! cleanup-group))
      (positive-timeout! "Environment :timeout-ms" timeout-ms)
      (positive-timeout! "Environment :cancel-timeout-ms" cancel-timeout-ms)
      (when-not (contains? #{nil :ctx}
@@ -512,6 +550,7 @@
               worker
               (start-task!
                room
+               cleanup-group
                (fn []
                  (binding [ec/*execution-context* (:ctx room)
                            ec/*spin-id* nil]

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -548,7 +548,11 @@
    ordinary evaluation `:from`/`:parent-run` plus host-owned `:parallelism`,
    `:max-parallelism`, `:max-attempts`, an optional process-local
    `:cleanup-group`, and an exact `:world-setups` capability map for environments
-   that name setup references. Experiment batches
+   that name setup references. A caller-supplied cleanup group is known before
+   realization and can be joined with `evaluation/await-cleanups-for!` after a
+   failed or cancelled operation. When omitted, detached cleanup remains owned
+   by the Room and must be joined with `evaluation/await-cleanups!` at teardown.
+   Experiment batches
    initially require discard settlement; retained partial experiments need
    durable execution identity and recovery first."
   ([room team experiment evaluators]
@@ -591,10 +595,7 @@
      (invalid! "Experiment parallelism exceeds the host admission ceiling"
                ::parallelism-exceeds-ceiling
                {:parallelism parallelism :max-parallelism max-parallelism}))
-   (let [cleanup-group (if (some? cleanup-group)
-                         cleanup-group
-                         (evaluation/cleanup-group))
-         attempt-count (* (count (:experiment/candidates experiment))
+   (let [attempt-count (* (count (:experiment/candidates experiment))
                           (count (get-in experiment
                                          [:experiment/dataset
                                           :dataset/environments]))

--- a/src/dvergr/agent/experiment.clj
+++ b/src/dvergr/agent/experiment.clj
@@ -546,14 +546,15 @@
    admission ceilings are preflighted before the Spin can admit a Run. Jobs and
    evaluation Spins are realized one bounded batch at a time. Options include
    ordinary evaluation `:from`/`:parent-run` plus host-owned `:parallelism`,
-   `:max-parallelism`, `:max-attempts`, and an exact `:world-setups` capability
-   map for environments that name setup references. Experiment batches
+   `:max-parallelism`, `:max-attempts`, an optional process-local
+   `:cleanup-group`, and an exact `:world-setups` capability map for environments
+   that name setup references. Experiment batches
    initially require discard settlement; retained partial experiments need
    durable execution identity and recovery first."
   ([room team experiment evaluators]
    (run room team experiment evaluators {}))
   ([room team experiment evaluators
-    {:keys [parallelism max-parallelism max-attempts world-setups]
+    {:keys [parallelism max-parallelism max-attempts world-setups cleanup-group]
      :or {parallelism 1 max-parallelism 16 max-attempts 256 world-setups {}}
      :as opts}]
    (validate-experiment experiment)
@@ -578,7 +579,7 @@
                                       [:environment/world :settlement])})))
    (when-let [unknown (seq (remove #{:from :parent-run :parallelism
                                      :max-parallelism :max-attempts
-                                     :world-setups}
+                                     :world-setups :cleanup-group}
                                    (keys opts)))]
      (invalid! "Experiment contains unknown run options"
                ::unknown-run-options {:unknown (set unknown)}))
@@ -590,7 +591,10 @@
      (invalid! "Experiment parallelism exceeds the host admission ceiling"
                ::parallelism-exceeds-ceiling
                {:parallelism parallelism :max-parallelism max-parallelism}))
-   (let [attempt-count (* (count (:experiment/candidates experiment))
+   (let [cleanup-group (if (some? cleanup-group)
+                         cleanup-group
+                         (evaluation/cleanup-group))
+         attempt-count (* (count (:experiment/candidates experiment))
                           (count (get-in experiment
                                          [:experiment/dataset
                                           :dataset/environments]))
@@ -600,7 +604,8 @@
                        ::attempts-exceed-ceiling
                        {:attempt-count attempt-count
                         :max-attempts max-attempts}))
-         base-evaluation-opts (select-keys opts [:from :parent-run])
+         base-evaluation-opts (assoc (select-keys opts [:from :parent-run])
+                                     :cleanup-group cleanup-group)
          ;; Validate every distinct candidate/environment pairing once before
          ;; execution. Repetitions are constructed lazily per bounded batch.
          _ (doseq [candidate (:experiment/candidates experiment)
@@ -622,7 +627,8 @@
                              (persist-scorecard! room))]
           {:experiment experiment
            :execution {:parallelism parallelism
-                       :attempt-count attempt-count}
+                       :attempt-count attempt-count
+                       :cleanup-group cleanup-group}
            :results results
            :attempts (mapv :attempt results)
            :scorecard scorecard}))))))

--- a/test/dvergr/agent/evaluation_test.clj
+++ b/test/dvergr/agent/evaluation_test.clj
@@ -63,13 +63,16 @@
         second-group (evaluation/cleanup-group)
         first-error (ex-info "first cleanup" {})
         second-error (ex-info "second cleanup" {})
+        room-error (ex-info "room-owned cleanup" {})
         first-task (#'evaluation/start-task!
                     room first-group #(throw first-error))
         second-task (#'evaluation/start-task!
-                     room second-group #(throw second-error))]
+                     room second-group #(throw second-error))
+        room-task (#'evaluation/start-task! room nil #(throw room-error))]
     (try
       @(:gate first-task)
       @(:gate second-task)
+      @(:gate room-task)
       (let [failure (try
                       (evaluation/await-cleanups-for! room first-group 1000)
                       nil
@@ -88,6 +91,13 @@
                (mapv :error (:failures (ex-data failure))))))
       (is (thrown? clojure.lang.ExceptionInfo
                    (evaluation/await-cleanups-for! room :not-a-uuid 1000)))
+      (let [failure (try
+                      (evaluation/await-cleanups! room 1000)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+        (is (= [room-error]
+               (mapv :error (:failures (ex-data failure))))
+            "room teardown retains cleanup for operations without a group"))
       (is (true? (evaluation/await-cleanups! room 1000)))
       (finally
         (d/close-room! room)))))

--- a/test/dvergr/agent/evaluation_test.clj
+++ b/test/dvergr/agent/evaluation_test.clj
@@ -57,6 +57,41 @@
         (do (Thread/sleep 5) (recur))
         :else false))))
 
+(deftest cleanup-groups-isolate-operation-failures
+  (let [room (test-room :cleanup-groups)
+        first-group (evaluation/cleanup-group)
+        second-group (evaluation/cleanup-group)
+        first-error (ex-info "first cleanup" {})
+        second-error (ex-info "second cleanup" {})
+        first-task (#'evaluation/start-task!
+                    room first-group #(throw first-error))
+        second-task (#'evaluation/start-task!
+                     room second-group #(throw second-error))]
+    (try
+      @(:gate first-task)
+      @(:gate second-task)
+      (let [failure (try
+                      (evaluation/await-cleanups-for! room first-group 1000)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+        (is (= :dvergr.agent.evaluation/cleanup-incomplete
+               (:type (ex-data failure))))
+        (is (= [first-error]
+               (mapv :error (:failures (ex-data failure))))))
+      (is (true? (evaluation/await-cleanups-for! room first-group 1000))
+          "the first group was consumed without touching the second")
+      (let [failure (try
+                      (evaluation/await-cleanups-for! room second-group 1000)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+        (is (= [second-error]
+               (mapv :error (:failures (ex-data failure))))))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (evaluation/await-cleanups-for! room :not-a-uuid 1000)))
+      (is (true? (evaluation/await-cleanups! room 1000)))
+      (finally
+        (d/close-room! room)))))
+
 (defn- definition [id opts]
   (environment/make-environment
    (merge {:id id

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -170,6 +170,12 @@
            (experiment/run room team definition
                            {(:ref exact-evaluator) exact-evaluator}
                            {:parallelism 3 :max-parallelism 2})))
+      (doseq [invalid-group [:not-a-uuid false]]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"Cleanup group must be a UUID"
+             (experiment/run room team definition
+                             {(:ref exact-evaluator) exact-evaluator}
+                             {:cleanup-group invalid-group}))))
       (is (empty? (run/active-runs (:id room))))
       (finally
         (d/close-room! room)))))
@@ -257,18 +263,23 @@
 (deftest repeated-paired-experiment-composes-ordinary-certified-evaluations
   (let [{:keys [team definition]} (fixture)
         room (d/make-room {:id :experiment-run :store (memory/make)})
-        evaluator-ref (:ref exact-evaluator)]
+        evaluator-ref (:ref exact-evaluator)
+        cleanup-group (evaluation/cleanup-group)]
     (try
       (binding [ec/*execution-context* (:ctx room)]
         (let [spin (experiment/run room team definition
                                    {evaluator-ref exact-evaluator}
-                                   {:parallelism 2})]
+                                   {:parallelism 2
+                                    :cleanup-group cleanup-group})]
           (is (empty? (run/active-runs (:id room)))
               "constructing the Experiment Spin admits no Runs")
           (let [{:keys [results attempts scorecard execution]} @spin]
             (try
               (is (= 8 (count results) (count attempts)))
-              (is (= {:parallelism 2 :attempt-count 8} execution))
+              (is (= {:parallelism 2
+                      :attempt-count 8
+                      :cleanup-group cleanup-group}
+                     execution))
               (is (= 8 (count (set (map :attempt/id attempts)))))
               (is (= 8 (count (:scorecard/entries scorecard))))
               (is (= [{:candidate/id :alpha :attempt-count 4

--- a/test/dvergr/agent/experiment_test.clj
+++ b/test/dvergr/agent/experiment_test.clj
@@ -208,11 +208,13 @@
                            :store (memory/make)})]
     (try
       (binding [ec/*execution-context* (:ctx room)]
-        (let [{:keys [attempts scorecard]}
+        (let [{:keys [attempts scorecard execution]}
               @(experiment/run room team definition
                                {(:ref exact-evaluator) exact-evaluator}
                                {:parallelism 2
                                 :world-setups {setup-ref setup}})]
+          (is (nil? (:cleanup-group execution))
+              "an omitted group leaves cleanup owned by the Room")
           (is (= 4 (count attempts)))
           (is (= 4 (count @prepared)))
           (is (= (set (map :attempt/run-id attempts)) (set @prepared)))
@@ -432,6 +434,11 @@
                 (throw (ex-info "deliberate parallel verifier failure" {})))))})
         room (d/make-room {:id :experiment-parallel-cleanup
                            :store (memory/make)})
+        cleanup-group (evaluation/cleanup-group)
+        unrelated-group (evaluation/cleanup-group)
+        unrelated-error (ex-info "unrelated cleanup" {})
+        unrelated-task (#'evaluation/start-task!
+                        room unrelated-group #(throw unrelated-error))
         discard! forks/discard-deferred!
         discard-count (atom 0)
         failing-discard
@@ -445,20 +452,31 @@
               :error :deliberate-discard-failure}
              (discard! fork reason claim!))))]
     (try
+      (is (map? @(:gate unrelated-task)))
       (with-redefs [forks/discard-deferred! failing-discard]
         (binding [ec/*execution-context* (:ctx room)]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo #"certification failed"
                @(experiment/run room team definition
                                 {(:ref evaluator) evaluator}
-                                {:parallelism 3}))))
+                                {:parallelism 3
+                                 :cleanup-group cleanup-group}))))
         (let [error (try
-                      (evaluation/await-cleanups! room 5000)
+                      (evaluation/await-cleanups-for! room cleanup-group 5000)
                       nil
                       (catch clojure.lang.ExceptionInfo error error))]
           (is (= :dvergr.agent.evaluation/cleanup-incomplete
                  (:type (ex-data error))))
           (is (= 1 (count (:failures (ex-data error))))))
+        (is (true? (evaluation/await-cleanups-for! room cleanup-group 5000))
+            "the failed operation's cleanup was consumed")
+        (let [error (try
+                      (evaluation/await-cleanups-for! room unrelated-group 5000)
+                      nil
+                      (catch clojure.lang.ExceptionInfo error error))]
+          (is (= [unrelated-error]
+                 (mapv :error (:failures (ex-data error))))
+              "operation cleanup did not consume another group's failure"))
         (is (= 3 @discard-count)
             "the barrier joins every sibling despite one cleanup failure"))
       (is (empty? (run/active-runs (:id room))))


### PR DESCRIPTION
## Summary

- add process-local cleanup group capabilities for evaluation work
- let experiments propagate and report one exact cleanup group
- preserve the room-wide teardown barrier while allowing shared-room callers to join only their own work
- prove failures from concurrent groups cannot be consumed across operation boundaries

This is deliberately coordination authority, not a new durable execution or evidence identity. Runs and certified Attempts remain the durable boundary.

## Verification

- clojure -M:format
- focused evaluation + experiment suite: 25 tests, 182 assertions