### PR TITLE
Add scoped frozen web search for agent benchmarks

### DIFF
--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -362,6 +362,28 @@ entailment. It does not certify Run completion, execute searches, or constitute 
 live discovery benchmark; those belong to the enclosing Environment/Evaluator
 workflow. Its reference answers must remain host-owned.
 
+For variable-query experiments, `dvergr.benchmarks.frozen-web/transport`
+compiles immutable `{url {:title text :body text}}` pages into an offline HTTP
+function. The host installs it with
+`(dvergr.sandbox.ns.io/add-http-ns! sci-ctx :fixture-transport transport)`.
+It accepts the Brave search endpoint and returns its JSON response shape;
+ranking uses distinct lexical overlap with stable URL tie-breaking, not Brave's
+production ranking. Queries may vary; the corpus and algorithm stay fixed.
+Page GETs return exact fixture text. Unsupported options/methods and unknown
+URLs return HTTP errors without DNS or live-network fallback.
+
+This namespace-local capability contains no mutable replay cursor. It is safe
+to share between interpreter forks, but newly constructed interpreters need
+explicit installation; this does not yet wire nested-room setup automatically.
+Use a fake `BRAVE_API_KEY` in the fixture's sandbox environment to exercise the
+existing intake without credentials. Domain checks still apply. With an active
+acquisition scope, each call creates a fresh receipt; successful transport
+responses (including HTTP errors) carry a content-derived
+`:acquisition/fixture-id`. Captured bodies still require host capture policy.
+Simulated acquisitions must not be represented as live observations or billed
+as actual provider usage. This slice does not add automatic accounting charges,
+model-response replay, or the complete discovery Environment/Evaluator.
+
 ## Port order driven by failures
 
 1. Complete scoped observation and expose it in the REPL/UI.

--- a/src/dvergr/benchmarks/frozen_web.clj
+++ b/src/dvergr/benchmarks/frozen_web.clj
@@ -1,0 +1,52 @@
+(ns dvergr.benchmarks.frozen-web
+  "Small immutable web environment for discovery experiments. Not a simulation
+   of Brave's ranking: lexical overlap, stable URL tie-breaking, no network."
+  (:require [hasch.core :as hasch]
+            [jsonista.core :as j]))
+
+(def search-url "https://api.search.brave.com/res/v1/web/search")
+
+(defn- terms [s]
+  (set (re-seq #"[\p{L}\p{N}]+" (.toLowerCase ^String s java.util.Locale/ROOT))))
+
+(defn transport
+  "Compile {url {:title string :body string}} into a pure host HTTP transport.
+   Search accepts Brave-style :query-params (:q, :count, :country). Freshness
+   and other options are unsupported rather than silently approximated.
+   HTTP errors are data; no request can fall through to the live web.
+   Install with add-http-ns!'s host-only :fixture-transport option."
+  [pages]
+  (when-not (and (map? pages) (seq pages)
+                 (every? (fn [[url page]]
+                           (and (string? url) (not= search-url url)
+                                (re-matches #"https://[^\s]+" url)
+                                (map? page) (= #{:title :body} (set (keys page)))
+                                (every? string? (vals page)))) pages))
+    (throw (ex-info "Expected frozen HTTPS pages with title and body" {})))
+  (let [fixture-id (hasch/uuid [:frozen-web/v1 pages])
+        indexed (mapv (fn [[url {:keys [title body]}]]
+                        {:url url :title title :description body
+                         :terms (terms (str title " " body))}) pages)
+        response (fn [status body]
+                   {:status status :headers {} :body body :dvergr/fixture-id fixture-id})]
+    (fn [{:keys [url method query-params body json] :or {method :get}}]
+      (cond
+        (not= :get method) (response 405 "Frozen web only supports GET")
+        (or body json) (response 400 "GET bodies are unsupported")
+        (= search-url url)
+        (let [{:keys [q count country] :or {count 5 country "US"}} query-params]
+          (if-not (and (map? query-params) (string? q) (<= 1 (clojure.core/count q) 4096)
+                       (integer? count) (<= 1 count 50) (= "US" country)
+                       (every? #{:q :count :country} (keys query-params)))
+            (response 400 "Unsupported frozen search parameters")
+            (let [query (terms q)
+                  hits (->> indexed
+                            (map #(assoc % :score (clojure.core/count (filter query (:terms %)))))
+                            (filter #(pos? (:score %)))
+                            (sort-by (juxt (comp - :score) :url))
+                            (take count)
+                            (mapv #(dissoc % :score :terms)))]
+              (response 200 (j/write-value-as-string {:web {:results hits}})))))
+        (seq query-params) (response 400 "Frozen pages do not support query parameters")
+        (contains? pages url) (response 200 (:body (get pages url)))
+        :else (response 404 "Not present in frozen web")))))

--- a/src/dvergr/io/acquisition.clj
+++ b/src/dvergr/io/acquisition.clj
@@ -25,6 +25,7 @@
          [:acquisition/body-ref :db.type/string]
          [:acquisition/body-store-ref :db.type/store-ref] [:acquisition/capture :db.type/keyword]
          [:acquisition/request-key :db.type/uuid]
+         [:acquisition/fixture-id :db.type/uuid]
          [:acquisition/error-class :db.type/string]]))
 
 (defn tool-scope [ctx]
@@ -102,6 +103,8 @@
                                             :acquisition/status (if (:error outcome) :failed :completed)}
                                            (when (:status response)
                                              {:acquisition/http-status (long (:status response))})
+                                           (when-let [fixture-id (:dvergr/fixture-id response)]
+                                             {:acquisition/fixture-id fixture-id})
                                            (when-let [e (:error outcome)]
                                              {:acquisition/error-class (.getName (class e))})
                                            captured)])

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -626,6 +626,10 @@
    JSON bodies are auto-parsed.
 
    :audit-log      - atom from (make-audit-log); records every request (method + url, no body)
+   :fixture-transport - trusted host-only offline request function, local to this
+                        SCI namespace. Preserves domain checks and acquisition
+                        recording; replaces DNS/network and secret injection.
+                        Never expose transport installation to candidate code.
    :allowed-domains - set of URL prefix strings; non-empty set restricts outbound requests.
                       Empty or nil permits all domains (open).
                       Example: #{\"https://api.github.com\" \"https://slack.com\"}
@@ -637,7 +641,7 @@
        {:headers {\"Authorization\" (str \"Bearer \" (env/get \"MY_SERVICE_TOKEN\"))}
         :json {:channel \"#general\" :text \"Hello from dvergr\"}})
      (http/request {:url \"...\" :method :put :headers {...} :body \"...\"})"
-  [sci-ctx & {:keys [audit-log allowed-domains secrets]}]
+  [sci-ctx & {:keys [audit-log allowed-domains secrets fixture-transport]}]
   (let [domain-check (make-domain-policy allowed-domains)
         perform-request
         (fn [{:keys [url method headers body json query-params timeout]
@@ -673,8 +677,18 @@
             {:status (:status resp)
              :headers (into {} (:headers resp))
              :body (:body resp)}))
+        ;; Host-only, namespace-local substitution. Never consult a global
+        ;; transport Var: concurrent live and simulated interpreters coexist.
+        ;; A fixture does no DNS, secret substitution or network fallback.
         do-request (fn [opts]
-                     (acquisition/record-request! opts #(perform-request opts)))]
+                     (acquisition/record-request!
+                      opts #(if fixture-transport
+                              (do
+                                (audit! audit-log :http/request
+                                        {:method (or (:method opts) :get) :url (:url opts)})
+                                (when domain-check (domain-check (:url opts)))
+                                (fixture-transport opts))
+                              (perform-request opts))))]
     (sci/add-namespace! sci-ctx 'babashka.http-client
                         {'request do-request
                          'get     (fn [url & [opts]] (do-request (merge {:url url :method :get} opts)))

--- a/test/dvergr/benchmarks/frozen_web_test.clj
+++ b/test/dvergr/benchmarks/frozen_web_test.clj
@@ -1,0 +1,62 @@
+(ns dvergr.benchmarks.frozen-web-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [dvergr.artifact :as artifact]
+            [dvergr.benchmarks.frozen-web :as web]
+            [dvergr.chat.schema :as schema]
+            [dvergr.io.acquisition :as acquisition]
+            [dvergr.sandbox.ns.io :as io]
+            [jsonista.core :as j]
+            [sci.core :as sci]))
+
+(def pages
+  {"https://example.org/aster" {:title "Aster" :body "Persistent agent teams share organizational memory."}
+   "https://example.org/beryl" {:title "Beryl" :body "Agent teams request human approval."}
+   "https://example.org/cinder" {:title "Cinder" :body "Personal autocomplete editor."}})
+
+(deftest frozen-search-is-query-dependent-and-order-independent
+  (let [request {:url web/search-url :query-params {:q "agent teams"}}
+        transport (web/transport pages)
+        response (transport request)
+        hits #(get-in (j/read-value (:body %) j/keyword-keys-object-mapper) [:web :results])]
+    (is (= response ((web/transport (into (sorted-map) pages)) request)))
+    (is (= ["Aster" "Beryl"] (mapv :title (hits response))))
+    (is (= ["Beryl"] (mapv :title (hits (transport (assoc-in request [:query-params :q] "approval"))))))
+    (is (empty? (hits (transport (assoc-in request [:query-params :q] "astronomy")))))
+    (doseq [bad [(assoc request :method :post)
+                 (assoc-in request [:query-params :freshness] "pd")
+                 (assoc-in request [:query-params :count] 0)
+                 {:url "https://unknown.invalid"}]]
+      (is (<= 400 (:status (transport bad)))))
+    (is (= "Persistent agent teams share organizational memory."
+           (:body (transport {:url "https://example.org/aster"}))))))
+
+(deftest sci-fixtures-are-local-and-produce-fresh-durable-receipts
+  (let [cfg {:store {:backend :memory :id (random-uuid)} :schema-flexibility :write}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        ctx (sci/init {})
+        other (sci/init {})
+        run-id (random-uuid)
+        artifacts (artifact/datahike-store conn)]
+    (try
+      (schema/ensure-full-schema! conn)
+      (io/add-http-ns! ctx :fixture-transport (web/transport pages))
+      (io/add-http-ns! other :allowed-domains #{"https://example.org"} :fixture-transport
+                       (web/transport {"https://example.org/aster" {:title "Other" :body "Other world"}}))
+      ;; Resolving .invalid would fail if a fixture accidentally used real DNS.
+      (is (= 404 (sci/eval-string* ctx "(:status (babashka.http-client/get \"https://unknown.invalid\"))")))
+      (is (= "Other world" (sci/eval-string* other "(:body (babashka.http-client/get \"https://example.org/aster\"))")))
+      (is (thrown? Exception (sci/eval-string* other "(babashka.http-client/get \"https://unknown.invalid\")")))
+      (binding [acquisition/*scope* {:conn conn :room-id :fixture :run-id run-id :artifacts artifacts
+                                     :capture-policy {:allowed-origins #{"https://example.org"} :max-bytes 1024}}]
+        (let [code "(babashka.http-client/get \"https://example.org/aster\")"
+              a (sci/eval-string* ctx code)
+              b (sci/eval-string* ctx code)
+              rows (acquisition/list-for-run conn :fixture run-id 10)]
+          (is (= (:body a) (:body b)))
+          (is (not= (get-in a [:dvergr/acquisition :id]) (get-in b [:dvergr/acquisition :id])))
+          (is (= 2 (count rows)))
+          (is (every? #(= (:dvergr/fixture-id a) (:acquisition/fixture-id %)) rows))
+          (is (= {:body (:body a)} (artifact/get-value artifacts (:acquisition/body-store-ref (first rows)))))))
+      (finally (d/release conn) (d/delete-database cfg)))))


### PR DESCRIPTION
## Summary

- Add a pure, content-addressed frozen web transport: variable queries rank an immutable page corpus by lexical overlap with locale-independent tokenization and stable URL tie-breaking; page fetches return exact text.
- Add host-only `:fixture-transport` installation to one SCI HTTP namespace. Preserve domain checks and acquisition recording; no DNS, credential substitution, or live-network fallback in fixture mode.
- Persist `:acquisition/fixture-id` to distinguish simulated responses from live observations. Each invocation still receives a fresh receipt.
- Document unsupported options, explicit installation for newly constructed interpreters, capture policy, and simulated accounting limitations.

This is the offline search substrate, not a complete discovery Environment/Evaluator or provider-model replay. It does not attempt to reproduce Brave's ranking. Existing public API defaults remain unchanged.

## Verification

- Interactive JVM regression suite: acquisition, market-evidence, discovery-citations, frozen-web — **12 tests, 112 assertions, zero failures/errors**.
- SCI REPL smoke using actual sibling `dvergr-sandbox/dvergr/intake/web_search.clj`, dummy key, JSON decoding binding, and empty unused `intake.core` namespace: `agent teams` returned Aster/Beryl; `approval` returned Beryl. No network or model requests. This local smoke is not a portable CI test of the sibling repository.
- Deterministic tests cover varied queries, stable ranking/corpus identity, unsupported requests, separate SCI namespaces, denied domains, fresh durable receipt IDs, fixture provenance, and captured artifact bodies.
- `clojure -J-Xmx256m -M:ffix`; `git diff --check`.
- Independent review: no medium-or-higher findings; addressed locale-independent ranking and denied-domain coverage suggestions.

Next: connect this substrate through trusted world setup and the existing Environment/Evaluator, preserve search receipt correlation through intake reshaping, and evaluate live agents on the frozen corpus.
