### PR TITLE
Add a serial RSS editing-affordance smoke comparison

### DIFF
--- a/doc/coding-benchmarks.md
+++ b/doc/coding-benchmarks.md
@@ -104,3 +104,42 @@ regression test's reported counts as well as independent source verification.
 Next steps are held-out task variants, repeated model attempts and recursive
 repair/review workflows. Comparing models
 requires distributions of outcomes and resource use, not one successful repair.
+
+## Compare editing affordances
+
+`examples/coding_tool_comparison.clj` composes the existing APIs into a four-Run
+smoke comparison. Both candidates have the same model, common prompt, 180-second
+RSS environment, and 32-request runaway fuse. One receives only `clojure_eval`;
+the other also receives `clojure_edit` and `write_file`. The treatment includes
+their descriptions/context overhead and optional use, not just editor speed.
+The fixture's instruction to use the REPL is unchanged; the common AgentDef
+prompt permits all granted tools. Inspect actual tool usage before attributing
+any outcome to structured editing.
+
+```clojure
+(load-file "examples/coding_tool_comparison.clj")
+(def comparison
+  (coding-tool-comparison/plan
+   {:provider :codex-subscription :model "codex-subscription-luna"}))
+(def group (evaluation/cleanup-group))
+(def done (promise))
+(binding [ec/*execution-context* (:ctx room)]
+  (let [workflow (coding-tool-comparison/run room comparison group)]
+    (workflow #(deliver done {:result %}) #(deliver done {:error %}))))
+(deref done 0 nil)
+;; Once finished/cancelled, join detached cleanup before closing the Room:
+;; (evaluation/await-cleanups-for! room group)
+```
+
+The order is REPL → editing → editing → REPL, implemented as two serial ordinary
+experiments. Each block persists its own scorecard and certified Attempts;
+aggregate both blocks when reporting the two observations per candidate. No
+failure is retried or dropped. A certification/cleanup error can abort the
+remaining workflow; report incomplete cells rather than inventing receipts.
+
+The Run API does not currently enforce token caps. This example measures tokens
+and uses time plus the request fuse as limits; it must not be described as a
+token-budget-controlled comparison. Four observations cannot establish a
+ranking, significance, or a causal performance improvement. Log model resolution,
+actual calls/tools, errors, tokens, elapsed time and captured artifacts, then
+choose larger repeated or held-out experiments based on those observations.

--- a/examples/coding_tool_comparison.clj
+++ b/examples/coding_tool_comparison.clj
@@ -1,0 +1,46 @@
+(ns coding-tool-comparison
+  "A four-attempt, counterbalanced RSS smoke comparison; not a model ranking.
+   Load this file at the host REPL. The caller owns the initialized Room."
+  (:require [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.benchmarks.rss :as rss]
+            [org.replikativ.spindel.core :as sp]))
+
+(defn plan [model-policy]
+  (let [base {:model-policy model-policy
+              :prompt "Work on saved files using the tools available to you; use the REPL for evaluation and tests. Once the task is complete, report the result."
+              :program {:kind :llm :auto-compact? false :max-model-steps 32}}
+        team (-> (roster/make-roster)
+                 (roster/make-agent (assoc base :id :repl :tools #{:clojure_eval}))
+                 (roster/make-agent (assoc base :id :editing
+                                           :tools #{:clojure_eval :clojure_edit :write_file})))
+        dataset (experiment/make-dataset {:id :coding/rss-tools
+                                          :environments [(rss/definition)]})
+        block (fn [id order]
+                (experiment/make-experiment
+                 {:id id :dataset dataset :repetitions 1
+                  :candidates (mapv #(roster/agent team %) order)
+                  :metadata {:purpose :smoke-comparison :candidate-order order
+                             :token-cap :not-supported :request-fuse 32}}))]
+    {:team team
+     :blocks [(block :coding/rss-tools-ab [:repl :editing])
+              (block :coding/rss-tools-ba [:editing :repl])]}))
+
+(defn run
+  "Compose two ordinary experiments serially: REPL, editing, editing, REPL.
+   Each Run has the unchanged RSS 180-second deadline. Token usage is measured,
+   not capped by this API. No retry, successful-only filtering, or world merge.
+   Pass an evaluation cleanup-group and join it at the host operation boundary."
+  [room {:keys [team blocks]} cleanup-group]
+  (sp/spin
+   (loop [remaining blocks results []]
+     (if-let [block (first remaining)]
+       (let [result (sp/await
+                     (experiment/run
+                      room team block {rss/verifier-ref (rss/evaluator)}
+                      {:parallelism 1 :max-parallelism 1 :max-attempts 2
+                       :cleanup-group cleanup-group
+                       :world-setups {rss/setup-ref (rss/world-setup)}}))]
+         (recur (next remaining) (conj results result)))
+       results))))

--- a/test/dvergr/benchmarks/coding_tool_comparison_test.clj
+++ b/test/dvergr/benchmarks/coding_tool_comparison_test.clj
@@ -33,7 +33,7 @@
   (let [room (d/make-room {:id :coding-comparison :store (memory/make)})
         calls (atom [])
         first-started (promise)
-        allow-first (sync/deferred)
+        allow-first (sync/create-deferred (:ctx room))
         group (evaluation/cleanup-group)
         plan (coding-tool-comparison/plan {:provider :test :model "stub"})]
     (try

--- a/test/dvergr/benchmarks/coding_tool_comparison_test.clj
+++ b/test/dvergr/benchmarks/coding_tool_comparison_test.clj
@@ -1,0 +1,79 @@
+(ns dvergr.benchmarks.coding-tool-comparison-test
+  (:require [clojure.test :refer [deftest is]]
+            [dvergr.agent.evaluation :as evaluation]
+            [dvergr.agent.experiment :as experiment]
+            [dvergr.agent.roster :as roster]
+            [dvergr.benchmarks.rss :as rss]
+            [dvergr.discourse :as d]
+            [dvergr.room.store.memory :as memory]
+            [dvergr.tools :as tools]
+            [muschel.fs :as fs]
+            [muschel.fs.geschichte :as gfs]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.sync :as sync]))
+
+(load-file "examples/coding_tool_comparison.clj")
+
+(deftest tool-availability-is-the-only-candidate-policy-difference
+  (let [{:keys [team blocks]} (coding-tool-comparison/plan {:provider :test :model "stub"})
+        repl (roster/agent team :repl)
+        editing (roster/agent team :editing)]
+    (is (= (dissoc repl :agent/id :agent/tools) (dissoc editing :agent/id :agent/tools)))
+    (is (= #{:clojure_eval} (:agent/tools repl)))
+    (is (= #{:clojure_eval :clojure_edit :write_file} (:agent/tools editing)))
+    (is (= 32 (get-in repl [:agent/program :max-model-steps])))
+    (is (= [[:repl :editing] [:editing :repl]]
+           (mapv #(mapv :candidate/id (:experiment/candidates %)) blocks)))
+    (doseq [block blocks]
+      (is (= 1 (:experiment/repetitions block)))
+      (is (= [(rss/definition)] (get-in block [:experiment/dataset :dataset/environments]))))))
+
+(deftest comparison-composes-existing-experiments-serially
+  (let [room (d/make-room {:id :coding-comparison :store (memory/make)})
+        calls (atom [])
+        first-started (promise)
+        allow-first (sync/deferred)
+        group (evaluation/cleanup-group)
+        plan (coding-tool-comparison/plan {:provider :test :model "stub"})]
+    (try
+      (with-redefs [experiment/run
+                    (fn [_ _ block _ options]
+                      (sp/spin
+                       (swap! calls conj [(:experiment/id block) options])
+                       (when (= :coding/rss-tools-ab (:experiment/id block))
+                         (deliver first-started true)
+                         (sp/await allow-first))
+                       {:block (:experiment/id block)}))]
+        (binding [ec/*execution-context* (:ctx room)]
+          (let [completion (promise)
+                workflow (coding-tool-comparison/run room plan group)]
+            (is (empty? @calls))
+            (workflow #(deliver completion {:result %}) #(deliver completion {:error %}))
+            (is (= true (deref first-started 5000 ::timeout)))
+            (is (= [:coding/rss-tools-ab] (mapv first @calls)))
+            (sync/deliver! allow-first true)
+            (let [outcome (deref completion 5000 ::timeout)]
+              (is (= [{:block :coding/rss-tools-ab} {:block :coding/rss-tools-ba}]
+                     (:result outcome)))))))
+      (is (= [:coding/rss-tools-ab :coding/rss-tools-ba] (mapv first @calls)))
+      (doseq [[_ opts] @calls]
+        (is (= {:parallelism 1 :max-parallelism 1 :max-attempts 2 :cleanup-group group}
+               (dissoc opts :world-setups))))
+      (finally (d/close-room! room)))))
+
+(deftest editing-tools-operate-on-the-virtual-filesystem
+  (let [{:keys [close!] :as repository} (gfs/memory-repository! {:name "coding-edit-tools"})
+        filesystem (gfs/make-root repository)
+        context (tools/make-context {:cwd "/" :filesystem filesystem})]
+    (try
+      (is (= :success (:type (tools/execute "write_file"
+                                            {:path "src/demo.clj" :content "(ns demo)\n(defn answer [] 41)\n"}
+                                            context))))
+      (is (= :success (:type (tools/execute "clojure_edit"
+                                            {:file_path "src/demo.clj" :form_type "defn" :form_name "answer"
+                                             :operation "replace" :new_source "(defn answer [] 42)"}
+                                            context))))
+      (is (= "(ns demo)\n(defn answer [] 42)\n" (fs/read-file filesystem "/src/demo.clj")))
+      (is (nil? (fs/physical-path filesystem "/src/demo.clj")))
+      (finally (close!)))))


### PR DESCRIPTION
## Summary

Adds a four-attempt REPL-versus-editing example using existing ExperimentDefs and Spindel await: AB then BA, serial fresh worlds, no new scheduling or world API. Both candidates share prompt, model policy, 180-second environment, and 32-request runaway fuse. Token usage is measured, not capped.

Documents limits and interpretation, including incomplete cells and tool-description overhead. Tests cover matched policies, deferred serial execution, and real editing on a virtual Geschichte filesystem.

## Validation

Independent review found no medium-or-higher issues. Live Codex subscription trials are running; complete results will follow in a comment. Deterministic tests are being rerun after correcting the test gate to use an explicit Spindel execution context. This is a smoke comparison, not a statistical ranking.