### PR TITLE
Verify frozen discovery citations against acquisition receipts

### DIFF
--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -347,6 +347,21 @@ These receipts establish acquisition provenance, not whether a quotation
 supports a claim. A discovery evaluator must still verify the Run, request
 fingerprint, captured body and submitted evidence together.
 
+`dvergr.benchmarks.discovery-citations/verify` provides the first frozen-fixture
+check over that boundary. A host supplies an exact reference map and room/Run;
+the submitted answer names receipt UUIDs, URLs and complete evidence sentences.
+Only successful, captured GET responses from that scope can earn credit.
+Partial valid coverage earns partial reward; any invalid extra citation gates
+reward to zero. Foreign or nonexistent receipts cannot authorize artifact reads.
+The provider-free test uses synthetic businesses, a failed response and an
+irrelevant page. It checks real persisted receipts and managed artifact bodies,
+not an agent-reported fetch log.
+
+This helper checks exact plaintext fixtures, not arbitrary HTML or semantic
+entailment. It does not certify Run completion, execute searches, or constitute a
+live discovery benchmark; those belong to the enclosing Environment/Evaluator
+workflow. Its reference answers must remain host-owned.
+
 ## Port order driven by failures
 
 1. Complete scoped observation and expose it in the REPL/UI.

--- a/src/dvergr/benchmarks/discovery_citations.clj
+++ b/src/dvergr/benchmarks/discovery_citations.clj
@@ -1,0 +1,60 @@
+(ns dvergr.benchmarks.discovery-citations
+  "Trusted citation checks for the frozen discovery fixture. Candidate receipt
+   IDs are claims to verify, never authority to read another Run's artifacts."
+  (:require [datahike.api :as d]
+            [dvergr.artifact :as artifact]
+            [dvergr.io.acquisition :as acquisition]))
+
+(defn verify
+  "Verify submitted discoveries against host-owned reference pages and this
+   exact room/Run's acquisition receipts. references is {url exact-evidence}.
+   This narrow fixture requires the complete evidence sentence, not entailment
+   judgments over arbitrary prose. Missing storage is a setup error, not reward 0."
+  [room run-id references answer]
+  (let [conn (some-> room :store :conn)
+        artifacts (some-> room :store :artifacts)]
+    (when-not (and conn artifacts (uuid? run-id)
+                   (map? references) (<= 1 (count references) 8)
+                   (every? string? (keys references))
+                   (every? #(and (string? %) (<= 1 (count %) 240)) (vals references)))
+      (throw (ex-info "Citation verification requires a Datahike Room, Run and reference pages" {})))
+    (let [entries (:alternatives answer)
+          shape? (and (map? answer) (= #{:alternatives} (set (keys answer)))
+                      (vector? entries) (<= (count entries) 8)
+                      (every? #(and (map? %) (= #{:url :receipt :quote} (set (keys %)))
+                                    (string? (:url %)) (uuid? (:receipt %))
+                                    (string? (:quote %)) (<= (count (:quote %)) 240)) entries)
+                      (= (count entries) (count (set (map :url entries))))
+                      (= (count entries) (count (set (map :receipt entries)))))
+          db @conn
+          valid (when shape?
+                  (mapv
+                   (fn [{:keys [url receipt quote]}]
+                     (let [row (d/q '[:find (pull ?e [*]) .
+                                      :in $ ?id ?room ?run
+                                      :where [?e :acquisition/id ?id]
+                                      [?e :acquisition/room-id ?room]
+                                      [?e :acquisition/run-id ?run]]
+                                    db receipt (:id room) run-id)
+                           ref (:acquisition/body-store-ref row)
+                           owned? (and (= (:id room) (:acquisition/room-id row))
+                                       (= run-id (:acquisition/run-id row)))
+                           acquired? (and owned? (= :completed (:acquisition/status row))
+                                          (= :get (:acquisition/method row))
+                                          (= 200 (:acquisition/http-status row))
+                                          (= :captured (:acquisition/capture row))
+                                          (uuid? ref)
+                                          (= (acquisition/request-key {:url url :method :get})
+                                             (:acquisition/request-key row)))
+                           ;; Do not dereference artifacts belonging to a different
+                           ;; scope, even when a submitted receipt exists.
+                           body (when acquired? (:body (artifact/get-value artifacts ref)))]
+                       (boolean (and acquired? (contains? references url)
+                                     (= (get references url) quote body)))))
+                   entries))
+          recovered (if shape? (count (filter true? valid)) 0)]
+      {:checks {:schema? (boolean shape?)
+                :citations? (boolean (and shape? (seq entries) (every? true? valid)))
+                :coverage? (boolean (and shape? (= recovered (count references))))}
+       :reward (if (and shape? (every? true? valid))
+                 (/ recovered (double (count references))) 0.0)})))

--- a/test/dvergr/benchmarks/discovery_citations_test.clj
+++ b/test/dvergr/benchmarks/discovery_citations_test.clj
@@ -1,0 +1,57 @@
+(ns dvergr.benchmarks.discovery-citations-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [dvergr.artifact :as artifact]
+            [dvergr.benchmarks.discovery-citations :as citations]
+            [dvergr.chat.schema :as schema]
+            [dvergr.io.acquisition :as acquisition]
+            [dvergr.room.store.datahike :as store]))
+
+;; Synthetic businesses, not a real-world competitor list. The failed source
+;; and irrelevant page must not receive credit merely because they were fetched.
+(def references
+  {"https://example.org/aster" "Aster supports persistent agent teams with shared organizational memory."
+   "https://example.org/beryl" "Beryl supports human approval of proposed business changes."})
+
+(deftest only-actual-in-scope-captured-sources-earn-credit
+  (let [cfg {:store {:backend :memory :id (random-uuid)} :schema-flexibility :write}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        _ (schema/ensure-full-schema! conn)
+        room {:id :discovery-fixture :store (store/make conn)}
+        run-id (random-uuid)
+        scope {:conn conn :room-id (:id room) :run-id run-id
+               :artifacts (:artifacts (:store room))
+               :capture-policy {:allowed-origins #{"https://example.org"} :max-bytes 1024}}
+        fetch (fn [url status body]
+                (let [response (acquisition/record-request!
+                                {:url url} (constantly {:status status :body body}))]
+                  {:url url :receipt (get-in response [:dvergr/acquisition :id]) :quote body}))]
+    (try
+      (binding [acquisition/*scope* scope]
+        (let [entries (mapv (fn [[url body]] (fetch url 200 body)) references)
+              answer {:alternatives entries}
+              score #(citations/verify room run-id references %)
+              wrong-run (binding [acquisition/*scope* (assoc scope :run-id (random-uuid))]
+                          (fetch (:url (first entries)) 200 (:quote (first entries))))
+              wrong-room (binding [acquisition/*scope* (assoc scope :room-id :another-room)]
+                           (fetch (:url (first entries)) 200 (:quote (first entries))))
+              failed (fetch (:url (first entries)) 503 (:quote (first entries)))
+              irrelevant (fetch "https://example.org/cinder" 200 "Cinder is a personal autocomplete editor.")]
+          (is (= 1.0 (:reward (score answer))))
+          (is (every? true? (vals (:checks (score answer)))))
+          (is (= 0.5 (:reward (score {:alternatives [(first entries)]}))))
+          (is (zero? (:reward (score {:alternatives (conj entries irrelevant)}))))
+          (doseq [bad [(assoc (first entries) :receipt (random-uuid))
+                       (assoc (first entries) :url "https://example.org/beryl")
+                       (assoc (first entries) :quote "Invented superiority.")
+                       (assoc (first entries) :receipt "not-a-uuid")
+                       wrong-run wrong-room failed irrelevant]]
+            (is (zero? (:reward (score {:alternatives [bad]})))))
+          (doseq [bad [nil {} {:alternatives entries :extra true}
+                       {:alternatives [(first entries) (first entries)]}]]
+            (is (zero? (:reward (score bad)))))
+          (with-redefs [artifact/get-value (fn [& _] (throw (ex-info "must not read foreign content" {})))]
+            (doseq [foreign [wrong-run wrong-room]]
+              (is (zero? (:reward (score {:alternatives [foreign]}))))))))
+      (finally (d/release conn) (d/delete-database cfg)))))


### PR DESCRIPTION
## Summary

- Add a narrow frozen-plaintext citation verifier backed by the exact room/Run's durable acquisition receipts and captured Datahike artifacts.
- Check request fingerprints, successful captured GET responses, and exact host-owned evidence; foreign or invented receipts earn no credit and cannot authorize foreign artifact reads.
- Allow partial valid coverage, but gate reward to zero if any submitted citation is invalid.
- Document the scope in the practical evaluation guide. This is the verification layer, not yet an end-to-end discovery Environment/Evaluator, arbitrary prose entailment judge, or Run-completion check.

Built on merged #103 (released as 0.1.82). Uses synthetic businesses and stubbed transport: no live model or HTTP requests.

## Verification

- Interactive Clojure REPL: acquisition, market-evidence and discovery-citations tests — 10 tests, 95 assertions, zero failures/errors.
- `clojure -J-Xmx256m -M:ffix` and `git diff --check` pass.
- Independent review completed; all medium-or-higher findings resolved.

Next: compose the actual discovery workflow through the existing Environment/Evaluator and exercise search/fetch/evidence production against this deterministic verification layer.
