### PR TITLE
Require RSS benchmark scaffold preservation for success

### DIFF
--- a/doc/coding-benchmarks.md
+++ b/doc/coding-benchmarks.md
@@ -85,8 +85,17 @@ Setup resets `/dvergr/intake/rss.clj`, `/test/rss_repair_test.clj`, and a labell
 stub at `/dvergr/intake/core.clj` in the candidate fork. The stub's `fetch-text`
 returns an error until a test supplies HTML/XML with `with-redefs`. Verification
 reconstructs the stub independently, so changing that dependency cannot fix
-the submitted RSS source. Source and test files are captured as in the
-permutation fixture; the parent dependency is not overwritten.
+the submitted RSS source. Fixture version 2 also captures the dependency and
+requires its exact original text at completion (`:dependency-unchanged?`). Missing,
+unreadable or oversized dependency captures fail that check. The task explicitly
+identifies the stub as intentional scaffolding: do not restore it from Git HEAD
+even if it appears as a working-tree modification. Source, tests and dependency
+are captured with the same per-file bounds; the parent dependency is not overwritten.
+
+This changes the fixture basis and checks version. Historical version-1 Attempts
+retain their original meaning: functional success did not imply scaffold
+preservation. This is a final-state check, not a prohibition on every intermediate
+write or a complete audit of unrelated workspace paths.
 
 There are 18 explicit URL cases covering document-relative paths, dot segments,
 scheme-relative links, absolute references, ports, encoded paths, queries and

--- a/src/dvergr/benchmarks/rss.clj
+++ b/src/dvergr/benchmarks/rss.clj
@@ -82,19 +82,21 @@
        "Write/run clojure.test regressions at " test-path "; load tests using load-string/slurp "
        "rather than reloading clojure.test. The fixture replaces dvergr.intake.core/fetch-text "
        "with an explicit offline stub: use with-redefs to supply HTML/XML bodies or {:error ...} "
-       "for each test. Do not change the stub to fix the task; verification reconstructs it. "
+       "for each test. Keep /dvergr/intake/core.clj byte-for-byte unchanged, including at completion. "
+       "The stub is intentional fixture scaffolding, even if Git shows it as modified; do not restore it from HEAD. "
+       "Verification reconstructs it independently and checks that your saved stub is unchanged. "
        "A fresh SCI interpreter verifies saved RSS source with 18 public URL cases and "
        "error/fallback/RSS/Atom regressions, not your final prose or REPL definitions. "
        "Finish with your counterexample, change summary and test results."))
 
 (def manifest
-  {:fixture/version 1 :source/repository "https://github.com/replikativ/dvergr-sandbox"
+  {:fixture/version 2 :source/repository "https://github.com/replikativ/dvergr-sandbox"
    :source/commit "25436365b401b928fc8bebf295afe017cd9c9a45"
    :source/path "dvergr/intake/rss.clj" :source/hash (hasch/uuid original-source)
    :dependency/hash (hasch/uuid dependency-source)
    :runtime/profile :dvergr-sci-closed-uri-v1
-   :checks/version 1 :checks/hash (hasch/uuid [cases check-expression])
-   :capture/paths [source-path test-path] :capture/max-file-bytes 32768
+   :checks/version 2 :checks/hash (hasch/uuid [cases check-expression :dependency-unchanged? dependency-source])
+   :capture/paths [source-path test-path dependency-path] :capture/max-file-bytes 32768
    :verification/timeout-ms 3000})
 (def basis (hasch/uuid [manifest task]))
 (def setup-ref {:setup/id :coding/rss :setup/version 1 :setup/basis basis})
@@ -151,12 +153,15 @@
   (evaluation/make-evaluator
    {:id :coding/rss :version 1 :basis basis
     :capture (fn [{:keys [world/room]}]
-               (workspace/capture room [source-path test-path] 32768))
+               (workspace/capture room [source-path test-path dependency-path] 32768))
     :observe (fn [{:keys [default execution/evidence result]}]
                (assoc default :artifacts evidence :fixture/basis basis
                       :completed? (= :completed (:run/status result))))
     :verify (fn [_ evidence]
               (let [file (get-in evidence [:artifacts :files source-path])
+                    dependency (get-in evidence [:artifacts :files dependency-path])
                     checks (assoc (check-source (when (= :ok (:status file)) (:source file)))
+                                  :dependency-unchanged? (and (= :ok (:status dependency))
+                                                              (= dependency-source (:source dependency)))
                                   :completed? (true? (:completed? evidence)))]
                 {:checks checks :reward (if (every? true? (vals checks)) 1.0 0.0)}))}))

--- a/test/dvergr/benchmarks/rss_test.clj
+++ b/test/dvergr/benchmarks/rss_test.clj
@@ -70,9 +70,10 @@
                     "(spit " (pr-str rss/test-path) " " (pr-str regression-source) ") "
                     "(require 'dvergr.intake.rss :reload) "
                     "(load-string (slurp " (pr-str rss/test-path) ")) "
-                    "(clojure.test/run-tests 'rss-repair-test) "
+                    "(let [result (clojure.test/run-tests 'rss-repair-test)] "
                     (when (= :scaffold-changed variant)
-                      (str "(spit " (pr-str rss/dependency-path) " \"restored upstream dependency\")")))]
+                      (str "(spit " (pr-str rss/dependency-path) " \"restored upstream dependency\") "))
+                    "result)")]
       (try
         (binding [ec/*execution-context* (:ctx room)]
           (ygg/register! (gy/create conn {:system-name "room-repo-rss-test"}))

--- a/test/dvergr/benchmarks/rss_test.clj
+++ b/test/dvergr/benchmarks/rss_test.clj
@@ -56,7 +56,7 @@
        "(:url (first (rss/discover-feeds \"https://example.org/blog/\")))))))\n"))
 
 (deftest rss-repair-through-real-sci-tools-and-disposal
-  (doseq [variant [:unchanged :repaired :failed]]
+  (doseq [variant [:unchanged :repaired :failed :scaffold-changed]]
     (let [{:keys [conn close!]} (gfs/memory-repository! {:name "rss-coding-run"})
           room (d/make-room {:id :rss-coding-run :store (memory/make)})
           source (if (= :unchanged variant) rss/original-source repaired-source)
@@ -70,7 +70,9 @@
                     "(spit " (pr-str rss/test-path) " " (pr-str regression-source) ") "
                     "(require 'dvergr.intake.rss :reload) "
                     "(load-string (slurp " (pr-str rss/test-path) ")) "
-                    "(clojure.test/run-tests 'rss-repair-test)")]
+                    "(clojure.test/run-tests 'rss-repair-test) "
+                    (when (= :scaffold-changed variant)
+                      (str "(spit " (pr-str rss/dependency-path) " \"restored upstream dependency\")")))]
       (try
         (binding [ec/*execution-context* (:ctx room)]
           (ygg/register! (gy/create conn {:system-name "room-repo-rss-test"}))
@@ -109,6 +111,9 @@
                     (str @tool-result))
                 (is (= source (get-in persisted [:attempt/evidence :artifacts :files rss/source-path :source])))
                 (is (= regression-source (get-in persisted [:attempt/evidence :artifacts :files rss/test-path :source])))
+                (is (= (not= :scaffold-changed variant) (:dependency-unchanged? (:attempt/checks receipt))))
+                (is (= (if (= :scaffold-changed variant) "restored upstream dependency" rss/dependency-source)
+                       (get-in persisted [:attempt/evidence :artifacts :files rss/dependency-path :source])))
                 (is (nil? (registry/lookup (get-in result [:run/result :run/world]))))
                 (is (nil? (fs/stat (g/filesystem) rss/source-path)))
                 (is (nil? (fs/stat (g/filesystem) rss/test-path)))
@@ -118,3 +123,15 @@
           (evaluation/await-cleanups! room)
           (d/close-room! room)
           (close!))))))
+
+(deftest scaffold-capture-fails-closed
+  (let [verify (:verify (rss/evaluator))]
+    (with-redefs [rss/check-source (constantly {:evaluated? true})]
+      (doseq [dependency [nil {:status :missing} {:status :size-rejected}
+                          {:status :ok :source "changed"}
+                          {:status :unreadable :source rss/dependency-source}]]
+        (let [result (verify (rss/definition)
+                             {:completed? true
+                              :artifacts {:files {rss/dependency-path dependency}}})]
+          (is (false? (get-in result [:checks :dependency-unchanged?])))
+          (is (= 0.0 (:reward result))))))))


### PR DESCRIPTION
## Summary

A live reviewer repaired RSS source but restored the intentional dependency stub from Git HEAD. Version 1 independently reconstructed the stub for functional checks but did not score preservation of the saved scaffold.

This change captures the dependency alongside source/tests and adds a fail-closed dependency-unchanged check to reward. It clarifies the task, increments fixture/check versions, and changes the content basis without reinterpreting historical Attempts. This is a final-state check, not an audit of all intermediate writes or unrelated files.

## Validation

Independent review found no medium-or-higher issues. Added a real SCI-tool lifecycle case where repaired source is followed by scaffold alteration, plus missing/unreadable/oversized capture checks. Targeted tests are rerunning after correcting the simulated tool return value; results will be attached before merge.