### PR TITLE
Fix live model switching across calls, tools, and forks

### DIFF
--- a/src/dvergr/discourse/llm.clj
+++ b/src/dvergr/discourse/llm.clj
@@ -59,6 +59,7 @@
             [dvergr.agent.process :as proc]
             [dvergr.room.store :as rstore]
             [dvergr.system.rooms :as srooms]
+            [dvergr.model.registry :as model-registry]
             [dvergr.model.quirks :as quirks]
             [org.replikativ.spindel.spin.sync :as ssync]
             [taoensso.telemere :as tel]
@@ -72,6 +73,16 @@
   "Default `run-turn-fn`: delegates to `dvergr.chat.agent/run-agent-turn!`."
   [chat-ctx opts]
   (ca/run-agent-turn! chat-ctx opts))
+
+(defn- admit-model-spec
+  "Complete one call-boundary model policy without overriding an explicit
+   provider. Unknown models retain the prior nil-provider failure semantics."
+  [spec]
+  (if (or (:provider spec) (nil? (:model spec)))
+    spec
+    (if-let [provider (some-> (:model spec) model-registry/get-model :provider)]
+      (assoc spec :provider provider)
+      spec)))
 
 (defn- assistant-text
   "Extract a string from an assistant message entity. Handles plain-string
@@ -439,18 +450,9 @@
                          tool-ctx          (cond-> (assoc tool-ctx
                                                           :execution-ctx turn-ctx
                                                           :control-room room
-                                                          :actor id
-                                                          :model-policy
-                                                          (select-keys spec
-                                                                       [:provider :model]))
+                                                          :actor id)
                                              run-id (assoc :run-id run-id))
-                         turn-opts {:provider         (:provider spec)
-                                ;; Per-room /model override (commands registry)
-                                ;; wins over the spec's model, matching the daemon.
-                                    :model            (or (when room
-                                                            (commands/model-override (:id room) id))
-                                                          (:model spec))
-                                    :tools            tools
+                         turn-opts {:tools            tools
                                     :tool-ctx         tool-ctx
                                 ;; SSE-abort predicate (Esc-cancel flips status).
                                     :cancel?          (turn/cancel?-fn
@@ -579,12 +581,32 @@
                                                   chat-ctx
                                                   :model (:model compaction))
                                                  (catch Throwable _ nil))))))))
-                             (let [h (gen/future-handle
+                             (let [;; Admit one immutable spec snapshot for the
+                                   ;; whole provider/tool step. A switch directive
+                                   ;; changes `spec-atom`, settles this call, and
+                                   ;; the restart admits the new snapshot. `/model`
+                                   ;; remains the room-local model override.
+                                   room-model-override
+                                   (when room
+                                     (commands/model-override (:id room) id))
+                                   admitted-spec
+                                   (admit-model-spec
+                                    (cond-> @spec-atom
+                                      room-model-override
+                                      (assoc :model room-model-override)))
+                                   admitted-tool-ctx
+                                   (assoc tool-ctx :model-policy
+                                          (select-keys admitted-spec
+                                                       [:provider :model]))
+                                   h (gen/future-handle
                                       turn-ctx
                                       #(run-turn-fn chat-ctx
                                                     (assoc turn-opts
+                                                           :provider (:provider admitted-spec)
+                                                           :model (:model admitted-spec)
+                                                           :tool-ctx admitted-tool-ctx
                                                            :turn-number turn
-                                                           :spec @spec-atom
+                                                           :spec admitted-spec
                                                            :tools tools
                                                            :run-id run-id)))
                                    call-id (random-uuid)
@@ -958,7 +980,10 @@
          ;; through the stable component ref. `:none` remains a lightweight
          ;; message-only clone. The room-less fallback stays lazy in both cases.
               (llm-agent {:id          id
-                          :spec        spec
+                          ;; A fork snapshots the latest admitted participant
+                          ;; policy, then owns an independent spec atom. Existing
+                          ;; forks therefore remain isolated from later switches.
+                          :spec        @spec-atom
                           :tools       tools
                           :db-conn     db-conn
                           :budget      budget

--- a/test/dvergr/discourse/llm_test.clj
+++ b/test/dvergr/discourse/llm_test.clj
@@ -7,7 +7,12 @@
             [dvergr.discourse :as d]
             [dvergr.discourse.attention :as attention]
             [dvergr.discourse.llm :as llm]
+            [dvergr.chat.agent :as chat-agent]
             [dvergr.chat.context :as cc]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.provider :as model-provider]
+            [dvergr.model.providers :as model-providers]
+            [dvergr.model.registry :as model-registry]
             [dvergr.runtime.ctx :as runtime-ctx]
             [dvergr.sandbox :as sandbox]
             [dvergr.agent.run :as run]
@@ -543,11 +548,12 @@
 
 (defn- make-queued-turn-fn
   "Each element of `steps-atom` is (fn [chat-ctx opts] -> result), consumed
-   one per LLM call. Exhausted → :complete. `calls-log` records the :spec
-   each call saw."
+   one per LLM call. Exhausted → :complete. `calls-log` records the admitted
+   model policy each call saw."
   [steps-atom calls-log]
   (fn [chat-ctx opts]
-    (swap! calls-log conj {:spec (:spec opts)})
+    (swap! calls-log conj
+           (select-keys opts [:provider :model :spec :tool-ctx]))
     (let [step (first @steps-atom)]
       (swap! steps-atom rest)
       (if step (step chat-ctx opts) :complete))))
@@ -1079,4 +1085,162 @@
           (is (= "answer from new model" (:content reply)))
           (is (= 2 (count @calls)))
           (is (= "mock-2" (get-in (second @calls) [:spec :model]))
-              "restarted call carries the swapped model in its spec"))))))
+              "restarted call carries the swapped model in its spec")
+          (is (= {:provider :mock :model "mock-2"}
+                 (select-keys (second @calls) [:provider :model]))
+              "the real turn options, not only the diagnostic spec, switch")
+          (is (= {:provider :mock :model "mock-2"}
+                 (get-in (second @calls) [:tool-ctx :model-policy]))
+              "delegation inherits the admitted provider and model")
+          (is (= :mock (:provider (second @calls)))
+              "omitting provider from the directive preserves the current one"))))))
+
+(deftest idle-switch-drives-the-default-turn-options
+  (testing "the shipped run-turn bridge receives the switched provider and model"
+    (let [r (d/room :default-switch-room)
+          calls (atom [])]
+      (try
+        (with-redefs [chat-agent/run-agent-turn!
+                      (fn [chat-ctx opts]
+                        (swap! calls conj opts)
+                        (cc/add-message! chat-ctx
+                                         {:role :assistant :content "switched"})
+                        :complete)]
+          (binding [ec/*execution-context* (:ctx r)]
+            (d/join r (llm/llm-agent
+                       {:id :switch-worker
+                        :spec {:provider :old-provider :model "old-model"}})))
+          (d/post! r {:to :switch-worker
+                      :type :directive/switch-model
+                      :payload {:provider :new-provider :model "new-model"}})
+          (is (= "switched"
+                 (:content
+                  (await-spin r #(d/ask % :switch-worker {:content "go"})
+                              10000))))
+          (is (= {:provider :new-provider :model "new-model"}
+                 (select-keys (first @calls) [:provider :model])))
+          (is (= {:provider :new-provider :model "new-model"}
+                 (get-in (first @calls) [:tool-ctx :model-policy]))))
+        (finally
+          (d/close-room! r))))))
+
+(deftest omitted-provider-is-completed-from-the-model-registry
+  (let [r (d/room :provider-inference-room)
+        calls (atom [])]
+    (try
+      (with-redefs [chat-agent/run-agent-turn!
+                    (fn [chat-ctx opts]
+                      (swap! calls conj opts)
+                      (cc/add-message! chat-ctx
+                                       {:role :assistant :content "inferred"})
+                      :complete)]
+        (binding [ec/*execution-context* (:ctx r)]
+          (d/join r (llm/llm-agent
+                     {:id :inferred-worker
+                      :spec {:model "gpt-5.6-sol"}})))
+        (is (= "inferred"
+               (:content
+                (await-spin r #(d/ask % :inferred-worker {:content "go"})
+                            10000))))
+        (is (= :openai (:provider (first @calls))))
+        (is (= {:provider :openai :model "gpt-5.6-sol"}
+               (get-in (first @calls) [:tool-ctx :model-policy]))))
+      (finally
+        (d/close-room! r)))))
+
+(deftest inferred-provider-reaches-the-default-formatter
+  (let [r (d/room :provider-formatter-room)
+        model-id "formatter-inference-test-model"
+        formatted (atom [])
+        calls (atom [])
+        original-models @model-registry/registry
+        original-providers @model-providers/providers
+        formatter (reify model-provider/MessageFormatter
+                    (format-messages [_ messages model]
+                      (swap! formatted conj {:messages messages :model model})
+                      messages))]
+    (try
+      (model-registry/register-model!
+       {:id model-id :provider :inferred-test-provider})
+      (model-providers/register! :inferred-test-provider formatter)
+      (with-redefs [model-chat/chat
+                    (fn [messages opts]
+                      (swap! calls conj {:messages messages :opts opts})
+                      {:content "formatted"
+                       :tool-calls []
+                       :usage {:input-tokens 1 :output-tokens 1}
+                       :stop-reason :end-turn})]
+        (binding [ec/*execution-context* (:ctx r)]
+          (d/join r (llm/llm-agent
+                     {:id :formatter-worker
+                      :spec {:model model-id}
+                      :tools {}})))
+        (is (= "formatted"
+               (:content
+                (await-spin r #(d/ask % :formatter-worker {:content "go"})
+                            10000))))
+        (is (= model-id (:model (first @formatted))))
+        (is (= {:provider :inferred-test-provider :model model-id}
+               (select-keys (:opts (first @calls)) [:provider :model]))))
+      (finally
+        (reset! model-registry/registry original-models)
+        (reset! model-providers/providers original-providers)
+        (d/close-room! r)))))
+
+(deftest fork-snapshots-the-latest-switched-spec
+  (let [parent (d/room :switched-fork-parent)
+        fork* (atom nil)
+        calls (atom [])
+        turn-fn (fn [chat-ctx opts]
+                  (swap! calls conj
+                         {:ctx ec/*execution-context*
+                          :provider (:provider opts)
+                          :model (:model opts)
+                          :model-policy (get-in opts [:tool-ctx :model-policy])})
+                  (cc/add-message! chat-ctx {:role :assistant :content "ok"})
+                  :complete)]
+    (try
+      (binding [ec/*execution-context* (:ctx parent)]
+        (d/join parent
+                (llm/llm-agent {:id :fork-worker
+                                :spec {:provider :mock :model "mock-1"}
+                                :run-turn-fn turn-fn})))
+      ;; The ask follows the directive in the participant's FIFO, so completion
+      ;; is also an acknowledgement that the parent applied the switch.
+      (d/post! parent {:to :fork-worker
+                       :type :directive/switch-model
+                       :payload {:model "mock-2"}})
+      (is (= "ok" (:content
+                   (await-spin parent
+                               #(d/ask % :fork-worker {:content "parent"})
+                               10000))))
+      (let [fork (d/fork-room parent {:isolation :ctx})]
+        (reset! fork* fork)
+        (is (= "ok" (:content
+                     (await-spin fork
+                                 #(d/ask % :fork-worker {:content "child"})
+                                 10000))))
+        (d/post! parent {:to :fork-worker
+                         :type :directive/switch-model
+                         :payload {:model "mock-3"}})
+        (is (= "ok" (:content
+                     (await-spin parent
+                                 #(d/ask % :fork-worker {:content "parent again"})
+                                 10000))))
+        (is (= "ok" (:content
+                     (await-spin fork
+                                 #(d/ask % :fork-worker {:content "child again"})
+                                 10000))))
+        (is (= ["mock-2" "mock-2" "mock-3" "mock-2"]
+               (mapv :model @calls))
+            "the child snapshots the latest parent spec and then diverges")
+        (is (identical? (:ctx parent) (:ctx (first @calls))))
+        (is (identical? (:ctx fork) (:ctx (second @calls)))
+            "the cloned participant executes in the fork's context")
+        (is (every? #(= {:provider :mock :model (:model %)}
+                        (:model-policy %))
+                    @calls)))
+      (finally
+        (when-let [fork @fork*]
+          (d/discard fork))
+        (d/close-room! parent)))))


### PR DESCRIPTION
## Summary

Prerequisite for non-destructive Simmis owner-model preference activation.

The existing `:directive/switch-model` updated participant state, but the real turn call retained the original lexical provider/model. Stub tests observed only nested `:spec`, hiding the mismatch.

- Snapshot the active spec at each provider-call boundary and pass its provider/model to the actual turn bridge.
- Use that same policy for tool delegation; infer an omitted provider from the registered model.
- Preserve explicit provider priority and the existing room `/model` override priority.
- Fork factories copy the currently switched spec; existing forks retain independent policy.
- Preserve the existing participant, inbox, active-call cancellation/settlement, and working context.

## Verification

- Independent review clean for medium-or-higher findings, including a follow-up correction to provider-omitted admission.
- Regression coverage: active switch, idle switch through default bridge, real provider formatting for an omitted provider, and fork inheritance/divergence.
- Full LLM-discourse suite before the provider-completion amendment: 28 tests / 143 assertions, green. The final real formatter/provider regression then passed independently: 1 test / 3 assertions. Fresh CI will verify the complete final head together.
- Final cljfmt and diff check green.
- No real model requests.

## Scope

This corrects the existing model directive, not generic prompt/tool/context replacement. The existing cross-provider `/model` command behavior remains a separate follow-up.
