### PR TITLE
Certify frozen discovery through isolated agent runs

### DIFF
--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -373,16 +373,43 @@ Page GETs return exact fixture text. Unsupported options/methods and unknown
 URLs return HTTP errors without DNS or live-network fallback.
 
 This namespace-local capability contains no mutable replay cursor. It is safe
-to share between interpreter forks, but newly constructed interpreters need
-explicit installation; this does not yet wire nested-room setup automatically.
+to share between interpreter forks. Used alone, newly constructed interpreters
+need explicit installation; the WorldSetup integration below supplies it.
 Use a fake `BRAVE_API_KEY` in the fixture's sandbox environment to exercise the
 existing intake without credentials. Domain checks still apply. With an active
 acquisition scope, each call creates a fresh receipt; successful transport
 responses (including HTTP errors) carry a content-derived
 `:acquisition/fixture-id`. Captured bodies still require host capture policy.
 Simulated acquisitions must not be represented as live observations or billed
-as actual provider usage. This slice does not add automatic accounting charges,
-model-response replay, or the complete discovery Environment/Evaluator.
+as actual provider usage. The transport itself does not add automatic accounting
+charges or model-response replay.
+
+`dvergr.benchmarks.discovery` composes this substrate into a synthetic discovery
+Environment/Evaluator. Give the durable control Room
+`{:http-capture discovery/capture-policy}` in its metadata, then execute
+`(evaluation/evaluate room team :researcher (discovery/definition)
+  (discovery/evaluator) {:world-setup (discovery/world-setup)})` as an ordinary
+Spin. The candidate AgentDef needs `:tools #{:clojure_eval}`. Bind the room's
+Spindel context at the host entry point; compose with `await` inside Spins.
+
+Trusted WorldSetup installs an immutable offline HTTP capability and dummy
+service config in Spindel execution-context state, before interpreter creation.
+New interpreters in descendant context forks inherit it; existing interpreters
+retain their already-installed transport. Reconstruct capabilities through the
+content-addressed setup after restart, not by serializing host functions.
+Fixture mode does not load host service secrets. Installation is host-only,
+not a new candidate-visible switch for choosing live versus simulated effects.
+
+Candidates must cite one actual search response and page receipts from the
+same Run. Scoring checks that submitted URLs occurred in those search results,
+that all receipts belong to this fixture, and that exact fetched text supports
+the submitted alternatives. Completion and correct setup gate reward; failure,
+cancellation and waiting earn no credit. This first contract deliberately uses
+one cited search response, not yet a multi-query causal discovery graph.
+The three synthetic companies are a plumbing test, not a substantive market
+benchmark. The provider-free test substitutes only model responses and unrelated
+workspace bootstrapping: tool execution, SCI, receipts, scoring and settlement
+remain real. Live candidates can use exactly the same Environment/Evaluator.
 
 ## Port order driven by failures
 

--- a/src/dvergr/benchmarks/discovery.clj
+++ b/src/dvergr/benchmarks/discovery.clj
@@ -1,0 +1,108 @@
+(ns dvergr.benchmarks.discovery
+  "Frozen discovery through the ordinary isolated Run and evaluator lifecycle.
+   Synthetic companies test acquisition and evidence handling, not market demand."
+  (:require [datahike.api :as d]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.artifact :as artifact]
+            [dvergr.benchmarks.discovery-citations :as citations]
+            [dvergr.benchmarks.frozen-web :as web]
+            [dvergr.benchmarks.market-evidence :as evidence]
+            [dvergr.sandbox.ns.io :as io]
+            [hasch.core :as hasch]
+            [jsonista.core :as j]))
+
+(def pages
+  {"https://example.org/aster" {:title "Aster" :body "Aster supports persistent agent teams with shared organizational memory."}
+   "https://example.org/beryl" {:title "Beryl" :body "Beryl supports agent teams with human approval of proposed business changes."}
+   "https://example.org/cinder" {:title "Cinder" :body "Cinder is a personal autocomplete editor, not an agent team workspace."}})
+
+(def references (into {} (map (fn [url] [url (:body (get pages url))])
+                              ["https://example.org/aster" "https://example.org/beryl"])))
+(def fixture-id (:dvergr/fixture-id ((web/transport pages) {:url "https://example.org/aster"})))
+(def basis (hasch/uuid [:discovery/v1 fixture-id references :search-and-captured-citations]))
+(def setup-ref {:setup/id :business/frozen-discovery :setup/version 1 :setup/basis basis})
+
+(def task
+  (str "Discover synthetic products supporting agent teams, excluding personal autocomplete editors. "
+       "Use clojure_eval and babashka.http-client. The web is a frozen lexical corpus, not the live internet. "
+       "Search GET " web/search-url " with {:query-params {:q your-query :count 10}}; "
+       "parse :body with cheshire.core/parse-string and keyword keys. Results are under [:web :results]. "
+       "Fetch relevant result URLs. HTTP responses carry a receipt UUID at [:dvergr/acquisition :id]. "
+       "Return exactly one EDN map {:search search-receipt-uuid :alternatives "
+       "[{:url url :receipt fetch-receipt-uuid :quote complete-page-text} ...]}. "
+       "All submitted URLs must occur in the cited search response. You may search again if needed. "
+       "Do not fabricate receipts. No fences or commentary in the final answer."))
+
+(defn definition []
+  (environment/make-environment
+   {:id :business/frozen-discovery :task task
+    :verifier {:id :business/discovery-checks :version 1 :basis basis}
+    :world {:isolation :ctx :settlement :discard :setup setup-ref}
+    :limits {:timeout-ms 180000 :cancel-timeout-ms 10000}
+    :metadata {:fixture-id fixture-id :kind :synthetic-discovery}}))
+
+(defn world-setup []
+  (evaluation/make-world-setup
+   {:id (:setup/id setup-ref) :version 1 :basis basis
+    :prepare (fn [_]
+               (io/install-http-fixture!
+                {:id fixture-id :transport (web/transport pages)
+                 :env {"BRAVE_API_KEY" "offline-fixture"}})
+               {:fixture-id fixture-id})}))
+
+(def capture-policy
+  {:allowed-origins #{"https://example.org" "https://api.search.brave.com"}
+   :max-bytes 16384})
+
+(defn score
+  "Host-only verification; requires the control Room's capture policy enabled.
+   Scope every lookup before reading captured data. No candidate-supplied body
+   or computed score is authoritative."
+  [room run-id answer]
+  (let [conn (some-> room :store :conn)
+        artifacts (some-> room :store :artifacts)
+        shape? (and (map? answer) (= #{:search :alternatives} (set (keys answer)))
+                    (uuid? (:search answer)))
+        scoped (fn [id]
+                 (when (uuid? id)
+                   (d/q '[:find (pull ?e [*]) . :in $ ?id ?room ?run
+                          :where [?e :acquisition/id ?id]
+                          [?e :acquisition/room-id ?room] [?e :acquisition/run-id ?run]]
+                        @conn id (:id room) run-id)))
+        page-score (citations/verify room run-id references
+                                     (when shape? (select-keys answer [:alternatives])))
+        row (when shape? (scoped (:search answer)))
+        search? (and (= fixture-id (:acquisition/fixture-id row))
+                     (= "https://api.search.brave.com" (:acquisition/origin row))
+                     (= :get (:acquisition/method row))
+                     (= :completed (:acquisition/status row))
+                     (= 200 (:acquisition/http-status row))
+                     (= :captured (:acquisition/capture row))
+                     (uuid? (:acquisition/body-store-ref row)))
+        body (when search? (:body (artifact/get-value artifacts (:acquisition/body-store-ref row))))
+        hits (when (string? body)
+               (try (get-in (j/read-value body j/keyword-keys-object-mapper) [:web :results])
+                    (catch Exception _ nil)))
+        urls (set (map :url hits))
+        grounded? (and shape? (get-in page-score [:checks :citations?]) search?
+                       (every? #(and (contains? urls (:url %))
+                                     (= fixture-id (:acquisition/fixture-id (scoped (:receipt %)))))
+                               (:alternatives answer)))]
+    (-> page-score
+        (assoc-in [:checks :search-grounded?] (boolean grounded?))
+        (update :reward #(if grounded? % 0.0)))))
+
+(defn evaluator []
+  (evaluation/make-evaluator
+   {:id :business/discovery-checks :version 1 :basis basis
+    :observe (fn [{:keys [room run-id result default setup/evidence]}]
+               (assoc default :execution-status (:run/status result)
+                      :fixture-id (:fixture-id evidence)
+                      :verification (score room run-id (evidence/parse-answer (:result default)))))
+    :verify (fn [_ observed]
+              (let [complete? (and (= :completed (:execution-status observed))
+                                   (= fixture-id (:fixture-id observed)))]
+                (-> (:verification observed)
+                    (assoc-in [:checks :completed?] (boolean complete?))
+                    (update :reward #(if complete? % 0.0)))))}))

--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -1092,10 +1092,14 @@
     ;; env), and share it between `env` (returns placeholders) and `http`
     ;; (substitutes at egress + scrubs the response). requiring-resolve to avoid a
     ;; sandbox→config compile dep; nil specs ⇒ empty registry ⇒ no-op.
-    (let [secret-specs (try ((requiring-resolve 'dvergr.substrate.config/secret-specs))
-                            (catch Throwable _ nil))
-          sandbox-env  (try ((requiring-resolve 'dvergr.substrate.config/sandbox-env))
-                            (catch Throwable _ nil))
+    (let [fixture (binding [rtc/*execution-context* spindel-ctx]
+                    (rtc/get-state [:dvergr.sandbox.ns.io/http-fixture]))
+          secret-specs (when-not fixture
+                         (try ((requiring-resolve 'dvergr.substrate.config/secret-specs))
+                              (catch Throwable _ nil)))
+          sandbox-env  (if fixture (:env fixture)
+                           (try ((requiring-resolve 'dvergr.substrate.config/sandbox-env))
+                                (catch Throwable _ nil)))
           secrets      (ns-io/build-secret-registry secret-specs)]
       (when binding-swap!
         (binding-swap! #(if (contains? % :sandbox-env)
@@ -1106,7 +1110,8 @@
       (ns-io/add-env-ns! sci-ctx
                          :user-config (atom (or sandbox-env {}))
                          :config-resolver (when binding-resolver
-                                            #(or (:sandbox-env (binding-resolver)) {}))
+                                            #(merge (or (:sandbox-env (binding-resolver)) {})
+                                                    (:env fixture)))
                          :config-swap! (when binding-swap!
                                          (fn [f & args]
                                            (binding-swap!
@@ -1115,7 +1120,7 @@
                                                        (apply f (or m {}) args))))))
                          :secrets secrets)
       (ns-io/add-http-ns! sci-ctx :audit-log audit-log :allowed-domains allowed-http-domains
-                          :secrets secrets))
+                          :secrets secrets :fixture-transport (:transport fixture)))
     (ns-agent/add-scheduler-ns! sci-ctx)
     ;; Default coder kit: discovery, dep-add, HTML, tests — these are
     ;; safe and useful for any coding agent regardless of role. Each

--- a/src/dvergr/sandbox/ns/io.clj
+++ b/src/dvergr/sandbox/ns/io.clj
@@ -9,10 +9,24 @@
             [babashka.fs :as fs]
             [muschel.fs :as mfs]
             [dvergr.io.acquisition :as acquisition]
+            [org.replikativ.spindel.engine.core :as ec]
             [dvergr.sandbox.ns.doc :as doc])
   (:import [java.io File]))
 
 (declare fs-safe-resolve git-run* parse-porcelain-status parse-git-log)
+
+(defn install-http-fixture!
+  "Host-only world setup: install an immutable offline capability in the current
+   Spindel context before constructing candidate interpreters. Forks inherit it;
+   it is not a durable function serialization scheme. Reconstruct via WorldSetup.
+   Existing interpreters retain their installed transport. env contains dummy,
+   non-secret configuration for the simulated service."
+  [{:keys [id transport env] :as fixture}]
+  (when-not (and (uuid? id) (fn? transport) (map? env)
+                 (every? string? (concat (keys env) (vals env))))
+    (throw (ex-info "Invalid host HTTP fixture" {})))
+  (ec/swap-state! [::http-fixture] (constantly fixture))
+  id)
 
 (defn- audit!
   "Append an IO event to the audit log (no-op when log is nil)."

--- a/test/dvergr/benchmarks/discovery_test.clj
+++ b/test/dvergr/benchmarks/discovery_test.clj
@@ -1,0 +1,132 @@
+(ns dvergr.benchmarks.discovery-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.string :as str]
+            [datahike.api :as dh]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.roster :as roster]
+            [dvergr.benchmarks.discovery :as discovery]
+            [dvergr.benchmarks.frozen-web :as web]
+            [dvergr.benchmarks.market-evidence :as evidence]
+            [dvergr.chat.agent :as chat-agent]
+            [dvergr.chat.schema :as schema]
+            [dvergr.discourse :as d]
+            [dvergr.io.acquisition :as acquisition]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.providers :as providers]
+            [dvergr.room.store.datahike :as store]
+            [dvergr.room.store.memory :as memory]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.substrate.git :as git]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(deftest fixture-capabilities-follow-context-forks
+  (let [parent (d/make-room {:id :fixture-parent :store (memory/make)})]
+    (try
+      (binding [ec/*execution-context* (:ctx parent)]
+        ((:prepare (discovery/world-setup)) {:room parent})
+        (let [child (d/fork-room parent {:isolation :ctx})]
+          (try
+            (binding [ec/*execution-context* (:ctx child)]
+              (is (= discovery/fixture-id (:id (ec/get-state [:dvergr.sandbox.ns.io/http-fixture]))))
+              (let [sci (sandbox/fork-for-session (:ctx child))]
+                (sandbox/setup-agent-namespaces! sci (:ctx child))
+                (is (= (:body (get discovery/pages "https://example.org/aster"))
+                       (:value (sandbox/eval-code sci "(:body (babashka.http-client/get \"https://example.org/aster\"))"
+                                                  :execution-context (:ctx child)))))
+                (is (= "offline-fixture" (:value (sandbox/eval-code sci "(env/get \"BRAVE_API_KEY\")"
+                                                                    :execution-context (:ctx child)))))))
+            (finally (d/close-room! child)))))
+      (finally (d/close-room! parent)))))
+
+(def candidate-code
+  (str "(require '[babashka.http-client :as http] '[cheshire.core :as json] '[clojure.string :as str]) "
+       (pr-str
+        '(let [search (http/get "https://api.search.brave.com/res/v1/web/search"
+                                {:query-params {:q "agent teams" :count 10}})
+               hits (get-in (json/parse-string (:body search) true) [:web :results])]
+           {:search (get-in search [:dvergr/acquisition :id])
+            :alternatives
+            (mapv (fn [hit]
+                    (let [page (http/get (:url hit))]
+                      {:url (:url hit) :receipt (get-in page [:dvergr/acquisition :id])
+                       :quote (:body page)}))
+                  (filter #(str/includes? (:description %) "supports") hits))}))))
+
+(deftest provider-free-discovery-uses-real-tools-world-and-certification
+  (let [cfg {:store {:backend :memory :id (random-uuid)} :schema-flexibility :write}
+        _ (dh/create-database cfg)
+        conn (dh/connect cfg)
+        _ (schema/ensure-full-schema! conn)
+        room (d/make-room {:id :discovery-workflow :store (store/make conn)
+                           :meta {:http-capture discovery/capture-policy}})
+        team (roster/make-agent (roster/make-roster)
+                                {:id :researcher :tools #{:clojure_eval}
+                                 :model-policy {:provider :test :model "stub"}
+                                 :program {:kind :llm :max-model-steps 2 :auto-compact? false}})
+        calls (atom 0)]
+    (try
+      (with-redefs [providers/ensure-initialized! (constantly nil)
+                    git/ensure-repo! (fn [root] (.mkdirs (java.io.File. (str root))) root)
+                    chat-agent/messages->api-format (fn [messages _ _] messages)
+                    model-chat/chat
+                    (fn [messages _]
+                      (if (= 1 (swap! calls inc))
+                        {:content "" :tool-calls [{:id "discovery" :name "clojure_eval"
+                                                   :input {:code candidate-code}}]
+                         :usage {:input-tokens 0 :output-tokens 0} :stop-reason :tool-use}
+                        (let [content (:message/content (last (filter #(= :tool-result (:message/role %)) messages)))]
+                          (when-not (and (string? content) (str/starts-with? content "=> "))
+                            (throw (ex-info "Candidate tool failed" {:content content})))
+                          {:content (str/trim (subs content 3)) :tool-calls nil
+                           :usage {:input-tokens 0 :output-tokens 0} :stop-reason :end-turn})))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [completion (promise)
+                spin (evaluation/evaluate room team :researcher
+                                          (discovery/definition) (discovery/evaluator)
+                                          {:world-setup (discovery/world-setup)})
+                _ (spin #(deliver completion {:result %}) #(deliver completion {:error %}))
+                outcome (deref completion 200000 ::timeout)]
+            (when (= ::timeout outcome) (throw (ex-info "Discovery timed out" {})))
+            (when-let [error (:error outcome)] (throw error))
+            (let [result (:result outcome)
+                  receipt (:attempt-receipt result)
+                  rows (acquisition/list-for-run conn (:id room) (:run/id result) 10)]
+              (is (= 1.0 (:attempt/reward receipt)) (pr-str (:evidence result)))
+              (is (every? true? (vals (:attempt/checks receipt))))
+              (is (= 3 (count rows)))
+              (is (every? #(= discovery/fixture-id (:acquisition/fixture-id %)) rows))
+              (is (= :discarded (get-in result [:run/result :run/settlement-status])))
+              (is (nil? (ec/get-state [:dvergr.sandbox.ns.io/http-fixture])))
+              (is (= 2 @calls))
+              (let [run-id (:run/id result)
+                    answer (evidence/parse-answer (get-in result [:evidence :result]))
+                    score #(discovery/score room run-id %)
+                    scope {:conn conn :room-id (:id room) :run-id run-id
+                           :artifacts (:artifacts (:store room))
+                           :capture-policy discovery/capture-policy}
+                    search (fn [query]
+                             (acquisition/record-request!
+                              {:url web/search-url :query-params {:q query}}
+                              #((web/transport discovery/pages)
+                                {:url web/search-url :query-params {:q query}})))]
+                (is (zero? (:reward (score (assoc answer :search (random-uuid))))))
+                (is (zero? (:reward (score (assoc answer :search "not-a-uuid")))))
+                (is (zero? (:reward (discovery/score room (random-uuid) answer))))
+                (is (zero? (:reward (score (assoc answer :search (:receipt (first (:alternatives answer))))))))
+                (binding [acquisition/*scope* scope]
+                  (let [narrow (search "approval")
+                        foreign (binding [acquisition/*scope* (assoc scope :run-id (random-uuid))]
+                                  (search "agent teams"))]
+                    (doseq [response [narrow foreign]]
+                      (is (zero? (:reward (score (assoc answer :search (get-in response [:dvergr/acquisition :id])))))))))
+                (doseq [status [:failed :waiting :cancelled]]
+                  (is (zero? (:reward ((:verify (discovery/evaluator)) (discovery/definition)
+                                                                       (assoc (:evidence result) :execution-status status))))))
+                (dh/transact conn [{:acquisition/id (:search answer)
+                                    :acquisition/fixture-id (random-uuid)}])
+                (is (zero? (:reward (score answer)))))))))
+      (finally
+        (evaluation/await-cleanups! room)
+        (d/close-room! room)
+        (dh/release conn)
+        (dh/delete-database cfg)))))


### PR DESCRIPTION
## Summary

- Connect trusted offline HTTP fixtures to Spindel execution-context state before interpreter creation. Descendant contexts inherit the immutable capability; host service secrets are not loaded in fixture mode.
- Add a synthetic discovery Environment, WorldSetup and Evaluator using ordinary isolated Runs, actual SCI tools and durable acquisition receipts.
- Verify captured search results, cited page membership, exact page evidence, fixture identity and completed Run status; discard the work world after certification.
- Document host setup, capture policy and the intentionally narrow one-search, three-company fixture. This is not a substantive market-quality benchmark yet.

## Verification

- New provider-free workflow tests: 2 tests, 20 assertions passing, including actual child-context SCI inheritance and negative receipt/provenance/completion gates.
- Existing acquisition/citation/market-evidence/frozen-web regression suite included in REPL verification.
- Model responses and unrelated workspace bootstrapping are stubbed; actual tool execution, SCI, stores, scoring and settlement are exercised.
- Formatting and whitespace checks pass.
- Independent review complete: no medium-or-higher findings.

Live model smoke results will be added separately; CI does not require provider credentials.
