### PR TITLE
Fix advertised clojure_edit insertion operations

### DIFF
--- a/src/dvergr/tools.clj
+++ b/src/dvergr/tools.clj
@@ -825,7 +825,10 @@
   :execute (fn [{:keys [file_path form_type form_name operation new_source]}
                 {:keys [session-id] :as ctx}]
              (let [full-path (tool-path ctx file_path)
-                   op-keyword (keyword operation)
+                   op-keyword (case operation
+                                "insert_before" :insert-before
+                                "insert_after" :insert-after
+                                (keyword operation))
                    result (if (:filesystem ctx)
                             (if-let [source (workspace-read ctx file_path)]
                               (structural/edit-clojure-source source form_type form_name

--- a/test/dvergr/tools/clojure_edit_test.clj
+++ b/test/dvergr/tools/clojure_edit_test.clj
@@ -1,0 +1,28 @@
+(ns dvergr.tools.clojure-edit-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dvergr.tools :as tools]
+            [muschel.fs :as fs]
+            [muschel.fs.geschichte :as gfs]))
+
+(deftest advertised-edit-operations-work-on-virtual-files
+  (let [{:keys [close!] :as repository} (gfs/memory-repository! {:name "edit-operations"})
+        filesystem (gfs/make-root repository)
+        context (tools/make-context {:cwd "/" :filesystem filesystem})
+        original "(ns demo)\n(defn answer [] 41)\n"
+        form '(defn answer [] 41)
+        helper '(defn helper [] 42)]
+    (try
+      (doseq [[operation new-source expected]
+              [["replace" "(defn answer [] 42)" '[(ns demo) (defn answer [] 42)]]
+               ["insert_before" (pr-str helper) [(list 'ns 'demo) helper form]]
+               ["insert_after" (pr-str helper) [(list 'ns 'demo) form helper]]]]
+        (testing operation
+          (is (= :success (:type (tools/execute "write_file"
+                                                {:path "demo.clj" :content original} context))))
+          (is (= :success (:type (tools/execute "clojure_edit"
+                                                {:file_path "demo.clj" :form_type "defn"
+                                                 :form_name "answer" :operation operation
+                                                 :new_source new-source} context))))
+          (is (= expected (read-string (str "[" (fs/read-file filesystem "/demo.clj") "]"))))))
+      (is (nil? (fs/physical-path filesystem "/demo.clj")))
+      (finally (close!)))))


### PR DESCRIPTION
## Summary

A live RSS repair benchmark exposed a tool-contract mismatch: clojure_edit advertises insert_before and insert_after, but keyword conversion passed underscored names to structural handlers expecting hyphens. Normalize these two names at the shared tool boundary for both virtual and native files.

Regression coverage exercises replacement and both advertised insertion operations through the real tool API on a virtual Geschichte filesystem and checks saved form order.

Independent review found no medium-or-higher issues. Targeted tests are running. Baseline live trials were not reloaded or modified; their results remain on PR #113.