### PR TITLE
Support bounded URI operations and improve SCI coding guidance

### DIFF
--- a/src/dvergr/sandbox.clj
+++ b/src/dvergr/sandbox.clj
@@ -99,6 +99,19 @@
    'java.time.format.DateTimeFormatter java.time.format.DateTimeFormatter
    'java.time.temporal.ChronoUnit java.time.temporal.ChronoUnit
    'java.util.UUID java.util.UUID
+   ;; Keep URI data operations, but never produce URL objects: their ordinary
+   ;; hash/equality methods can resolve DNS even without explicit URL interop.
+   'java.net.URI
+   {:class java.net.URI
+    :closed true
+    :static-methods {'create true}
+    :instance-methods
+    (zipmap '[resolve normalize relativize parseServerAuthority
+              getScheme getAuthority getRawAuthority getHost getPort
+              getUserInfo getRawUserInfo getPath getRawPath getQuery getRawQuery
+              getFragment getRawFragment getSchemeSpecificPart getRawSchemeSpecificPart
+              isAbsolute isOpaque toString toASCIIString equals hashCode compareTo]
+            (repeat true))}
    'java.util.Date java.util.Date})
 
 (def ^:private core-extras
@@ -877,6 +890,18 @@
        "with a task string) only when each run needs your judgment. To publish a STATIC SITE for "
        "this room, write `app/index.html` (+ assets under `app/`) in your "
        "workspace — served at `/apps/<room-slug>/`.\n\n"
+       "**Editing and testing Clojure.** Prefer `slurp`/`spit` and small REPL "
+       "expressions for source edits. Generate new forms with `pr-str` on quoted "
+       "data rather than hand-escaping Clojure inside strings. After saving, "
+       "`(require 'my.ns :reload)` reloads your workspace code. Require "
+       "`clojure.test` separately WITHOUT `:reload`: sandbox-provided namespaces "
+       "cannot be replaced. `test/` is not a source root; use "
+       "`(load-string (slurp \"test/my_test.clj\"))`, then "
+       "`(clojure.test/run-tests 'my-test)`. Inspect `:fail` and `:error` in the "
+       "summary: successful evaluation alone does not mean tests passed. "
+       "`java.net.URI` supports immutable URI parsing/resolution, e.g. "
+       "`(str (.resolve (java.net.URI. \"https://example.org/blog/\") \"feed.xml\"))`. "
+       "`toURL` is unavailable; fetching uses the HTTP capability.\n\n"
        "**Reactive agent programs.** `dvergr.agent` provides immutable rosters "
        "and Run-backed execution; `agent/environment` creates a content-addressed "
        "task/verifier/policy definition without starting an attempt. Use the exact Spindel namespaces: "

--- a/test/dvergr/sandbox/test_output_test.clj
+++ b/test/dvergr/sandbox/test_output_test.clj
@@ -53,6 +53,20 @@
         (is (:success r))
         (is (= {:body "saved" :receipt :receipt} (:value r)))))))
 
+(deftest quoted-source-writing-guidance-is-executable
+  (with-sandbox
+    (fn [sci-ctx ec]
+      (let [forms '[(defn generated [] "a quoted \"value\"")
+                    (clojure.test/deftest generated-test
+                      (clojure.test/is (= "a quoted \"value\"" (generated))))]
+            r (eval-in sci-ctx ec
+                       (str "(require 'clojure.test) "
+                            "(load-string (clojure.string/join \"\\n\" (map pr-str '"
+                            (pr-str forms) "))) (clojure.test/run-tests 'user)"))]
+        (is (:success r))
+        (is (= {:test 1 :pass 1 :fail 0 :error 0}
+               (select-keys (:value r) [:test :pass :fail :error])))))))
+
 (deftest failing-assertion-detail-reaches-the-sandbox-stdout
   (with-sandbox
     (fn [sci-ctx ec]

--- a/test/dvergr/sandbox/uri_test.clj
+++ b/test/dvergr/sandbox/uri_test.clj
@@ -1,0 +1,66 @@
+(ns dvergr.sandbox.uri-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.sandbox :as sandbox]
+            [org.replikativ.spindel.engine.context :as ctx]))
+
+(def references
+  [["feed.xml" "https://example.org/blog/feed.xml"]
+   ["../feed.xml" "https://example.org/feed.xml"]
+   ["/feed.xml" "https://example.org/feed.xml"]
+   ["//feeds.example.net/rss" "https://feeds.example.net/rss"]
+   ["https://elsewhere.example/rss?q=1" "https://elsewhere.example/rss?q=1"]
+   ["./rss?q=1" "https://example.org/blog/rss?q=1"]])
+
+(defn check-uri [interpreter runtime]
+  (doseq [[reference expected] references]
+    (let [r (sandbox/eval-code
+             interpreter
+             (str "(str (.resolve (java.net.URI. \"https://example.org/blog/\") "
+                  (pr-str reference) "))")
+             :execution-context runtime)]
+      (is (:success r))
+      (is (= expected (:value r))))))
+
+(deftest uri-in-session-and-managed-world
+  (let [runtime (ctx/create-execution-context)]
+    (try
+      (testing "ordinary session uses the same class surface"
+        (check-uri (sandbox/fork-for-session runtime) runtime))
+      (let [ref (sandbox/create-spindel-sci-world! runtime)
+            interpreter (sandbox/sci-context-in runtime ref)]
+        (sandbox/setup-agent-namespaces! interpreter runtime)
+        (check-uri interpreter runtime)
+        (is (:success (sandbox/eval-code
+                       interpreter
+                       "(def location (atom (java.net.URI. \"https://example.org/blog/\")))"
+                       :execution-context runtime)))
+        (let [child (ctx/fork-context runtime)]
+          (try
+            (let [child-sci (sandbox/sci-context-in child ref)]
+              (check-uri child-sci child)
+              (is (= "https://example.org/blog/feed.xml"
+                     (:value (sandbox/eval-code
+                              child-sci
+                              "(swap! location #(.resolve % \"feed.xml\")) (str @location)"
+                              :execution-context child))))
+              (is (= "https://example.org/blog/"
+                     (:value (sandbox/eval-code interpreter "(str @location)"
+                                                :execution-context runtime)))))
+            (finally (ctx/close-context! child)))))
+      (finally (ctx/close-context! runtime)))))
+
+(deftest uri-does-not-enable-url-or-jvm-authority
+  (let [runtime (ctx/create-execution-context)
+        ref (sandbox/create-spindel-sci-world! runtime)
+        interpreter (sandbox/sci-context-in runtime ref)]
+    (try
+      (sandbox/setup-agent-namespaces! interpreter runtime)
+      ;; Harmless probes: no network requests or process operations performed.
+      (doseq [form ["(java.net.URL. \"https://example.invalid\")"
+                    "(.toURL (java.net.URI. \"https://example.invalid\"))"
+                    "(.getProtocol (.toURL (java.net.URI. \"https://example.invalid\")))"
+                    "(System/getProperty \"java.version\")"
+                    "(Class/forName \"java.lang.System\")"]]
+        (is (false? (:success (sandbox/eval-code interpreter form
+                                                 :execution-context runtime))) form))
+      (finally (ctx/close-context! runtime)))))


### PR DESCRIPTION
## Summary

- Expose immutable URI data operations through SCI's closed member allowlist.
- Explicitly exclude toURL and leave URL/connection/System authority unavailable.
- Teach direct source editing, quoted-form serialization, workspace-only reload,
  explicit test-file loading, and checking test failure/error counts.
- Test ordinary sessions and managed forked interpreter state, denied interop,
  and executable source-generation guidance.

No new dependency, agent lifecycle, or world abstraction. No benchmark fixtures
or task-specific patches included.

## Validation

- `clojure -M:ffix`
- Targeted JVM REPL suite: 11 tests, 81 assertions, zero failures/errors.
- Independent review completed; its URI.toURL concern was fixed using the
  member controls already present in the pinned SCI release. No remaining
  medium-or-higher findings.
- Live Codex-subscription RSS repair with this normal sandbox profile (no
  experiment-only injector): completed in 10 model calls / 103 seconds. Saved
  source passed six independent URL-resolution checks in a fresh SCI interpreter.
  This is a development smoke experiment, not a reliability benchmark. Earlier
  diagnostic attempts failed and are retained separately.

The agent-produced RSS patch is not part of this PR.
