### PR TITLE
feat(io): persist Run-correlated HTTP acquisition receipts

### DIFF
--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -308,7 +308,10 @@ Response capture is off by default. A host can opt in on its Room:
 ```
 
 This stores eligible credential-scrubbed text responses in the RoomStore's
-content-addressed artifact store. Responses expose a `:dvergr/acquisition`
+content-addressed artifact store. By default, payload bytes live in that room
+database's Konserve store, addressed by `datahike.blob/blob-id`. The receipt's
+`:acquisition/body-store-ref` is `:db.type/store-ref`: Datahike tracks its
+reachability through branches and retained history. Responses expose a `:dvergr/acquisition`
 envelope only after outcome persistence succeeds. The metadata records origin,
 not raw request paths, queries, headers or request bodies. A deterministic
 `request-key` over pre-injection URL/method/query parameters permits host-side
@@ -322,7 +325,23 @@ and cumulative resource budgets are separate follow-ups. A request left
 `:started` after interruption has an unknown outcome. Persistence failures do
 not retry the HTTP effect, and an outcome-recording failure must not be treated
 as proof that the request never happened. Room deletion retracts receipt
-projections; shared artifact reclamation is a separate storage lifecycle.
+projections; Datahike GC can reclaim managed bodies once no retained branch or
+history references them, subject to its normal retention and writer-age policy.
+
+Attempts and Scorecards use the same managed publication path through
+`:attempt/payload-ref` and `:scorecard/payload-ref`. `artifact/publish-value!`
+holds Datahike's canonical-store write guard from the binary write through the
+referencing transaction. Its host callback must finish the transaction before
+returning; it must not return an unfinished future or Spin. This is a storage
+commit boundary, not a new agent scheduling primitive.
+
+Existing string `payload-blob` / `body-ref` attributes retain their types; old
+Attempt/Scorecard payloads remain readable from the legacy global blob store.
+No existing records or historical blobs are rewritten. Explicit legacy artifact
+store injection still uses that unmanaged path and does not gain automatic GC.
+Failed publications leave collectable orphans: reference-only persistence dead
+letters are diagnostic records, not self-contained replay bundles. Recovery
+must republish the exact payload before retrying the domain write.
 
 These receipts establish acquisition provenance, not whether a quotation
 supports a claim. A discovery evaluator must still verify the Run, request

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -289,6 +289,45 @@ validation, strict output parsing, scripted certification, persistence and
 cleanup. This small fixture is not a general entailment judge, competitor
 discovery benchmark, deployment audit or validation of market demand.
 
+## HTTP acquisition receipts
+
+Tool-driven sandbox HTTP requests in a Datahike-backed control Room record
+Run-correlated acquisition metadata before executing the request and its outcome
+afterward. A receipt also identifies the tool call and execution world. Execution
+audit stays in the control Room when a speculative work world is discarded.
+Receipt reads are host-only and require the caller to authorize Room/Run access;
+`dvergr.io.acquisition/list-for-run` reads a bounded prefix in Run-index order.
+An in-memory RoomStore or a direct HTTP call outside a tool invocation does not
+automatically acquire this durable audit capability.
+
+Response capture is off by default. A host can opt in on its Room:
+
+```clojure
+(swap! (:meta room) assoc :http-capture
+       {:allowed-origins #{"https://example.org"} :max-bytes 65536})
+```
+
+This stores eligible credential-scrubbed text responses in the RoomStore's
+content-addressed artifact store. Responses expose a `:dvergr/acquisition`
+envelope only after outcome persistence succeeds. The metadata records origin,
+not raw request paths, queries, headers or request bodies. A deterministic
+`request-key` over pre-injection URL/method/query parameters permits host-side
+citation matching; it is not encryption. Captured response text can itself be
+sensitive, so enable capture only for sources the host intends to retain.
+Redirects are not followed automatically.
+
+`:max-bytes` limits each stored body, not network bytes, total Run storage or
+HTTP transport allocation. The HTTP client still buffers its response; transport
+and cumulative resource budgets are separate follow-ups. A request left
+`:started` after interruption has an unknown outcome. Persistence failures do
+not retry the HTTP effect, and an outcome-recording failure must not be treated
+as proof that the request never happened. Room deletion retracts receipt
+projections; shared artifact reclamation is a separate storage lifecycle.
+
+These receipts establish acquisition provenance, not whether a quotation
+supports a claim. A discovery evaluator must still verify the Run, request
+fingerprint, captured body and submitted evidence together.
+
 ## Port order driven by failures
 
 1. Complete scoped observation and expose it in the REPL/UI.

--- a/src/dvergr/agent/attempt/governance.clj
+++ b/src/dvergr/agent/attempt/governance.clj
@@ -9,7 +9,7 @@
 
 (def ^:private attempt-required
   #{:attempt/id :attempt/chat :attempt/run :attempt/content-id
-    :attempt/payload-blob :attempt/payload-codec :attempt/environment-id
+    :attempt/payload-codec :attempt/environment-id
     :attempt/environment-version :attempt/environment-content-id
     :attempt/verifier-id :attempt/verifier-version :attempt/provider
     :attempt/model :attempt/status :attempt/started-at :attempt/elapsed-ms
@@ -19,7 +19,7 @@
     :attempt/settlement-intent :attempt/checks})
 
 (def ^:private scorecard-required
-  #{:scorecard/id :scorecard/chat :scorecard/payload-blob
+  #{:scorecard/id :scorecard/chat
     :scorecard/payload-codec :scorecard/experiment-id
     :scorecard/experiment-version :scorecard/experiment-content-id
     :scorecard/dataset-id :scorecard/dataset-version
@@ -74,7 +74,14 @@
   (= (:db/id (:scorecard/chat scorecard))
      (:db/id (:attempt/chat attempt))))
 
+(defn- validate-payload! [entity ref-key legacy-key]
+  (when-not (or (and (uuid? (get entity ref-key)) (not (contains? entity legacy-key)))
+                (and (string? (get entity legacy-key)) (not (contains? entity ref-key))))
+    (throw (ex-info "Require exactly one immutable payload representation"
+                    {:type ::invalid-payload-reference :attribute ref-key}))))
+
 (defn- validate-new-attempt! [db entity]
+  (validate-payload! entity :attempt/payload-ref :attempt/payload-blob)
   (let [missing (remove #(contains? entity %) attempt-required)
         run (:attempt/run entity)]
     (when (seq missing)
@@ -120,6 +127,7 @@
     db))
 
 (defn- validate-new-scorecard! [db entity]
+  (validate-payload! entity :scorecard/payload-ref :scorecard/payload-blob)
   (let [missing (remove #(contains? entity %) scorecard-required)]
     (when (seq missing)
       (throw (ex-info "Certified Scorecard row is incomplete"

--- a/src/dvergr/artifact.clj
+++ b/src/dvergr/artifact.clj
@@ -2,16 +2,19 @@
   "Content-addressed storage for exact portable values.
 
    Durable domain projections keep typed, queryable attributes in Datahike and
-   place open-ended immutable values behind these references. The default
-   implementation reuses Dvergr's blob CAS; tests and ephemeral stores may use
-   the in-memory implementation."
+   place exact immutable payloads behind GC-tracked UUID references in the
+   database's own store. String references remain readable from the legacy CAS."
   (:require [clojure.edn :as edn]
+            [datahike.blob :as blob]
+            [datahike.gc-guard :as guard]
+            [datahike.store :as ds]
+            [konserve.core :as k]
             [dvergr.drive.blobs :as blobs])
   (:import [java.nio.charset StandardCharsets]))
 
 (defprotocol PArtifactStore
   (-put-value! [this value]
-    "Store one EDN value and return its immutable string content reference.")
+    "Store one EDN value in an unmanaged store. Managed stores require publish-value!.")
   (-get-value [this ref]
     "Load the value named by `ref`, or nil when the content is unavailable."))
 
@@ -30,11 +33,43 @@
 
 (defn blob-store [] (->BlobArtifactStore))
 
+(defprotocol PArtifactPublication
+  (-publish-value! [this value publish]
+    "Write immutable bytes and call publish with their reference while GC-protected.
+     publish must synchronously finish the referencing transaction."))
+
+(defrecord DatahikeArtifactStore [conn]
+  PArtifactStore
+  (-put-value! [_ _]
+    (throw (ex-info "Datahike artifacts require publish-value!" {})))
+  (-get-value [_ ref]
+    (if (string? ref)
+      ;; Historical string payloads remain in the legacy global blob store.
+      (-get-value (blob-store) ref)
+      (k/bget (:store @conn) ref
+              (fn [{:keys [input-stream]}]
+                (when input-stream
+                  (decode (if (bytes? input-stream) input-stream
+                              (.readAllBytes ^java.io.InputStream input-stream)))))
+              {:sync? true})))
+  PArtifactPublication
+  (-publish-value! [_ value publish]
+    (let [db @conn
+          bytes (encode value)
+          ref (blob/blob-id bytes)]
+      (guard/with-unreferenced-writes (ds/canonical-store-id (:store db) (get-in db [:config :store]))
+        ;; Rewrite even on dedup: refresh the timestamp under the guard so an
+        ;; older unreferenced copy cannot race a concurrent sweep.
+        (k/bassoc (:store db) ref bytes {:sync? true})
+        (publish ref)))))
+
+(defn datahike-store [conn] (->DatahikeArtifactStore conn))
+
 (defrecord MemoryArtifactStore [values]
   PArtifactStore
   (-put-value! [_ value]
     (let [bytes (encode value)
-          ref (blobs/sha256-hex bytes)]
+          ref (blob/blob-id bytes)]
       (swap! values #(if (contains? % ref) % (assoc % ref value)))
       ref))
   (-get-value [_ ref]
@@ -47,3 +82,12 @@
 
 (defn get-value [store ref]
   (-get-value store ref))
+
+(defn publish-value!
+  "Publish a payload reference, guarding managed bytes until publish returns.
+   The callback must finish its transaction here, not return a future/Spin.
+   Failure leaves an unreferenced object eligible for normal collection."
+  [store value publish]
+  (if (satisfies? PArtifactPublication store)
+    (-publish-value! store value publish)
+    (publish (-put-value! store value))))

--- a/src/dvergr/chat/agent.clj
+++ b/src/dvergr/chat/agent.clj
@@ -315,7 +315,7 @@
                                     ;; the room's own + attached repos (load-fn falls
                                     ;; back to the base workspace if absent).
                                    result (binding [workspace/*workspace-roots* (:workspace-roots ctx)]
-                                            (tools/execute name input ctx))
+                                            (tools/execute name input (assoc ctx :tool-use-id id)))
                                    duration-ms (- (System/currentTimeMillis) start-time)
                                    error? (= :error (:type result))]
                                (when-let [conn (:db-conn chat-ctx)]

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -745,6 +745,11 @@
     :db/cardinality :db.cardinality/one
     :db/doc "Immutable CAS reference for exact EnvironmentDef, AgentDef, receipt, and evidence"}
 
+   {:db/ident :attempt/payload-ref
+    :db/valueType :db.type/store-ref
+    :db/cardinality :db.cardinality/one
+    :db/doc "GC-tracked immutable exact Attempt payload"}
+
    {:db/ident :attempt/payload-codec
     :db/valueType :db.type/keyword
     :db/cardinality :db.cardinality/one}
@@ -897,6 +902,10 @@
 
    {:db/ident :scorecard/payload-codec
     :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident :scorecard/payload-ref
+    :db/valueType :db.type/store-ref
     :db/cardinality :db.cardinality/one}
 
    {:db/ident :scorecard/experiment-id

--- a/src/dvergr/chat/schema.clj
+++ b/src/dvergr/chat/schema.clj
@@ -13,6 +13,7 @@
   (:require [datahike.api :as d]
             [taoensso.telemere :as tel]
             [dvergr.kb.schema :as kb]
+            [dvergr.io.acquisition :as acquisition]
             [dvergr.chat.tool-schema :as tool-schema]))
 
 ;; ============================================================================
@@ -1441,6 +1442,7 @@
   (vec (concat chat-schema
                message-schema
                run-schema
+               acquisition/schema
                attempt-schema
                scorecard-schema
                attention-schema

--- a/src/dvergr/io/acquisition.clj
+++ b/src/dvergr/io/acquisition.clj
@@ -22,7 +22,8 @@
          [:acquisition/status :db.type/keyword] [:acquisition/method :db.type/keyword]
          [:acquisition/origin :db.type/string] [:acquisition/started-at :db.type/instant]
          [:acquisition/ended-at :db.type/instant] [:acquisition/http-status :db.type/long]
-         [:acquisition/body-ref :db.type/string] [:acquisition/capture :db.type/keyword]
+         [:acquisition/body-ref :db.type/string]
+         [:acquisition/body-store-ref :db.type/store-ref] [:acquisition/capture :db.type/keyword]
          [:acquisition/request-key :db.type/uuid]
          [:acquisition/error-class :db.type/string]]))
 
@@ -34,7 +35,7 @@
     (when (and conn (:run-id ctx))
       {:conn conn :room-id (:id room) :run-id (:run-id ctx)
        :tool-use-id (:tool-use-id ctx) :execution-ctx (:execution-ctx ctx)
-       :artifacts (or (some-> room :store :artifacts) (artifact/blob-store))
+       :artifacts (or (some-> room :store :artifacts) (artifact/datahike-store conn))
        :capture-policy (:http-capture @(:meta room))})))
 
 (defn origin [url]
@@ -53,25 +54,25 @@
   (hasch/uuid [:http-acquisition/v1 (or (:method opts) :get)
                (str (:url opts)) (:query-params opts)]))
 
-(defn- capture [scope request-origin response]
+(defn- capture [scope request-origin response publish]
   (let [{:keys [allowed-origins max-bytes]} (:capture-policy scope)
         body (:body response)]
     (cond
       (not (and (set? allowed-origins) (contains? allowed-origins request-origin)
                 (integer? max-bytes) (pos? max-bytes)))
-      {:acquisition/capture :disabled}
+      (publish {:acquisition/capture :disabled})
 
-      (not (string? body)) {:acquisition/capture :unsupported-body}
+      (not (string? body)) (publish {:acquisition/capture :unsupported-body})
 
       ;; UTF-16 length is a lower bound on UTF-8 bytes for valid text. Reject
       ;; huge responses before allocating a second full-size encoding buffer.
       (or (> (count body) max-bytes)
           (> (alength (.getBytes ^String body java.nio.charset.StandardCharsets/UTF_8)) max-bytes))
-      {:acquisition/capture :too-large}
+      (publish {:acquisition/capture :too-large})
 
-      :else {:acquisition/capture :captured
-             :acquisition/body-ref
-             (artifact/put-value! (:artifacts scope) {:body body})})))
+      :else (artifact/publish-value! (:artifacts scope) {:body body}
+                                     #(publish {:acquisition/capture :captured
+                                                (if (uuid? %) :acquisition/body-store-ref :acquisition/body-ref) %})))))
 
 (defn record-request!
   "Observe one HTTP invocation. `perform` retains existing transport/egress policy
@@ -94,31 +95,33 @@
       (dh/transact conn [started])
       (let [outcome (try {:response (perform)} (catch Exception e {:error e}))
             response (:response outcome)
+            publish (fn [captured]
+                      (dh/transact conn
+                                   [(merge {:acquisition/id id
+                                            :acquisition/ended-at (java.util.Date.)
+                                            :acquisition/status (if (:error outcome) :failed :completed)}
+                                           (when (:status response)
+                                             {:acquisition/http-status (long (:status response))})
+                                           (when-let [e (:error outcome)]
+                                             {:acquisition/error-class (.getName (class e))})
+                                           captured)])
+                      captured)
             captured (try
-                       (if response (capture scope request-origin response)
-                           {:acquisition/capture :disabled})
+                       (if response
+                         (capture scope request-origin response publish)
+                         (publish {:acquisition/capture :disabled}))
                        (catch Exception e
-                         (throw (ex-info "HTTP capture failed; the request may have completed. Do not retry the HTTP effect automatically."
+                         (throw (ex-info "HTTP outcome recording failed; the request may have completed. Do not retry the HTTP effect automatically."
                                          {:type ::outcome-recording-failed :acquisition/id id} e))))]
-        (try
-          (dh/transact conn
-                       [(merge {:acquisition/id id :acquisition/ended-at (java.util.Date.)
-                                :acquisition/status (if (:error outcome) :failed :completed)}
-                               (when (:status response) {:acquisition/http-status (long (:status response))})
-                               (when-let [e (:error outcome)]
-                                 {:acquisition/error-class (.getName (class e))})
-                               captured)])
-          (catch Exception e
-            (throw (ex-info "HTTP outcome recording failed; the request may have completed. Do not retry the HTTP effect automatically."
-                            {:type ::outcome-recording-failed :acquisition/id id} e))))
         (if-let [e (:error outcome)]
           (throw e)
           ;; Correlation only, not permission to read the audit DB or artifact
           ;; store. Publish this envelope only AFTER outcome persistence succeeds.
           (assoc response :dvergr/acquisition
                  (cond-> {:id id :capture (:acquisition/capture captured)}
-                   (:acquisition/body-ref captured)
-                   (assoc :body-ref (:acquisition/body-ref captured)))))))
+                   (or (:acquisition/body-store-ref captured) (:acquisition/body-ref captured))
+                   (assoc :body-ref (or (:acquisition/body-store-ref captured)
+                                        (:acquisition/body-ref captured))))))))
     (perform)))
 
 (defn list-for-run

--- a/src/dvergr/io/acquisition.clj
+++ b/src/dvergr/io/acquisition.clj
@@ -1,0 +1,136 @@
+(ns dvergr.io.acquisition
+  "Private HTTP acquisition projections. Execution audit is not work-world state.
+   No receipt/body read capability is exposed to SCI by this namespace."
+  (:require [datahike.api :as dh]
+            [hasch.core :as hasch]
+            [dvergr.artifact :as artifact]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(def ^:dynamic *scope*
+  "Host-owned tool invocation scope, conveyed by supervised evaluation workers.
+   Never captured in an SCI function: saved functions use the current invocation."
+  nil)
+
+(def schema
+  (mapv (fn [[ident type unique?]]
+          (cond-> {:db/ident ident :db/valueType type :db/cardinality :db.cardinality/one}
+            (= ident :acquisition/run-id) (assoc :db/index true)
+            unique? (assoc :db/unique :db.unique/identity)))
+        [[:acquisition/id :db.type/uuid true]
+         [:acquisition/run-id :db.type/uuid] [:acquisition/room-id :db.type/keyword]
+         [:acquisition/world-id :db.type/string] [:acquisition/tool-use-id :db.type/string]
+         [:acquisition/status :db.type/keyword] [:acquisition/method :db.type/keyword]
+         [:acquisition/origin :db.type/string] [:acquisition/started-at :db.type/instant]
+         [:acquisition/ended-at :db.type/instant] [:acquisition/http-status :db.type/long]
+         [:acquisition/body-ref :db.type/string] [:acquisition/capture :db.type/keyword]
+         [:acquisition/request-key :db.type/uuid]
+         [:acquisition/error-class :db.type/string]]))
+
+(defn tool-scope [ctx]
+  (let [room (:control-room ctx)
+        conn (some-> room :store :conn)]
+    ;; Only an explicit durable control-room store owns these receipts. Do not
+    ;; silently put audit into the disposable work DB or a temporary ChatContext.
+    (when (and conn (:run-id ctx))
+      {:conn conn :room-id (:id room) :run-id (:run-id ctx)
+       :tool-use-id (:tool-use-id ctx) :execution-ctx (:execution-ctx ctx)
+       :artifacts (or (some-> room :store :artifacts) (artifact/blob-store))
+       :capture-policy (:http-capture @(:meta room))})))
+
+(defn origin [url]
+  (try
+    (let [u (java.net.URI. (str url))]
+      (when (and (#{"http" "https"} (.getScheme u)) (.getHost u))
+        (str (.getScheme u) "://" (.getHost u)
+             (when (not= -1 (.getPort u)) (str ":" (.getPort u))))))
+    (catch Exception _ nil)))
+
+(defn request-key
+  "Fingerprint the pre-injection URL, method and query parameters for citation
+   matching. No raw path/query is stored. This is not encryption or proof that
+   a document supports a claim; the host must also verify the captured body."
+  [opts]
+  (hasch/uuid [:http-acquisition/v1 (or (:method opts) :get)
+               (str (:url opts)) (:query-params opts)]))
+
+(defn- capture [scope request-origin response]
+  (let [{:keys [allowed-origins max-bytes]} (:capture-policy scope)
+        body (:body response)]
+    (cond
+      (not (and (set? allowed-origins) (contains? allowed-origins request-origin)
+                (integer? max-bytes) (pos? max-bytes)))
+      {:acquisition/capture :disabled}
+
+      (not (string? body)) {:acquisition/capture :unsupported-body}
+
+      ;; UTF-16 length is a lower bound on UTF-8 bytes for valid text. Reject
+      ;; huge responses before allocating a second full-size encoding buffer.
+      (or (> (count body) max-bytes)
+          (> (alength (.getBytes ^String body java.nio.charset.StandardCharsets/UTF_8)) max-bytes))
+      {:acquisition/capture :too-large}
+
+      :else {:acquisition/capture :captured
+             :acquisition/body-ref
+             (artifact/put-value! (:artifacts scope) {:body body})})))
+
+(defn record-request!
+  "Observe one HTTP invocation. `perform` retains existing transport/egress policy
+   and returns its credential-scrubbed response. Body capture is off by default.
+   A :started record after a crash means unknown outcome, never safe-to-retry.
+   Completion persistence failures are surfaced without retrying the HTTP effect."
+  [opts perform]
+  (if-let [{:keys [conn room-id run-id tool-use-id execution-ctx] :as scope} *scope*]
+    (let [id (random-uuid)
+          request-origin (origin (:url opts))
+          world (if (ec/execution-context-bound?) (ec/current-execution-context) execution-ctx)
+          started (cond-> {:acquisition/id id :acquisition/room-id room-id
+                           :acquisition/run-id run-id :acquisition/status :started
+                           :acquisition/request-key (request-key opts)
+                           :acquisition/method (keyword (or (:method opts) :get))
+                           :acquisition/started-at (java.util.Date.)}
+                    request-origin (assoc :acquisition/origin request-origin)
+                    (:fork-id world) (assoc :acquisition/world-id (str (:fork-id world)))
+                    tool-use-id (assoc :acquisition/tool-use-id (str tool-use-id)))]
+      (dh/transact conn [started])
+      (let [outcome (try {:response (perform)} (catch Exception e {:error e}))
+            response (:response outcome)
+            captured (try
+                       (if response (capture scope request-origin response)
+                           {:acquisition/capture :disabled})
+                       (catch Exception e
+                         (throw (ex-info "HTTP capture failed; the request may have completed. Do not retry the HTTP effect automatically."
+                                         {:type ::outcome-recording-failed :acquisition/id id} e))))]
+        (try
+          (dh/transact conn
+                       [(merge {:acquisition/id id :acquisition/ended-at (java.util.Date.)
+                                :acquisition/status (if (:error outcome) :failed :completed)}
+                               (when (:status response) {:acquisition/http-status (long (:status response))})
+                               (when-let [e (:error outcome)]
+                                 {:acquisition/error-class (.getName (class e))})
+                               captured)])
+          (catch Exception e
+            (throw (ex-info "HTTP outcome recording failed; the request may have completed. Do not retry the HTTP effect automatically."
+                            {:type ::outcome-recording-failed :acquisition/id id} e))))
+        (if-let [e (:error outcome)]
+          (throw e)
+          ;; Correlation only, not permission to read the audit DB or artifact
+          ;; store. Publish this envelope only AFTER outcome persistence succeeds.
+          (assoc response :dvergr/acquisition
+                 (cond-> {:id id :capture (:acquisition/capture captured)}
+                   (:acquisition/body-ref captured)
+                   (assoc :body-ref (:acquisition/body-ref captured)))))))
+    (perform)))
+
+(defn list-for-run
+  "Trusted host query. Caller must authorize room/run access before calling.
+   Returns metadata in Run index/entity order, not chronological order.
+   Pulls at most limit rows; no response content or arbitrary room scan."
+  [conn room-id run-id limit]
+  (when-not (and (keyword? room-id) (uuid? run-id) (integer? limit) (<= 1 limit 1000))
+    (throw (ex-info "Require room ID, Run UUID and limit 1..1000" {})))
+  (let [db @conn]
+    (->> (dh/datoms db :avet :acquisition/run-id run-id)
+         (map #(dh/entity db (:e %)))
+         (filter #(= room-id (:acquisition/room-id %)))
+         (take limit)
+         (mapv #(dh/pull db '[*] (:db/id %))))))

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -408,7 +408,7 @@
     :run/reason :run/error])
 
 (def ^:private attempt-pull-pattern
-  '[:attempt/id :attempt/content-id :attempt/payload-blob
+  '[:attempt/id :attempt/content-id :attempt/payload-ref :attempt/payload-blob
     :attempt/payload-codec :attempt/environment-id
     :attempt/environment-version :attempt/environment-content-id
     :attempt/verifier-id :attempt/verifier-version
@@ -425,7 +425,7 @@
                       :attempt.check/passed?]}])
 
 (def ^:private scorecard-pull-pattern
-  '[:scorecard/id :scorecard/payload-blob :scorecard/payload-codec
+  '[:scorecard/id :scorecard/payload-ref :scorecard/payload-blob :scorecard/payload-codec
     :scorecard/experiment-id :scorecard/experiment-version
     :scorecard/experiment-content-id :scorecard/dataset-id
     :scorecard/dataset-version :scorecard/dataset-content-id
@@ -493,7 +493,7 @@
              :attempt/chat [:chat/id chat-id]
              :attempt/run [:run/id (:attempt/run-id value)]
              :attempt/content-id (:attempt/content-id value)
-             :attempt/payload-blob payload-ref
+             (if (uuid? payload-ref) :attempt/payload-ref :attempt/payload-blob) payload-ref
              :attempt/payload-codec :edn-v1
              :attempt/environment-id (:environment/id definition)
              :attempt/environment-version (:environment/version definition)
@@ -535,12 +535,12 @@
       (throw (ex-info "Unsupported Attempt payload codec"
                       {:type :room-store/unsupported-attempt-payload
                        :codec (:attempt/payload-codec entity)})))
-    (let [value (artifact/get-value artifacts (:attempt/payload-blob entity))]
+    (let [value (artifact/get-value artifacts (or (:attempt/payload-ref entity) (:attempt/payload-blob entity)))]
       (when-not value
         (throw (ex-info "Attempt payload artifact is unavailable"
                         {:type :room-store/missing-attempt-payload
                          :attempt/id (:attempt/id entity)
-                         :artifact/ref (:attempt/payload-blob entity)})))
+                         :artifact/ref (or (:attempt/payload-ref entity) (:attempt/payload-blob entity))})))
       (attempt/validate-attempt value)
       (let [receipt (:attempt/receipt value)
             definition (:attempt/environment value)
@@ -609,7 +609,7 @@
         scorecard-id (:scorecard/content-id value)]
     {:scorecard/id scorecard-id
      :scorecard/chat [:chat/id chat-id]
-     :scorecard/payload-blob payload-ref
+     (if (uuid? payload-ref) :scorecard/payload-ref :scorecard/payload-blob) payload-ref
      :scorecard/payload-codec :edn-v1
      :scorecard/experiment-id (:experiment/id definition)
      :scorecard/experiment-version (long (:experiment/version definition))
@@ -642,12 +642,12 @@
       (throw (ex-info "Unsupported Scorecard payload codec"
                       {:type :room-store/unsupported-scorecard-payload
                        :codec (:scorecard/payload-codec entity)})))
-    (let [value (artifact/get-value artifacts (:scorecard/payload-blob entity))]
+    (let [value (artifact/get-value artifacts (or (:scorecard/payload-ref entity) (:scorecard/payload-blob entity)))]
       (when-not value
         (throw (ex-info "Scorecard payload artifact is unavailable"
                         {:type :room-store/missing-scorecard-payload
                          :scorecard/id (:scorecard/id entity)
-                         :artifact/ref (:scorecard/payload-blob entity)})))
+                         :artifact/ref (or (:scorecard/payload-ref entity) (:scorecard/payload-blob entity))})))
       (validate-scorecard value)
       (let [definition (:scorecard/experiment value)
             dataset (:experiment/dataset definition)
@@ -1146,38 +1146,40 @@
     (let [value (attempt/validate-attempt value)
           slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
-        ;; CAS is immutable: a blob written before a failed Datahike commit is a
-        ;; harmless unreferenced object and can be collected independently.
-        (let [payload-ref (artifact/put-value! artifacts value)
-              entity (attempt->entity (:chat/id ent) value payload-ref)]
-          (locking conn
-            (if-let [existing (store/-load-attempt this room-id
-                                                   (:attempt/id value))]
-              (if (= existing value)
-                existing
-                (throw (ex-info "Attempt identity is immutable"
-                                {:type :room-store/attempt-identity-collision
-                                 :existing existing :attempt value})))
-              (let [report
-                    (attempt-governance/with-authorized-write
-                      conn (:attempt/id value)
-                      (fn [tx-meta]
-                        (persist/persist-tx-result!
-                         conn
-                         [[:db.fn/call store-attempt-if-absent entity]]
-                         {:op :store-attempt :room-id room-id
-                          :attempt-id (:attempt/id value)
-                          :tx-meta tx-meta})))]
-                (when report
+        ;; Publication holds the Datahike write guard across bytes and commit.
+        ;; A failed publication leaves a collectable orphan, never a live root.
+        (artifact/publish-value!
+         artifacts value
+         (fn [payload-ref]
+           (let [entity (attempt->entity (:chat/id ent) value payload-ref)]
+             (locking conn
+               (if-let [existing (store/-load-attempt this room-id
+                                                      (:attempt/id value))]
+                 (if (= existing value)
+                   existing
+                   (throw (ex-info "Attempt identity is immutable"
+                                   {:type :room-store/attempt-identity-collision
+                                    :existing existing :attempt value})))
+                 (let [report
+                       (attempt-governance/with-authorized-write
+                         conn (:attempt/id value)
+                         (fn [tx-meta]
+                           (persist/persist-tx-result!
+                            conn
+                            [[:db.fn/call store-attempt-if-absent entity]]
+                            {:op :store-attempt :room-id room-id
+                             :attempt-id (:attempt/id value)
+                             :tx-meta tx-meta})))]
+                   (when report
                   ;; A concurrent identical writer may have won. Always compare
                   ;; the exact payload after the serialized first-write decision.
-                  (let [stored (store/-load-attempt this room-id
-                                                    (:attempt/id value))]
-                    (when-not (= stored value)
-                      (throw (ex-info "Concurrent Attempt identity collision"
-                                      {:type :room-store/attempt-identity-collision
-                                       :stored stored :attempt value})))
-                    stored)))))))))
+                     (let [stored (store/-load-attempt this room-id
+                                                       (:attempt/id value))]
+                       (when-not (= stored value)
+                         (throw (ex-info "Concurrent Attempt identity collision"
+                                         {:type :room-store/attempt-identity-collision
+                                          :stored stored :attempt value})))
+                       stored)))))))))))
 
   (-load-attempt [_ room-id attempt-id]
     (let [slug (store/room-id->slug room-id)]
@@ -1238,57 +1240,59 @@
           scorecard-id (:scorecard/content-id value)
           slug (store/room-id->slug room-id)]
       (when-let [ent (room-by-slug conn slug)]
-        (let [payload-ref (artifact/put-value! artifacts value)
-              entity (scorecard->entity (:chat/id ent) value payload-ref
-                                        (java.util.Date.))]
-          (locking conn
-            (if-let [existing (store/-load-scorecard this room-id scorecard-id)]
-              (if (= existing value)
-                existing
-                (throw (ex-info "Scorecard identity is immutable"
-                                {:type :room-store/scorecard-identity-collision
-                                 :existing existing :scorecard value})))
-              (let [existing-chat-id
-                    (dh/q '[:find ?chat-id .
-                            :in $ ?scorecard-id
-                            :where
-                            [?s :scorecard/id ?scorecard-id]
-                            [?s :scorecard/chat ?c]
-                            [?c :chat/id ?chat-id]]
-                          @conn scorecard-id)
-                    _ (when (and existing-chat-id
-                                 (not= existing-chat-id (:chat/id ent)))
-                        (throw
-                         (ex-info "Scorecard identity belongs to another Room"
-                                  {:type :room-store/scorecard-room-mismatch
-                                   :scorecard/id scorecard-id})))
-                    _ (validate-scorecard-attempts
-                       value
-                       (into {}
-                             (keep
-                              (fn [entry]
-                                (when-let [stored
-                                           (store/-load-attempt
-                                            this room-id (:attempt/id entry))]
-                                  [(:attempt/id entry) stored])))
-                             (:scorecard/entries value)))
-                    report
-                    (attempt-governance/with-authorized-scorecard-write
-                      conn scorecard-id
-                      (fn [tx-meta]
-                        (persist/persist-tx-result!
-                         conn
-                         [[:db.fn/call store-scorecard-if-absent entity]]
-                         {:op :store-scorecard :room-id room-id
-                          :scorecard-id scorecard-id :tx-meta tx-meta})))]
-                (when report
-                  (let [stored (store/-load-scorecard this room-id scorecard-id)]
-                    (when-not (= stored value)
-                      (throw
-                       (ex-info "Concurrent Scorecard identity collision"
-                                {:type :room-store/scorecard-identity-collision
-                                 :stored stored :scorecard value})))
-                    stored)))))))))
+        (artifact/publish-value!
+         artifacts value
+         (fn [payload-ref]
+           (let [entity (scorecard->entity (:chat/id ent) value payload-ref
+                                           (java.util.Date.))]
+             (locking conn
+               (if-let [existing (store/-load-scorecard this room-id scorecard-id)]
+                 (if (= existing value)
+                   existing
+                   (throw (ex-info "Scorecard identity is immutable"
+                                   {:type :room-store/scorecard-identity-collision
+                                    :existing existing :scorecard value})))
+                 (let [existing-chat-id
+                       (dh/q '[:find ?chat-id .
+                               :in $ ?scorecard-id
+                               :where
+                               [?s :scorecard/id ?scorecard-id]
+                               [?s :scorecard/chat ?c]
+                               [?c :chat/id ?chat-id]]
+                             @conn scorecard-id)
+                       _ (when (and existing-chat-id
+                                    (not= existing-chat-id (:chat/id ent)))
+                           (throw
+                            (ex-info "Scorecard identity belongs to another Room"
+                                     {:type :room-store/scorecard-room-mismatch
+                                      :scorecard/id scorecard-id})))
+                       _ (validate-scorecard-attempts
+                          value
+                          (into {}
+                                (keep
+                                 (fn [entry]
+                                   (when-let [stored
+                                              (store/-load-attempt
+                                               this room-id (:attempt/id entry))]
+                                     [(:attempt/id entry) stored])))
+                                (:scorecard/entries value)))
+                       report
+                       (attempt-governance/with-authorized-scorecard-write
+                         conn scorecard-id
+                         (fn [tx-meta]
+                           (persist/persist-tx-result!
+                            conn
+                            [[:db.fn/call store-scorecard-if-absent entity]]
+                            {:op :store-scorecard :room-id room-id
+                             :scorecard-id scorecard-id :tx-meta tx-meta})))]
+                   (when report
+                     (let [stored (store/-load-scorecard this room-id scorecard-id)]
+                       (when-not (= stored value)
+                         (throw
+                          (ex-info "Concurrent Scorecard identity collision"
+                                   {:type :room-store/scorecard-identity-collision
+                                    :stored stored :scorecard value})))
+                       stored)))))))))))
 
   (-load-scorecard [_ room-id scorecard-id]
     (let [slug (store/room-id->slug room-id)]
@@ -1495,9 +1499,10 @@
 (defn make
   "Create a DatahikeStore. `conn` must be an existing Datahike
    connection whose db includes the dvergr.chat.schema attributes. An optional
-   artifact store can be injected for tests; production uses the blob CAS."
+   artifact store can be injected for tests; by default payloads live in this
+   database's Konserve store and participate in its store-ref GC lifecycle."
   ([conn]
-   (make conn (artifact/blob-store)))
+   (make conn (artifact/datahike-store conn)))
   ([conn artifacts]
    (attempt-governance/govern! conn)
    (->DatahikeStore conn artifacts)))

--- a/src/dvergr/room/store/datahike.clj
+++ b/src/dvergr/room/store/datahike.clj
@@ -755,6 +755,9 @@
                               [?r :run/chat ?c]
                               [?r :run/id ?rid]]
                             @conn chat-id)
+              acquisition-ids (dh/q '[:find [?id ...] :in $ ?room
+                                      :where [?e :acquisition/room-id ?room]
+                                      [?e :acquisition/id ?id]] @conn room-id)
               attempt-ids (dh/q '[:find [?aid ...]
                                   :in $ ?cid
                                   :where
@@ -784,6 +787,7 @@
                                            attempt-ids))
                                 (into (map (fn [mid] [:db/retractEntity [:message/id mid]]) msg-ids))
                                 (into (map (fn [rid] [:db/retractEntity [:run/id rid]]) run-ids))
+                                (into (map (fn [id] [:db/retractEntity [:acquisition/id id]]) acquisition-ids))
                                 (into (map (fn [aid]
                                              [:db/retractEntity [:attention/id aid]])
                                            attention-ids))

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -8,6 +8,7 @@
             [jsonista.core :as j]
             [babashka.fs :as fs]
             [muschel.fs :as mfs]
+            [dvergr.io.acquisition :as acquisition]
             [dvergr.sandbox.ns.doc :as doc])
   (:import [java.io File]))
 
@@ -638,7 +639,7 @@
      (http/request {:url \"...\" :method :put :headers {...} :body \"...\"})"
   [sci-ctx & {:keys [audit-log allowed-domains secrets]}]
   (let [domain-check (make-domain-policy allowed-domains)
-        do-request
+        perform-request
         (fn [{:keys [url method headers body json query-params timeout]
               :or {method :get timeout 30000}}]
           ;; Audit first (even blocked requests should appear in the log)
@@ -650,6 +651,7 @@
           (let [hato-request (requiring-resolve 'hato.client/request)
                 opts (cond-> {:url url
                               :method method
+                              :http-client {:redirect-policy :never}
                               :connect-timeout timeout
                               :socket-timeout timeout}
                        headers (assoc :headers headers)
@@ -670,7 +672,9 @@
             ;; The agent parses explicitly — (cheshire.core/parse-string (:body r) true).
             {:status (:status resp)
              :headers (into {} (:headers resp))
-             :body (:body resp)}))]
+             :body (:body resp)}))
+        do-request (fn [opts]
+                     (acquisition/record-request! opts #(perform-request opts)))]
     (sci/add-namespace! sci-ctx 'babashka.http-client
                         {'request do-request
                          'get     (fn [url & [opts]] (do-request (merge {:url url :method :get} opts)))

--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -6,6 +6,7 @@
             [clojure.edn :as edn]
             [datahike.api :as d]
             [dvergr.sandbox :as sandbox]
+            [dvergr.io.acquisition :as acquisition]
             [dvergr.agent.process :as proc]
             [dvergr.code.index :as idx]
             [dvergr.tools.structural :as structural]
@@ -302,12 +303,13 @@
             ;; The runtime, not the tool implementation, owns this field: an
             ;; untrusted/custom tool cannot claim broader authority by putting
             ;; a fabricated receipt in its result.
-            (assoc (-> (if-let [exec-fn (:execute tool)]
-                         (exec-fn input ctx)
-                         (when-let [handler-fn (:handler tool)]
-                           (handler-fn input)))
-                       (compaction/truncate-tool-result))
-                   :authorization decision)
+            (binding [acquisition/*scope* (acquisition/tool-scope ctx)]
+              (assoc (-> (if-let [exec-fn (:execute tool)]
+                           (exec-fn input ctx)
+                           (when-let [handler-fn (:handler tool)]
+                             (handler-fn input)))
+                         (compaction/truncate-tool-result))
+                     :authorization decision))
             (catch Exception e
               {:type :error
                :error (.getMessage e)
@@ -331,7 +333,7 @@
   [tool-calls ctx]
   (let [futures (mapv (fn [{:keys [id name input]}]
                         {:id id
-                         :future (future (execute name input ctx))})
+                         :future (future (execute name input (assoc ctx :tool-use-id id)))})
                       tool-calls)]
     (mapv (fn [{:keys [id future]}]
             {:id id

--- a/test/dvergr/artifact_test.clj
+++ b/test/dvergr/artifact_test.clj
@@ -1,0 +1,97 @@
+(ns dvergr.artifact-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :as async]
+            [datahike.api :as d]
+            [datahike.gc :as gc]
+            [datahike.gc-guard :as guard]
+            [datahike.versioning :as versioning]
+            [datahike.store :as ds]
+            [dvergr.artifact :as artifact]
+            [dvergr.drive.blobs :as blobs]))
+
+(defn- config [history?]
+  {:store {:backend :file :id (random-uuid)
+           :path (str (java.nio.file.Files/createTempDirectory
+                       "artifact-store-ref-" (make-array java.nio.file.attribute.FileAttribute 0)) "/db")}
+   :schema-flexibility :write :keep-history? history? :commit-graph? false
+   :writer {:backend :self :writer-ownership :exclusive}})
+
+(def schema [{:db/ident :test/id :db/valueType :db.type/keyword
+              :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+             {:db/ident :test/payload :db/valueType :db.type/store-ref
+              :db/cardinality :db.cardinality/one}])
+
+(deftest publication-guards-bytes-through-commit-and-releases-on-failure
+  (let [cfg (config false)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        st (artifact/datahike-store conn)
+        sid (ds/canonical-store-id (:store @conn) (get-in @conn [:config :store]))]
+    (try
+      (d/transact conn schema)
+      (is (thrown? Exception (artifact/put-value! st {:body "unsafe"})))
+      (let [ref (artifact/publish-value! st {:body "source"}
+                                         (fn [ref]
+                    (is (guard/in-flight? sid))
+                    (is (not (contains? (set (async/<!! (gc/gc-storage! @conn))) ref))
+                        "collection during the unpublished write window must spare the bytes")
+                                           (is (= {:body "source"} (artifact/get-value st ref)))
+                                           (d/transact conn [{:test/id :one :test/payload ref}])
+                                           ref))]
+        (is (uuid? ref))
+        (is (not (guard/in-flight? sid)))
+        (is (contains? (async/<!! (gc/reachable-store-refs @conn)) ref))
+        (is (not (contains? (set (async/<!! (gc/gc-storage! @conn))) ref)))
+        (is (thrown-with-msg? Exception #"fixture failure"
+                              (artifact/publish-value! st {:body "orphan"}
+                                                       (fn [_] (is (guard/in-flight? sid))
+                                                         (throw (ex-info "fixture failure" {}))))))
+        (is (not (guard/in-flight? sid)))
+        (d/transact conn [[:db/retractEntity [:test/id :one]]])
+        (is (contains? (set (async/<!! (gc/gc-storage! @conn))) ref)))
+      (finally (d/release conn) (d/delete-database cfg)))))
+
+(deftest retained-history-and-cold-reopen-keep-captured-content
+  (let [cfg (config true)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        st (artifact/datahike-store conn)]
+    (try
+      (d/transact conn schema)
+      (let [ref (artifact/publish-value! st {:body "historical source"}
+                                         (fn [ref] (d/transact conn [{:test/id :one :test/payload ref}]) ref))]
+        (d/transact conn [[:db/retractEntity [:test/id :one]]])
+        (is (contains? (async/<!! (gc/reachable-store-refs @conn)) ref))
+        (is (not (contains? (set (async/<!! (gc/gc-storage! @conn))) ref)))
+        (d/release conn)
+        (let [reopened (d/connect cfg)]
+          (try
+            (is (= {:body "historical source"}
+                   (artifact/get-value (artifact/datahike-store reopened) ref)))
+            (finally (d/release reopened)))))
+      (finally (d/release conn) (d/delete-database cfg)))))
+
+(deftest legacy-string-reference-reads-remain-available
+  (with-redefs [blobs/get-bytes (fn [ref]
+                                  (is (= "legacy-sha" ref))
+                                  (.getBytes "{:body \"old\"}" "UTF-8"))]
+    (is (= {:body "old"}
+           (artifact/get-value (artifact/datahike-store nil) "legacy-sha")))))
+
+(deftest another-branch-keeps-a-payload-live
+  (let [cfg (config false)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        st (artifact/datahike-store conn)]
+    (try
+      (d/transact conn schema)
+      (let [ref (artifact/publish-value! st {:body "branch-only source"}
+                                         (fn [ref] (d/transact conn [{:test/id :one :test/payload ref}]) ref))]
+        (versioning/branch! conn :db :retained)
+        (d/transact conn [[:db/retractEntity [:test/id :one]]])
+        (is (contains? (async/<!! (gc/reachable-store-refs @conn)) ref))
+        (is (not (contains? (set (async/<!! (gc/gc-storage! @conn))) ref)))
+        (is (= {:body "branch-only source"} (artifact/get-value st ref)))
+        (versioning/delete-branch! conn :retained)
+        (is (contains? (set (async/<!! (gc/gc-storage! @conn))) ref)))
+      (finally (d/release conn) (d/delete-database cfg)))))

--- a/test/dvergr/artifact_test.clj
+++ b/test/dvergr/artifact_test.clj
@@ -32,9 +32,9 @@
       (is (thrown? Exception (artifact/put-value! st {:body "unsafe"})))
       (let [ref (artifact/publish-value! st {:body "source"}
                                          (fn [ref]
-                    (is (guard/in-flight? sid))
-                    (is (not (contains? (set (async/<!! (gc/gc-storage! @conn))) ref))
-                        "collection during the unpublished write window must spare the bytes")
+                                           (is (guard/in-flight? sid))
+                                           (is (not (contains? (set (async/<!! (gc/gc-storage! @conn))) ref))
+                                               "collection during the unpublished write window must spare the bytes")
                                            (is (= {:body "source"} (artifact/get-value st ref)))
                                            (d/transact conn [{:test/id :one :test/payload ref}])
                                            ref))]

--- a/test/dvergr/benchmarks/market_evidence_test.clj
+++ b/test/dvergr/benchmarks/market_evidence_test.clj
@@ -72,10 +72,19 @@
                                    :program {:kind :scripted :reply reply}})]
       (try
         (binding [ec/*execution-context* (:ctx room)]
-          (let [result @(evaluation/evaluate
-                         room team :fixture
-                         (evidence/definition)
-                         (evidence/evaluator))
+          (let [completion (promise)
+                computation (evaluation/evaluate room team :fixture
+                                                 (evidence/definition)
+                                                 (evidence/evaluator))
+                ;; Observe asynchronous completion; never block by dereferencing
+                ;; the Spin. Only the host test runner waits on this barrier.
+                _ (computation #(deliver completion {:result %})
+                               #(deliver completion {:error %}))
+                outcome (deref completion 200000 ::timeout)
+                _ (when (= ::timeout outcome)
+                    (throw (ex-info "Evaluation did not complete" {})))
+                _ (when-let [error (:error outcome)] (throw error))
+                result (:result outcome)
                 receipt (:attempt-receipt result)]
             (is (= :completed (:attempt/status receipt)))
             (is (= reward (:attempt/reward receipt)))

--- a/test/dvergr/chat/agent_test.clj
+++ b/test/dvergr/chat/agent_test.clj
@@ -5,6 +5,7 @@
             [dvergr.chat.context :as chat-ctx]
             [dvergr.chat.accounting :as accounting]
             [datahike.api :as dh]
+            [dvergr.tools :as tools]
             [dvergr.model.chat :as model-chat]))
 
 (defn- response [content]
@@ -12,6 +13,29 @@
    :tool-calls []
    :usage {}
    :stop-reason :stop})
+
+(deftest dispatch-correlates-each-tool-call
+  (let [ctx (chat-ctx/create-chat-context {:title "tool-correlation" :with-sci? false})
+        calls [{:id "call-a" :name "fixture" :input {}}
+               {:id "call-b" :name "fixture" :input {}}]
+        observed (atom [])]
+    (try
+      (with-redefs [agent/messages->api-format (fn [messages _ _] messages)
+                    model-chat/chat (fn [& _] (assoc (response "") :tool-calls calls))
+                    tools/execute (fn [_ _ tool-ctx]
+                                    (swap! observed conj (:tool-use-id tool-ctx))
+                                    {:type :success :content "done"
+                                     :authorization {:decision :authorized
+                                                     :sources #{:test}}})]
+        (is (= :continue
+               (agent/run-agent-turn! ctx {:provider :test :model "stub" :tools {}
+                                           :tool-ctx {:tool-use-id "stale"}
+                                           :auto-compact? false :turn-number 0})))
+        (is (= ["call-a" "call-b"] @observed))
+        (reset! observed [])
+        (tools/execute-parallel calls {:tool-use-id "stale"})
+        (is (= #{"call-a" "call-b"} (set @observed))))
+      (finally (chat-ctx/close-chat! ctx)))))
 
 (deftest provider-usage-is-accounted-once-with-model-pricing
   (doseq [model ["codex-subscription-sol" "claude-sonnet-4-5"]]

--- a/test/dvergr/io/acquisition_test.clj
+++ b/test/dvergr/io/acquisition_test.clj
@@ -18,7 +18,8 @@
         cfg {:store {:backend :file :path path :id (random-uuid)} :schema-flexibility :write :keep-history? true}
         _ (dh/create-database cfg)
         conn (dh/connect cfg)
-        artifacts (artifact/memory-store)
+        artifacts (artifact/datahike-store conn)
+        captured-ref (atom nil)
         run-id (random-uuid)
         room-id (keyword (str "receipt-" (random-uuid)))]
     (try
@@ -62,8 +63,9 @@
                                                       (assoc ctx :run-id second-run :execution-ctx (:ctx child))))))
                 (let [row (first (acquisition/list-for-run conn room-id second-run 10))]
                   (is (= :captured (:acquisition/capture row)))
+                  (reset! captured-ref (:acquisition/body-store-ref row))
                   (is (= {:body "private fixture"}
-                         (artifact/get-value artifacts (:acquisition/body-ref row))))
+                         (artifact/get-value artifacts (:acquisition/body-store-ref row))))
                   (is (not= (:acquisition/world-id (first (acquisition/list-for-run conn room-id run-id 10)))
                             (:acquisition/world-id row))))
                 (finally (d/discard child)))
@@ -72,6 +74,8 @@
       (dh/release conn)
       (let [reopened (dh/connect cfg)]
         (try (is (= 1 (count (acquisition/list-for-run reopened room-id run-id 10))))
+             (is (= {:body "private fixture"}
+                    (artifact/get-value (artifact/datahike-store reopened) @captured-ref)))
              (is (empty? (acquisition/list-for-run reopened :other-room run-id 10)))
              (room-store/-delete-room! (store/make reopened artifacts) room-id)
              (is (empty? (acquisition/list-for-run reopened room-id run-id 10)))
@@ -110,7 +114,7 @@
         (acquisition/record-request! {:url "https://example.org/path?token=private"}
                                      #(identity {:status 200 :body "éé"}))
         (is (= :too-large (:acquisition/capture (last @txs))))
-        (is (nil? (:acquisition/body-ref (last @txs))))
+        (is (nil? (:acquisition/body-store-ref (last @txs))))
         (is (not (.contains (pr-str @txs) "private")))
         (acquisition/record-request! {:url "https://other.example/path"}
                                      #(identity {:status 200 :body "x"}))
@@ -137,5 +141,5 @@
           (is (= (:acquisition/id (first @txs)) (:id provenance)))
           (is (= :completed (:acquisition/status (last @txs))))
           (is (= :captured (:capture provenance)))
-          (is (= (:acquisition/body-ref (last @txs)) (:body-ref provenance)))
+          (is (= (:acquisition/body-store-ref (last @txs)) (:body-ref provenance)))
           (is (= {:body "source"} (artifact/get-value artifacts (:body-ref provenance)))))))))

--- a/test/dvergr/io/acquisition_test.clj
+++ b/test/dvergr/io/acquisition_test.clj
@@ -1,0 +1,141 @@
+(ns dvergr.io.acquisition-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as dh]
+            [dvergr.artifact :as artifact]
+            [dvergr.chat.schema :as schema]
+            [dvergr.discourse :as d]
+            [dvergr.io.acquisition :as acquisition]
+            [dvergr.room.store :as room-store]
+            [dvergr.room.store.datahike :as store]
+            [dvergr.sandbox.ns.io :as io]
+            [dvergr.tools :as tools]
+            [hato.client :as http]
+            [sci.core :as sci]))
+
+(deftest durable-tool-acquisition
+  (let [path (str (java.nio.file.Files/createTempDirectory
+                   "dvergr-acquisition-" (make-array java.nio.file.attribute.FileAttribute 0)) "/db")
+        cfg {:store {:backend :file :path path :id (random-uuid)} :schema-flexibility :write :keep-history? true}
+        _ (dh/create-database cfg)
+        conn (dh/connect cfg)
+        artifacts (artifact/memory-store)
+        run-id (random-uuid)
+        room-id (keyword (str "receipt-" (random-uuid)))]
+    (try
+      (schema/ensure-full-schema! conn)
+      (let [room (d/make-room {:id room-id :store (store/make conn artifacts)})
+            sci-ctx (sci/init {})
+            _ (io/add-http-ns! sci-ctx)
+            ;; A saved function must select the invocation scope, not its setup room.
+            _ (sci/eval-string* sci-ctx "(def saved-get babashka.http-client/get)")
+            ctx {:control-room room :run-id run-id :tool-use-id "call-1"
+                 :sci-ctx sci-ctx :execution-ctx (:ctx room)}]
+        (try
+          ;; Hato/JDK returns Integer, not Clojure's default Long literal.
+          (with-redefs [http/request (fn [opts]
+                                       (is (= :never (get-in opts [:http-client :redirect-policy])))
+                                       {:status (int 200) :headers {} :body "private fixture"})]
+            (is (= :success (:type (tools/execute "clojure_eval"
+                                                  {:code "(saved-get \"https://93.184.216.34/?secret=value\")"} ctx))))
+            (let [rows (acquisition/list-for-run conn room-id run-id 10)]
+              (is (= 1 (count rows)))
+              (is (= :completed (:acquisition/status (first rows))))
+              (is (= (acquisition/request-key {:url "https://93.184.216.34/?secret=value" :method :get})
+                     (:acquisition/request-key (first rows))))
+              (is (= "call-1" (:acquisition/tool-use-id (first rows))))
+              (is (= :disabled (:acquisition/capture (first rows))))
+              (is (not (.contains (pr-str rows) "secret"))))
+            ;; Pull only the requested prefix; do not materialize the whole Run
+            ;; before imposing the public result limit.
+            (let [pull dh/pull
+                  pulls (atom 0)]
+              (with-redefs [dh/pull (fn [& args] (swap! pulls inc) (apply pull args))]
+                (is (= 1 (count (acquisition/list-for-run conn room-id run-id 1))))
+                (is (= 1 @pulls))))
+            (swap! (:meta room) assoc :http-capture
+                   {:allowed-origins #{"https://93.184.216.34"} :max-bytes 1024})
+            (let [child (d/fork-room room {:isolation :ctx})
+                  second-run (random-uuid)]
+              (try
+                (is (= :success (:type (tools/execute "clojure_eval"
+                                                      {:code "(saved-get \"https://93.184.216.34/evidence\")"}
+                                                      (assoc ctx :run-id second-run :execution-ctx (:ctx child))))))
+                (let [row (first (acquisition/list-for-run conn room-id second-run 10))]
+                  (is (= :captured (:acquisition/capture row)))
+                  (is (= {:body "private fixture"}
+                         (artifact/get-value artifacts (:acquisition/body-ref row))))
+                  (is (not= (:acquisition/world-id (first (acquisition/list-for-run conn room-id run-id 10)))
+                            (:acquisition/world-id row))))
+                (finally (d/discard child)))
+              (is (= 1 (count (acquisition/list-for-run conn room-id second-run 10))))))
+          (finally (d/close-room! room))))
+      (dh/release conn)
+      (let [reopened (dh/connect cfg)]
+        (try (is (= 1 (count (acquisition/list-for-run reopened room-id run-id 10))))
+             (is (empty? (acquisition/list-for-run reopened :other-room run-id 10)))
+             (room-store/-delete-room! (store/make reopened artifacts) room-id)
+             (is (empty? (acquisition/list-for-run reopened room-id run-id 10)))
+             (finally (dh/release reopened))))
+      (finally (dh/release conn) (dh/delete-database cfg)))))
+
+(deftest recording-failure-does-not-retry
+  (let [calls (atom 0) txs (atom 0)
+        scope {:conn :stub :room-id :research :run-id (random-uuid)}
+        perform #(do (swap! calls inc) {:status 200 :body "fixture"})]
+    (binding [acquisition/*scope* scope]
+      (with-redefs [dh/transact (fn [& _] (throw (ex-info "offline" {})))]
+        (is (thrown? Exception (acquisition/record-request! {} perform)))
+        (is (zero? @calls)))
+      (with-redefs [dh/transact (fn [& _] (when (= 2 (swap! txs inc)) (throw (ex-info "offline" {}))))]
+        (is (thrown-with-msg? Exception #"Do not retry"
+                              (acquisition/record-request! {} perform)))
+        (is (= 1 @calls))))))
+
+(deftest request-fingerprint-distinguishes-citation-targets
+  (let [request {:url "https://example.org/a" :method :get}]
+    (is (= (acquisition/request-key request)
+           (acquisition/request-key (dissoc request :method))))
+    (doseq [other [(assoc request :url "https://example.org/b")
+                   (assoc request :method :post)
+                   (assoc request :query-params {:page 2})]]
+      (is (not= (acquisition/request-key request) (acquisition/request-key other))))))
+
+(deftest capture-and-failure-projections
+  (let [txs (atom [])
+        scope {:conn :stub :room-id :research :run-id (random-uuid)
+               :artifacts (artifact/memory-store)
+               :capture-policy {:allowed-origins #{"https://example.org"} :max-bytes 2}}]
+    (binding [acquisition/*scope* scope]
+      (with-redefs [dh/transact (fn [_ tx] (swap! txs into tx))]
+        (acquisition/record-request! {:url "https://example.org/path?token=private"}
+                                     #(identity {:status 200 :body "éé"}))
+        (is (= :too-large (:acquisition/capture (last @txs))))
+        (is (nil? (:acquisition/body-ref (last @txs))))
+        (is (not (.contains (pr-str @txs) "private")))
+        (acquisition/record-request! {:url "https://other.example/path"}
+                                     #(identity {:status 200 :body "x"}))
+        (is (= :disabled (:acquisition/capture (last @txs))))
+        (is (thrown? Exception
+                     (acquisition/record-request! {:url "bad-url"}
+                                                  #(throw (ex-info "private details" {})))))
+        (is (= :failed (:acquisition/status (last @txs))))
+        (is (not (.contains (pr-str @txs) "private details")))))))
+
+(deftest response-provenance-is-issued-after-persistence
+  (let [txs (atom [])
+        artifacts (artifact/memory-store)
+        response {:status 200 :headers {} :body "source"}
+        scope {:conn :stub :room-id :research :run-id (random-uuid)
+               :artifacts artifacts
+               :capture-policy {:allowed-origins #{"https://example.org"} :max-bytes 1024}}]
+    (is (= response (acquisition/record-request! {} (constantly response))))
+    (binding [acquisition/*scope* scope]
+      (with-redefs [dh/transact (fn [_ tx] (swap! txs into tx))]
+        (let [actual (acquisition/record-request! {:url "https://example.org/"} (constantly response))
+              provenance (:dvergr/acquisition actual)]
+          (is (= response (dissoc actual :dvergr/acquisition)))
+          (is (= (:acquisition/id (first @txs)) (:id provenance)))
+          (is (= :completed (:acquisition/status (last @txs))))
+          (is (= :captured (:capture provenance)))
+          (is (= (:acquisition/body-ref (last @txs)) (:body-ref provenance)))
+          (is (= {:body "source"} (artifact/get-value artifacts (:body-ref provenance)))))))))

--- a/test/dvergr/room/store/datahike_test.clj
+++ b/test/dvergr/room/store/datahike_test.clj
@@ -275,6 +275,27 @@
                              :where [?a :attempt/checks ?check]] @conn)
                      0))))))
 
+(deftest legacy-artifact-injection-and-domain-readers-remain-compatible
+  (let [[conn _] (mem-store)
+        bytes-by-id (atom {})]
+    (try
+      (with-redefs [dvergr.drive.blobs/store!
+                    (fn [bytes _]
+                      (let [id (dvergr.drive.blobs/sha256-hex bytes)]
+                        (swap! bytes-by-id assoc id bytes)
+                        {:blob/id id}))
+                    dvergr.drive.blobs/get-bytes #(get @bytes-by-id %)]
+        (contract/assert-cross-room-scorecard-identity!
+         (dhs/make conn (artifact/blob-store)))
+        ;; Schema installation must leave historical string attributes intact.
+        (dvergr.chat.schema/ensure-full-schema! conn)
+        (is (= :db.type/string (get-in @conn [:schema :attempt/payload-blob :db/valueType])))
+        (is (= :db.type/store-ref (get-in @conn [:schema :attempt/payload-ref :db/valueType])))
+        (let [modern (dhs/make conn)]
+          (is (= 1 (count (store/-list-attempts modern :scorecard-room-a {}))))
+          (is (= 1 (count (store/-list-scorecards modern :scorecard-room-a {}))))))
+      (finally (dh/release conn)))))
+
 (deftest message-envelope-contract
   (let [[_conn st] (mem-store)]
     (contract/assert-message-envelope! st :envelope-datahike)))


### PR DESCRIPTION
## Summary

- Record sandbox HTTP acquisition start/outcome in the existing Datahike control-room store, correlated with Run, tool call and execution world. Receipts survive discarded work worlds.
- Default to metadata only; host-opted-in origin/byte policy captures credential-scrubbed text into the existing artifact store. Return provenance only after outcome persistence; never retry the HTTP effect because its recording failed.
- Add a request fingerprint for matching citation targets without storing raw paths/queries, and a Run-indexed metadata query that applies the result limit before pulling rows.
- Propagate actual tool-call IDs in sequential model dispatch and parallel dispatch. Explicitly disable redirects using Hato's client options.
- Observe benchmark Spin completion asynchronously; no blocking Spin deref in the regression test (only a host promise barrier).
- Unify new captured bodies, Attempt payloads and Scorecard payloads on Datahike `:db.type/store-ref`, using content-addressed UUIDs in the room database's Konserve store. Shared `artifact/publish-value!` guards bytes through reference commit using the canonical store identity.

## Scope and limitations

This is acquisition provenance, not a complete discovery benchmark or citation-entailment verifier. Capture byte limits bound stored bodies and additional encoding, not HTTP transport buffering or cumulative Run resources. No receipts are automatically created for direct HTTP calls outside a tool invocation or memory-only RoomStores. Access to the host query must be authorized by its caller.

Room deletion retracts receipt projections. Datahike GC reclaims managed payloads only after all retained branches/history release them, subject to normal retention and writer-age policy. Receipt metadata and captured bodies now both have cold-reopen coverage using the database's file-backed store.

Existing string schema attributes are preserved; new UUID attributes are added. Legacy Attempt/Scorecard payloads remain readable from the global CAS; explicit legacy artifact-store injection still works. No old records are rewritten and no legacy global blob sweep is added. Reference-only dead letters are diagnostic, not self-contained recovery bundles: republish the exact payload before retrying its domain write.

Public usage and boundaries are documented in the existing practical evaluation guide; campaign notes remain internal.

## Validation

- Provider-free acquisition, evidence benchmark and chat-agent tests: 15 tests / 101 assertions passed.
- Datahike room-store tests: 27 tests / 129 assertions passed. Combined: 42 tests / 230 assertions.
- Tests cover saved SCI functions, current world/Run scope, fork discard, receipt reopen/delete, capture opt-in/byte limits, fingerprint changes, persistence failure ordering, and real/parallel tool dispatch IDs.
- Independent static review performed; query materialization, dispatch correlation and Hato option findings addressed.
- No live model or external HTTP calls; transport is stubbed.
- Store-ref integration adds actual GC/reclamation, GC-during-publication, failure guard release, retained history, another-branch-only references, body cold reopen, legacy schema/read/write compatibility, and evaluation regression coverage. Independent review found no remaining medium+ issues after fixes.
- Final store-ref regression run: 60 tests / 353 assertions passed across artifact lifecycle, acquisition, room Datahike store, market evidence and evaluation. No dependency bump: pinned Datahike 0.8.1865 supplies the APIs.
