### PR TITLE
feat(evaluation): capture exit evidence before world settlement

### DIFF
--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -105,6 +105,43 @@ context/tool discovery, orchestration, effect execution, verification,
 settlement, delivery, or external-system drift. A failed setup must not be
 reported as deficient model reasoning.
 
+### Evidence from unsuccessful coding attempts
+
+A failed or cancelled Run discards its work world after supervised execution
+and cleanup stop. The evaluator's ordinary `:observe` therefore cannot assume
+that `:world/room` still exists. Use the optional host-only `:capture` callback
+to snapshot selected source/test files before settlement, on successful and
+unsuccessful execution alike. It receives the exact work Room, control Room,
+Run ID and EnvironmentDef, and runs after other owned resource cleanup.
+
+The callback must be a bounded, read-only collector, not a test runner. Check
+file sizes before reading, select explicit paths, and return portable data or
+artifact references. Do not fall back to reading the parent workspace when a
+candidate file is missing. Verify saved source separately in a clean,
+resource-bounded interpreter; candidate-authored test results are diagnostic
+evidence, not the trusted score.
+
+```clojure
+(evaluation/make-evaluator
+ {:id :coding/checks :version 1 :basis fixture-and-checks-hash
+  ;; Host-supplied bounded file collector, not an SCI capability.
+  :capture (fn [{work-room :world/room}]
+             (capture-selected-files work-room))
+  :observe (fn [{:keys [default execution/evidence]}]
+             (assoc default :files evidence))
+  :verify verify-saved-source})
+```
+
+The observer must include captured data in its returned evidence map for it to
+be persisted in the Attempt. A thrown capture error or non-portable capture
+result prevents certification and uses the existing uncertified-world cleanup;
+it does not rewrite the candidate Run as a capture failure. Setup failures
+still produce no Attempt. Capture time counts toward the total Run deadline,
+but cleanup must finish before disposal, even after cancellation. Consequently
+capture must terminate promptly and must not depend on live resources already
+closed by cleanup. This facility preserves diagnostics; it does not introduce
+another world retention, forking, or settlement policy.
+
 The first environment, `:business/renewal-risk-brief-v1`, is deliberately small.
 It requires a model to construct sales and support specialists, join evidence,
 inspect its own execution tree, and produce an exact risk brief while unrelated

--- a/src/dvergr/agent/evaluation.clj
+++ b/src/dvergr/agent/evaluation.clj
@@ -20,7 +20,7 @@
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]))
 
-(defrecord Evaluator [ref observe verify])
+(defrecord Evaluator [ref observe verify capture])
 (defrecord WorldSetup [ref prepare])
 
 (defonce ^:private pending-tasks (atom {}))
@@ -161,8 +161,18 @@
    EnvironmentDef verifier reference. `observe` receives durable execution
    facts and returns portable evidence. `verify` receives the EnvironmentDef
    plus that evidence and returns `{:checks {keyword boolean} :reward number}`.
+   Optional `capture` receives `{:room control-room :world/room work-room
+   :run-id uuid :environment EnvironmentDef}` after candidate work and owned
+   resource cleanup quiesce, before world settlement (including failure and
+   cancellation). It must perform bounded, read-only collection of portable
+   data, not execute candidate source or depend on already-closed resources.
+   Its result is passed to `observe` as `:execution/evidence`; the observer must
+   include it in its returned map to persist it. Capture errors fail
+   certification, not the candidate Run. Capture is supervised cleanup and
+   must terminate promptly. Capture time counts toward the Run deadline, but
+   cancellation does not interrupt cleanup.
    Evaluators are deliberately not portable and are never exposed to SCI."
-  [{:keys [id version basis observe verify]
+  [{:keys [id version basis observe verify capture]
     :or {version 1}}]
   (when-not (keyword? id)
     (throw (ex-info "Evaluator :id must be a keyword"
@@ -176,12 +186,15 @@
   (when-not (fn? verify)
     (throw (ex-info "Evaluator :verify must be a function"
                     {:type ::invalid-verifier})))
+  (when-not (or (nil? capture) (fn? capture))
+    (throw (ex-info "Evaluator :capture must be a function"
+                    {:type ::invalid-capture})))
   (when-not (roster/data-value? basis)
     (throw (ex-info "Evaluator :basis must contain only portable data"
                     {:type ::invalid-evaluator-basis :basis basis})))
   (->Evaluator (cond-> {:verifier/id id :verifier/version version}
                  (some? basis) (assoc :verifier/basis basis))
-               observe verify))
+               observe verify capture))
 
 (defn make-world-setup
   "Create a process-local trusted preparer for one exact world setup.
@@ -347,12 +360,13 @@
           (recur (ex-cause error))))))
 
 (defn- certification-candidate
-  [{:keys [room world-room setup-evidence definition evaluator agent run-id
+  [{:keys [room world-room setup-evidence execution-evidence definition evaluator agent run-id
            result durable started-at started-nanos timeout?]}]
   (let [evidence ((:observe evaluator)
                   {:room room
                    :world/room world-room
                    :setup/evidence setup-evidence
+                   :execution/evidence execution-evidence
                    :environment definition
                    :run-id run-id
                    :result result
@@ -448,16 +462,38 @@
                         (seq resources) (assoc :resources resources)
                         (seq model-limits) (assoc :limits model-limits))
             setup-evidence (atom nil)
+            ;; Per-invocation host handoff, not another world-state store.
+            ;; Portable captured evidence enters the durable Attempt.
+            captured (atom ::pending)
             prepare-world!
-            (when world-setup
+            (when (or world-setup (:capture evaluator))
               (fn [context]
-                (let [evidence ((:prepare world-setup)
-                                (assoc context :environment definition))]
-                  (when-not (roster/data-value? evidence)
-                    (throw (ex-info "World setup evidence must be portable"
-                                    {:type ::non-portable-setup-evidence
-                                     :setup (:ref world-setup)})))
-                  (reset! setup-evidence evidence))))
+                (when-let [capture (:capture evaluator)]
+                  ;; Register first: supervisor cleanup is LIFO, so capture
+                  ;; sees the final substrate after other resource cleanup.
+                  ((:register-cleanup! context)
+                   (fn []
+                     (reset! captured
+                             (try
+                               (let [evidence
+                                     (capture {:room room
+                                               :world/room (:room context)
+                                               :run-id (:run/id context)
+                                               :environment definition})]
+                                 (when-not (roster/data-value? evidence)
+                                   (throw (ex-info "Captured evidence must be portable"
+                                                   {:type ::invalid-captured-evidence})))
+                                 {:ok evidence})
+                               (catch Throwable error {:error error})))
+                     nil)))
+                (when world-setup
+                  (let [evidence ((:prepare world-setup)
+                                  (assoc context :environment definition))]
+                    (when-not (roster/data-value? evidence)
+                      (throw (ex-info "World setup evidence must be portable"
+                                      {:type ::non-portable-setup-evidence
+                                       :setup (:ref world-setup)})))
+                    (reset! setup-evidence evidence)))))
             handle (program/hire-prepared-in! room room team agent-ref hire-opts
                                               prepare-world!)
             timed-out ::timed-out
@@ -555,12 +591,19 @@
                  (binding [ec/*execution-context* (:ctx room)
                            ec/*spin-id* nil]
                    (try
-                     (let [{:keys [evidence receipt]}
+                     (let [_ (when (and (:capture evaluator)
+                                        (not (and (map? @captured)
+                                                  (contains? @captured :ok))))
+                               (throw (ex-info "Execution evidence capture failed"
+                                               {:type ::capture-failed :run/id run-id}
+                                               (:error @captured))))
+                           {:keys [evidence receipt]}
                            (certification-candidate
                             {:room room :definition definition
                              :evaluator evaluator :agent agent :run-id run-id
                              :world-room fork
                              :setup-evidence @setup-evidence
+                             :execution-evidence (:ok @captured)
                              :result result :durable durable
                              :started-at started-at :started-nanos started-nanos
                              :timeout? timeout?})

--- a/test/dvergr/agent/evaluation_capture_test.clj
+++ b/test/dvergr/agent/evaluation_capture_test.clj
@@ -1,0 +1,167 @@
+(ns dvergr.agent.evaluation-capture-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.program :as program]
+            [dvergr.agent.roster :as roster]
+            [dvergr.agent.run :as run]
+            [dvergr.discourse :as d]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.sync :as sync]))
+
+(def team
+  (roster/make-agent (roster/make-roster)
+                     {:id :candidate :program {:kind :echo}}))
+
+(defn- evaluator [capture]
+  (evaluation/make-evaluator
+   {:id :test/capture :capture capture
+    :observe (fn [{:keys [default execution/evidence result]}]
+               (assoc default :captured evidence
+                      :completed? (= :completed (:run/status result))))
+    :verify (fn [_ evidence]
+              {:checks {:completed? (:completed? evidence)}
+               :reward (if (:completed? evidence) 1.0 0.0)})}))
+
+(defn- definition [opts]
+  (environment/make-environment
+   (merge {:id :test/capture :task :work
+           :verifier {:id :test/capture :version 1}
+           :world {:isolation :ctx :settlement :discard}
+           :limits {:timeout-ms 5000 :cancel-timeout-ms 5000}} opts)))
+
+(defn- launch! [room computation]
+  (let [done (promise)]
+    (binding [ec/*execution-context* (:ctx room)]
+      (sync/spawn! computation {:on-success #(deliver done {:ok %})
+                                :on-error #(deliver done {:error %})}))
+    done))
+
+(defn- result! [done]
+  (let [result (deref done 15000 ::timeout)]
+    (when (= ::timeout result) (throw (ex-info "Test timed out" {})))
+    (if-let [error (:error result)] (throw error) (:ok result))))
+
+(deftest capture-preserves-failed-and-cancelled-work-without-retaining-worlds
+  (doseq [status [:completed :failed :cancelled]]
+    (testing (name status)
+      (let [room (d/make-room {:id (keyword (str "capture-" (name status)))
+                               :store (memory/make)})
+            wrote (promise)
+            captured (atom [])
+            check (evaluator
+                   (fn [{:keys [world/room run-id]}]
+                     (let [value (rtp/get-state (:ctx room) [:test :source])]
+                       (swap! captured conj run-id)
+                       {:source value :run-id run-id})))
+            original @#'program/execute-program]
+        (try
+          (with-redefs-fn
+            {#'program/execute-program
+             (fn [& args]
+               (sp/spin
+                ;; The orchestration Spin lives in the control context. Tool
+                ;; execution explicitly enters the work context, as here.
+                (binding [ec/*execution-context* (:ctx (second args))]
+                  (ec/swap-state! [:test :source] (constantly "(def answer 42)")))
+                (deliver wrote true)
+                (case status
+                  :failed (throw (ex-info "Candidate failed after edit" {}))
+                  :cancelled (sp/await (comb/sleep 60000))
+                  :completed (sp/await (apply original args)))))}
+            (fn []
+              (let [done (binding [ec/*execution-context* (:ctx room)]
+                           (launch! room (evaluation/evaluate room team :candidate
+                                                              (definition {}) check)))]
+                (is (= true (deref wrote 5000 ::timeout)))
+                (when (= :cancelled status)
+                  (is (run/cancel-room-run! (:id room)
+                                            (:run/id (first (run/active-runs (:id room)))))))
+                (let [result (result! done)
+                      id (:run/id result)
+                      evidence {:source "(def answer 42)" :run-id id}]
+                  (is (= status (get-in result [:attempt-receipt :attempt/status])))
+                  (is (= evidence (get-in result [:evidence :captured])))
+                  (is (= evidence (get-in result [:attempt :attempt/evidence :captured])))
+                  (is (= evidence
+                         (-> (store/-list-attempts (:store room) (:id room) {})
+                             first :attempt/evidence :captured)))
+                  (is (= [id] @captured))
+                  (is (= :discarded (get-in result [:run/result :run/settlement-status])))
+                  (binding [ec/*execution-context* (:ctx room)]
+                    (is (nil? (registry/lookup (get-in result [:run/result :run/world])))))
+                  (is (nil? (rtp/get-state (:ctx room) [:test :source])))
+                  (is (empty? (run/active-runs (:id room))))))))
+          (finally
+            (evaluation/await-cleanups! room)
+            (d/close-room! room)))))))
+
+(deftest capture-runs-after-resource-cleanup-in-the-work-context
+  (let [room (d/make-room {:id :capture-cleanup :store (memory/make)})
+        setup (evaluation/make-world-setup
+               {:id :test/setup
+                :prepare (fn [{:keys [register-cleanup!]}]
+                           (register-cleanup!
+                            #(ec/swap-state! [:test :cleaned] (constantly true)))
+                           nil)})
+        check (evaluator
+               (fn [{:keys [world/room]}]
+                 {:cleaned? (ec/get-state [:test :cleaned])
+                  :work-context? (identical? (:ctx room) (ec/current-execution-context))}))]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [result (result!
+                      (launch! room
+                               (evaluation/evaluate
+                                room team :candidate
+                                (definition {:world {:isolation :ctx :settlement :discard
+                                                     :setup (evaluation/world-setup-ref setup)}})
+                                check {:world-setup setup})))]
+          (is (= {:cleaned? true :work-context? true}
+                 (get-in result [:evidence :captured])))))
+      (finally
+        (evaluation/await-cleanups! room)
+        (d/close-room! room)))))
+
+(deftest capture-errors-prevent-certification-but-do-not-rewrite-the-run
+  (doseq [capture [(fn [_] (throw (ex-info "Cannot read artifact" {})))
+                   (fn [_] (atom :not-portable))]]
+    (let [room (d/make-room {:id :capture-error :store (memory/make)})]
+      (try
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [done (launch! room (evaluation/evaluate room team :candidate
+                                                        (definition {}) (evaluator capture)))
+                error (:error (deref done 15000 nil))]
+            (is (= ::evaluation/certification-failed (:type (ex-data error))))
+            (is (= ::evaluation/capture-failed (:type (ex-data (ex-cause error)))))
+            (let [[value] (run/runs room)]
+              (is (= :completed (:run/status value)))
+              (is (= :discarded (:run/settlement-status value)))
+              (is (nil? (registry/lookup (:run/world value)))))
+            (is (empty? (store/-list-attempts (:store room) (:id room) {})))))
+        (finally
+          (evaluation/await-cleanups! room)
+          (d/close-room! room))))))
+
+(deftest one-evaluator-captures-parallel-attempts-independently
+  (let [room (d/make-room {:id :capture-parallel :store (memory/make)})
+        check (evaluator (fn [{:keys [run-id]}] {:run-id run-id}))]
+    (try
+      (binding [ec/*execution-context* (:ctx room)]
+        (let [results (result!
+                       (launch! room
+                                (comb/parallel
+                                 (evaluation/evaluate room team :candidate (definition {}) check)
+                                 (evaluation/evaluate room team :candidate (definition {}) check))))]
+          (is (= 2 (count (set (map :run/id results)))))
+          (doseq [result results]
+            (is (= (:run/id result) (get-in result [:evidence :captured :run-id]))))))
+      (finally
+        (evaluation/await-cleanups! room)
+        (d/close-room! room)))))


### PR DESCRIPTION
## Summary

Preserve diagnostic evidence from unsuccessful benchmark attempts without changing RunWorld retention or settlement policies.

- Add optional host-only evaluator `:capture`, using the existing supervisor's LIFO cleanup after candidate work/resource cleanup and before settlement.
- Pass portable captured data to `:observe` as `:execution/evidence`; include it in the observer result to persist it in the ordinary Attempt.
- Capture errors prevent certification without rewriting the candidate outcome. Failed/cancelled worlds still discard normally; setup failures still do not become Attempts.
- Document bounded read-only collection, exact work-world access, cleanup ordering and total-Run deadline semantics.

This is a small prerequisite for reusable RSS/permutation coding fixtures. It does not add another world lifecycle, exposed SCI capability, or merge policy.

## Validation

- REPL: evaluation and new capture tests — 23 tests, 166 assertions, zero failures/errors.
- REPL: program and frozen discovery regressions — 54 tests, 346 assertions, zero failures/errors.
- REPL smoke: real clojure_eval/SCI source write into a Geschichte-backed fork, followed by deliberate stub-provider failure. The failed Attempt retains exact source, the world is discarded, and the parent is unchanged. This uses a memory Room store; it is not a process-restart durability claim.
- `clojure -M:ffix`, `git diff --check`.
- Independent review: no medium-or-higher findings.

No live-model calls or external writes were used for benchmark validation.
