### PR TITLE
feat(resources): govern native model dispatches with Run wallets

### DIFF
--- a/doc/agent-programs.md
+++ b/doc/agent-programs.md
@@ -252,6 +252,47 @@ SCI exposes only `agent/balance` and the `:resources` argument to `hire!`. It
 does not expose connections, minting, arbitrary transfers, or a way to redirect
 `:parent-run`. Installation and minting remain trusted host operations.
 
+### Opt-in native model dispatch allowance
+
+The trusted host can install and provision a conserved `"model-dispatch"`
+coordinate, then allocate part of it with the existing `:resources` option:
+
+```clojure
+(resource/install-unit! room {:symbol resource/model-dispatches
+                              :name "Native model dispatch admission" :precision 0})
+(resource/mint! room {:id (random-uuid)
+                      :resources {resource/model-dispatches 20M}})
+;; In the room's Spindel context, with an existing LLM AgentDef:
+(agent/hire! team :researcher
+             {:task "Investigate the supplied evidence"
+              :resources {"model-dispatch" 8M}})
+```
+
+An AgentDef Run whose original allocation contains this coordinate spends one
+unit **before each native gateway dispatch**, including explicit authentication
+and transient-error retries. Main and compaction calls made by its supervised
+model worker use the same wallet. Kontor rejects concurrent overdrafts atomically;
+an empty balance does not disable enforcement. Exhaustion fails the Run rather
+than resuming it automatically. Unspent units return through normal Run cleanup.
+
+The unit buys admission, not a successful answer: a failed or ambiguous dispatch
+remains spent, as does one cancelled between debit and network handoff. Discarding
+a work world does not refund it. Cancellation observed before admission spends
+nothing. Receipts live in the control store and reference the Run's wallet.
+
+Governed calls reject redirects and require a non-redirecting HTTP client.
+Opaque DirectChat/CLI providers are rejected under this allowance because their
+internal dispatches are not observable here; native Codex subscription HTTP is
+supported. Runs without this coordinate retain their previous behavior.
+
+This counts gateway admissions, not transport-internal reconnects, tokens,
+elapsed time, heap, or provider charges. It is not an equal-token team budget.
+`"microUSD"` is still not automatically debited for model usage, and a zero-priced
+subscription does not consume a dollar ceiling. Token reservation, unknown-usage
+reconciliation and agent-spawned paid LLM children remain follow-up work; the
+existing paid-child restriction is unchanged. No new turn-based programming
+semantics or fork-local spending counter is introduced.
+
 ## Execution and world settlement
 
 Execution and settlement are independent durable axes. `:run/status` describes
@@ -755,5 +796,6 @@ than wrapping another harness. It preserves:
 `:roster/scope` is still portable policy data, not an enforced resource grant.
 The native interpreter enforces its concrete tool allowlist, model-step bound, and
 ChatContext spending ceiling, but does not pretend those are an affine resource
-split. A Kontor-backed admission/settlement interpreter should make declared
-resource vectors executable before scopes can delegate assets to child Runs.
+split. The opt-in native dispatch allowance above makes one resource coordinate
+executable at the gateway; token/cost reservation and reconciliation are still
+required before scopes can delegate paid model work to child Runs.

--- a/src/dvergr/agent/program.clj
+++ b/src/dvergr/agent/program.clj
@@ -679,24 +679,27 @@
                  (start-worker!
                   supervisor
                   (fn []
-                    (chat-agent/run-agent-turn!
-                     chat-ctx
-                     {:provider (:provider model-spec)
-                      :model (:model model-spec)
+                    (binding [resource/*model-scope*
+                              (some-> (resource/model-scope control-room run-id)
+                                      (assoc :cancel? #(run/cancel-requested? run-id)))]
+                      (chat-agent/run-agent-turn!
+                       chat-ctx
+                       {:provider (:provider model-spec)
+                        :model (:model model-spec)
                         ;; The SAME normalized map defines both the model schema
                         ;; and execute-side authority. Empty means no tools.
-                      :tools tool-map
-                      :tool-ctx tool-ctx
-                      :cancel? (turn/cancel?-fn
-                                chat-ctx (:ctx work-room)
-                                (fn [] (run/cancel-requested? run-id)))
-                      :auto-compact? auto-compact?
-                      :compaction-model compaction-model
+                        :tools tool-map
+                        :tool-ctx tool-ctx
+                        :cancel? (turn/cancel?-fn
+                                  chat-ctx (:ctx work-room)
+                                  (fn [] (run/cancel-requested? run-id)))
+                        :auto-compact? auto-compact?
+                        :compaction-model compaction-model
                       ;; The existing single-exchange core still calls this
                       ;; trace field `turn-number`; semantically it is a model
                       ;; integration step, not a conversational turn.
-                      :turn-number model-step
-                      :run-id run-id})))
+                        :turn-number model-step
+                        :run-id run-id}))))
                  outcome (sp/await (worker-result-spin call))
                  budget (chat-context/get-budget chat-ctx)]
              (update-llm-metrics!

--- a/src/dvergr/model/chat.clj
+++ b/src/dvergr/model/chat.clj
@@ -7,6 +7,7 @@
             [dvergr.model.gateway :as gateway]
             [dvergr.model.providers :as providers]
             [dvergr.model.registry :as registry]
+            [dvergr.resource :as resource]
             [hato.client :as hc]
             [jsonista.core :as json]
             [clojure.java.io :as io]
@@ -25,7 +26,7 @@
 (defn- get-http-client []
   (or *http-client*
       (hc/build-http-client {:connect-timeout 30000
-                             :redirect-policy :normal})))
+                             :redirect-policy (if resource/*model-scope* :never :normal)})))
 
 ;; ============================================================================
 ;; Retry Configuration
@@ -283,7 +284,11 @@
 
     ;; DirectChat providers bypass the HTTP+SSE path entirely
     (if (p/implements-direct-chat? provider)
-      (p/direct-chat provider messages opts)
+      (if resource/*model-scope*
+        (throw (ex-info "Dispatch-governed Runs require a native HTTP provider"
+                        {:type ::unsupported-dispatch-accounting
+                         :provider provider-key}))
+        (p/direct-chat provider messages opts))
 
       ;; Standard HTTP+SSE streaming path
       (let [{:keys [events close!]} (stream-chat provider model-def messages opts)

--- a/src/dvergr/model/gateway.clj
+++ b/src/dvergr/model/gateway.clj
@@ -6,8 +6,10 @@
    and attach a Credentials implementation. The gateway validates the target,
    injects authentication at the last possible moment, and owns the one-shot
    unauthorized recovery path used by rotating credentials."
-  (:require [hato.client :as hc])
+  (:require [hato.client :as hc]
+            [dvergr.resource :as resource])
   (:import [java.io Closeable]
+           [java.net.http HttpClient HttpClient$Redirect]
            [java.net URI]))
 
 (defprotocol Credentials
@@ -86,6 +88,26 @@
                     (assoc :headers (merge headers (:headers auth))))
        :auth auth})))
 
+(defn- dispatch! [request]
+  (resource/admit-model-dispatch!)
+  (let [response (*request-fn* request)]
+    (when (and resource/*model-scope* (<= 300 (:status response) 399))
+      (close-body! response)
+      (throw (ex-info "Governed model dispatch does not follow redirects"
+                      {:type ::redirect-not-supported :status (:status response)})))
+    response))
+
+(defn- governed-client [request]
+  (if-not resource/*model-scope*
+    request
+    (let [client (or (:http-client request)
+                     (hc/build-http-client {:connect-timeout 30000 :redirect-policy :never}))]
+      (when-not (and (instance? HttpClient client)
+                     (= HttpClient$Redirect/NEVER (.followRedirects ^HttpClient client)))
+        (throw (ex-info "Governed model dispatch requires a non-redirecting HTTP client"
+                        {:type ::redirecting-client})))
+      (assoc request :http-client client))))
+
 (defn request!
   "Execute a trusted provider request.
 
@@ -94,12 +116,13 @@
    before retrying. Authentication headers are never returned in errors or
    telemetry by this layer."
   [request]
-  (let [{authorized :request auth :auth} (authorize request)
-        response (*request-fn* authorized)]
+  (let [request (governed-client request)
+        {authorized :request auth :auth} (authorize request)
+        response (dispatch! authorized)]
     (if (and (= 401 (:status response))
              (recover-auth! (:credentials request) request auth))
       (do
         (close-body! response)
         (let [{retry :request} (authorize request)]
-          (*request-fn* retry)))
+          (dispatch! retry)))
       response)))

--- a/src/dvergr/resource.clj
+++ b/src/dvergr/resource.clj
@@ -16,6 +16,16 @@
    may be installed by the trusted host API."
   "microUSD")
 
+(def model-dispatches
+  "Optional conserved allowance for native provider HTTP dispatch admissions.
+   This is neither a token budget nor a price. Each retry needs another unit."
+  "model-dispatch")
+
+(def ^:dynamic *model-scope*
+  "Trusted process-local scope for a resource-governed model worker. Balances
+   remain in Kontor's control store, never in this binding or a forked counter."
+  nil)
+
 (defn- stable-id [value]
   (UUID/nameUUIDFromBytes
    (.getBytes (str value) StandardCharsets/UTF_8)))
@@ -139,6 +149,27 @@
      effective-date (assoc :effective-date effective-date)
      posted-at (assoc :posted-at posted-at)
      actor (assoc :actor actor))))
+
+(defn model-scope
+  "Resolve opt-in dispatch authority from the original durable Run allocation,
+   not its remaining balance (zero must never disable enforcement)."
+  [room run-id]
+  (when (satisfies? store/PResourceStore (:store room))
+    (let [allocation (store/-resource-receipt (:store room) (allocation-id run-id))]
+      (when (contains? (:resources allocation) model-dispatches)
+        {:room room :run-id run-id}))))
+
+(defn admit-model-dispatch!
+  "Spend one admission immediately before native model egress. No read/check/
+   write race: Kontor validates the debit atomically. Rejected admission never
+   reaches the provider. An admitted failed/ambiguous dispatch is not refunded.
+   Each gateway retry has a new identity, not a replay of the previous effect."
+  []
+  (when-let [{:keys [room run-id cancel?]} *model-scope*]
+    (when (or (.isInterrupted (Thread/currentThread)) (and cancel? (cancel?)))
+      (throw (java.util.concurrent.CancellationException. "Model admission cancelled")))
+    (consume! room run-id {:id (UUID/randomUUID)
+                           :resources {model-dispatches 1M}})))
 
 (defn return!
   "Return an explicit positive vector from a Run to its immediate parent/Room."

--- a/test/dvergr/agent/program_test.clj
+++ b/test/dvergr/agent/program_test.clj
@@ -11,6 +11,7 @@
             [dvergr.chat.schema :as chat-schema]
             [dvergr.discourse :as d]
             [dvergr.model.chat :as model-chat]
+            [dvergr.model.gateway :as gateway]
             [dvergr.model.providers :as providers]
             [dvergr.resource :as resource]
             [dvergr.room.registry :as registry]
@@ -964,6 +965,43 @@
             (d/discard (registry/lookup (:run/world result))))))
       (finally
         (d/close-room! room)))))
+
+(deftest llm-worker-enforces-dispatch-authority-and-returns-only-unused-units
+  (doseq [complete? [true false]]
+    (let [[room conn] (resource-test-room (keyword (str "dispatch-worker-" (random-uuid))))
+          called (atom 0)
+          team (roster/make-agent (roster/make-roster)
+                                  {:id :worker :model-policy {:provider :test :model "stub"}
+                                   :program {:kind :llm :max-model-steps 4}})]
+      (try
+        (resource/install-unit! room {:symbol resource/model-dispatches
+                                      :name "Dispatch admission" :precision 0})
+        (resource/mint! room {:id (random-uuid) :resources {resource/model-dispatches 3M}})
+        (with-redefs [providers/ensure-initialized! (constantly nil)
+                      chat-agent/run-agent-turn!
+                      (fn [chat-ctx _]
+                        (binding [gateway/*request-fn* (fn [_] (swap! called inc) {:status 200})]
+                          (gateway/request! {:url "https://model.test/responses"
+                                             :credentials (gateway/static-credentials
+                                                           :test {} #{"https://model.test"})}))
+                        (if complete?
+                          (do (chat-context/add-message! chat-ctx {:role :assistant :content "done"})
+                              :complete)
+                          :continue))]
+          (let [handle (binding [ec/*execution-context* (:ctx room)]
+                         (program/hire! room team :worker
+                                        {:task "bounded" :settlement :discard
+                                         :resources {resource/model-dispatches 2M}}))
+                finished (promise)]
+            (binding [ec/*execution-context* (:ctx room)]
+              ((program/owned-result-spin handle) #(deliver finished %) #(deliver finished %)))
+            (let [result (deref finished 30000 ::timeout)]
+              (is (= (if complete? :completed :failed) (:run/status result)))
+              (is (= (if complete? 1 2) @called))
+              (is (= {resource/model-dispatches (if complete? 2M 1M)} (resource/balance room)))
+              (is (= {} (resource/run-balance room (program/run-id handle))))
+              (is (= :discarded (:run/settlement-status result))))))
+        (finally (close-resource-test-room! room conn))))))
 
 (deftest llm-program-cancellation-aborts-the-live-turn
   (let [room (test-room :program-llm-cancel)

--- a/test/dvergr/model/admission_test.clj
+++ b/test/dvergr/model/admission_test.clj
@@ -1,0 +1,164 @@
+(ns dvergr.model.admission-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as dh]
+            [dvergr.agent.run :as run]
+            [dvergr.chat.schema :as schema]
+            [dvergr.discourse :as d]
+            [dvergr.model.chat :as chat]
+            [dvergr.model.api.openai :as openai]
+            [dvergr.model.gateway :as gateway]
+            [dvergr.model.provider :as provider]
+            [dvergr.model.providers :as providers]
+            [dvergr.model.registry :as registry]
+            [dvergr.resource :as resource]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.datahike :as datahike-store])
+  (:import [java.io ByteArrayInputStream IOException]
+           [java.util.concurrent CancellationException CountDownLatch TimeUnit]))
+
+(defn- with-wallet [units f]
+  (let [cfg {:store {:backend :memory :id (random-uuid)} :schema-flexibility :write}
+        id (keyword (str "admission-" (random-uuid)))
+        chat-id (random-uuid)
+        run-id (random-uuid)]
+    (dh/create-database cfg)
+    (let [conn (dh/connect cfg)]
+      (schema/ensure-full-schema! conn)
+      (dh/transact conn [(merge (schema/create-chat-entity {:id chat-id :title "admission"})
+                                {:room/slug (store/room-id->slug id) :room/type :internal})])
+      (resource/install-connection! conn id chat-id)
+      (let [room (d/make-room {:id id :store (datahike-store/make conn)})
+            trigger (d/message :test :_runs "admission" nil {:role :user})]
+        (try
+          (resource/install-unit! room {:symbol resource/model-dispatches
+                                        :name "Native model dispatch admission" :precision 0})
+          (resource/mint! room {:id (random-uuid) :resources {resource/model-dispatches units}})
+          (d/post! room trigger)
+          (run/start! room :test trigger nil {:id run-id})
+          (resource/allocate-run! room run-id nil {resource/model-dispatches units})
+          (binding [resource/*model-scope* (resource/model-scope room run-id)]
+            (f room run-id))
+          (finally
+            (run/finish! run-id :completed)
+            (d/close-room! room)
+            (dh/release conn)))))))
+
+(def credentials
+  (gateway/static-credentials :test {} #{"https://model.test"}))
+(def request {:url "https://model.test/responses" :method :post :credentials credentials})
+
+(deftest concurrent-dispatches-cannot-spend-the-last-unit-twice
+  (with-wallet
+    1M
+    (fn [room run-id]
+      (let [gate (CountDownLatch. 1) called (atom 0)]
+        (binding [gateway/*request-fn* (fn [_] (swap! called inc) {:status 200})]
+          (let [jobs (mapv (fn [_] (future
+                                     (.await gate 5 TimeUnit/SECONDS)
+                                     (try (gateway/request! request) :ok
+                                          (catch Exception _ :rejected)))) (range 2))]
+            (.countDown gate)
+            (is (= {:ok 1 :rejected 1} (frequencies (map #(deref % 10000 :timeout) jobs))))
+            (is (= 1 @called))
+            (is (= {} (resource/run-balance room run-id)))
+            (is (some? (resource/model-scope room run-id)) "empty wallet stays governed")
+            (is (thrown? Exception (gateway/request! request)))
+            (is (= 1 @called))))))))
+
+(deftest failed-dispatch-is-not-refunded
+  (with-wallet
+    1M
+    (fn [room run-id]
+      (let [called (atom 0)]
+        (binding [gateway/*request-fn* (fn [_] (swap! called inc) (throw (IOException. "unknown outcome")))]
+          (is (thrown? IOException (gateway/request! request)))
+          (is (= {} (resource/run-balance room run-id)))
+          (is (thrown? Exception (gateway/request! request)))
+          (is (= 1 @called)))))))
+
+(deftest cancelled-before-admission-does-not-spend
+  (with-wallet
+    1M
+    (fn [room run-id]
+      (binding [resource/*model-scope* (assoc resource/*model-scope* :cancel? (constantly true))
+                gateway/*request-fn* (fn [_] (throw (AssertionError. "Should not dispatch")))]
+        (is (thrown? CancellationException (gateway/request! request)))
+        (is (= {resource/model-dispatches 1M} (resource/run-balance room run-id)))))))
+
+(deftest authentication-retry-needs-another-admission
+  (doseq [units [1M 2M]]
+    (with-wallet
+      units
+      (fn [room run-id]
+        (let [closed? (atom false) called (atom 0)
+              credentials (reify gateway/Credentials
+                            (credential-kind [_] :test)
+                            (allowed-origins [_] #{"https://model.test"})
+                            (resolve-auth! [_ _] {:headers {} :version :test})
+                            (recover-auth! [_ _ _] true))]
+          (binding [gateway/*request-fn*
+                    (fn [_]
+                      (if (= 1 (swap! called inc))
+                        {:status 401 :body (proxy [ByteArrayInputStream] [(byte-array 0)]
+                                             (close [] (reset! closed? true)))}
+                        {:status 200}))]
+            (if (= 1M units)
+              (is (thrown? Exception (gateway/request! (assoc request :credentials credentials))))
+              (is (= 200 (:status (gateway/request! (assoc request :credentials credentials))))))
+            (is @closed?)
+            (is (= (long units) @called))
+            (is (= {} (resource/run-balance room run-id)))))))))
+
+(deftest direct-providers-cannot-hide-dispatches-from-a-governed-run
+  (let [called (atom false)
+        direct (reify provider/DirectChat
+                 (direct-chat [_ _ _] (reset! called true)))]
+    (with-redefs [providers/ensure-initialized! (constantly nil)
+                  registry/resolve-alias identity
+                  registry/get-model! (constantly {:provider :test})
+                  registry/get-quirk (constantly nil)
+                  providers/get-provider! (constantly direct)]
+      (binding [resource/*model-scope* {:run-id (random-uuid)}]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"native HTTP provider"
+                              (chat/chat [] {:model "test"})))
+        (is (false? @called))))))
+
+(deftest redirects-cannot-hide-extra-dispatches
+  (with-wallet
+    1M
+    (fn [room run-id]
+      (let [closed? (atom false) called (atom 0)
+            redirecting (-> (java.net.http.HttpClient/newBuilder)
+                            (.followRedirects java.net.http.HttpClient$Redirect/NORMAL)
+                            .build)]
+        (binding [gateway/*request-fn*
+                  (fn [request]
+                    (swap! called inc)
+                    (is (= java.net.http.HttpClient$Redirect/NEVER
+                           (.followRedirects ^java.net.http.HttpClient (:http-client request))))
+                    {:status 302 :body (proxy [ByteArrayInputStream] [(byte-array 0)]
+                                         (close [] (reset! closed? true)))})]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"non-redirecting"
+                                (gateway/request! (assoc request :http-client redirecting))))
+          (is (= {resource/model-dispatches 1M} (resource/run-balance room run-id)))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not follow redirects"
+                                (gateway/request! request)))
+          (is @closed?)
+          (is (= 1 @called))
+          (is (= {} (resource/run-balance room run-id))))))))
+
+(deftest transient-provider-retries-each-consume-admission
+  (with-wallet
+    2M
+    (fn [room run-id]
+      (let [called (atom 0)]
+        (binding [gateway/*request-fn* (fn [_] (swap! called inc)
+                                         {:status 503 :body (ByteArrayInputStream.
+                                                             (.getBytes "{}" "UTF-8"))})]
+          (with-redefs-fn {#'chat/calculate-backoff (constantly 0)}
+            #(is (thrown? Exception
+                          (chat/stream-chat (openai/create {:api-key "test"
+                                                            :base-url "https://model.test"})
+                                            {} [] {:model "stub"}))))
+          (is (= 2 @called))
+          (is (= {} (resource/run-balance room run-id))))))))


### PR DESCRIPTION
## Summary

Connect an opt-in conserved `model-dispatch` coordinate to AgentDef Run workers
and native provider egress, using existing Kontor wallets and Datahike invariants.
This is the first narrow model-admission step, not token/cost reconciliation.

- Resolve enforcement from the original durable allocation, so exhaustion never disables it.
- Atomically spend before each gateway dispatch, including 401 and transient retries.
- Preserve spent admission after failure/ambiguous outcome; return only unused units through existing cleanup.
- Reject opaque DirectChat/CLI providers and automatic redirects when governed.
- Keep uncapped behavior and the existing restriction on agent-spawned paid children unchanged.
- Document trusted provisioning, semantics, and limitations in agent-programs.md.

No new scheduler, world/fork API, budget store or turn-based workflow semantics.
The scope is trusted process-local authority; conserved state stays in the
control Room store. Native Codex subscription HTTP uses the same gateway path.

## Validation

- REPL regression run: 63 tests, 377 assertions, zero failures/errors across
  agent.program-test, model.gateway-test and model.admission-test.
- Tests cover concurrent final-unit spending, exhausted-wallet enforcement,
  cancellation before admission, ambiguous HTTP failure, authentication and 503
  retries, redirects, DirectChat rejection, and actual Run worker debit/return.
- clojure -M:ffix; git diff --check.
- Independent review: redirect bypass identified and fixed; no remaining medium+ findings.

## Explicit limits

Counts gateway admission, not exact wire reconnects, tokens or provider charges.
Admission spent immediately before handoff may remain spent if cancellation
races with handoff. No automatic microUSD debit or exact shared token cap yet.
Token reservation, unknown-usage reconciliation and paid-child delegation remain
follow-ups. The private market experiments remain gitignored.
