### PR TITLE
feat(benchmarks): package isolated permutation source repair

### DIFF
--- a/doc/coding-benchmarks.md
+++ b/doc/coding-benchmarks.md
@@ -1,0 +1,79 @@
+# Coding benchmarks in the SCI workspace
+
+The first reusable fixture is `dvergr.benchmarks.permutation`: repair a seeded
+composition-direction regression in a pinned Spindel source file. The original
+upstream code is correct. The fixture packages its source and license, so no
+sibling checkout or network fetch is needed to construct the task.
+
+It uses ordinary EnvironmentDef / WorldSetup / Evaluator values and returns an
+evaluation Spin. It is not another agent loop, workspace manager, or scheduler.
+The caller supplies a Room with a registered Geschichte workspace and an
+AgentDef; an already initialized Dvergr room is the intended entry point.
+
+```clojure
+(require '[dvergr.agent.evaluation :as evaluation]
+         '[dvergr.agent.roster :as roster]
+         '[dvergr.benchmarks.permutation :as permutation]
+         '[org.replikativ.spindel.engine.core :as ec])
+
+(def team
+  (roster/make-agent
+   (roster/make-roster)
+   {:id :coder
+    :tools #{:clojure_eval}
+    :model-policy {:provider :codex-subscription :model "codex-subscription-luna"}
+    :program {:kind :llm :auto-compact? false :max-model-steps 16}}))
+
+;; REPL top-level convenience. Inside a workflow, use spin/await and compose
+;; evaluation Spins with Spindel's existing parallel/race/etc. combinators.
+(def completion (promise))
+(binding [ec/*execution-context* (:ctx room)]
+  (let [attempt (evaluation/evaluate
+                 room team :coder (permutation/definition) (permutation/evaluator)
+                 {:world-setup (permutation/world-setup)})]
+    (attempt #(deliver completion {:result %})
+             #(deliver completion {:error %}))))
+
+;; Poll without blocking the REPL. A nil result means it is still running.
+(deref completion 0 nil)
+```
+
+The environment allows 180 seconds. The model-step cap is a runaway fuse, not
+the definition of useful work. Choose resource grants and model/token limits
+through the existing evaluation options for a particular experiment. Subscription
+access does not imply unlimited compute or a measurable per-request dollar bill.
+
+Setup resets both the source and the specified test file in the candidate fork,
+and installs an offline HTTP fixture. A missing workspace fails setup; it must
+not fall back to a physical checkout. Other unrelated workspace files remain,
+so use a clean seed when comparing candidates. This fixture is not a hermetic
+VM and does not claim that every possible external effect is stubbed.
+
+On success, failure or cancellation, bounded capture snapshots the source and
+test file (32 KiB each) before disposal. These appear under
+`:attempt/evidence :artifacts :files`; missing, non-file, unreadable and oversized
+files have explicit statuses. Test text is diagnostic evidence, not a trusted
+score. Verification loads saved source in a fresh SCI execution context and
+checks all 576 binary compositions over four positions plus nullary, unary,
+ternary and vector-arrangement cases. Failed/cancelled/waiting execution never
+earns success reward even if its saved source passes. Worlds are discarded and
+the parent remains unchanged.
+
+## What these results mean
+
+The manifest and content basis identify the source commit, seeded source,
+task wording, public checker, required runtime surface, capture bounds and
+verification deadline. Record the actual Dvergr revision, dependency resolution
+(including local overrides), JVM and provider/model resolution alongside each
+launch. The named runtime surface is not an automatically detected binary lock.
+
+This is a development benchmark, not hidden evaluation data or a tamper-resistant
+training reward service. It measures whether an agent can inspect, edit, reload
+and test a small real source library through the SCI workspace. A deterministic
+stub provider exercises the same tool/world/capture path in tests; it does not
+measure model reasoning. The checker has a bounded SCI evaluation window, not a
+separate process/heap boundary. Do not treat it as an adversarial code runner.
+
+Next steps are the RSS reference-resolution fixture, held-out task variants,
+repeated model attempts and recursive repair/review workflows. Comparing models
+requires distributions of outcomes and resource use, not one successful repair.

--- a/doc/practical-agent-evaluation.md
+++ b/doc/practical-agent-evaluation.md
@@ -107,6 +107,9 @@ reported as deficient model reasoning.
 
 ### Evidence from unsuccessful coding attempts
 
+See [Coding benchmarks](coding-benchmarks.md) for the reusable Spindel
+permutation repair fixture and its REPL entry point.
+
 A failed or cancelled Run discards its work world after supervised execution
 and cleanup stop. The evaluator's ordinary `:observe` therefore cannot assume
 that `:world/room` still exists. Use the optional host-only `:capture` callback

--- a/resources/benchmarks/permutation/LICENSE
+++ b/resources/benchmarks/permutation/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-2026 Christian Weilbach, org.replikativ
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/resources/benchmarks/permutation/README.md
+++ b/resources/benchmarks/permutation/README.md
@@ -1,0 +1,14 @@
+# Spindel composition repair fixture
+
+`permutation.cljc` is an unmodified snapshot from replikativ/spindel, commit
+`6b87946a58a7c1bbcbf023f2ff4c657e7a6970a0`, path
+`src/org/replikativ/spindel/incremental/permutation.cljc`.
+
+Copyright 2026 Christian Weilbach, org.replikativ. Distributed under the
+included Apache 2.0 LICENSE. The benchmark seeds a reversed binary composition
+direction at setup time and marks that generated copy as modified.
+
+The snapshot is the correct reference, not a claimed upstream bug. Public
+checks enumerate all 576 ordered pairs of permutations on four positions and
+also cover nullary, unary, ternary composition and vector arrangement.
+These are development checks, not hidden evaluation data.

--- a/resources/benchmarks/permutation/permutation.cljc
+++ b/resources/benchmarks/permutation/permutation.cljc
@@ -1,0 +1,208 @@
+(ns org.replikativ.spindel.incremental.permutation
+  "Permutations of finite positions, sparse-map representation.
+
+   A permutation is a bijection on `[0, n)` for some `n`. We represent
+   it as a Clojure map `{i → π(i)}` *omitting fixed points*. So the
+   identity permutation is `{}`, a transposition `(0 1)` is `{0 1, 1 0}`,
+   and a rotation of position 0 to position 2 is `{0 2, 1 0, 2 1}`.
+
+   This representation has three useful properties:
+
+   - **Canonical.** Two permutations are equal iff their sparse maps are
+     equal. In particular the identity is uniquely `{}`.
+   - **Compact.** Memory is `O(|non-fixed|)` — important for large
+     sequences with localised reorderings.
+   - **Group operations are simple.** `compose` is one map-iteration,
+     `inverse` is `clojure.set/map-invert`.
+
+   Conventions
+   -----------
+   A permutation `p` is interpreted *forward*: `p(i) = j` means \"the
+   element at position i moves to position j.\" Composition order
+   matches function composition: `(compose p q)(i) = p(q(i))`, i.e. apply
+   `q` first, then `p`.
+
+   `arrange` applies a permutation to a vector by reading: the new
+   vector at position `j` contains the value that was at position
+   `p⁻¹(j)`. Equivalently, `new[p(i)] = old[i]` for every i (with
+   `p(i) = i` for fixed points).
+
+   Algebraic structure
+   -------------------
+   Permutations form the symmetric group `S_n` for any fixed `n`:
+
+   - **Closure.** `compose` of two permutations is a permutation.
+   - **Associativity.** `(compose (compose p q) r) = (compose p (compose q r))`.
+   - **Identity.** `(compose p {}) = (compose {} p) = p`.
+   - **Inverse.** `(compose p (inverse p)) = (compose (inverse p) p) = {}`.
+
+   Permutations form a *group*, not just a monoid — the only one of
+   our five sequence-diff fields with full group structure (shrink is
+   irreversible)."
+  (:refer-clojure :exclude [cycle])
+  (:require [clojure.set :as set]))
+
+;; =============================================================================
+;; Predicates and accessors
+;; =============================================================================
+
+(defn identity-perm?
+  "True iff `p` is the identity permutation."
+  [p]
+  (or (nil? p) (zero? (count p))))
+
+(defn canonicalize
+  "Return `p` in canonical sparse-map form: any `(i, i)` fixed points
+   are removed. The constructors in this namespace already produce
+   canonical permutations; this helper is for callers who build
+   permutations by hand and want to normalise before composition or
+   comparison."
+  [p]
+  (persistent!
+   (reduce-kv (fn [acc k v]
+                (if (= k v) acc (assoc! acc k v)))
+              (transient {})
+              p)))
+
+(defn apply-perm
+  "Apply permutation `p` at position `i`. Returns `p(i)` if `i` is a
+   non-fixed point, else `i` itself (fixed-point default)."
+  [p i]
+  (get p i i))
+
+(defn fixed-points
+  "Return the set of positions `< size` that are fixed by `p`."
+  [p size]
+  (into #{} (remove #(contains? p %)) (range size)))
+
+;; =============================================================================
+;; Group operations
+;; =============================================================================
+
+(defn compose
+  "Compose two permutations: `(compose p q)(i) = p(q(i))`. Apply q
+   first, then p. The result is in canonical form (fixed points
+   omitted).
+
+   Variadic: `(compose)` is the identity; `(compose p)` is `p`."
+  ([] {})
+  ([p] p)
+  ([p q]
+   ;; r(i) = p(q(i)). Domain of r is contained in dom(p) ∪ dom(q):
+   ;; any i not in either is fixed by both, hence fixed by r.
+   (let [touched (into #{} (concat (keys p) (keys q)))]
+     (persistent!
+      (reduce (fn [acc i]
+                (let [qi  (apply-perm q i)
+                      pqi (apply-perm p qi)]
+                  (if (= pqi i)
+                    acc
+                    (assoc! acc i pqi))))
+              (transient {})
+              touched))))
+  ([p q & more]
+   (reduce compose (compose p q) more)))
+
+(defn inverse
+  "Return the inverse permutation: `(compose p (inverse p)) = {}`. For
+   the sparse-map representation this is a key/value swap."
+  [p]
+  (set/map-invert p))
+
+;; =============================================================================
+;; Constructors for common permutations
+;; =============================================================================
+
+(defn cycle
+  "Build a permutation from a cycle in one-line notation. `(cycle a b c)`
+   produces a permutation that sends `a → b`, `b → c`, `c → a`. A
+   one-element cycle is the identity. Positions must be distinct."
+  [& positions]
+  (let [n (count positions)]
+    (cond
+      (<= n 1) {}
+      :else    (into {}
+                     (map vector positions
+                          (concat (rest positions) [(first positions)]))))))
+
+(defn transposition
+  "Build a transposition swapping positions `i` and `j`. Equivalent to
+   `(cycle i j)` for `i ≠ j`; identity when `i = j`."
+  [i j]
+  (if (= i j) {} {i j j i}))
+
+(defn rotation
+  "Build a permutation that moves the element at position `from` to
+   position `to`, shifting the elements between them by one to make
+   room.
+
+   When `from < to`: elements at `(from, to]` shift one slot toward the
+   head (positions `from+1, …, to` become `from, …, to-1`).
+   When `from > to`: elements at `[to, from)` shift one slot toward the
+   tail.
+   When `from = to`: identity."
+  [from to]
+  (cond
+    (= from to) {}
+    (< from to) (assoc (into {} (for [k (range (inc from) (inc to))] [k (dec k)]))
+                       from to)
+    :else       (assoc (into {} (for [k (range to from)] [k (inc k)]))
+                       from to)))
+
+(defn split-swap
+  "The permutation that swaps two adjacent contiguous ranges
+   `[a, a+m)` and `[a+m, a+m+n)`. After application the second range
+   precedes the first. Used by sequence-diff composition to interleave
+   slots grown by two consecutive diffs."
+  [a m n]
+  (if (or (zero? m) (zero? n))
+    {}
+    (into {}
+          (concat
+           ;; first range slides up by n
+           (for [i (range a (+ a m))] [i (+ i n)])
+           ;; second range slides down by m
+           (for [i (range (+ a m) (+ a m n))] [i (- i m)])))))
+
+;; =============================================================================
+;; Action on vectors
+;; =============================================================================
+
+(defn arrange
+  "Apply `p` to vector `coll`: the new vector has `coll[i]` at position
+   `(apply-perm p i)`. Equivalently, `new[j] = coll[(inverse p)[j]]`.
+
+   Permutation `p` must be a valid permutation on `[0, (count coll))` —
+   if any `(p i) ≥ (count coll)` or `(p i) < 0`, behaviour is
+   undefined (will produce nils or throw). Callers are expected to
+   ensure the permutation matches the vector's size."
+  [p coll]
+  (let [v (vec coll)]
+    (if (identity-perm? p)
+      v
+      (reduce-kv (fn [acc i j] (assoc acc j (nth v i))) v p))))
+
+;; =============================================================================
+;; Decomposition (helper for the diff layer; not part of the group ops)
+;; =============================================================================
+
+(defn decompose-cycles
+  "Decompose `p` into its disjoint cycles, each represented as a vector
+   of positions. The identity decomposes to `[]`. Useful for diff
+   composition and for emitting minimal DOM moves."
+  [p]
+  (if (identity-perm? p)
+    []
+    (loop [remaining p
+           cycles    []]
+      (if-let [[start _] (first remaining)]
+        (let [cyc (loop [i start
+                         acc [start]]
+                    (let [j (get remaining i)]
+                      (if (or (nil? j) (= j start))
+                        acc
+                        (recur j (conj acc j)))))
+              consumed (set cyc)]
+          (recur (into {} (remove (fn [[k _]] (consumed k))) remaining)
+                 (conj cycles cyc)))
+        cycles))))

--- a/src/dvergr/benchmarks/coding_workspace.clj
+++ b/src/dvergr/benchmarks/coding_workspace.clj
@@ -1,0 +1,41 @@
+(ns dvergr.benchmarks.coding-workspace
+  "Bounded host-side snapshots of explicit virtual workspace files."
+  (:require [dvergr.substrate.geschichte :as g]
+            [muschel.fs :as fs]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(defn capture
+  "Collect up to 16 explicitly named absolute paths, at most 64 KiB each.
+   Reads only the registered Geschichte filesystem, never the host or parent.
+   Missing/rejected files are evidence, not exceptions or empty source. The
+   caller must run this after candidate quiescence (Evaluator :capture)."
+  [room paths max-bytes]
+  (when-not (and (vector? paths) (<= 1 (count paths) 16)
+                 (= (count paths) (count (set paths)))
+                 (every? #(and (string? %) (.startsWith ^String % "/")) paths)
+                 (integer? max-bytes) (<= 1 max-bytes 65536))
+    (throw (ex-info "Invalid coding artifact capture bounds" {})))
+  (if-not (:ctx room)
+    {:status :world-unavailable}
+    (binding [ec/*execution-context* (:ctx room)]
+      (if-let [filesystem (g/filesystem)]
+        {:status :captured
+         :files
+         (into {}
+               (map (fn [path]
+                      [path
+                       (let [{:keys [type size]} (fs/stat filesystem path)]
+                         (cond
+                           (nil? type) {:status :missing}
+                           (not= :file type) {:status :not-file}
+                           (not (and (integer? size) (<= 0 size max-bytes)))
+                           {:status :size-rejected}
+                           :else
+                           (let [text (fs/read-file filesystem path)]
+                             (cond
+                               (not (string? text)) {:status :unreadable}
+                               (> (alength (.getBytes ^String text "UTF-8")) max-bytes)
+                               {:status :size-rejected}
+                               :else {:status :ok :source text}))))]))
+               paths)}
+        {:status :no-workspace}))))

--- a/src/dvergr/benchmarks/permutation.clj
+++ b/src/dvergr/benchmarks/permutation.clj
@@ -1,0 +1,155 @@
+(ns dvergr.benchmarks.permutation
+  "Offline source-repair fixture over a pinned Spindel namespace.
+   The regression is seeded; upstream is not broken. Checks are public and
+   deterministic, not held-out or a tamper-resistant training reward service."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [dvergr.agent.environment :as environment]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.benchmarks.coding-workspace :as workspace]
+            [dvergr.sandbox :as sandbox]
+            [dvergr.sandbox.ns.io :as sandbox-io]
+            [dvergr.substrate.geschichte :as g]
+            [hasch.core :as hasch]
+            [muschel.fs :as fs]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.core :as ec]))
+
+(def source-path "/src/org/replikativ/spindel/incremental/permutation.cljc")
+(def test-path "/test/permutation_repair_test.clj")
+(def original-source (slurp (io/resource "benchmarks/permutation/permutation.cljc")))
+(def seeded-source
+  (str ";; Benchmark copy: binary composition direction deliberately reversed.\n"
+       (-> original-source
+           (str/replace "qi  (apply-perm q i)" "qi  (apply-perm p i)")
+           (str/replace "pqi (apply-perm p qi)" "pqi (apply-perm q qi)"))))
+
+(defn- permutations [xs]
+  (if (empty? xs) [[]]
+      (for [x xs p (permutations (remove #{x} xs))] (vec (cons x p)))))
+
+(def inputs
+  (mapv #(into {} (remove (fn [[a b]] (= a b))) (map-indexed vector %))
+        (permutations (range 4))))
+
+(defn- composition [ps]
+  (into {} (keep (fn [i]
+                   (let [j (reduce (fn [j p] (get p j j)) i (reverse ps))]
+                     (when (not= i j) [i j]))))
+        (range 4)))
+
+(def expected
+  {:binary (mapv #(composition %) (for [p inputs q inputs] [p q]))
+   :nullary {}
+   :unary inputs
+   :ternary (mapv #(composition [% {0 1, 1 0} {1 2, 2 1}]) inputs)
+   :arrange [:b :c :a :d]})
+
+(def check-expression
+  ;; Do not require the target: that could load the correct host library when
+  ;; submitted source is empty. Resolve only definitions loaded from the file.
+  (str/replace
+   (str
+    "(let [ps '" (pr-str inputs) "] "
+    "{:binary (vec (for [a ps b ps] (p/compose a b))) "
+    ":nullary (p/compose) :unary (mapv p/compose ps) "
+    ":ternary (mapv #(p/compose % {0 1, 1 0} {1 2, 2 1}) ps) "
+    ":arrange (p/arrange (p/rotation 0 2) [:a :b :c :d])})")
+   "p/" "org.replikativ.spindel.incremental.permutation/"))
+
+(def task
+  (str "Repair a seeded composition regression in " source-path ". "
+       "The documented convention is (compose p q)(i) = p(q(i)). Preserve the "
+       "public API, sparse canonical representation, and zero/unary/variadic compose. "
+       "Reproduce a non-commuting counterexample, edit the saved SOURCE, and write/run "
+       "clojure.test regressions at " test-path ". Require the source with :reload; "
+       "load your test file with (load-string (slurp path)). Do not reload clojure.test. "
+       "Use clojure_eval. No live web is needed; HTTP is an offline 404 fixture. "
+       "A fresh interpreter checks saved source, not REPL definitions or your final reply. "
+       "Tests cover all 576 ordered pairs on four positions, identity, unary/variadic "
+       "composition, and vector arrangement. Finish with your counterexample and test summary. "
+       "This experimental copy does not imply that upstream Spindel is broken."))
+
+(def manifest
+  {:fixture/version 1
+   :source/repository "https://github.com/replikativ/spindel"
+   :source/commit "6b87946a58a7c1bbcbf023f2ff4c657e7a6970a0"
+   :source/path "src/org/replikativ/spindel/incremental/permutation.cljc"
+   :source/hash (hasch/uuid original-source)
+   :candidate/hash (hasch/uuid seeded-source)
+   :runtime/profile :dvergr-sci-closed-uri-v1
+   ;; This names the required surface, not an automatically detected binary
+   ;; lock. Record actual dependency/checkout identity with each launch.
+   :checks/version 1 :checks/hash (hasch/uuid [check-expression expected])
+   :capture/paths [source-path test-path] :capture/max-file-bytes 32768
+   :verification/timeout-ms 3000})
+
+(def basis (hasch/uuid [manifest task]))
+(def setup-ref {:setup/id :coding/permutation :setup/version 1 :setup/basis basis})
+(def verifier-ref {:verifier/id :coding/permutation :verifier/version 1 :verifier/basis basis})
+(def offline-id (hasch/uuid [:coding/offline-http-v1]))
+
+(defn- offline! []
+  (sandbox-io/install-http-fixture!
+   {:id offline-id :env {}
+    :transport (fn [_] {:status 404 :headers {} :body "Offline coding fixture"})}))
+
+(defn definition []
+  (environment/make-environment
+   {:id :coding/permutation :task task
+    :verifier {:id :coding/permutation :version 1 :basis basis}
+    :world {:isolation :ctx :settlement :discard :setup setup-ref}
+    :limits {:timeout-ms 180000 :cancel-timeout-ms 10000}
+    :metadata manifest}))
+
+(defn world-setup []
+  (evaluation/make-world-setup
+   {:id (:setup/id setup-ref) :version 1 :basis basis
+    :prepare
+    (fn [{:keys [room]}]
+      (binding [ec/*execution-context* (:ctx room)]
+        (offline!)
+        (let [filesystem (g/filesystem)]
+          (when-not filesystem
+            (throw (ex-info "Coding fixture needs a registered Geschichte workspace" {})))
+          (doseq [[path text] [[source-path seeded-source]
+                               [test-path ";; Write regression tests here.\n"]]]
+            (when-not (fs/write-string! filesystem path text false)
+              (throw (ex-info "Cannot seed coding fixture" {:path path}))))))
+      {:fixture/basis basis})}))
+
+(defn check-source
+  "Check saved text in a fresh context, never the candidate's interpreter.
+   A bounded SCI eval covers source loading and the public reference cases.
+   This is a development benchmark, not an adversarial reward boundary."
+  [source]
+  (if-not (and (string? source) (<= 1 (alength (.getBytes ^String source "UTF-8")) 32768))
+    {:source? false}
+    (let [runtime (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* runtime] (offline!))
+        (let [interpreter (sandbox/fork-for-session runtime)
+              _ (sandbox/setup-agent-namespaces! interpreter runtime)
+              result (sandbox/eval-code
+                      interpreter
+                      (str "(load-string " (pr-str source) ") " check-expression)
+                      :execution-context runtime :timeout-ms 3000)]
+          (into {:evaluated? (true? (:success result))}
+                (map (fn [[k value]]
+                       [k (and (true? (:success result)) (= value (get (:value result) k)))]))
+                expected))
+        (finally (ctx/close-context! runtime))))))
+
+(defn evaluator []
+  (evaluation/make-evaluator
+   {:id (:verifier/id verifier-ref) :version 1 :basis basis
+    :capture (fn [{:keys [world/room]}]
+               (workspace/capture room [source-path test-path] 32768))
+    :observe (fn [{:keys [default execution/evidence result]}]
+               (assoc default :artifacts evidence :fixture/basis basis
+                      :completed? (= :completed (:run/status result))))
+    :verify (fn [_ evidence]
+              (let [file (get-in evidence [:artifacts :files source-path])
+                    checks (assoc (check-source (when (= :ok (:status file)) (:source file)))
+                                  :completed? (true? (:completed? evidence)))]
+                {:checks checks :reward (if (every? true? (vals checks)) 1.0 0.0)}))}))

--- a/test/dvergr/benchmarks/permutation_test.clj
+++ b/test/dvergr/benchmarks/permutation_test.clj
@@ -1,0 +1,151 @@
+(ns dvergr.benchmarks.permutation-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.string :as str]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.roster :as roster]
+            [dvergr.benchmarks.coding-workspace :as workspace]
+            [dvergr.benchmarks.permutation :as p]
+            [dvergr.chat.agent :as chat-agent]
+            [dvergr.discourse :as d]
+            [dvergr.model.chat :as model-chat]
+            [dvergr.model.providers :as providers]
+            [dvergr.room.registry :as registry]
+            [dvergr.room.store :as store]
+            [dvergr.room.store.memory :as memory]
+            [dvergr.substrate.geschichte :as g]
+            [muschel.fs :as fs]
+            [muschel.fs.geschichte :as gfs]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [yggdrasil.adapters.geschichte :as gy]))
+
+(deftest reference-checks-distinguish-the-seeded-regression
+  (is (= 24 (count p/inputs)))
+  (is (= 576 (count (:binary p/expected))))
+  (is (str/includes? p/seeded-source "qi  (apply-perm p i)"))
+  (is (every? true? (vals (p/check-source p/original-source))))
+  (let [checks (p/check-source p/seeded-source)]
+    (is (:evaluated? checks))
+    (is (false? (:binary checks)))
+    (is (false? (:ternary checks)))
+    (is (:nullary checks)))
+  (is (false? (:evaluated? (p/check-source "("))))
+  (is (false? (:evaluated? (p/check-source "nil"))))
+  (is (= {:source? false} (p/check-source nil)))
+  (is (= {:source? false} (p/check-source (apply str (repeat 32769 "a"))))))
+
+(deftest setup-and-capture-use-explicit-virtual-files
+  (let [{:keys [close!] :as repository} (gfs/memory-repository! {:name "coding-fixture"})
+        filesystem (gfs/make-root repository)
+        runtime (ctx/create-execution-context)
+        room {:ctx runtime}]
+    (try
+      (with-redefs [g/filesystem (constantly filesystem)]
+        (binding [ec/*execution-context* runtime]
+          ((:prepare (p/world-setup)) {:room room})
+          (is (= p/seeded-source (fs/read-file filesystem p/source-path)))
+          (is (= :file (:type (fs/stat filesystem p/test-path))))
+          ;; Reset inherited tests every time, not just the source.
+          (fs/write-string! filesystem p/test-path "old answer" false)
+          ((:prepare (p/world-setup)) {:room room})
+          (is (not= "old answer" (fs/read-file filesystem p/test-path))))
+        (let [capture ((:capture (p/evaluator)) {:world/room room})]
+          (is (= p/seeded-source (get-in capture [:files p/source-path :source])))
+          (is (= :ok (get-in capture [:files p/test-path :status])))))
+      (finally
+        (ctx/close-context! runtime)
+        (close!)))))
+
+(deftest capture-rejects-files-before-reading
+  (let [runtime (ctx/create-execution-context)]
+    (try
+      (is (= {:status :world-unavailable} (workspace/capture nil ["/file"] 4)))
+      (doseq [[stat status] [[nil :missing]
+                             [{:type :dir :size 0} :not-file]
+                             [{:type :file :size 5} :size-rejected]]]
+        (with-redefs [g/filesystem (constantly :virtual)
+                      fs/stat (fn [& _] stat)
+                      fs/read-file (fn [& _] (throw (ex-info "Must not read" {})))]
+          (is (= status (get-in (workspace/capture {:ctx runtime} ["/file"] 4)
+                                [:files "/file" :status])))))
+      (with-redefs [g/filesystem (constantly :virtual)
+                    fs/stat (fn [& _] {:type :file :size 2})
+                    fs/read-file (fn [& _] "ééé")]
+        (is (= :size-rejected (get-in (workspace/capture {:ctx runtime} ["/file"] 4)
+                                      [:files "/file" :status]))))
+      (finally (ctx/close-context! runtime)))))
+
+(deftest execution-status-is-not-inferred-from-correct-source
+  (let [check (p/evaluator)
+        artifacts {:status :captured
+                   :files {p/source-path {:status :ok :source p/original-source}}}]
+    (is (= p/verifier-ref (evaluation/evaluator-ref check)))
+    (is (= p/setup-ref (evaluation/world-setup-ref (p/world-setup))))
+    (doseq [status [:failed :cancelled :waiting]]
+      (let [evidence ((:observe check) {:default {} :execution/evidence artifacts
+                                        :result {:run/status status}})
+            score ((:verify check) (p/definition) evidence)]
+        (is (zero? (:reward score)))
+        (is (false? (get-in score [:checks :completed?])))))))
+
+(deftest coding-fixture-through-real-tool-and-world-lifecycle
+  (doseq [fail? [false true]]
+    (let [{:keys [conn close!]} (gfs/memory-repository! {:name "coding-run"})
+          room (d/make-room {:id :coding-fixture-run :store (memory/make)})
+          team (roster/make-agent (roster/make-roster)
+                                  {:id :coder :tools #{:clojure_eval}
+                                   :model-policy {:provider :test :model "stub"}
+                                   :program {:kind :llm :max-model-steps 3 :auto-compact? false}})
+          calls (atom 0)
+          tool-result (atom nil)
+          test-source "(ns permutation-repair-test (:require [clojure.test :refer [deftest is]]))\n(deftest identity-check (is (= {} (org.replikativ.spindel.incremental.permutation/compose))))\n"
+          code (str "(spit " (pr-str p/source-path) " " (pr-str p/original-source) ") "
+                    "(spit " (pr-str p/test-path) " " (pr-str test-source) ") "
+                    "(require 'org.replikativ.spindel.incremental.permutation :reload) "
+                    "(load-string (slurp " (pr-str p/test-path) ")) "
+                    "(clojure.test/run-tests 'permutation-repair-test)")]
+      (try
+        (binding [ec/*execution-context* (:ctx room)]
+          (ygg/register! (gy/create conn {:system-name "room-repo-coding-test"}))
+          (with-redefs [providers/ensure-initialized! (constantly nil)
+                        chat-agent/messages->api-format (fn [messages _ _] messages)
+                        model-chat/chat
+                        (fn [messages _]
+                          (if (= 1 (swap! calls inc))
+                            {:content "" :tool-calls [{:id "repair" :name "clojure_eval" :input {:code code}}]
+                             :usage {:input-tokens 0 :output-tokens 0} :stop-reason :tool-use}
+                            (do
+                              (reset! tool-result
+                                      (:message/content
+                                       (last (filter #(= :tool-result (:message/role %)) messages))))
+                              (if fail?
+                                (throw (ex-info "Provider failed after repair" {}))
+                                {:content "Saved repair and tests." :tool-calls nil
+                                 :usage {:input-tokens 0 :output-tokens 0} :stop-reason :end-turn}))))]
+            (let [done (promise)
+                  computation (evaluation/evaluate room team :coder (p/definition) (p/evaluator)
+                                                   {:world-setup (p/world-setup)})
+                  _ (computation #(deliver done {:result %}) #(deliver done {:error %}))
+                  outcome (deref done 60000 ::timeout)]
+              (is (not= ::timeout outcome))
+              (when-let [error (:error outcome)] (throw error))
+              (let [result (:result outcome)
+                    receipt (:attempt-receipt result)
+                    persisted (first (store/-list-attempts (:store room) (:id room) {}))]
+                (is (= (if fail? :failed :completed) (:attempt/status receipt)))
+                (is (= (if fail? 0.0 1.0) (:attempt/reward receipt)))
+                (doseq [summary [":test 1" ":pass 1" ":fail 0" ":error 0"]]
+                  (is (str/includes? (str @tool-result) summary) (str @tool-result)))
+                (is (= p/original-source
+                       (get-in persisted [:attempt/evidence :artifacts :files p/source-path :source])))
+                (is (= test-source
+                       (get-in persisted [:attempt/evidence :artifacts :files p/test-path :source])))
+                (is (nil? (registry/lookup (get-in result [:run/result :run/world]))))
+                (is (nil? (fs/stat (g/filesystem) p/source-path)))
+                (is (nil? (fs/stat (g/filesystem) p/test-path)))
+                (is (= 2 @calls))))))
+        (finally
+          (evaluation/await-cleanups! room)
+          (d/close-room! room)
+          (close!))))))


### PR DESCRIPTION
## Summary

Package the first reusable SCI coding fixture on top of #110, without another agent or world runtime.

- Pin an Apache-licensed Spindel permutation source snapshot and seed a clearly labelled composition-direction regression.
- Provide ordinary EnvironmentDef, WorldSetup and Evaluator constructors, with a content-addressed manifest and explicit REPL instructions.
- Reset source and the prescribed test file in the isolated Geschichte workspace; install offline HTTP; reject missing workspace setup.
- Capture up to 32 KiB each of source and authored tests before disposal, including failed attempts.
- Verify saved source in a fresh SCI context against all 576 binary permutation pairs, plus nullary, unary, ternary and arrangement cases. Do not require the target from the host classpath.
- Require completed execution for positive reward. Tests are captured as diagnostic artifacts, not trusted scoring input.

The resource snapshot and LICENSE account for much of the diff. This is a public development fixture, not held-out data or a tamper-resistant training reward service. Runtime surface requirements are named; actual checkout/dependency/JVM/provider identities must be recorded with launch reports.

## Validation

- REPL: fixture tests — 5 tests, 56 assertions, zero failures/errors.
- REPL: fixture plus evaluation/capture regression run before the final 8 tool-summary assertions — 28 tests, 214 assertions, zero failures/errors.
- The provider-free end-to-end test drives the real clojure_eval tool through source writes, reload, authored clojure.test execution, capture, independent verification and disposal. It covers completed execution and deliberate provider failure after repair. Both preserve files, neither changes the parent; only completion earns reward.
- Tool result assertions confirm 1 test / 1 passing assertion / 0 failures / 0 errors.
- `clojure -M:ffix`; `git diff --check`.
- Independent review found no remaining medium-or-higher issues. Its optional tool-summary assertion recommendation is included.

No live model calls were made for this fixture packaging pass. RSS, held-out variants and repeated live attempts follow separately.
