### PR TITLE
feat(agent): add a state-backed renewal intervention arena

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -83,7 +83,7 @@
         ;; Yggdrasil — CoW branching for git and Datahike
         ;; 0.3.41 includes the Geschichte content-level merge adapter and the
         ;; current persistent-sorted-set substrate.
-        org.replikativ/yggdrasil   {:mvn/version "0.3.41"
+        org.replikativ/yggdrasil   {:mvn/version "0.3.42"
                                     :exclusions  [org.babashka/sci]}
 
         ;; Scriptum — CoW Lucene indices for fulltext search

--- a/dev/dvergr/agent/arenas/renewal_bench.clj
+++ b/dev/dvergr/agent/arenas/renewal_bench.clj
@@ -15,6 +15,7 @@
             [dvergr.discourse :as discourse]
             [dvergr.resource :as resource]
             [dvergr.room.store.datahike]
+            [dvergr.tools :as tools]
             [org.replikativ.spindel.engine.core :as ec]))
 
 (def default-prompt
@@ -57,6 +58,10 @@
     (throw (ex-info "Renewal benchmark requires a durable Datahike Room"
                     {:type ::datahike-room-required
                      :room/id (:id room)})))
+  (when-not (= renewal/renewal-plan-tool (tools/get-tool "renewal_plan"))
+    (throw (ex-info "Install the exact renewal arena tool before running"
+                    {:type ::renewal-tool-not-installed
+                     :tool "renewal_plan"})))
   (let [balance (resource/balance room)
         available (get balance renewal/review-unit 0)]
     (when (< available 1)
@@ -97,13 +102,14 @@
    subscription/API resources. Invalid storage or missing review capacity fail
    before the Experiment can admit model work.
 
-     (renewal/provision-review-capacity! room 1)
+     (renewal/register-tool!)
+     (renewal/provision-review-capacity!
+      room {:id (random-uuid) :amount 1})
      (run! room {:id :codex-renewal
                  :provider :codex-subscription
                  :model \"codex-subscription-sol\"})"
   [room candidate-opts]
   (preflight-room! room)
-  (renewal/register-tool!)
   (let [cleanup-group (evaluation/cleanup-group)
         environment (renewal/environment-def)
         team (candidate

--- a/dev/dvergr/agent/arenas/renewal_bench.clj
+++ b/dev/dvergr/agent/arenas/renewal_bench.clj
@@ -1,0 +1,134 @@
+(ns dvergr.agent.arenas.renewal-bench
+  "Opt-in live-provider REPL runner for the state-backed renewal arena.
+
+   The trusted evaluator and certified Attempt remain the authority for reward.
+   This dev-only runner additionally returns the host's generated tool inputs
+   and semantic outcomes so API discovery failures can be diagnosed without
+   widening `agent/inspect`."
+  (:refer-clojure :exclude [run!])
+  (:require [dvergr.activity :as activity]
+            [dvergr.agent.arenas.renewal :as renewal]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as discourse]
+            [dvergr.resource :as resource]
+            [dvergr.room.store.datahike]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(def default-prompt
+  (str "Work directly through the Dvergr SCI REPL. Execute the portable task "
+       "contract exactly. Use clojure_eval to query the fork-local Datahike "
+       "room state, construct the required immutable specialist roster, hire "
+       "and await both specialists through Spindel, then call renewal_plan "
+       "with their returned evidence IDs. Return the exact requested EDN "
+       "shape. Do not answer from prose or guessed identifiers."))
+
+(defn- candidate [team {:keys [id provider model prompt]}]
+  (when-not (and (keyword? id) (keyword? provider) (string? model))
+    (throw (ex-info "Candidate requires keyword :id/:provider and string :model"
+                    {:id id :provider provider :model model})))
+  (roster/make-agent
+   team
+   {:id id
+    :prompt (or prompt default-prompt)
+    :tools #{:clojure-eval :renewal-plan}
+    :model-policy {:provider provider :model model}
+    :program {:kind :llm :max-model-steps 16
+              :budget-dollars 2.0 :auto-compact? false}}))
+
+(defn- host-tool-trace [room root-run-id]
+  (when-not (uuid? root-run-id)
+    (throw (ex-info "Host tool trace requires one admitted root Run"
+                    {:type ::missing-root-run :run/id root-run-id})))
+  (let [run-ids (into #{} (map :run/id)
+                      (run/runs room {:root-run-id root-run-id :limit 200}))]
+    (into []
+          (comp
+           (filter #(and (= :_activity (:to %))
+                         (contains? run-ids (activity/message-run-id %))))
+           (map activity/tool-trace-entry)
+           (filter #(seq (:tool-uses %))))
+          (discourse/messages room {:limit 500 :run-ids run-ids}))))
+
+(defn- preflight-room! [room]
+  (when-not (instance? dvergr.room.store.datahike.DatahikeStore (:store room))
+    (throw (ex-info "Renewal benchmark requires a durable Datahike Room"
+                    {:type ::datahike-room-required
+                     :room/id (:id room)})))
+  (let [balance (resource/balance room)
+        available (get balance renewal/review-unit 0)]
+    (when (< available 1)
+      (throw (ex-info "Renewal benchmark requires one provisioned review unit"
+                      {:type ::insufficient-review-capacity
+                       :room/id (:id room)
+                       :resource renewal/review-unit
+                       :required 1
+                       :available available}))))
+  room)
+
+(defn- run-with-cleanup-barrier [room cleanup-group f]
+  (let [outcome (try
+                  {:value (f)}
+                  (catch Throwable error
+                    {:error error}))
+        cleanup-error (try
+                        (evaluation/await-cleanups-for! room cleanup-group)
+                        nil
+                        (catch Throwable error error))]
+    (if-let [error (:error outcome)]
+      (do
+        (when cleanup-error
+          (.addSuppressed ^Throwable error ^Throwable cleanup-error))
+        (throw error))
+      (if cleanup-error
+        (throw cleanup-error)
+        (:value outcome)))))
+
+(defn run!
+  "Run one live candidate through the exact renewal arena in `room`.
+
+   `candidate-opts` requires keyword `:id` and `:provider`, string `:model`,
+   and optionally a prompt. Returns the portable ExperimentDef, certified
+   Attempt and Scorecard plus a host-only scoped tool-input trace. The caller
+   owns the fully initialized Datahike/Kontor Room and must provision one
+  renewal-review unit per Attempt before calling. Provider calls consume real
+   subscription/API resources. Invalid storage or missing review capacity fail
+   before the Experiment can admit model work.
+
+     (renewal/provision-review-capacity! room 1)
+     (run! room {:id :codex-renewal
+                 :provider :codex-subscription
+                 :model \"codex-subscription-sol\"})"
+  [room candidate-opts]
+  (preflight-room! room)
+  (renewal/register-tool!)
+  (let [cleanup-group (evaluation/cleanup-group)
+        environment (renewal/environment-def)
+        team (candidate
+              (roster/make-roster {:id :renewal/live-candidates})
+              candidate-opts)
+        agent (roster/agent team (:id candidate-opts))
+        definition
+        (experiment/make-experiment
+         {:id :business/renewal-live-probe-v1
+          :dataset
+          (experiment/make-dataset
+           {:id :business/renewal-live-probe-v1
+            :environments [environment]})
+          :candidates [agent]})
+        result
+        (run-with-cleanup-barrier
+         room cleanup-group
+         (fn []
+           (binding [ec/*execution-context* (:ctx room)]
+             @(experiment/run
+               room team definition
+               {renewal/verifier-ref (renewal/evaluator)}
+               {:parallelism 1
+                :cleanup-group cleanup-group
+                :world-setups {renewal/setup-ref (renewal/world-setup)}}))))
+        root-run-id (get-in result [:attempts 0 :attempt/run-id])]
+    (assoc (select-keys result [:experiment :execution :attempts :scorecard])
+           :host/tool-trace (host-tool-trace room root-run-id))))

--- a/dev/dvergr/agent/arenas/renewal_bench.clj
+++ b/dev/dvergr/agent/arenas/renewal_bench.clj
@@ -58,7 +58,7 @@
     (throw (ex-info "Renewal benchmark requires a durable Datahike Room"
                     {:type ::datahike-room-required
                      :room/id (:id room)})))
-  (when-not (= renewal/renewal-plan-tool (tools/get-tool "renewal_plan"))
+  (when-not (renewal/exact-tool-installed? (tools/get-tool "renewal_plan"))
     (throw (ex-info "Install the exact renewal arena tool before running"
                     {:type ::renewal-tool-not-installed
                      :tool "renewal_plan"})))

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -142,6 +142,43 @@ The deterministic model contract exercises this complete path in CI. Live
 Codex/Claude candidates can use the same EnvironmentDef, evaluator and setup;
 only their AgentDefs and prompt policies differ.
 
+The first native Codex-subscription probe of this arena exposed two benchmark
+contract bugs before it passed. The portable task originally said only that a
+specialist returned a signal and that the root returned a plan ID, while the
+trusted verifier required full signal records and a `{:plan/id UUID}` result.
+Those shapes now live explicitly in the task data rather than only in hidden
+host code. The probe also showed that three provider exchanges and 30 seconds
+were accidental turn-like limits: Codex was still inspecting the unfamiliar
+SCI surface when the first attempt stopped. The environment now uses time and
+resource limits as its work budget and retains sixteen model exchanges only as
+a runaway fuse. With a 120-second limit, Codex queried the fork-local state,
+authored and ran both specialists, submitted the exact evidence, consumed one
+review unit, and passed all fifteen trusted checks in eight model exchanges.
+This is one successful discoverability probe, not yet a model-quality estimate.
+The same path is available from a fully initialized room REPL without exposing
+the raw trace to evaluated agents:
+
+```clojure
+(require '[dvergr.agent.arenas.renewal :as renewal]
+         '[dvergr.agent.arenas.renewal-bench :as renewal-bench])
+
+(renewal/provision-review-capacity! room 1)
+(def report
+  (renewal-bench/run!
+   room
+   {:id :codex-renewal
+    :provider :codex-subscription
+    :model "codex-subscription-sol"}))
+
+(get-in report [:scorecard :scorecard/summary])
+(:host/tool-trace report) ; host-only generated inputs and semantic outcomes
+```
+
+`run!` uses the caller's real Room and leaves its lifecycle with the caller. It
+does not manufacture a lighter pseudo-room or copy the experiment scheduler.
+Cleanup is joined before it returns or throws, and the diagnostic trace is
+restricted to the admitted root Run and its structural descendants.
+
 The comparison unit is now explicit. A DatasetDef fixes a non-empty ordered set
 of exact environments; an ExperimentDef fixes exact candidate AgentDef content
 and repetitions. Host-owned admission policy caps total attempts and

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -128,16 +128,23 @@ scheduler:
 
 ```clojure
 (require '[dvergr.agent.arenas.renewal :as renewal]
+         '[dvergr.agent.evaluation :as evaluation]
          '[dvergr.agent.experiment :as experiment])
 
 (renewal/register-tool!)
 (renewal/provision-review-capacity!
  room {:id provisioning-event-id :amount candidate-cells})
 
-@(experiment/run
-  room roster experiment-def
-  {renewal/verifier-ref (renewal/evaluator)}
-  {:world-setups {renewal/setup-ref (renewal/world-setup)}})
+(let [cleanup-group (evaluation/cleanup-group)]
+  (try
+    @(experiment/run
+      room roster experiment-def
+      {renewal/verifier-ref (renewal/evaluator)}
+      {:cleanup-group cleanup-group
+       :world-setups {renewal/setup-ref (renewal/world-setup)}})
+    (finally
+      ;; Shared-Room callers join only this operation's detached cleanup.
+      (evaluation/await-cleanups-for! room cleanup-group))))
 ```
 
 The deterministic model contract exercises this complete path in CI. Live

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -112,6 +112,36 @@ private work exists in the same control Room. Its deterministic SCI contract and
 trusted model-backed verifier establish the recursive boundary before real CRM,
 support, scheduling, or delivery effects are added.
 
+`dvergr.agent.arenas.renewal` is the first consequential state-backed successor.
+Its exact WorldSetup seeds an account and sales/support signals inside every
+candidate Run world. A candidate must hire both specialists, obtain their actual
+results, and call the semantic `renewal_plan` tool with the exact evidence IDs.
+That tool validates the fork-local business state, consumes one conserved
+`renewal-review` unit from the Run wallet, and writes the proposed intervention
+only into the disposable candidate world. The trusted evaluator then checks the
+plan, Run topology, causal observation, tool activity, resource receipt, and
+returned result before discard settlement. Static prose cannot pass it.
+
+The host composes it from ordinary definitions rather than a special arena
+scheduler:
+
+```clojure
+(require '[dvergr.agent.arenas.renewal :as renewal]
+         '[dvergr.agent.experiment :as experiment])
+
+(renewal/register-tool!)
+(renewal/provision-review-capacity! room candidate-cells)
+
+@(experiment/run
+  room roster experiment-def
+  {renewal/verifier-ref (renewal/evaluator)}
+  {:world-setups {renewal/setup-ref (renewal/world-setup)}})
+```
+
+The deterministic model contract exercises this complete path in CI. Live
+Codex/Claude candidates can use the same EnvironmentDef, evaluator and setup;
+only their AgentDefs and prompt policies differ.
+
 The comparison unit is now explicit. A DatasetDef fixes a non-empty ordered set
 of exact environments; an ExperimentDef fixes exact candidate AgentDef content
 and repetitions. Host-owned admission policy caps total attempts and

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -114,8 +114,9 @@ support, scheduling, or delivery effects are added.
 
 `dvergr.agent.arenas.renewal` is the first consequential state-backed successor.
 Its exact WorldSetup seeds an account and sales/support signals inside every
-candidate Run world. A candidate must hire both specialists, obtain their actual
-results, and call the semantic `renewal_plan` tool with the exact evidence IDs.
+candidate Run world. A candidate must construct and hire both exact scripted
+specialist-service fixtures, obtain their actual child Run results, and call the
+semantic `renewal_plan` tool with the exact evidence IDs.
 That tool validates the fork-local business state, consumes one conserved
 `renewal-review` unit from the Run wallet, and writes the proposed intervention
 only into the disposable candidate world. The trusted evaluator then checks the
@@ -130,7 +131,8 @@ scheduler:
          '[dvergr.agent.experiment :as experiment])
 
 (renewal/register-tool!)
-(renewal/provision-review-capacity! room candidate-cells)
+(renewal/provision-review-capacity!
+ room {:id provisioning-event-id :amount candidate-cells})
 
 @(experiment/run
   room roster experiment-def
@@ -140,7 +142,10 @@ scheduler:
 
 The deterministic model contract exercises this complete path in CI. Live
 Codex/Claude candidates can use the same EnvironmentDef, evaluator and setup;
-only their AgentDefs and prompt policies differ.
+only their AgentDefs and prompt policies differ. The scripted children measure
+recursive construction, causal joining, world/resource ownership, and merge—not
+specialist model reasoning. A later arena can replace them with paid specialist
+models once nested provider effects debit conserved Run wallets.
 
 The first native Codex-subscription probe of this arena exposed two benchmark
 contract bugs before it passed. The portable task originally said only that a
@@ -153,7 +158,9 @@ SCI surface when the first attempt stopped. The environment now uses time and
 resource limits as its work budget and retains sixteen model exchanges only as
 a runaway fuse. With a 120-second limit, Codex queried the fork-local state,
 authored and ran both specialists, submitted the exact evidence, consumed one
-review unit, and passed all fifteen trusted checks in eight model exchanges.
+review unit, and passed the then-current fifteen trusted checks in eight model
+exchanges. The current contract additionally verifies exact child AgentDef
+identities; the historical probe has not yet been rerun against that revision.
 This is one successful discoverability probe, not yet a model-quality estimate.
 The same path is available from a fully initialized room REPL without exposing
 the raw trace to evaluated agents:
@@ -162,7 +169,9 @@ the raw trace to evaluated agents:
 (require '[dvergr.agent.arenas.renewal :as renewal]
          '[dvergr.agent.arenas.renewal-bench :as renewal-bench])
 
-(renewal/provision-review-capacity! room 1)
+(renewal/register-tool!)
+(renewal/provision-review-capacity!
+ room {:id (random-uuid) :amount 1})
 (def report
   (renewal-bench/run!
    room
@@ -175,9 +184,11 @@ the raw trace to evaluated agents:
 ```
 
 `run!` uses the caller's real Room and leaves its lifecycle with the caller. It
-does not manufacture a lighter pseudo-room or copy the experiment scheduler.
-Cleanup is joined before it returns or throws, and the diagnostic trace is
-restricted to the admitted root Run and its structural descendants.
+requires the semantic tool to be installed explicitly and never mutates the
+process-global tool registry itself. It does not manufacture a lighter
+pseudo-room or copy the experiment scheduler. Evaluation cleanup is joined
+before it returns or throws, and the diagnostic trace is restricted to the
+admitted root Run and its structural descendants.
 
 The comparison unit is now explicit. A DatasetDef fixes a non-empty ordered set
 of exact environments; an ExperimentDef fixes exact candidate AgentDef content

--- a/src/dvergr/agent/arenas/renewal.clj
+++ b/src/dvergr/agent/arenas/renewal.clj
@@ -1,0 +1,498 @@
+(ns dvergr.agent.arenas.renewal
+  "State-backed renewal-intervention arena.
+
+   The account, evidence and proposed plan live in the evaluation Run's
+   fork-local Room store. Conserved review capacity lives in the durable
+   control Room's Kontor book. A candidate can therefore speculate on business
+   state without copying or rolling back the authority it spent doing so."
+  (:require [clojure.edn :as edn]
+            [datahike.api :as d]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.observation :as observation]
+            [dvergr.resource :as resource]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.datahike :as datahike-store]
+            [dvergr.tools :as tools]
+            [hasch.core :as hasch])
+  (:import [java.util UUID]))
+
+(def arena-version 1)
+(def review-unit "renewal-review")
+(def account-id :acme)
+
+(def sales-signal-id
+  (hasch/uuid [:dvergr/renewal-signal arena-version account-id :sales]))
+
+(def support-signal-id
+  (hasch/uuid [:dvergr/renewal-signal arena-version account-id :support]))
+
+(def arena-basis
+  {:account {:id account-id
+             :name "Acme"
+             :value-microusd 120000000000
+             :days-remaining 14}
+   :signals [{:id sales-signal-id
+              :source :sales
+              :kind :renewal-date
+              :value "14"}
+             {:id support-signal-id
+              :source :support
+              :kind :open-critical
+              :count 3
+              :severity :high}]
+   :required-plan {:risk :high
+                   :action :executive-escalation
+                   :status :proposed}
+   :resource {review-unit 1}})
+
+(def task-contract
+  {:objective :propose-renewal-intervention
+   :account account-id
+   :specialists [{:id :sales :task :report-sales-evidence
+                  :returns :sales-signal}
+                 {:id :support :task :report-support-evidence
+                  :returns :support-signal}]
+   :coordination {:hire :both
+                  :await :both
+                  :use-returned-signal-ids-as-plan-evidence true}
+   :submission-tool "renewal_plan"
+   :requires-resource-receipt true})
+
+(def verification-contract
+  {:setup :exact-scenario
+   :plan {:count 1 :owner :root-run :id :content-derived
+          :decision (:required-plan arena-basis)
+          :evidence #{sales-signal-id support-signal-id}}
+   :children {:count 2 :actors #{:sales :support}
+              :status :completed :settlement :merged
+              :causality :all-results-observed
+              :results {:sales sales-signal-id :support support-signal-id}}
+   :tool {:name "renewal_plan" :completed-count 1}
+   :resource {:kind :consume :unit review-unit :amount 1}
+   :result :returns-plan-id
+   :reward {:all-checks 1.0 :otherwise 0.0}})
+
+(def schema
+  [{:db/ident :arena/id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :arena/kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :arena/version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :renewal.account/id
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :renewal.account/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.account/value-microusd
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.account/days-remaining
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :renewal.signal/id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :renewal.signal/account
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.signal/source
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.signal/kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.signal/value
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.signal/count
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.signal/severity
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :renewal.plan/id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :renewal.plan/account
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.plan/run-id
+    :db/valueType :db.type/uuid
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.plan/risk
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.plan/action
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :renewal.plan/evidence
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many}
+   {:db/ident :renewal.plan/status
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}])
+
+(def arena-content-id
+  (hasch/uuid [:dvergr/renewal-arena arena-version
+               {:scenario arena-basis
+                :task task-contract
+                :schema schema
+                :verification verification-contract}]))
+
+(def setup-ref
+  {:setup/id :business/renewal-arena
+   :setup/version arena-version
+   :setup/basis {:scenario/content-id arena-content-id}})
+
+(def verifier-ref
+  {:verifier/id :business/renewal-intervention
+   :verifier/version arena-version
+   :verifier/basis {:scenario/content-id arena-content-id}})
+
+(def seed-tx
+  [{:arena/id arena-content-id
+    :arena/kind :renewal-risk
+    :arena/version arena-version}
+   {:renewal.account/id account-id
+    :renewal.account/name "Acme"
+    :renewal.account/value-microusd 120000000000
+    :renewal.account/days-remaining 14}
+   {:renewal.signal/id sales-signal-id
+    :renewal.signal/account [:renewal.account/id account-id]
+    :renewal.signal/source :sales
+    :renewal.signal/kind :renewal-date
+    :renewal.signal/value "14"}
+   {:renewal.signal/id support-signal-id
+    :renewal.signal/account [:renewal.account/id account-id]
+    :renewal.signal/source :support
+    :renewal.signal/kind :open-critical
+    :renewal.signal/count 3
+    :renewal.signal/severity :high}])
+
+(defn plan-id [run-id]
+  (hasch/uuid [:dvergr/renewal-plan arena-content-id run-id account-id]))
+
+(defn charge-id [run-id]
+  (hasch/uuid [:dvergr/renewal-charge arena-content-id run-id account-id]))
+
+(defn mint-id [room-id amount]
+  (hasch/uuid [:dvergr/renewal-mint arena-content-id room-id amount]))
+
+(defn environment-def []
+  (environment/make-environment
+   {:id :business/renewal-intervention-v1
+    :version arena-version
+    :task task-contract
+    :verifier {:id :business/renewal-intervention
+               :version arena-version
+               :basis {:scenario/content-id arena-content-id}}
+    :limits {:timeout-ms 30000 :cancel-timeout-ms 5000
+             :max-model-steps 3 :budget-dollars 2.0}
+    :world {:isolation :ctx
+            :settlement :discard
+            :resources {review-unit 1}
+            :setup setup-ref}}))
+
+(defn world-setup []
+  (evaluation/make-world-setup
+   {:id (:setup/id setup-ref)
+    :version (:setup/version setup-ref)
+    :basis (:setup/basis setup-ref)
+    :prepare
+    (fn [{:keys [room]}]
+      (when-not (instance? dvergr.room.store.datahike.DatahikeStore
+                           (:store room))
+        (throw (ex-info "Renewal arena requires a fork-local Datahike Room store"
+                        {:type ::datahike-world-required
+                         :room/id (:id room)})))
+      (let [conn (:conn (:store room))]
+        (d/transact conn schema)
+        (d/transact conn seed-tx)
+        {:arena/content-id arena-content-id
+         :account/id account-id
+         :signal/ids #{sales-signal-id support-signal-id}}))}))
+
+(defn provision-review-capacity!
+  "Install and mint `amount` review units in the durable control Room."
+  [room amount]
+  (when-not (and (integer? amount) (pos? amount))
+    (throw (ex-info "Renewal review capacity must be a positive integer"
+                    {:type ::invalid-review-capacity :amount amount})))
+  (resource/install-unit! room {:symbol review-unit
+                                :name "Renewal reviews"
+                                :precision 0})
+  (resource/mint! room {:id (mint-id (:id room) amount)
+                        :resources {review-unit amount}}))
+
+(defn- parse-evidence-uuid [value]
+  (cond
+    (uuid? value) value
+    (string? value) (try (UUID/fromString value)
+                         (catch IllegalArgumentException _ nil))
+    :else nil))
+
+(defn- exact-arena? [conn]
+  (= [:renewal-risk arena-version]
+     (d/q '[:find [?kind ?version]
+            :in $ ?id
+            :where
+            [?e :arena/id ?id]
+            [?e :arena/kind ?kind]
+            [?e :arena/version ?version]]
+          @conn arena-content-id)))
+
+(defn- load-account [conn]
+  (d/q '[:find (pull ?e [:renewal.account/id
+                         :renewal.account/name
+                         :renewal.account/value-microusd
+                         :renewal.account/days-remaining]) .
+         :in $ ?id
+         :where [?e :renewal.account/id ?id]]
+       @conn account-id))
+
+(defn- signals [conn]
+  (d/q '[:find [(pull ?e [:renewal.signal/id
+                          :renewal.signal/source
+                          :renewal.signal/kind
+                          :renewal.signal/value
+                          :renewal.signal/count
+                          :renewal.signal/severity]) ...]
+         :in $ ?account
+         :where
+         [?a :renewal.account/id ?account]
+         [?e :renewal.signal/account ?a]]
+       @conn account-id))
+
+(defn- plan [conn id]
+  (d/q '[:find (pull ?e [:renewal.plan/id
+                         :renewal.plan/run-id
+                         :renewal.plan/risk
+                         :renewal.plan/action
+                         :renewal.plan/status
+                         {:renewal.plan/account [:renewal.account/id]}
+                         {:renewal.plan/evidence [:renewal.signal/id]}]) .
+         :in $ ?id
+         :where [?e :renewal.plan/id ?id]]
+       @conn id))
+
+(defn- expected-decision [account signals]
+  (let [critical (some #(and (= :support (:renewal.signal/source %))
+                             (= :open-critical (:renewal.signal/kind %))
+                             (= :high (:renewal.signal/severity %))
+                             (pos? (or (:renewal.signal/count %) 0)))
+                       signals)
+        urgent (<= (:renewal.account/days-remaining account) 30)]
+    (when (and critical urgent)
+      {:risk :high :action :executive-escalation})))
+
+(defn- reject! [message data]
+  (throw (ex-info message (assoc data :type ::invalid-plan-command))))
+
+(def renewal-plan-tool
+  {:name "renewal_plan"
+   :description
+   (str "After hiring and awaiting the :sales and :support specialists, propose "
+        "the verified Acme intervention using the exact signal UUID returned by "
+        "each child. Consumes one renewal-review unit.")
+   :parameters
+   {:type "object"
+    :properties
+    {:account {:type "string" :enum ["acme"]}
+     :risk {:type "string" :enum ["high"]}
+     :action {:type "string" :enum ["executive-escalation"]}
+     :evidence {:type "array" :items {:type "string"} :minItems 2 :maxItems 2}}
+    :required ["account" "risk" "action" "evidence"]}
+   :execute
+   (fn [{:keys [account risk action evidence]} ctx]
+     (let [conn (:db-conn ctx)
+           control-room (:control-room ctx)
+           run-id (:run-id ctx)]
+       (when-not (and conn control-room (uuid? run-id))
+         (reject! "renewal_plan requires a Run-scoped Datahike/Kontor context"
+                  {:run/id run-id}))
+       (when-not (exact-arena? conn)
+         (reject! "renewal_plan is unavailable outside the exact renewal arena"
+                  {:arena/content-id arena-content-id}))
+       (let [evidence-values (when (sequential? evidence) (vec evidence))
+             parsed-evidence (when evidence-values
+                               (mapv parse-evidence-uuid evidence-values))]
+         (when-not (and (= 2 (count evidence-values))
+                        (every? some? parsed-evidence)
+                        (= 2 (count (distinct parsed-evidence))))
+           (reject! "renewal_plan requires exactly two distinct signal UUIDs"
+                    {:evidence evidence}))
+         (let [account-row (load-account conn)
+               signal-rows (signals conn)
+               supplied-evidence (set parsed-evidence)
+               expected-evidence (into #{} (map :renewal.signal/id) signal-rows)
+               expected (expected-decision account-row signal-rows)
+               command {:account (if (keyword? account) account (keyword account))
+                        :risk (if (keyword? risk) risk (keyword risk))
+                        :action (if (keyword? action) action (keyword action))}]
+           (when-not (= account-id (:account command))
+             (reject! "renewal_plan names an unknown account" {:account account}))
+           (when-not (= expected (select-keys command [:risk :action]))
+             (reject! "renewal_plan decision is not supported by arena state"
+                      {:expected expected :actual (select-keys command [:risk :action])}))
+           (when-not (= expected-evidence supplied-evidence)
+             (reject! "renewal_plan requires the exact account evidence set"
+                      {:expected expected-evidence :actual supplied-evidence}))
+           (let [plan-id (plan-id run-id)
+                 charge-id (charge-id run-id)
+                 receipt (resource/consume!
+                          control-room run-id
+                          {:id charge-id :resources {review-unit 1}
+                           :actor (:actor ctx)})]
+             (d/transact
+              conn
+              [{:renewal.plan/id plan-id
+                :renewal.plan/account [:renewal.account/id account-id]
+                :renewal.plan/run-id run-id
+                :renewal.plan/risk (:risk expected)
+                :renewal.plan/action (:action expected)
+                :renewal.plan/evidence
+                (mapv (fn [id] [:renewal.signal/id id])
+                      (sort-by str expected-evidence))
+                :renewal.plan/status :proposed}])
+             (let [value {:plan/id plan-id
+                          :charge/id charge-id
+                          :receipt/id (:id receipt)}]
+               {:type :success
+                :content (pr-str value)
+                :metadata {:value value}}))))))})
+
+(defn register-tool! []
+  (tools/register! renewal-plan-tool)
+  renewal-plan-tool)
+
+(def expected-specialist-results
+  {:sales {:renewal.signal/id sales-signal-id
+           :renewal.signal/source :sales
+           :renewal.signal/kind :renewal-date
+           :renewal.signal/value "14"}
+   :support {:renewal.signal/id support-signal-id
+             :renewal.signal/source :support
+             :renewal.signal/kind :open-critical
+             :renewal.signal/count 3
+             :renewal.signal/severity :high}})
+
+(defn- read-result [value]
+  (if (string? value)
+    (try (edn/read-string value) (catch Throwable _ nil))
+    value))
+
+(defn- specialist-results-match? [children]
+  (= expected-specialist-results
+     (into {}
+           (map (fn [child]
+                  [(:run/actor child) (read-result (:run/value child))]))
+           children)))
+
+(defn- attach-specialist-results [children messages]
+  (mapv
+   (fn [child]
+     (let [output
+           (some #(when (and (= (:run/id child) (:message/run-id %))
+                             (= (:run/actor child) (:message/from %))
+                             (= :_runs (:message/to %))
+                             (not (:message/content-truncated? %)))
+                    (:message/content-preview %))
+                 messages)]
+       ;; Parse only the already-bounded projection and retain the canonical
+       ;; value, never the candidate's raw message body.
+       (assoc child :run/value (read-result output))))
+   children))
+
+(defn evaluator []
+  (evaluation/make-evaluator
+   {:id :business/renewal-intervention
+    :version arena-version
+    :basis {:scenario/content-id arena-content-id}
+    :observe
+    (fn [{control-room :room world-room :world/room
+          setup-evidence :setup/evidence run-id :run-id result :result}]
+      (let [conn (some-> world-room :store :conn)
+            control-conn (some-> control-room :store :conn)
+            plan-id (plan-id run-id)
+            snapshot (observation/snapshot
+                      control-room run-id
+                      {:run-limit 20 :message-limit 100
+                       :content-limit 1000 :content-budget 32000
+                       :detail-limit 100})
+            runs (:observation/runs snapshot)
+            children (filterv #(= run-id (:run/parent %)) runs)
+            messages (:observation/messages snapshot)
+            children (attach-specialist-results children messages)
+            receipt (store/-resource-receipt (:store control-room)
+                                             (charge-id run-id))]
+        {:setup setup-evidence
+         :result (:run/value result)
+         :plan (when conn (plan conn plan-id))
+         :root (some #(when (= run-id (:run/id %)) %) runs)
+         :children children
+         :activities (:observation/activities snapshot)
+         :completed-plan-tool-count
+         (or (when control-conn
+               (d/q '[:find (count ?call) .
+                      :in $ ?run
+                      :where
+                      [?call :tool-call/run-id ?run]
+                      [?call :tool-call/name "renewal_plan"]
+                      [?call :tool-call/status :completed]]
+                    @control-conn run-id))
+             0)
+         :receipt (select-keys receipt [:id :kind :source :destination
+                                        :resources])}))
+    :verify
+    (fn [_ {:keys [setup result plan root children activities receipt
+                   completed-plan-tool-count]}]
+      (let [child-ids (into #{} (map :run/id) children)
+            evidence-ids (into #{} (map :renewal.signal/id)
+                               (:renewal.plan/evidence plan))
+            plan-tools (filter #(= "renewal_plan" (:activity/tool-name %))
+                               activities)
+            result (if (string? result)
+                     (try (edn/read-string result) (catch Throwable _ nil))
+                     result)
+            checks
+            {:exact-setup? (= {:arena/content-id arena-content-id
+                               :account/id account-id
+                               :signal/ids #{sales-signal-id support-signal-id}}
+                              setup)
+             :one-plan? (some? plan)
+             :root-owned-plan? (= (:run/id root) (:renewal.plan/run-id plan))
+             :stable-plan-id? (= (plan-id (:run/id root)) (:renewal.plan/id plan))
+             :decision-derived? (= [:high :executive-escalation :proposed]
+                                   ((juxt :renewal.plan/risk
+                                          :renewal.plan/action
+                                          :renewal.plan/status) plan))
+             :exact-evidence? (= #{sales-signal-id support-signal-id} evidence-ids)
+             :two-specialists? (= #{:sales :support}
+                                  (set (map :run/actor children)))
+             :structural-parentage? (= 2 (count children))
+             :all-results-observed? (= child-ids (set (:run/caused-by root)))
+             :specialist-results? (specialist-results-match? children)
+             :specialists-completed? (every? #(= :completed (:run/status %)) children)
+             :specialists-merged? (every? #(= :merged (:run/settlement-status %)) children)
+             :one-plan-tool? (and (= 1 (count plan-tools))
+                                  (= 1 completed-plan-tool-count))
+             :charged-once? (and (= :consume (:kind receipt))
+                                 (= #{review-unit} (set (keys (:resources receipt))))
+                                 (== 1 (get (:resources receipt) review-unit 0)))
+             :returned-plan? (= (:renewal.plan/id plan)
+                                (or (:plan/id result) (:plan-id result)))}]
+        {:checks checks
+         :reward (if (every? true? (vals checks)) 1.0 0.0)}))}))

--- a/src/dvergr/agent/arenas/renewal.clj
+++ b/src/dvergr/agent/arenas/renewal.clj
@@ -328,8 +328,13 @@
 (defn- reject! [message data]
   (throw (ex-info message (assoc data :type ::invalid-plan-command))))
 
+(def tool-owner
+  {:kind :dvergr.agent.arena
+   :content-id arena-content-id})
+
 (def renewal-plan-tool
   {:name "renewal_plan"
+   :dvergr.tool/owner tool-owner
    :description
    (str "After hiring and awaiting the :sales and :support specialists, propose "
         "the verified Acme intervention using the exact signal UUID returned by "
@@ -401,10 +406,22 @@
                 :content (pr-str value)
                 :metadata {:value value}}))))))})
 
+(defn exact-tool-installed?
+  "Whether `tool` is this arena's exact stable tool contract.
+
+   The executable closure is deliberately excluded: reloading this namespace
+   creates a fresh function object without changing the durable tool contract."
+  [tool]
+  (= (dissoc renewal-plan-tool :execute)
+     (some-> tool (dissoc :execute))))
+
 (defn register-tool! []
   (if-let [installed (tools/get-tool "renewal_plan")]
-    (if (= renewal-plan-tool installed)
-      renewal-plan-tool
+    (if (exact-tool-installed? installed)
+      ;; Refresh the executable after an ordinary REPL namespace reload. The
+      ;; registry itself enforces compatible durable schema evolution.
+      (do (tools/register! renewal-plan-tool)
+          renewal-plan-tool)
       (throw (ex-info "A different renewal_plan tool is already installed"
                       {:type ::tool-name-conflict :name "renewal_plan"})))
     (do (tools/register! renewal-plan-tool)

--- a/src/dvergr/agent/arenas/renewal.clj
+++ b/src/dvergr/agent/arenas/renewal.clj
@@ -27,6 +27,19 @@
 (def support-signal-id
   (hasch/uuid [:dvergr/renewal-signal arena-version account-id :support]))
 
+(def specialist-output-contracts
+  {:sales
+   {:record :renewal.signal
+    :exact-fields
+    [:renewal.signal/id :renewal.signal/source
+     :renewal.signal/kind :renewal.signal/value]}
+   :support
+   {:record :renewal.signal
+    :exact-fields
+    [:renewal.signal/id :renewal.signal/source
+     :renewal.signal/kind :renewal.signal/count
+     :renewal.signal/severity]}})
+
 (def arena-basis
   {:account {:id account-id
              :name "Acme"
@@ -50,14 +63,15 @@
   {:objective :propose-renewal-intervention
    :account account-id
    :specialists [{:id :sales :task :report-sales-evidence
-                  :returns :sales-signal}
+                  :returns (:sales specialist-output-contracts)}
                  {:id :support :task :report-support-evidence
-                  :returns :support-signal}]
+                  :returns (:support specialist-output-contracts)}]
    :coordination {:hire :both
                   :await :both
                   :use-returned-signal-ids-as-plan-evidence true}
    :submission-tool "renewal_plan"
-   :requires-resource-receipt true})
+   :requires-resource-receipt true
+   :result {:exact-shape {:plan/id :uuid}}})
 
 (def verification-contract
   {:setup :exact-scenario
@@ -67,7 +81,8 @@
    :children {:count 2 :actors #{:sales :support}
               :status :completed :settlement :merged
               :causality :all-results-observed
-              :results {:sales sales-signal-id :support support-signal-id}}
+              :results {:match :exact-seeded-record-by-actor
+                        :contracts specialist-output-contracts}}
    :tool {:name "renewal_plan" :completed-count 1}
    :resource {:kind :consume :unit review-unit :amount 1}
    :result :returns-plan-id
@@ -199,8 +214,9 @@
     :verifier {:id :business/renewal-intervention
                :version arena-version
                :basis {:scenario/content-id arena-content-id}}
-    :limits {:timeout-ms 30000 :cancel-timeout-ms 5000
-             :max-model-steps 3 :budget-dollars 2.0}
+    :limits {:timeout-ms 120000 :cancel-timeout-ms 10000
+             ;; A malfunction fuse, not the conversational work budget.
+             :max-model-steps 16 :budget-dollars 2.0}
     :world {:isolation :ctx
             :settlement :discard
             :resources {review-unit 1}
@@ -401,6 +417,9 @@
                   [(:run/actor child) (read-result (:run/value child))]))
            children)))
 
+(defn- returned-plan-match? [plan result]
+  (= {:plan/id (:renewal.plan/id plan)} result))
+
 (defn- attach-specialist-results [children messages]
   (mapv
    (fn [child]
@@ -492,7 +511,6 @@
              :charged-once? (and (= :consume (:kind receipt))
                                  (= #{review-unit} (set (keys (:resources receipt))))
                                  (== 1 (get (:resources receipt) review-unit 0)))
-             :returned-plan? (= (:renewal.plan/id plan)
-                                (or (:plan/id result) (:plan-id result)))}]
+             :returned-plan? (returned-plan-match? plan result)}]
         {:checks checks
          :reward (if (every? true? (vals checks)) 1.0 0.0)}))}))

--- a/src/dvergr/agent/arenas/renewal.clj
+++ b/src/dvergr/agent/arenas/renewal.clj
@@ -10,6 +10,8 @@
             [dvergr.agent.environment :as environment]
             [dvergr.agent.evaluation :as evaluation]
             [dvergr.agent.observation :as observation]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
             [dvergr.resource :as resource]
             [dvergr.room.store :as store]
             [dvergr.room.store.datahike :as datahike-store]
@@ -63,8 +65,10 @@
   {:objective :propose-renewal-intervention
    :account account-id
    :specialists [{:id :sales :task :report-sales-evidence
+                  :program {:kind :scripted :reply :exact-seeded-record}
                   :returns (:sales specialist-output-contracts)}
                  {:id :support :task :report-support-evidence
+                  :program {:kind :scripted :reply :exact-seeded-record}
                   :returns (:support specialist-output-contracts)}]
    :coordination {:hire :both
                   :await :both
@@ -203,8 +207,8 @@
 (defn charge-id [run-id]
   (hasch/uuid [:dvergr/renewal-charge arena-content-id run-id account-id]))
 
-(defn mint-id [room-id amount]
-  (hasch/uuid [:dvergr/renewal-mint arena-content-id room-id amount]))
+(defn mint-id [room-id provision-id]
+  (hasch/uuid [:dvergr/renewal-mint arena-content-id room-id provision-id]))
 
 (defn environment-def []
   (environment/make-environment
@@ -242,15 +246,22 @@
          :signal/ids #{sales-signal-id support-signal-id}}))}))
 
 (defn provision-review-capacity!
-  "Install and mint `amount` review units in the durable control Room."
-  [room amount]
+  "Install and mint review units in the durable control Room.
+
+   `provision` is `{:id UUID :amount positive-integer}`. The caller-owned ID is
+   an idempotency identity: retrying the same event cannot mint twice, while a
+   distinct event can provision the same amount again."
+  [room {:keys [id amount] :as provision}]
+  (when-not (and (= #{:id :amount} (set (keys provision))) (uuid? id))
+    (throw (ex-info "Renewal provisioning requires exactly :id UUID and :amount"
+                    {:type ::invalid-provision :provision provision})))
   (when-not (and (integer? amount) (pos? amount))
     (throw (ex-info "Renewal review capacity must be a positive integer"
                     {:type ::invalid-review-capacity :amount amount})))
   (resource/install-unit! room {:symbol review-unit
                                 :name "Renewal reviews"
                                 :precision 0})
-  (resource/mint! room {:id (mint-id (:id room) amount)
+  (resource/mint! room {:id (mint-id (:id room) id)
                         :resources {review-unit amount}}))
 
 (defn- parse-evidence-uuid [value]
@@ -391,8 +402,13 @@
                 :metadata {:value value}}))))))})
 
 (defn register-tool! []
-  (tools/register! renewal-plan-tool)
-  renewal-plan-tool)
+  (if-let [installed (tools/get-tool "renewal_plan")]
+    (if (= renewal-plan-tool installed)
+      renewal-plan-tool
+      (throw (ex-info "A different renewal_plan tool is already installed"
+                      {:type ::tool-name-conflict :name "renewal_plan"})))
+    (do (tools/register! renewal-plan-tool)
+        renewal-plan-tool)))
 
 (def expected-specialist-results
   {:sales {:renewal.signal/id sales-signal-id
@@ -405,6 +421,24 @@
              :renewal.signal/count 3
              :renewal.signal/severity :high}})
 
+(defn specialist-fixture-roster
+  "Return the exact deterministic specialist-service fixture for this arena.
+
+   These scripted children certify recursive construction, hiring, observation,
+   merge, and provenance. They deliberately do not claim to measure specialist
+   model reasoning; paid recursive model work awaits metered provider effects."
+  []
+  (reduce-kv
+   (fn [team id reply]
+     (roster/make-agent team {:id id :program {:kind :scripted :reply reply}}))
+   (roster/make-roster {:id :renewal-specialists})
+   expected-specialist-results))
+
+(def expected-specialist-agent-hashes
+  (into {}
+        (map (fn [agent] [(:agent/id agent) (hasch/uuid agent)]))
+        (roster/agents (specialist-fixture-roster))))
+
 (defn- read-result [value]
   (if (string? value)
     (try (edn/read-string value) (catch Throwable _ nil))
@@ -415,6 +449,12 @@
      (into {}
            (map (fn [child]
                   [(:run/actor child) (read-result (:run/value child))]))
+           children)))
+
+(defn- specialist-definitions-match? [children]
+  (= expected-specialist-agent-hashes
+     (into {}
+           (map (juxt :run/actor :run/agent-def-hash))
            children)))
 
 (defn- returned-plan-match? [plan result]
@@ -435,6 +475,46 @@
        (assoc child :run/value (read-result output))))
    children))
 
+(defn- verification-checks
+  [{:keys [setup result plan plan-count root children activities receipt
+           completed-plan-tool-count]}]
+  (let [child-ids (into #{} (map :run/id) children)
+        evidence-ids (into #{} (map :renewal.signal/id)
+                           (:renewal.plan/evidence plan))
+        plan-tools (filter #(= "renewal_plan" (:activity/tool-name %))
+                           activities)
+        result (read-result result)]
+    {:exact-setup? (= {:arena/content-id arena-content-id
+                       :account/id account-id
+                       :signal/ids #{sales-signal-id support-signal-id}}
+                      setup)
+     :one-plan? (and (= 1 plan-count) (some? plan))
+     :root-owned-plan? (= (:run/id root) (:renewal.plan/run-id plan))
+     :stable-plan-id? (= (plan-id (:run/id root)) (:renewal.plan/id plan))
+     :decision-derived? (= [:high :executive-escalation :proposed]
+                           ((juxt :renewal.plan/risk
+                                  :renewal.plan/action
+                                  :renewal.plan/status) plan))
+     :exact-evidence? (= #{sales-signal-id support-signal-id} evidence-ids)
+     :two-specialists? (= #{:sales :support} (set (map :run/actor children)))
+     :structural-parentage? (= 2 (count children))
+     :all-results-observed? (= child-ids (set (:run/caused-by root)))
+     :specialist-results? (specialist-results-match? children)
+     :specialist-definitions? (specialist-definitions-match? children)
+     :specialists-completed? (every? #(= :completed (:run/status %)) children)
+     :specialists-merged? (every? #(= :merged (:run/settlement-status %)) children)
+     :one-plan-tool? (and (= 1 (count plan-tools))
+                          (= 1 completed-plan-tool-count))
+     :charged-once? (and (= :consume (:kind receipt))
+                         (= #{review-unit} (set (keys (:resources receipt))))
+                         (== 1 (get (:resources receipt) review-unit 0)))
+     :returned-plan? (returned-plan-match? plan result)}))
+
+(defn- verification-result [evidence]
+  (let [checks (verification-checks evidence)]
+    {:checks checks
+     :reward (if (every? true? (vals checks)) 1.0 0.0)}))
+
 (defn evaluator []
   (evaluation/make-evaluator
    {:id :business/renewal-intervention
@@ -452,14 +532,28 @@
                        :content-limit 1000 :content-budget 32000
                        :detail-limit 100})
             runs (:observation/runs snapshot)
-            children (filterv #(= run-id (:run/parent %)) runs)
+            durable-runs (into {}
+                               (map (juxt :run/id identity))
+                               (run/runs control-room
+                                         {:root-run-id run-id :limit 20}))
+            children (->> runs
+                          (filter #(= run-id (:run/parent %)))
+                          (mapv #(merge %
+                                        (select-keys
+                                         (get durable-runs (:run/id %))
+                                         [:run/agent-def-hash]))))
             messages (:observation/messages snapshot)
             children (attach-specialist-results children messages)
             receipt (store/-resource-receipt (:store control-room)
-                                             (charge-id run-id))]
+                                             (charge-id run-id))
+            plan-count (when conn
+                         (d/q '[:find (count ?plan) .
+                                :where [?plan :renewal.plan/id]]
+                              @conn))]
         {:setup setup-evidence
          :result (:run/value result)
          :plan (when conn (plan conn plan-id))
+         :plan-count (or plan-count 0)
          :root (some #(when (= run-id (:run/id %)) %) runs)
          :children children
          :activities (:observation/activities snapshot)
@@ -475,42 +569,4 @@
              0)
          :receipt (select-keys receipt [:id :kind :source :destination
                                         :resources])}))
-    :verify
-    (fn [_ {:keys [setup result plan root children activities receipt
-                   completed-plan-tool-count]}]
-      (let [child-ids (into #{} (map :run/id) children)
-            evidence-ids (into #{} (map :renewal.signal/id)
-                               (:renewal.plan/evidence plan))
-            plan-tools (filter #(= "renewal_plan" (:activity/tool-name %))
-                               activities)
-            result (if (string? result)
-                     (try (edn/read-string result) (catch Throwable _ nil))
-                     result)
-            checks
-            {:exact-setup? (= {:arena/content-id arena-content-id
-                               :account/id account-id
-                               :signal/ids #{sales-signal-id support-signal-id}}
-                              setup)
-             :one-plan? (some? plan)
-             :root-owned-plan? (= (:run/id root) (:renewal.plan/run-id plan))
-             :stable-plan-id? (= (plan-id (:run/id root)) (:renewal.plan/id plan))
-             :decision-derived? (= [:high :executive-escalation :proposed]
-                                   ((juxt :renewal.plan/risk
-                                          :renewal.plan/action
-                                          :renewal.plan/status) plan))
-             :exact-evidence? (= #{sales-signal-id support-signal-id} evidence-ids)
-             :two-specialists? (= #{:sales :support}
-                                  (set (map :run/actor children)))
-             :structural-parentage? (= 2 (count children))
-             :all-results-observed? (= child-ids (set (:run/caused-by root)))
-             :specialist-results? (specialist-results-match? children)
-             :specialists-completed? (every? #(= :completed (:run/status %)) children)
-             :specialists-merged? (every? #(= :merged (:run/settlement-status %)) children)
-             :one-plan-tool? (and (= 1 (count plan-tools))
-                                  (= 1 completed-plan-tool-count))
-             :charged-once? (and (= :consume (:kind receipt))
-                                 (= #{review-unit} (set (keys (:resources receipt))))
-                                 (== 1 (get (:resources receipt) review-unit 0)))
-             :returned-plan? (returned-plan-match? plan result)}]
-        {:checks checks
-         :reward (if (every? true? (vals checks)) 1.0 0.0)}))}))
+    :verify (fn [_ evidence] (verification-result evidence))}))

--- a/test/dvergr/agent/arenas/renewal_test.clj
+++ b/test/dvergr/agent/arenas/renewal_test.clj
@@ -1,0 +1,306 @@
+(ns dvergr.agent.arenas.renewal-test
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.api :as dh]
+            [dvergr.agent.arenas.renewal :as renewal]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.agent.world :as world]
+            [dvergr.chat.agent :as chat-agent]
+            [dvergr.discourse :as discourse]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.providers :as providers]
+            [dvergr.orchestration.daemon :as daemon]
+            [dvergr.resource :as resource]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store :as store]
+            [dvergr.rooms :as rooms]
+            [dvergr.substrate.paths :as paths]
+            [dvergr.system.db :as system-db]
+            [dvergr.system.rooms :as system-rooms]
+            [dvergr.tools :as tools]
+            [kontor.governance :as kontor-governance]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(defn- delete-tree! [path]
+  (when (.exists (io/file path))
+    (run! io/delete-file (reverse (file-seq (io/file path))))))
+
+(defn- with-production-room [f]
+  (let [original-home (paths/home)
+        test-home (str (io/file (System/getProperty "java.io.tmpdir")
+                                (str "dvergr-renewal-arena-" (random-uuid))))
+        root (atom nil)
+        room (atom nil)]
+    (try
+      (paths/set-home! test-home)
+      (system-db/reset-conn!)
+      (system-rooms/clear-room-ctxs!)
+      (let [root-ctx (daemon/create-shared-context :with-git? false)]
+        (reset! root root-ctx)
+        (binding [ec/*execution-context* root-ctx]
+          (let [slug (str "renewal-arena-" (random-uuid))
+                room-id (rooms/create-room! {:slug slug :title "Renewal arena"
+                                             :parent-id false})
+                live (registry/lookup room-id)]
+            (when-not live
+              (throw (ex-info "Production renewal test Room was not provisioned"
+                              {:room/id room-id})))
+            (reset! room live)
+            (binding [ec/*execution-context* (:ctx live)]
+              (f live)))))
+      (finally
+        (when-let [live @room]
+          (try
+            (binding [ec/*execution-context* (:ctx live)]
+              (kontor-governance/ungovern! (:conn (:store live)))
+              (discourse/close-room! live))
+            (catch Throwable _)))
+        (system-rooms/clear-room-ctxs!)
+        (system-db/reset-conn!)
+        (when-let [root-ctx @root]
+          (try (context/close-context! root-ctx) (catch Throwable _)))
+        (paths/set-home! original-home)
+        (delete-tree! test-home)))))
+
+(defn- invoke-setup! [setup work-room run-id]
+  ((:prepare setup) {:room work-room
+                     :run/id run-id
+                     :environment (renewal/environment-def)}))
+
+(deftest portable-task-exposes-recursion-and-verifier-requires-child-results
+  (let [task (:environment/task (renewal/environment-def))
+        real-children (mapv (fn [[actor value]]
+                              {:run/id (random-uuid)
+                               :run/actor actor :run/value value})
+                            renewal/expected-specialist-results)
+        messages (mapv (fn [{:run/keys [id actor value]}]
+                         {:message/run-id id :message/from actor
+                          :message/to :_runs
+                          :message/content-truncated? false
+                          :message/content-preview (pr-str value)})
+                       real-children)
+        children-without-values (mapv #(dissoc % :run/value) real-children)]
+    (is (= renewal/task-contract task))
+    (is (= #{:sales :support} (set (map :id (:specialists task)))))
+    (is (true? (#'renewal/specialist-results-match? real-children)))
+    (is (false? (#'renewal/specialist-results-match?
+                 (mapv #(assoc % :run/value nil) real-children)))
+        "child topology without the specialists' returned evidence is insufficient")
+    (is (true? (#'renewal/specialist-results-match?
+                (#'renewal/attach-specialist-results
+                 children-without-values messages))))
+    (is (false? (#'renewal/specialist-results-match?
+                 (#'renewal/attach-specialist-results
+                  children-without-values
+                  (mapv #(assoc % :message/content-truncated? true) messages))))
+        "a truncated child body is never parsed or certified")))
+
+(deftest setup-and-semantic-tool-use-the-real-fork-and-affine-book
+  (with-production-room
+    (fn [room]
+      (renewal/provision-review-capacity! room 1)
+      (let [run-id (random-uuid)
+            trigger (discourse/message :test :_runs "renewal" nil {:role :user})
+            run-world (world/open! room run-id :discard)
+            work-room (:work run-world)
+            setup (renewal/world-setup)]
+        (try
+          (discourse/post! room trigger)
+          (run/start! room :candidate trigger nil {:id run-id})
+          (resource/allocate-run! room run-id nil {renewal/review-unit 1})
+          (let [setup-evidence (invoke-setup! setup work-room run-id)
+                work-conn (:conn (:store work-room))
+                parent-conn (:conn (:store room))
+                tool-ctx {:db-conn work-conn
+                          :control-room room
+                          :run-id run-id
+                          :actor :candidate
+                          :tools {"renewal_plan" renewal/renewal-plan-tool}}
+                valid-input {:account "acme"
+                             :risk "high"
+                             :action "executive-escalation"
+                             :evidence [(str renewal/sales-signal-id)
+                                        (str renewal/support-signal-id)]}]
+            (is (= renewal/arena-content-id (:arena/content-id setup-evidence)))
+            (is (= renewal/arena-content-id
+                   (dh/q '[:find ?id . :where [?e :arena/id ?id]] @work-conn)))
+            (is (nil? (dh/q '[:find ?id . :where [?e :arena/id ?id]] @parent-conn))
+                "trusted setup writes only into the Run branch")
+
+            (testing "invalid evidence is rejected before charging"
+              (doseq [evidence [[(str renewal/sales-signal-id)]
+                                [(str renewal/sales-signal-id)
+                                 (str renewal/support-signal-id)
+                                 "not-a-uuid"]
+                                [(str renewal/sales-signal-id)
+                                 (str renewal/sales-signal-id)]]]
+                (let [invalid (tools/execute
+                               "renewal_plan"
+                               (assoc valid-input :evidence evidence)
+                               tool-ctx)]
+                  (is (= :error (:type invalid)) (pr-str evidence invalid))
+                  (is (= {renewal/review-unit 1M}
+                         (resource/run-balance room run-id)))
+                  (is (nil? (store/-resource-receipt
+                             (:store room) (renewal/charge-id run-id)))))))
+
+            (testing "a stable retry neither writes nor charges twice"
+              (let [first-result (tools/execute "renewal_plan" valid-input tool-ctx)
+                    second-result (tools/execute "renewal_plan" valid-input tool-ctx)
+                    charge (store/-resource-receipt
+                            (:store room) (renewal/charge-id run-id))]
+                (is (= :success (:type first-result) (:type second-result))
+                    (pr-str first-result second-result))
+                (is (= (get-in first-result [:metadata :value])
+                       (get-in second-result [:metadata :value])))
+                (is (= :consume (:kind charge)))
+                (is (= {renewal/review-unit 1M} (:resources charge)))
+                (is (= 1
+                       (dh/q '[:find (count ?plan) .
+                               :where [?plan :renewal.plan/id]]
+                             @work-conn)))
+                (is (= {} (resource/run-balance room run-id)))))
+            (let [{:keys [status reason]} (world/settle! run-world :completed)]
+              (run/finish! run-id :completed
+                           {:settlement-status status
+                            :settlement-reason reason}))
+            (is (nil? (registry/lookup (:id run-world))))
+            (is (nil? (dh/q '[:find ?id . :where [?e :arena/id ?id]] @parent-conn))
+                "discard leaves the durable parent business state unchanged"))
+          (finally
+            (when (some #(= run-id (:run/id %)) (run/active-runs))
+              (run/finish! run-id :cancelled {:reason :test-cleanup}))
+            (when (registry/lookup (:id run-world))
+              (discourse/discard (:work run-world)))))))))
+
+(def recursive-evidence-program
+  (str
+   "(require '[datahike.api :as d] '[dvergr.room :as room] "
+   "         '[dvergr.agent :as agent] "
+   "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+   "         '[org.replikativ.spindel.effects.await :refer [await]] "
+   "         '[spindel.comb :as comb]) "
+   "(let [signals (d/q '[:find [(pull ?e [:renewal.signal/id "
+   "                                      :renewal.signal/source "
+   "                                      :renewal.signal/kind "
+   "                                      :renewal.signal/value "
+   "                                      :renewal.signal/count "
+   "                                      :renewal.signal/severity]) ...] "
+   "                           :where [?e :renewal.signal/id]] @room/*room*) "
+   "      sales (first (filter #(= :sales (:renewal.signal/source %)) signals)) "
+   "      support (first (filter #(= :support (:renewal.signal/source %)) signals)) "
+   "      team (-> (agent/roster {:id :renewal-specialists}) "
+   "               (agent/make-agent {:id :sales :program {:kind :scripted :reply sales}}) "
+   "               (agent/make-agent {:id :support :program {:kind :scripted :reply support}})) "
+   "      a (agent/hire! team :sales {:task :report-sales-evidence}) "
+   "      b (agent/hire! team :support {:task :report-support-evidence}) "
+   "      [ra rb] @(spin (await (comb/parallel (agent/result-spin a) "
+   "                                           (agent/result-spin b))))] "
+   "  {:sales (:run/value ra) :support (:run/value rb)})"))
+
+(defn- tool-result [messages id]
+  (some (fn [message]
+          (when (and (= :tool-result (:message/role message))
+                     (= id (:message/tool-use-id message)))
+            (:message/content message)))
+        messages))
+
+(defn- read-tool-edn [content]
+  (when (string? content)
+    (edn/read-string (if (str/starts-with? content "=> ")
+                       (subs content 3)
+                       content))))
+
+(deftest deterministic-model-certifies-a-consequential-recursive-business-run
+  (with-production-room
+    (fn [room]
+      (let [previous-tool (tools/get-tool "renewal_plan")]
+        (try
+          (renewal/register-tool!)
+          (renewal/provision-review-capacity! room 1)
+          (let [environment (renewal/environment-def)
+                team (-> (roster/make-roster {:id :renewal/candidates})
+                         (roster/make-agent
+                          {:id :simulated-model
+                           :tools #{:clojure-eval :renewal-plan}
+                           :model-policy {:provider :test :model "deterministic"}
+                           :program {:kind :llm :max-model-steps 3
+                                     :budget-dollars 2.0 :auto-compact? false}}))
+                definition
+                (experiment/make-experiment
+                 {:id :business/renewal-intervention-v1
+                  :dataset (experiment/make-dataset
+                            {:id :business/renewal-intervention-v1
+                             :environments [environment]})
+                  :candidates [(roster/agent team :simulated-model)]})
+                calls (atom 0)]
+            (with-redefs
+             [providers/ensure-initialized! (constantly nil)
+              chat-agent/messages->api-format (fn [messages _ _] messages)
+              model-chat/chat
+              (fn [messages _]
+                (case (swap! calls inc)
+                  1 {:content ""
+                     :tool-calls [{:id "collect-evidence"
+                                   :name "clojure_eval"
+                                   :input {:code recursive-evidence-program}}]
+                     :usage {:input-tokens 10 :output-tokens 20}
+                     :stop-reason :tool-use}
+                  2 (let [{:keys [sales support]}
+                          (read-tool-edn (tool-result messages "collect-evidence"))]
+                      {:content ""
+                       :tool-calls
+                       [{:id "propose-plan"
+                         :name "renewal_plan"
+                         :input {:account "acme"
+                                 :risk "high"
+                                 :action "executive-escalation"
+                                 :evidence [(str (:renewal.signal/id sales))
+                                            (str (:renewal.signal/id support))]}}]
+                       :usage {:input-tokens 30 :output-tokens 20}
+                       :stop-reason :tool-use})
+                  3 (let [plan (read-tool-edn
+                                (tool-result messages "propose-plan"))]
+                      {:content (pr-str {:plan/id (:plan/id plan)})
+                       :tool-calls nil
+                       :usage {:input-tokens 30 :output-tokens 10}
+                       :stop-reason :end-turn})
+                  (throw (ex-info "deterministic model called too often"
+                                  {:calls @calls}))))]
+              (let [{:keys [attempts scorecard]}
+                    @(experiment/run
+                      room team definition
+                      {renewal/verifier-ref (renewal/evaluator)}
+                      {:parallelism 1
+                       :world-setups {renewal/setup-ref (renewal/world-setup)}})
+                    attempt (first attempts)
+                    checks (get-in attempt [:attempt/receipt :attempt/checks])
+                    run-id (:attempt/run-id attempt)
+                    durable-runs (run/runs room {:limit 20})
+                    parent-conn (:conn (:store room))]
+                (is (= 3 @calls))
+                (is (= 1 (count attempts)))
+                (is (every? true? (vals checks)) (pr-str checks))
+                (is (= 1.0 (get-in attempt [:attempt/receipt :attempt/reward])))
+                (is (= scorecard
+                       (experiment/scorecard room (:scorecard/content-id scorecard))))
+                (is (= :discarded
+                       (:run/settlement-status
+                        (some #(when (= run-id (:run/id %)) %) durable-runs))))
+                (is (every? #(nil? (registry/lookup (:run/world %))) durable-runs))
+                (is (nil? (dh/q '[:find ?id . :where [?e :arena/id ?id]]
+                                @parent-conn)))
+                (is (= {} (resource/balance room))
+                    "the review unit is consumed even though speculative state is discarded"))))
+          (finally
+            (evaluation/await-cleanups! room 5000)
+            (if previous-tool
+              (tools/register! previous-tool)
+              (swap! tools/registry dissoc "renewal_plan"))))))))

--- a/test/dvergr/agent/arenas/renewal_test.clj
+++ b/test/dvergr/agent/arenas/renewal_test.clj
@@ -121,6 +121,22 @@
       (is (false? (#'renewal/returned-plan-match?
                    plan {:plan/id id :extra true}))))))
 
+(deftest arena-tool-registration-survives-namespace-style-reload
+  (let [previous-tool (tools/get-tool "renewal_plan")
+        stale-closure-tool
+        (assoc renewal/renewal-plan-tool :execute (fn [_ _] :stale))]
+    (try
+      (tools/register! stale-closure-tool)
+      (is (renewal/exact-tool-installed? (tools/get-tool "renewal_plan")))
+      (renewal/register-tool!)
+      (is (identical? (:execute renewal/renewal-plan-tool)
+                      (:execute (tools/get-tool "renewal_plan")))
+          "registration refreshes only the reload-sensitive executable")
+      (finally
+        (if previous-tool
+          (tools/register! previous-tool)
+          (swap! tools/registry dissoc "renewal_plan"))))))
+
 (deftest setup-and-semantic-tool-use-the-real-fork-and-affine-book
   (with-production-room
     (fn [room]

--- a/test/dvergr/agent/arenas/renewal_test.clj
+++ b/test/dvergr/agent/arenas/renewal_test.clj
@@ -92,6 +92,10 @@
     (is (= {:exact-shape {:plan/id :uuid}} (:result task)))
     (is (every? #(= :renewal.signal (get-in % [:returns :record]))
                 (:specialists task)))
+    (is (every? #(= {:kind :scripted :reply :exact-seeded-record}
+                    (:program %))
+                (:specialists task))
+        "the portable contract describes fixture semantics honestly")
     (is (every? #(not (contains? (:returns %) :required-fields))
                 (:specialists task)))
     (is (true? (#'renewal/specialist-results-match? real-children)))
@@ -120,7 +124,14 @@
 (deftest setup-and-semantic-tool-use-the-real-fork-and-affine-book
   (with-production-room
     (fn [room]
-      (renewal/provision-review-capacity! room 1)
+      (let [provision-id (random-uuid)]
+        (renewal/provision-review-capacity!
+         room {:id provision-id :amount 1})
+        (is (= {renewal/review-unit 1M} (resource/balance room)))
+        (renewal/provision-review-capacity!
+         room {:id provision-id :amount 1})
+        (is (= {renewal/review-unit 1M} (resource/balance room))
+            "retrying one provisioning event is idempotent"))
       (let [run-id (random-uuid)
             trigger (discourse/message :test :_runs "renewal" nil {:role :user})
             run-world (world/open! room run-id :discard)
@@ -182,6 +193,10 @@
                                :where [?plan :renewal.plan/id]]
                              @work-conn)))
                 (is (= {} (resource/run-balance room run-id)))))
+            (renewal/provision-review-capacity!
+             room {:id (random-uuid) :amount 1})
+            (is (= {renewal/review-unit 1M} (resource/balance room))
+                "a distinct provisioning event may add the same amount again")
             (let [{:keys [status reason]} (world/settle! run-world :completed)]
               (run/finish! run-id :completed
                            {:settlement-status status
@@ -239,7 +254,8 @@
       (let [previous-tool (tools/get-tool "renewal_plan")]
         (try
           (renewal/register-tool!)
-          (renewal/provision-review-capacity! room 1)
+          (renewal/provision-review-capacity!
+           room {:id (random-uuid) :amount 1})
           (let [environment (renewal/environment-def)
                 team (-> (roster/make-roster {:id :renewal/candidates})
                          (roster/make-agent
@@ -297,6 +313,7 @@
                        :world-setups {renewal/setup-ref (renewal/world-setup)}})
                     attempt (first attempts)
                     checks (get-in attempt [:attempt/receipt :attempt/checks])
+                    evidence (:attempt/evidence attempt)
                     run-id (:attempt/run-id attempt)
                     durable-runs (run/runs room {:limit 20})
                     parent-conn (:conn (:store room))]
@@ -304,6 +321,20 @@
                 (is (= 1 (count attempts)))
                 (is (every? true? (vals checks)) (pr-str checks))
                 (is (= 1.0 (get-in attempt [:attempt/receipt :attempt/reward])))
+                (let [extra-plan ((:verify (renewal/evaluator))
+                                  environment (assoc evidence :plan-count 2))
+                      forged-child
+                      ((:verify (renewal/evaluator))
+                       environment
+                       (update-in evidence [:children 0 :run/agent-def-hash]
+                                  (constantly (random-uuid))))]
+                  (is (false? (get-in extra-plan [:checks :one-plan?]))
+                      "an additional candidate-authored plan loses certification")
+                  (is (zero? (:reward extra-plan)))
+                  (is (false? (get-in forged-child
+                                      [:checks :specialist-definitions?]))
+                      "arbitrary scripted provenance cannot impersonate the fixture")
+                  (is (zero? (:reward forged-child))))
                 (is (= scorecard
                        (experiment/scorecard room (:scorecard/content-id scorecard))))
                 (is (= :discarded

--- a/test/dvergr/agent/arenas/renewal_test.clj
+++ b/test/dvergr/agent/arenas/renewal_test.clj
@@ -89,7 +89,16 @@
         children-without-values (mapv #(dissoc % :run/value) real-children)]
     (is (= renewal/task-contract task))
     (is (= #{:sales :support} (set (map :id (:specialists task)))))
+    (is (= {:exact-shape {:plan/id :uuid}} (:result task)))
+    (is (every? #(= :renewal.signal (get-in % [:returns :record]))
+                (:specialists task)))
+    (is (every? #(not (contains? (:returns %) :required-fields))
+                (:specialists task)))
     (is (true? (#'renewal/specialist-results-match? real-children)))
+    (is (false? (#'renewal/specialist-results-match?
+                 (update-in real-children [0 :run/value]
+                            assoc :renewal.signal/extra true)))
+        "the visible exact-fields contract rejects extra child output")
     (is (false? (#'renewal/specialist-results-match?
                  (mapv #(assoc % :run/value nil) real-children)))
         "child topology without the specialists' returned evidence is insufficient")
@@ -100,7 +109,13 @@
                  (#'renewal/attach-specialist-results
                   children-without-values
                   (mapv #(assoc % :message/content-truncated? true) messages))))
-        "a truncated child body is never parsed or certified")))
+        "a truncated child body is never parsed or certified")
+    (let [id (random-uuid)
+          plan {:renewal.plan/id id}]
+      (is (true? (#'renewal/returned-plan-match? plan {:plan/id id})))
+      (is (false? (#'renewal/returned-plan-match? plan {:plan-id id})))
+      (is (false? (#'renewal/returned-plan-match?
+                   plan {:plan/id id :extra true}))))))
 
 (deftest setup-and-semantic-tool-use-the-real-fork-and-affine-book
   (with-production-room


### PR DESCRIPTION
Adds the first consequential business-state arena on the certified experiment path: real Room/Datahike state, isolated recursive Run worlds, exact scripted specialist-service fixtures, Kontor-backed review capacity, semantic plan submission, trusted verification, and an opt-in Codex/Claude REPL runner.

Dependency: requires replikativ/yggdrasil#20 and a subsequent Yggdrasil release before this PR can become mergeable. Released 0.3.41 replays inherited anonymous Kontor postings during child-world merge; the generic semantic three-way merge fix makes the complete arena test pass without weakening accounting invariants.

Verification with the Yggdrasil #20 worktree override: formatting and diff checks pass; 3 tests, 50 assertions, 0 failures.

The scripted children intentionally certify recursive orchestration, provenance, world ownership, resource conservation, and settlement—not specialist model reasoning. Paid nested-provider evaluation follows once provider usage is debited from conserved Run wallets.
